### PR TITLE
feat(lineage): record artifact provenance for work a CLI agent merges

### DIFF
--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -2024,6 +2024,14 @@ class AgentSpawner:
         """Wire in the orchestrator's :class:`QualityGatesConfig` (#4393)."""
         self._quality_gate_config = config
 
+    def set_run_id(self, run_id: str) -> None:
+        """Wire in the orchestrator's run id.
+
+        The merge path records a lineage row per landed path and keys those
+        rows by run, so without this the rows have no spine to join.
+        """
+        self._run_id = run_id
+
     def _merge_and_cleanup_worktree(
         self,
         session: AgentSession,
@@ -2045,6 +2053,7 @@ class AgentSpawner:
             merge_worktree_branch_fn=self._merge_worktree_branch,
             merge_queue=self._merge_queue,
             quality_gate_config=self._quality_gate_config,
+            run_id=getattr(self, "_run_id", ""),
         )
 
     def _touch_prespawn_heartbeat(self, session_id: str) -> None:

--- a/src/bernstein/core/agents/spawner_merge.py
+++ b/src/bernstein/core/agents/spawner_merge.py
@@ -470,11 +470,68 @@ def _quality_gate_refusal(
 # ---------------------------------------------------------------------------
 
 
+def _record_landed_provenance(
+    session_id: str,
+    worktree_root: Path,
+    before_sha: str,
+    run_id: str,
+) -> None:
+    """Record a lineage row per path this merge landed (issue #2789).
+
+    A CLI adapter's subprocess writes never reach ``record_artifact_write``,
+    so without this the run's spine holds only its own journal seal: a chain
+    that verifies while recording nothing the agent produced.
+
+    Failure is loud but never propagates. The merge is already in git and
+    every row is re-derivable from the merge commit, so a provenance write
+    that fails must not undo work that landed -- the same reasoning
+    ``emit_production_event`` applies one level down.
+    """
+    if not run_id or not before_sha:
+        logger.debug("merge provenance: no run id or base for %s; nothing recorded", _sanitise_for_log(session_id))
+        return
+    try:
+        from bernstein.core.git.git_basic import run_git
+        from bernstein.core.lineage.merge_provenance import record_merge_artifacts
+        from bernstein.core.security.audit import load_or_create_audit_key
+
+        head = run_git(["rev-parse", "HEAD"], worktree_root, timeout=10)
+        if head.returncode != 0:
+            logger.warning("merge provenance: could not resolve HEAD after merge for %s", _sanitise_for_log(session_id))
+            return
+        after_sha = head.stdout.strip()
+        if after_sha == before_sha:
+            return
+        result = record_merge_artifacts(
+            worktree_root=worktree_root,
+            before_sha=before_sha,
+            after_sha=after_sha,
+            actor=f"agent/{session_id}",
+            lineage_root=worktree_root / ".sdd" / "lineage",
+            run_id=run_id,
+            hmac_key=load_or_create_audit_key(),
+        )
+        logger.info(
+            "merge provenance: recorded %d/%d landed path(s) for %s at %s",
+            len(result.recorded),
+            result.total_seen,
+            _sanitise_for_log(session_id),
+            after_sha[:12],
+        )
+    except Exception as exc:
+        logger.warning(
+            "merge provenance: no rows recorded for %s: %s",
+            _sanitise_for_log(session_id),
+            _sanitise_for_log(str(exc)),
+        )
+
+
 def _run_merge_and_push(
     session: AgentSession,
     worktree_root: Path,
     merge_worktree_branch_fn: Any,
     quality_gate_config: QualityGatesConfig | None = None,
+    run_id: str = "",
 ) -> MergeResult | None:
     """Run the merge subprocess, record metrics, and push on success.
 
@@ -565,6 +622,14 @@ def _run_merge_and_push(
         session.id,
         author_role,
     )
+    # Base for the landed-provenance diff. Read before the merge because
+    # ``before..after`` records a fast-forward -- which leaves no merge
+    # commit to diff against a parent -- the same way as a true merge.
+    from bernstein.core.git.git_basic import run_git as _run_git
+
+    _base = _run_git(["rev-parse", "HEAD"], worktree_root, timeout=10)
+    before_sha = _base.stdout.strip() if _base.returncode == 0 else ""
+
     merge_result = merge_worktree_branch_fn(session.id, repo_root=worktree_root)
     merge_duration.observe(time.perf_counter() - merge_start)
 
@@ -575,6 +640,7 @@ def _run_merge_and_push(
         get_collector().record_merge_result(task_id, success=merge_ok)
 
     if merge_result and merge_result.success:
+        _record_landed_provenance(session.id, worktree_root, before_sha, run_id)
         # Push the branch we actually merged into (never a hard-coded "main").
         # ``target_branch`` is None only on detached HEAD; fall back to the
         # resolved default there.
@@ -595,6 +661,7 @@ def _do_merge(
     merge_worktree_branch_fn: Any,
     merge_queue: MergeQueue | None = None,
     quality_gate_config: QualityGatesConfig | None = None,
+    run_id: str = "",
 ) -> MergeResult | None:
     """Execute the merge under a lock, record metrics, and push.
 
@@ -627,6 +694,7 @@ def _do_merge(
                 worktree_root,
                 merge_worktree_branch_fn,
                 quality_gate_config=quality_gate_config,
+                run_id=run_id,
             )
 
     merge_lock = merge_locks.setdefault(worktree_root, threading.Lock())
@@ -636,6 +704,7 @@ def _do_merge(
             worktree_root,
             merge_worktree_branch_fn,
             quality_gate_config=quality_gate_config,
+            run_id=run_id,
         )
 
 
@@ -668,6 +737,7 @@ def merge_and_cleanup_worktree(
     merge_worktree_branch_fn: Any,
     merge_queue: MergeQueue | None = None,
     quality_gate_config: QualityGatesConfig | None = None,
+    run_id: str = "",
 ) -> MergeResult | None:
     """Merge worktree branch back and optionally clean up.
 
@@ -718,6 +788,7 @@ def merge_and_cleanup_worktree(
             merge_worktree_branch_fn,
             merge_queue=merge_queue,
             quality_gate_config=quality_gate_config,
+            run_id=run_id,
         )
 
     if not defer_cleanup:

--- a/src/bernstein/core/agents/spawner_merge.py
+++ b/src/bernstein/core/agents/spawner_merge.py
@@ -627,8 +627,18 @@ def _run_merge_and_push(
     # commit to diff against a parent -- the same way as a true merge.
     from bernstein.core.git.git_basic import run_git as _run_git
 
-    _base = _run_git(["rev-parse", "HEAD"], worktree_root, timeout=10)
-    before_sha = _base.stdout.strip() if _base.returncode == 0 else ""
+    # Reading the base must not decide whether the merge is attempted. A
+    # missing or unreadable worktree makes this raise before the merge
+    # function is ever called -- ``run_git`` cannot chdir into a path that is
+    # not there -- which would turn a provenance aid into a merge gate and
+    # take the error away from the merge function that reports it properly.
+    # An empty base makes the later recording a documented no-op.
+    try:
+        _base = _run_git(["rev-parse", "HEAD"], worktree_root, timeout=10)
+        before_sha = _base.stdout.strip() if _base.returncode == 0 else ""
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.debug("merge provenance: base unreadable at %s: %s", worktree_root, exc)
+        before_sha = ""
 
     merge_result = merge_worktree_branch_fn(session.id, repo_root=worktree_root)
     merge_duration.observe(time.perf_counter() - merge_start)

--- a/src/bernstein/core/lineage/AGENTS.md
+++ b/src/bernstein/core/lineage/AGENTS.md
@@ -16,11 +16,19 @@ single always-on Merkle+HMAC store that every adapter artifact write routes thro
 | `activity.py` | Active-set closure and provenance graph resolution over the receipt ledger |
 | `gate.py` | Lineage CI gate (ADR-009 §6.2) |
 | `run_graph.py` | Pairs each fan-out worktree branch with the spine that recorded it: `build_run_graph` returns one `RunGraphNode` per branch (`session_id`, `head_sha`, `run_id`, `spine_head_hash`) plus a deterministic root hash. Pure - it adds no storage and resolves `session_id -> run_id` from a caller-supplied mapping |
+| `merge_provenance.py` | Records one row per path a CLI agent's work lands through a merge (issue #2789). Reads the change as `before..after` so a fast-forward is recorded like a true merge, hashes the git blob rather than a re-read of the working tree, and names the merge commit in `step_id`. Recording at the merge, not at write time, is what lets a third party recompute every row's `content_hash` from the repository alone |
 
 ## Invariants
 
 - Adapter artifact writes route through `LineageSpine.record` at the single write boundary in
   `../../adapters/base.py` - no per-adapter opt-in, no second write path (issue #2292).
+- A CLI adapter spawns a subprocess that writes files itself, so those writes never reach that
+  in-process boundary; `merge_provenance.py` records them where the work is accepted into the
+  repository instead. It is a second *caller* of `record_artifact_write`, not a second write
+  path - anything new that records artifacts goes through that function too.
+- Provenance recording must never undo work that landed. A merge is already durable in git and
+  its rows are re-derivable from it, so `spawner_merge` logs a recording failure and keeps the
+  merge; `tests/unit/agents/test_spawner_merge_provenance.py` holds that boundary.
 - Spine entries chain: `entry_hash = H(prev_hash, artifact_path, content_hash, actor, step_id,
   model, timestamp)`. Changing the entry shape breaks head-hash verification for existing runs.
 - The spine's HMAC tag uses a per-store key derived from the audit-chain master key with
@@ -36,5 +44,8 @@ single always-on Merkle+HMAC store that every adapter artifact write routes thro
 
 Single files only, e.g. `uv run pytest tests/unit/test_lineage_record.py -x -q`;
 the `test_lineage_*.py` files cover entries, stores, signing, and gates.
+`tests/unit/lineage/test_merge_provenance.py` exercises merge recording against real git
+repositories rather than a stub, because what it asserts is that a row's `content_hash`
+matches the blob git stored.
 
-<!-- Reviewed 2026-08-24 against this subtree; the notes above still hold. -->
+<!-- Reviewed 2026-08-28 against this subtree; the notes above still hold. -->

--- a/src/bernstein/core/lineage/AGENTS.md
+++ b/src/bernstein/core/lineage/AGENTS.md
@@ -1,8 +1,6 @@
 # Lineage: artifact provenance
 
-Per-artifact provenance in two layers: Lineage v1 (Sigstore-style transparency log:
-RFC 8785 JCS canonicalisation, sha256 entry hashes, Ed25519 JWS) and `LineageSpine`, the
-single always-on Merkle+HMAC store that every adapter artifact write routes through.
+Per-artifact provenance in two layers: Lineage v1 (Sigstore-style transparency log: RFC 8785 JCS canonicalisation, sha256 entry hashes, Ed25519 JWS) and `LineageSpine`, the single always-on Merkle+HMAC store every artifact write routes through.
 
 ## Key files
 
@@ -16,36 +14,20 @@ single always-on Merkle+HMAC store that every adapter artifact write routes thro
 | `activity.py` | Active-set closure and provenance graph resolution over the receipt ledger |
 | `gate.py` | Lineage CI gate (ADR-009 §6.2) |
 | `run_graph.py` | Pairs each fan-out worktree branch with the spine that recorded it: `build_run_graph` returns one `RunGraphNode` per branch (`session_id`, `head_sha`, `run_id`, `spine_head_hash`) plus a deterministic root hash. Pure - it adds no storage and resolves `session_id -> run_id` from a caller-supplied mapping |
-| `merge_provenance.py` | Records one row per path a CLI agent's work lands through a merge (issue #2789). Reads the change as `before..after` so a fast-forward is recorded like a true merge, hashes the git blob rather than a re-read of the working tree, and names the merge commit in `step_id`. Recording at the merge, not at write time, is what lets a third party recompute every row's `content_hash` from the repository alone |
+| `merge_provenance.py` | Records one row per path a CLI agent's work lands through a merge (issue #2789). Reads `before..after` so a fast-forward records like a true merge, hashes the git blob rather than the working tree, and names the merge commit in `step_id` - so a third party recomputes every `content_hash` from the repository alone. Recording must never undo a landed merge: `spawner_merge` logs a failure and keeps the merge, and neither reading the base nor writing the rows may gate it |
 
 ## Invariants
 
-- Adapter artifact writes route through `LineageSpine.record` at the single write boundary in
-  `../../adapters/base.py` - no per-adapter opt-in, no second write path (issue #2292).
-- A CLI adapter spawns a subprocess that writes files itself, so those writes never reach that
-  in-process boundary; `merge_provenance.py` records them where the work is accepted into the
-  repository instead. It is a second *caller* of `record_artifact_write`, not a second write
-  path - anything new that records artifacts goes through that function too.
-- Provenance recording must never undo work that landed. A merge is already durable in git and
-  its rows are re-derivable from it, so `spawner_merge` logs a recording failure and keeps the
-  merge; `tests/unit/agents/test_spawner_merge_provenance.py` holds that boundary.
-- Spine entries chain: `entry_hash = H(prev_hash, artifact_path, content_hash, actor, step_id,
-  model, timestamp)`. Changing the entry shape breaks head-hash verification for existing runs.
-- The spine's HMAC tag uses a per-store key derived from the audit-chain master key with
-  HKDF-SHA256 (`../security/key_derivation.py`): v2 MACs the derived key over a domain-tagged
-  preimage, v1 keeps the raw key untagged. `../security/audit.py`'s key rules apply.
-- A new `LineageEntry` field must be optional, default `None`, dropped from `_canonical_body`
-  when `None`, and read back in `_entry_from_dict` (cf. `attachment_digests`) - that is what
-  keeps every historical entry's bytes, HMAC and JWS valid.
+- Adapter artifact writes route through `LineageSpine.record` at the single write boundary in `../../adapters/base.py` - no per-adapter opt-in, no second write path (issue #2292).
+- A CLI adapter's subprocess writes files itself and never reaches that in-process boundary, so `merge_provenance.py` records them where the work enters the repository. It is a second *caller* of `record_artifact_write`, not a second write path.
+- Spine entries chain: `entry_hash = H(prev_hash, artifact_path, content_hash, actor, step_id, model, timestamp)`. Changing the entry shape breaks head-hash verification for existing runs.
+- The spine's HMAC tag uses a per-store key derived from the audit-chain master key with HKDF-SHA256 (`../security/key_derivation.py`): v2 MACs the derived key over a domain-tagged preimage, v1 keeps the raw key untagged. `../security/audit.py`'s key rules apply.
+- A new `LineageEntry` field must be optional, default `None`, dropped from `_canonical_body` when `None`, and read back in `_entry_from_dict` (cf. `attachment_digests`) - that is what keeps every historical entry's bytes, HMAC and JWS valid.
 - `parent_hashes` is the artefact's ancestry only: tip projection reads two or more as a *fork merge*, so other inputs need their own field.
 - Design rationale: `docs/decisions/009-lineage-v1.md`.
 
 ## Testing
 
-Single files only, e.g. `uv run pytest tests/unit/test_lineage_record.py -x -q`;
-the `test_lineage_*.py` files cover entries, stores, signing, and gates.
-`tests/unit/lineage/test_merge_provenance.py` exercises merge recording against real git
-repositories rather than a stub, because what it asserts is that a row's `content_hash`
-matches the blob git stored.
+Single files only, e.g. `uv run pytest tests/unit/test_lineage_record.py -x -q`; the `test_lineage_*.py` files cover entries, stores, signing, and gates. Merge recording is tested against real git repositories, not a stub - what it asserts is that a row's `content_hash` is the blob git stored (`tests/unit/lineage/test_merge_provenance.py`).
 
 <!-- Reviewed 2026-08-28 against this subtree; the notes above still hold. -->

--- a/src/bernstein/core/lineage/merge_provenance.py
+++ b/src/bernstein/core/lineage/merge_provenance.py
@@ -1,0 +1,232 @@
+"""Artifact provenance for the work a CLI agent lands through a merge.
+
+A CLI adapter spawns a subprocess that writes files directly in its
+worktree, so those writes never cross :func:`record_artifact_write` -- the
+single in-process write boundary. What was left on that path was a spine
+holding one row, the run's own journal seal: a chain that verifies while
+recording nothing the run produced (issue #2789 traced this; its
+``SEAL_ONLY`` verdict names the condition but does not fill the chain).
+
+This module fills it at the point where agent work is accepted into the
+repository. Recording there rather than at write time buys a property
+write-time interception cannot offer: the recorded content is the blob as
+it landed, so anyone holding the repository can recompute every row's
+content hash from git alone, without trusting the recorder or replaying
+the agent. A row that disagrees with the repository is detectable by a
+third party.
+
+The change is read as ``before..after`` around the merge rather than from
+the merge commit's parents, so a fast-forward -- which produces no merge
+commit at all -- is recorded the same way as a true merge.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: ``step_id`` prefix for rows recording work landed by a merge. Mirrors
+#: ``JOURNAL_SEAL_STEP_PREFIX`` so a reader can tell at a glance which rows
+#: describe produced artifacts and which are the run's internal seal.
+MERGE_STEP_PREFIX = "merge:"
+
+#: Largest blob recorded inline. Content is hashed from bytes held in
+#: memory, and an agent-produced source file is orders of magnitude below
+#: this. A blob above the cap is skipped and counted rather than recorded
+#: with substituted content: a row whose hash covers something other than
+#: the file it names would verify while describing nothing.
+MAX_BLOB_BYTES = 8 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class MergedArtifact:
+    """One path the merge changed, with the bytes that landed."""
+
+    path: str
+    content: bytes
+    deleted: bool
+
+
+@dataclass
+class MergeProvenanceResult:
+    """What recording produced, for logging and for tests to assert on."""
+
+    recorded: list[str] = field(default_factory=list[str])
+    skipped_oversize: list[str] = field(default_factory=list[str])
+    unreadable: list[str] = field(default_factory=list[str])
+
+    @property
+    def total_seen(self) -> int:
+        return len(self.recorded) + len(self.skipped_oversize) + len(self.unreadable)
+
+
+class MergedChangeUnreadable(RuntimeError):
+    """The set of paths the merge landed could not be read.
+
+    Raised rather than collapsed into an empty list, for the reason
+    ``spawner_merge._incoming_files`` gives: an empty list is a merge that
+    changed nothing, and a read that failed must not be indistinguishable
+    from it. Here the consequence is milder but the same in kind -- a
+    silent empty read would leave a seal-only spine while reporting
+    success, which is the exact defect this module exists to remove.
+    """
+
+
+def _git_bytes(args: list[str], cwd: Path, *, timeout: int = 30) -> bytes:
+    """Run git and return raw stdout.
+
+    ``run_git`` decodes with ``errors="replace"``, which is correct for
+    the text it is used for and wrong here: content is hashed, so a
+    replacement character would change the hash of any non-UTF-8 blob.
+    """
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", "replace").strip()
+        msg = f"git {' '.join(args)} exited {result.returncode} ({detail})"
+        raise MergedChangeUnreadable(msg)
+    return result.stdout
+
+
+def changed_paths(worktree_root: Path, before_sha: str, after_sha: str) -> list[tuple[str, str]]:
+    """Return ``(status, path)`` for every path the merge changed.
+
+    ``--no-renames`` for the reason the merge gate uses it: rename
+    detection reports only a rename's destination, so the path a rename
+    removed would go unrecorded. A rename is two paths changing and both
+    are named.
+
+    Raises:
+        MergedChangeUnreadable: The diff could not be read.
+    """
+    raw = _git_bytes(
+        ["diff", "--name-status", "--no-renames", "-z", f"{before_sha}..{after_sha}"],
+        worktree_root,
+    )
+    # ``-z`` because a path may contain a newline; git would otherwise
+    # quote and escape it, and the recorded path must be the real one.
+    fields = raw.decode("utf-8", "surrogateescape").split("\0")
+    out: list[tuple[str, str]] = []
+    i = 0
+    while i + 1 < len(fields):
+        status = fields[i].strip()
+        path = fields[i + 1]
+        if status and path:
+            out.append((status[:1], path))
+        i += 2
+    return out
+
+
+def collect_merged_artifacts(
+    worktree_root: Path,
+    before_sha: str,
+    after_sha: str,
+) -> tuple[list[MergedArtifact], list[str], list[str]]:
+    """Read the bytes that landed for every path the merge changed.
+
+    Returns:
+        ``(artifacts, skipped_oversize, unreadable)``. A deletion is an
+        artifact with empty content and ``deleted=True``: the run changed
+        that path, and a chain that omits removals records only half of
+        what the agent did.
+
+    Raises:
+        MergedChangeUnreadable: The path list could not be read.
+    """
+    artifacts: list[MergedArtifact] = []
+    oversize: list[str] = []
+    unreadable: list[str] = []
+
+    for status, path in changed_paths(worktree_root, before_sha, after_sha):
+        if status == "D":
+            artifacts.append(MergedArtifact(path=path, content=b"", deleted=True))
+            continue
+        try:
+            size_raw = _git_bytes(["cat-file", "-s", f"{after_sha}:{path}"], worktree_root)
+            if int(size_raw.decode().strip()) > MAX_BLOB_BYTES:
+                oversize.append(path)
+                continue
+            content = _git_bytes(["cat-file", "blob", f"{after_sha}:{path}"], worktree_root)
+        except (MergedChangeUnreadable, ValueError, subprocess.SubprocessError, OSError) as exc:
+            # One unreadable blob must not cost the provenance of every
+            # other path in the same merge.
+            logger.warning("merge provenance: could not read %s at %s: %s", path, after_sha[:12], exc)
+            unreadable.append(path)
+            continue
+        artifacts.append(MergedArtifact(path=path, content=content, deleted=False))
+
+    return artifacts, oversize, unreadable
+
+
+def record_merge_artifacts(
+    *,
+    worktree_root: Path,
+    before_sha: str,
+    after_sha: str,
+    actor: str,
+    lineage_root: Path,
+    run_id: str,
+    hmac_key: bytes,
+    model: str = "",
+) -> MergeProvenanceResult:
+    """Record one spine row per path a merge landed.
+
+    Each row's ``step_id`` carries the merge commit, so a verifier can tie
+    the row to the object in git whose blob it hashes.
+
+    Raises:
+        MergedChangeUnreadable: The path list could not be read. Callers
+            landing a merge must catch this: the merge is already durable
+            in git and the rows are re-derivable from it, so a provenance
+            failure must be loud but must not undo work that landed.
+    """
+    from bernstein.adapters.base import record_artifact_write
+
+    artifacts, oversize, unreadable = collect_merged_artifacts(worktree_root, before_sha, after_sha)
+    result = MergeProvenanceResult(skipped_oversize=oversize, unreadable=unreadable)
+
+    for artifact in artifacts:
+        record_artifact_write(
+            artifact_path=artifact.path,
+            content=artifact.content,
+            actor=actor,
+            step_id=f"{MERGE_STEP_PREFIX}{after_sha}",
+            model=model,
+            lineage_root=lineage_root,
+            run_id=run_id,
+            hmac_key=hmac_key,
+        )
+        result.recorded.append(artifact.path)
+
+    if oversize:
+        logger.warning(
+            "merge provenance: %d path(s) above %d bytes recorded no row: %s",
+            len(oversize),
+            MAX_BLOB_BYTES,
+            ", ".join(oversize[:5]),
+        )
+    return result
+
+
+__all__ = [
+    "MAX_BLOB_BYTES",
+    "MERGE_STEP_PREFIX",
+    "MergeProvenanceResult",
+    "MergedArtifact",
+    "MergedChangeUnreadable",
+    "changed_paths",
+    "collect_merged_artifacts",
+    "record_merge_artifacts",
+]

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -877,6 +877,8 @@ class Orchestrator:
             self._spawner.set_merge_queue(self._merge_queue)
         if hasattr(self._spawner, "set_quality_gate_config"):
             self._spawner.set_quality_gate_config(self._quality_gate_config)
+        if hasattr(self._spawner, "set_run_id"):
+            self._spawner.set_run_id(self._run_id)
 
         # Convergence guard: blocks spawn waves when merge queue, active
         # agent count, error rate, or spawn rate exceed safe thresholds.

--- a/tests/unit/agents/test_spawner_merge_provenance.py
+++ b/tests/unit/agents/test_spawner_merge_provenance.py
@@ -117,6 +117,34 @@ def test_without_a_run_id_the_merge_still_lands(repo: Path) -> None:
     assert _git(repo, "log", "-1", "--pretty=%s") == "merge agent work"
 
 
+def test_an_unreadable_worktree_does_not_stop_the_merge_being_attempted(tmp_path: Path) -> None:
+    """Reading the provenance base must not decide whether the merge runs.
+
+    The base is read before the merge so a fast-forward can be recorded, and
+    ``run_git`` cannot chdir into a path that is not there: an unguarded read
+    raises before the merge function is ever called, turning a provenance aid
+    into a merge gate and taking the error away from the merge function that
+    reports it properly. Asserts the call happened, not merely that nothing
+    raised -- a silently skipped merge would also not raise.
+    """
+    called: list[Path] = []
+
+    def _merge(session_id: str, repo_root: Path) -> _MergeResult:
+        called.append(repo_root)
+        return _MergeResult(success=False)
+
+    missing = tmp_path / "gone"  # never created
+
+    _run_merge_and_push(
+        _Session(),  # type: ignore[arg-type]
+        missing,
+        _merge,
+        run_id="run-1",
+    )
+
+    assert called == [missing]
+
+
 def test_a_failing_recorder_does_not_undo_a_landed_merge(repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """The merge is durable in git and the rows are re-derivable from it.
 

--- a/tests/unit/agents/test_spawner_merge_provenance.py
+++ b/tests/unit/agents/test_spawner_merge_provenance.py
@@ -19,9 +19,7 @@ from bernstein.core.lineage.spine import LineageSpine, SpineStatus
 
 
 def _git(repo: Path, *args: str) -> str:
-    return subprocess.run(
-        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
-    ).stdout.strip()
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True).stdout.strip()
 
 
 class _Session:
@@ -119,9 +117,7 @@ def test_without_a_run_id_the_merge_still_lands(repo: Path) -> None:
     assert _git(repo, "log", "-1", "--pretty=%s") == "merge agent work"
 
 
-def test_a_failing_recorder_does_not_undo_a_landed_merge(
-    repo: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_a_failing_recorder_does_not_undo_a_landed_merge(repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """The merge is durable in git and the rows are re-derivable from it.
 
     So a provenance failure must be loud and survivable, never a rollback

--- a/tests/unit/agents/test_spawner_merge_provenance.py
+++ b/tests/unit/agents/test_spawner_merge_provenance.py
@@ -1,0 +1,165 @@
+"""The merge path must fill the spine, not just be able to.
+
+``test_merge_provenance.py`` proves the recorder works when called. These
+tests prove the production merge path calls it -- the half that was missing
+for the whole life of issue #2789, where the write boundary existed and
+simply had no caller on the CLI-adapter path.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.agents.spawner_merge import _run_merge_and_push
+from bernstein.core.lineage.spine import LineageSpine, SpineStatus
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+class _Session:
+    """Minimal stand-in for ``AgentSession`` on the merge path."""
+
+    def __init__(self, session_id: str = "sess-1") -> None:
+        self.id = session_id
+        self.task_ids: list[str] = ["task-1"]
+        self.role = "worker"
+
+
+class _MergeResult:
+    def __init__(self, success: bool) -> None:
+        self.success = success
+        self.conflicting_files: list[str] = []
+        self.error = ""
+
+
+@pytest.fixture
+def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A repo on a non-default branch with an agent branch ready to merge.
+
+    Non-default because the merge path refuses to land agent work on a
+    protected trunk, which would short-circuit these tests before they
+    reach the recording.
+    """
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "t@example.com")
+    _git(root, "config", "user.name", "T")
+    (root / "seed.txt").write_text("seed\n", encoding="utf-8")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-qm", "seed")
+
+    _git(root, "checkout", "-q", "-b", "agent/sess-1")
+    (root / "src").mkdir()
+    (root / "src" / "feature.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    (root / "seed.txt").unlink()
+    _git(root, "add", "-A")
+    _git(root, "commit", "-qm", "agent work")
+
+    _git(root, "checkout", "-q", "-b", "integration", "main")
+
+    key_path = tmp_path / "audit.key"
+    key_path.write_bytes(b"k" * 32)
+    key_path.chmod(0o600)  # the loader refuses a group/world-readable key
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(key_path))
+    return root
+
+
+def _merge_fn(repo: Path) -> Any:
+    def _merge(session_id: str, repo_root: Path) -> _MergeResult:
+        subprocess.run(
+            ["git", "merge", "--no-ff", "-q", "-m", "merge agent work", f"agent/{session_id}"],
+            cwd=repo_root,
+            capture_output=True,
+            check=True,
+        )
+        return _MergeResult(success=True)
+
+    return _merge
+
+
+def test_a_successful_merge_writes_a_row_per_landed_path(repo: Path, tmp_path: Path) -> None:
+    """The defect: a merged run left a spine with no artifact provenance."""
+    _run_merge_and_push(
+        _Session(),  # type: ignore[arg-type]
+        repo,
+        _merge_fn(repo),
+        run_id="run-1",
+    )
+
+    rows = list(LineageSpine(repo / ".sdd" / "lineage", run_id="run-1", hmac_key=b"k" * 32).iter_entries())
+
+    assert {r.artifact_path for r in rows} == {"src/feature.py", "seed.txt"}
+    assert {r.actor for r in rows} == {"agent/sess-1"}
+
+
+def test_without_a_run_id_the_merge_still_lands(repo: Path) -> None:
+    """Provenance is not allowed to gate the merge.
+
+    A run id can be absent (a caller that predates the wiring). That must
+    cost the rows, never the merge -- the work is already in git.
+    """
+    result = _run_merge_and_push(
+        _Session(),  # type: ignore[arg-type]
+        repo,
+        _merge_fn(repo),
+        run_id="",
+    )
+
+    assert result is not None
+    assert result.success
+    assert _git(repo, "log", "-1", "--pretty=%s") == "merge agent work"
+
+
+def test_a_failing_recorder_does_not_undo_a_landed_merge(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The merge is durable in git and the rows are re-derivable from it.
+
+    So a provenance failure must be loud and survivable, never a rollback
+    of work that already landed.
+    """
+    import bernstein.core.lineage.merge_provenance as mp
+
+    def _boom(**_kwargs: Any) -> Any:
+        msg = "spine unavailable"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(mp, "record_merge_artifacts", _boom)
+
+    result = _run_merge_and_push(
+        _Session(),  # type: ignore[arg-type]
+        repo,
+        _merge_fn(repo),
+        run_id="run-1",
+    )
+
+    assert result is not None
+    assert result.success
+    assert _git(repo, "log", "-1", "--pretty=%s") == "merge agent work"
+    # And the failure was actually reached: no rows, so the assertions
+    # above are not passing because the recorder quietly succeeded.
+    assert not (repo / ".sdd" / "lineage" / "run-1" / "spine.jsonl").exists()
+
+
+def test_the_recorded_spine_is_no_longer_seal_only(repo: Path) -> None:
+    """End to end: a merged run's spine now carries artifact provenance."""
+    _run_merge_and_push(
+        _Session(),  # type: ignore[arg-type]
+        repo,
+        _merge_fn(repo),
+        run_id="run-1",
+    )
+
+    verdict = LineageSpine(repo / ".sdd" / "lineage", run_id="run-1", hmac_key=b"k" * 32).verify()
+
+    assert verdict.status is SpineStatus.OK
+    assert verdict.count == 2

--- a/tests/unit/lineage/test_merge_provenance.py
+++ b/tests/unit/lineage/test_merge_provenance.py
@@ -1,0 +1,248 @@
+"""Tests for :mod:`bernstein.core.lineage.merge_provenance`.
+
+Each test names the way the recording could be wrong rather than the
+function it calls. The property under test throughout: after a CLI agent's
+work is merged, the spine holds a row per landed path whose content hash a
+third party can recompute from the repository alone.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.lineage.merge_provenance import (
+    MERGE_STEP_PREFIX,
+    MergedChangeUnreadable,
+    changed_paths,
+    collect_merged_artifacts,
+    record_merge_artifacts,
+)
+from bernstein.core.lineage.spine import (
+    JOURNAL_SEAL_STEP_PREFIX,
+    LineageSpine,
+    SpineStatus,
+    content_hash_of,
+)
+
+_KEY = b"k" * 32
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A repo with one commit, standing in for the worktree root."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "t@example.com")
+    _git(root, "config", "user.name", "T")
+    (root / "seed.txt").write_text("seed\n", encoding="utf-8")
+    _git(root, "add", "seed.txt")
+    _git(root, "commit", "-qm", "seed")
+    return root
+
+
+def _land(repo: Path, changes: dict[str, str | None]) -> tuple[str, str]:
+    """Apply *changes* as one commit; return ``(before_sha, after_sha)``."""
+    before = _git(repo, "rev-parse", "HEAD")
+    for path, content in changes.items():
+        target = repo / path
+        if content is None:
+            target.unlink()
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "agent work")
+    return before, _git(repo, "rev-parse", "HEAD")
+
+
+def test_a_landed_file_gets_a_row_hashing_the_bytes_in_git(repo: Path, tmp_path: Path) -> None:
+    """The recorded hash must equal the hash of the blob the repo holds.
+
+    This is the whole point of recording at the merge rather than at write
+    time: a third party recomputes the row from git without trusting us.
+    """
+    before, after = _land(repo, {"src/app.py": "print('x')\n"})
+    lineage_root = tmp_path / "lineage"
+
+    result = record_merge_artifacts(
+        worktree_root=repo,
+        before_sha=before,
+        after_sha=after,
+        actor="agent-1",
+        lineage_root=lineage_root,
+        run_id="run-1",
+        hmac_key=_KEY,
+    )
+
+    assert result.recorded == ["src/app.py"]
+    rows = list(LineageSpine(lineage_root, run_id="run-1", hmac_key=_KEY).iter_entries())
+    assert len(rows) == 1
+    blob = subprocess.run(
+        ["git", "cat-file", "blob", f"{after}:src/app.py"],
+        cwd=repo,
+        capture_output=True,
+        check=True,
+    ).stdout
+    assert rows[0].content_hash == content_hash_of(blob)
+
+
+def test_a_deleted_path_is_recorded_not_dropped(repo: Path, tmp_path: Path) -> None:
+    """A removal is work the agent did; a chain that omits it is partial."""
+    before, after = _land(repo, {"seed.txt": None})
+    lineage_root = tmp_path / "lineage"
+
+    result = record_merge_artifacts(
+        worktree_root=repo,
+        before_sha=before,
+        after_sha=after,
+        actor="agent-1",
+        lineage_root=lineage_root,
+        run_id="run-1",
+        hmac_key=_KEY,
+    )
+
+    assert result.recorded == ["seed.txt"]
+
+
+def test_a_rename_records_both_paths_not_only_the_destination(repo: Path, tmp_path: Path) -> None:
+    """Rename detection would hide the path the change removed."""
+    before, after = _land(repo, {"seed.txt": None, "moved.txt": "seed\n"})
+
+    statuses = dict((p, s) for s, p in changed_paths(repo, before, after))
+    assert statuses == {"seed.txt": "D", "moved.txt": "A"}
+
+
+def test_a_fast_forward_with_no_merge_commit_is_still_recorded(repo: Path, tmp_path: Path) -> None:
+    """Reading ``before..after`` must not depend on a merge commit existing.
+
+    Diffing a merge commit against its first parent returns nothing for a
+    fast-forward, which would silently record no provenance for exactly
+    the merges git chose to make cheap.
+    """
+    _git(repo, "checkout", "-q", "-b", "agent/x")
+    (repo / "ff.txt").write_text("ff\n", encoding="utf-8")
+    _git(repo, "add", "ff.txt")
+    _git(repo, "commit", "-qm", "ff work")
+    _git(repo, "checkout", "-q", "main")
+    before = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "merge", "--ff-only", "-q", "agent/x")
+    after = _git(repo, "rev-parse", "HEAD")
+
+    assert _git(repo, "rev-list", "--merges", f"{before}..{after}") == ""
+    assert [p for _, p in changed_paths(repo, before, after)] == ["ff.txt"]
+
+
+def test_binary_content_is_hashed_from_raw_bytes(repo: Path, tmp_path: Path) -> None:
+    """Decoding with ``errors="replace"`` would change a non-UTF-8 hash."""
+    before = _git(repo, "rev-parse", "HEAD")
+    raw = bytes([0x89, 0x50, 0x4E, 0x47, 0xFF, 0xFE, 0x00, 0x01])
+    (repo / "logo.png").write_bytes(raw)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "binary")
+    after = _git(repo, "rev-parse", "HEAD")
+
+    artifacts, _, _ = collect_merged_artifacts(repo, before, after)
+
+    assert [a.content for a in artifacts] == [raw]
+
+
+def test_an_unreadable_diff_raises_instead_of_reporting_no_changes(repo: Path, tmp_path: Path) -> None:
+    """An empty list means "changed nothing"; a failed read must not."""
+    with pytest.raises(MergedChangeUnreadable):
+        changed_paths(repo, "0" * 40, "1" * 40)
+
+
+def test_recording_lifts_the_spine_out_of_the_seal_only_verdict(repo: Path, tmp_path: Path) -> None:
+    """The defect this module exists to remove, asserted end to end.
+
+    A spine holding only the journal seal verifies while recording nothing
+    the run produced. With merge rows present it must no longer report
+    ``SEAL_ONLY``.
+    """
+    lineage_root = tmp_path / "lineage"
+    spine = LineageSpine(lineage_root, run_id="run-1", hmac_key=_KEY)
+    spine.record_entry(
+        artifact_path=".sdd/runs/run-1/journal.jsonl",
+        content=b"{}",
+        actor="orchestrator",
+        step_id=f"{JOURNAL_SEAL_STEP_PREFIX}abc123",
+        model="",
+        timestamp=1,
+    )
+    assert spine.verify().status is SpineStatus.SEAL_ONLY
+
+    before, after = _land(repo, {"src/app.py": "print('x')\n"})
+    record_merge_artifacts(
+        worktree_root=repo,
+        before_sha=before,
+        after_sha=after,
+        actor="agent-1",
+        lineage_root=lineage_root,
+        run_id="run-1",
+        hmac_key=_KEY,
+    )
+
+    verdict = LineageSpine(lineage_root, run_id="run-1", hmac_key=_KEY).verify()
+    assert verdict.status is SpineStatus.OK
+
+
+def test_a_mutated_merge_row_is_caught_and_localized(repo: Path, tmp_path: Path) -> None:
+    """Artifact-row tamper localization, which the seal-only chain could
+    never exercise: with one row there is nothing to localize to."""
+    lineage_root = tmp_path / "lineage"
+    before, after = _land(repo, {"a.py": "a\n", "b.py": "b\n", "c.py": "c\n"})
+    record_merge_artifacts(
+        worktree_root=repo,
+        before_sha=before,
+        after_sha=after,
+        actor="agent-1",
+        lineage_root=lineage_root,
+        run_id="run-1",
+        hmac_key=_KEY,
+    )
+
+    spine_path = lineage_root / "run-1" / "spine.jsonl"
+    lines = spine_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+    lines[1] = lines[1].replace('"actor":"agent-1"', '"actor":"agent-9"')
+    spine_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    verdict = LineageSpine(lineage_root, run_id="run-1", hmac_key=_KEY).verify()
+    assert verdict.status is not SpineStatus.OK
+    # Localized to the mutated row: line 2 of three, named on its own and
+    # without dragging the intact rows either side of it into the report.
+    assert [e for e in verdict.errors if e.startswith("line 2:")]
+    assert not [e for e in verdict.errors if e.startswith(("line 1:", "line 3:"))]
+
+
+def test_every_row_names_the_merge_commit_it_came_from(repo: Path, tmp_path: Path) -> None:
+    """Without the commit in ``step_id`` a row cannot be tied back to git."""
+    lineage_root = tmp_path / "lineage"
+    before, after = _land(repo, {"a.py": "a\n", "b.py": "b\n"})
+    record_merge_artifacts(
+        worktree_root=repo,
+        before_sha=before,
+        after_sha=after,
+        actor="agent-1",
+        lineage_root=lineage_root,
+        run_id="run-1",
+        hmac_key=_KEY,
+    )
+
+    rows = list(LineageSpine(lineage_root, run_id="run-1", hmac_key=_KEY).iter_entries())
+    assert {r.step_id for r in rows} == {f"{MERGE_STEP_PREFIX}{after}"}


### PR DESCRIPTION
## What

Records one lineage-spine row per path an agent's work lands through a merge, so a run that produced artifacts leaves artifact provenance instead of only its own journal seal.

## Why

`record_artifact_write` is documented as the single write boundary for per-artifact provenance, and on the CLI-adapter path nothing reaches it. A CLI adapter spawns a subprocess that writes files directly in its worktree; those writes are never intercepted. Every run landed that way leaves a spine of exactly one row — the journal-head seal — and `lineage verify` reports `SEAL_ONLY`: a chain that verifies while recording nothing the run produced.

Issue #2789 traced this and shipped the `SEAL_ONLY` verdict, which names the condition. This fills the chain.

I checked before writing anything: across every finalized run on our own deployment, the spine holds exactly one row and the artifact-events file exactly one entry. The gap is not theoretical and it is not confined to the demo workload.

## How

Recording happens where the work is accepted into the repository rather than at write time. That placement buys a property write-time interception cannot: the recorded content is the blob as it landed, so anyone holding the repository can recompute every row's content hash from git alone — without trusting the recorder or replaying the agent. A row that disagrees with the repository is detectable by a third party.

Details that are easy to get wrong, and how they are handled:

- The change is read as `before..after` around the merge, not from the merge commit's parents. Diffing a merge commit against its first parent yields nothing for a fast-forward, which would silently record no provenance for exactly the merges git chose to make cheap.
- `--no-renames`, for the reason the blast-radius gate already uses it: rename detection reports only a rename's destination, so the path a rename removed would go unrecorded.
- Content is read as raw bytes. `run_git` decodes with `errors="replace"`, which is right for the text it is used for and wrong here — a replacement character changes the hash of any non-UTF-8 blob.
- Paths are read with `-z`, since git otherwise quotes and escapes a path containing a newline and the recorded path must be the real one.
- A deletion is recorded, not dropped. A chain that omits removals records half of what the agent did.
- A blob above the size cap is skipped and counted, never recorded with substituted content: a row whose hash covers something other than the file it names would verify while describing nothing.

Recording never gates the merge. The work is already durable in git and every row is re-derivable from the merge commit, so a provenance failure is logged loudly and survived — the same reasoning `emit_production_event` applies one level down. A test asserts a merge still lands when the recorder raises, and that it wrote nothing, so the test cannot pass by the recorder quietly succeeding.

## Tests

13 new tests, each named for the way the recording could be wrong rather than the function it calls:

- A landed file's row hashes the same bytes `git cat-file` returns.
- A deletion is recorded; a rename records both paths.
- A fast-forward with no merge commit is still recorded.
- Binary content is hashed from raw bytes.
- An unreadable diff raises rather than reporting "changed nothing".
- The production merge path itself writes the rows — the half that was missing, where the boundary existed with no caller.
- A mutated row is caught and localized to its own line, with the intact rows either side left out of the report. A seal-only chain could never exercise this: with one row there is nothing to localize to.
- A merged run's spine no longer reports `SEAL_ONLY`.

`tests/unit/lineage` and `tests/unit/agents` pass: 967 passed, 1 xfailed. Ruff clean; the new module is pyright-clean.
