### PR TITLE
fix: sort manifest entries and reject duplicate paths (#4697)

### DIFF
--- a/src/bernstein/core/tasks/task_pack.py
+++ b/src/bernstein/core/tasks/task_pack.py
@@ -36,7 +36,7 @@ class TaskContextPack:
         sorted_entries = sorted(self.entries, key=lambda e: e.path)
 
         return json.dumps(
-            [{"path": e.path, "sha256": e.sha256} for e in sorted_entries],
+            TaskContextPack(entries=sorted_entries).to_dict(),
             sort_keys=True,
             separators=(",", ":"),
         ).encode("utf-8")

--- a/src/bernstein/core/tasks/task_pack.py
+++ b/src/bernstein/core/tasks/task_pack.py
@@ -22,4 +22,21 @@ class TaskContextPack:
         return {"entries": [entry.to_dict() for entry in self.entries]}
 
     def canonical_bytes(self) -> bytes:
-        return json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":")).encode("utf-8")
+        """
+        Serializes the pack into deterministic bytes.
+        Duplicate paths are rejected and raise a ValueError.
+        """
+        seen_paths = set()
+        for entry in self.entries:
+            if entry.path in seen_paths:
+                raise ValueError(f"Duplicate path detected: {entry.path}")
+            seen_paths.add(entry.path)
+
+        # Sort deterministically by path before JSON serialization
+        sorted_entries = sorted(self.entries, key=lambda e: e.path)
+
+        return json.dumps(
+            [{"path": e.path, "sha256": e.sha256} for e in sorted_entries],
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")

--- a/tests/unit/test_task_pack.py
+++ b/tests/unit/test_task_pack.py
@@ -3,6 +3,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
+from bernstein.core.tasks.task_pack import PackEntry, TaskContextPack
+
 
 def test_a_pack_rebuilds_byte_identically(tmp_path: Path):
     script = tmp_path / "build_pack.py"
@@ -34,3 +38,15 @@ sys.stdout.buffer.write(pack.canonical_bytes())
 
     assert run1.stdout == run2.stdout
     assert b"12345" in run1.stdout
+
+
+def test_entry_order_does_not_change_bytes():
+    a = TaskContextPack(entries=[PackEntry(path="a.py", sha256="1"), PackEntry(path="b.py", sha256="2")])
+    b = TaskContextPack(entries=[PackEntry(path="b.py", sha256="2"), PackEntry(path="a.py", sha256="1")])
+    assert a.canonical_bytes() == b.canonical_bytes()
+
+
+def test_duplicate_paths_are_rejected():
+    pack = TaskContextPack(entries=[PackEntry(path="a.py", sha256="1"), PackEntry(path="a.py", sha256="2")])
+    with pytest.raises(ValueError, match="Duplicate path"):
+        pack.canonical_bytes()

--- a/tests/unit/test_task_pack.py
+++ b/tests/unit/test_task_pack.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess
 import sys
@@ -50,3 +51,18 @@ def test_duplicate_paths_are_rejected():
     pack = TaskContextPack(entries=[PackEntry(path="a.py", sha256="1"), PackEntry(path="a.py", sha256="2")])
     with pytest.raises(ValueError, match="Duplicate path"):
         pack.canonical_bytes()
+
+
+def test_canonical_bytes_keeps_the_to_dict_envelope():
+    """Sorting must not change the shape the pack serialises to.
+
+    ``to_dict`` is the pack's declared projection. Hashing a different
+    shape would leave a consumer that writes ``to_dict`` and verifies
+    ``canonical_bytes`` comparing two encodings of the same pack - and the
+    existing rebuild test cannot catch it, because it compares two fresh
+    builds that would both carry the new shape.
+    """
+    pack = TaskContextPack(entries=[PackEntry(path="b.py", sha256="2"), PackEntry(path="a.py", sha256="1")])
+    assert json.loads(pack.canonical_bytes()) == {
+        "entries": [{"path": "a.py", "sha256": "1"}, {"path": "b.py", "sha256": "2"}],
+    }


### PR DESCRIPTION
Resolves #4697

Changes:
Updated TaskContextPack.canonical_bytes() to deterministically sort entries by path prior to JSON serialization.
Added test_entry_order_does_not_change_bytes to prove that packs built from the same files in shuffled orders serialize identically.
Design Decision: Duplicate Paths
Following the prompt in the issue, I opted to reject duplicate paths with a ValueError rather than using a last-one-wins collapse. A duplicate path within a single pack implies a bug in the upstream directory walker or assembly logic. Failing loudly prevents us from silently dropping or overwriting file states.
Added test_duplicate_paths_are_rejected to enforce this contract.