### PR TITLE
fix(mypy): fix valid-type shadowing in core/preview/manager.py

### DIFF
--- a/src/bernstein/core/preview/manager.py
+++ b/src/bernstein/core/preview/manager.py
@@ -35,7 +35,7 @@ import time
 from dataclasses import asdict, dataclass, field
 from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from bernstein.core.preview.command_discovery import (
     DiscoveredCommand,
@@ -55,8 +55,6 @@ from bernstein.core.preview.port_capture import (
 from bernstein.core.preview.token_issuer import IssuedAuth, PreviewTokenIssuer
 from bernstein.core.preview.tunnel_bridge import TunnelBridge, TunnelBridgeError
 from bernstein.core.security.audit import AuditLog
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import builtins

--- a/src/bernstein/core/preview/manager.py
+++ b/src/bernstein/core/preview/manager.py
@@ -22,7 +22,6 @@ clock).
 
 from __future__ import annotations
 
-import builtins
 import contextlib
 import json
 import logging
@@ -56,6 +55,11 @@ from bernstein.core.preview.port_capture import (
 from bernstein.core.preview.token_issuer import IssuedAuth, PreviewTokenIssuer
 from bernstein.core.preview.tunnel_bridge import TunnelBridge, TunnelBridgeError
 from bernstein.core.security.audit import AuditLog
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import builtins
 
 logger = logging.getLogger(__name__)
 

--- a/src/bernstein/core/preview/manager.py
+++ b/src/bernstein/core/preview/manager.py
@@ -22,6 +22,7 @@ clock).
 
 from __future__ import annotations
 
+import builtins
 import contextlib
 import json
 import logging
@@ -245,7 +246,7 @@ class PreviewStore:
     # Internal
     # ------------------------------------------------------------------
 
-    def _load(self) -> list[PreviewState]:
+    def _load(self) -> builtins.list[PreviewState]:
         if not self._path.exists():
             return []
         try:
@@ -264,7 +265,7 @@ class PreviewStore:
                 logger.debug("Skipping malformed preview state row: %s", exc)
         return out
 
-    def _save(self, records: list[PreviewState]) -> None:
+    def _save(self, records: builtins.list[PreviewState]) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
         payload = {"previews": [r.to_dict() for r in records]}
         tmp = self._path.with_suffix(self._path.suffix + ".tmp")
@@ -344,7 +345,7 @@ class PreviewManager:
         """Return state for *preview_id* or ``None``."""
         return self._store.get(preview_id)
 
-    def discover(self, cwd: Path) -> list[DiscoveredCommand]:
+    def discover(self, cwd: Path) -> builtins.list[DiscoveredCommand]:
         """Return every discovered candidate command under *cwd*."""
         return list_candidates(cwd)
 


### PR DESCRIPTION
## What
Fixes mypy errors in `core/preview/manager.py`.

Part of #2980.

## Why
`PreviewStore.list` and `PreviewManager.list` methods shadowed the builtin `list` type, causing `valid-type` errors on all `list[...]` annotations within the classes.

## How
- Changed `list[...]` → `builtins.list[...]` on type annotations inside `PreviewStore` and `PreviewManager` classes to avoid method shadowing. Added `import builtins`.

Verified: `uv run mypy src` reports 0 errors in `core/preview`. Full strict gate (`uv run mypy --config-file mypy.gate.ini`) clean.

## Checklist
- [x] `uv run ruff check src/ tests/` passes
- [x] `uv run pyright src/` passes *(N/A)*
- [x] `uv run python scripts/run_tests.py -x` passes *(N/A)*
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)
- [x] User-visible README section updated (or N/A if internal-only)
- [x] `docs/operations/<area>.md` updated (or N/A)
- [x] `docs/api/` schema regenerated if a public surface changed (or N/A)
- [x] `uv run bernstein agents-md sync` run (or N/A)
- [x] Tests cover the documented behaviour