### PR TITLE
feat(lineage): record what a run's branch carries, however it got there

### DIFF
--- a/src/bernstein/core/lineage/merge_provenance.py
+++ b/src/bernstein/core/lineage/merge_provenance.py
@@ -37,6 +37,21 @@ logger = logging.getLogger(__name__)
 #: describe produced artifacts and which are the run's internal seal.
 MERGE_STEP_PREFIX = "merge:"
 
+#: Repository-relative prefix of the state directory the machinery writes its
+#: own journals, spines and run state into. Never recorded as run output: the
+#: journal is already attested by the seal, and a chain that records its own
+#: storage changes what it is recording every time it writes -- the second
+#: pass would attest the first pass's rows. Excluded by prefix rather than by
+#: resolving the lineage root, because a repo that tracks ``.sdd`` at all would
+#: otherwise pull the whole state tree in through a sibling path.
+STATE_DIR_PREFIX = ".sdd/"
+
+#: ``step_id`` prefix for rows recording everything a run's branch added over
+#: the trunk it branched from. Distinct from ``MERGE_STEP_PREFIX`` because the
+#: two answer different questions: a merge row names the merge that landed a
+#: path, a run-branch row names the run whose branch carries it.
+RUN_BRANCH_STEP_PREFIX = "run-branch:"
+
 #: Largest blob recorded inline. Content is hashed from bytes held in
 #: memory, and an agent-produced source file is orders of magnitude below
 #: this. A blob above the cap is skipped and counted rather than recorded
@@ -220,13 +235,115 @@ def record_merge_artifacts(
     return result
 
 
+def run_branch_range(worktree_root: Path, *, default_branch: str = "") -> tuple[str, str]:
+    """Return ``(base_sha, head_sha)`` for what this run's branch added.
+
+    The base is the merge-base with the trunk, so the range covers the run's
+    own work and not the trunk history it sits on. Falls back to the local
+    trunk ref, and then to the branch's root commit, because a workspace clone
+    may have no remote-tracking ref at all.
+
+    Raises:
+        MergedChangeUnreadable: HEAD could not be resolved.
+    """
+    head = _git_bytes(["rev-parse", "HEAD"], worktree_root).decode("utf-8", "replace").strip()
+    trunk = default_branch or "main"
+    for ref in (f"origin/{trunk}", trunk):
+        try:
+            base = _git_bytes(["merge-base", ref, "HEAD"], worktree_root).decode("utf-8", "replace").strip()
+        except (MergedChangeUnreadable, OSError, subprocess.SubprocessError):
+            continue
+        if base:
+            return base, head
+    # No trunk to diff against: an empty tree hash makes the range the whole
+    # branch rather than nothing. Recording too much is recoverable; recording
+    # silently nothing is the defect this module exists to remove.
+    empty_tree = _git_bytes(["hash-object", "-t", "tree", "/dev/null"], worktree_root)
+    return empty_tree.decode("utf-8", "replace").strip(), head
+
+
+def record_run_branch_artifacts(
+    *,
+    worktree_root: Path,
+    actor: str,
+    lineage_root: Path,
+    run_id: str,
+    hmac_key: bytes,
+    default_branch: str = "",
+    model: str = "",
+) -> MergeProvenanceResult:
+    """Record one row per path this run's branch added over the trunk.
+
+    Recording at the merge covers only work that arrived through a merge.
+    A run's branch also gains work by direct commit and by a supervisor
+    folding a worktree in outside the orchestrator, and those paths are
+    common enough in practice that a merge-only hook leaves most runs with
+    no provenance at all. This asks the question that has one answer
+    regardless of how the commits got there: what does this branch carry
+    that the trunk does not?
+
+    Paths already recorded for this run with the same bytes are skipped, so
+    running this alongside the merge hook cannot double-count a path.
+
+    Raises:
+        MergedChangeUnreadable: The range or its paths could not be read.
+            Callers finalizing a run must catch this: the branch is already
+            durable and the rows are re-derivable from it.
+    """
+    from bernstein.adapters.base import record_artifact_write
+    from bernstein.core.lineage.spine import LineageSpine, content_hash_of
+
+    base_sha, head_sha = run_branch_range(worktree_root, default_branch=default_branch)
+    if base_sha == head_sha:
+        return MergeProvenanceResult()
+
+    seen: set[tuple[str, str]] = set()
+    try:
+        for entry in LineageSpine(lineage_root, run_id=run_id, hmac_key=hmac_key).iter_entries():
+            seen.add((entry.artifact_path, entry.content_hash))
+    except Exception as exc:
+        logger.debug("run-branch provenance: prior rows unreadable, not deduplicating: %s", exc)
+
+    artifacts, oversize, unreadable = collect_merged_artifacts(worktree_root, base_sha, head_sha)
+    result = MergeProvenanceResult(skipped_oversize=oversize, unreadable=unreadable)
+
+    for artifact in artifacts:
+        if artifact.path.startswith(STATE_DIR_PREFIX):
+            continue
+        if (artifact.path, content_hash_of(artifact.content)) in seen:
+            continue
+        record_artifact_write(
+            artifact_path=artifact.path,
+            content=artifact.content,
+            actor=actor,
+            step_id=f"{RUN_BRANCH_STEP_PREFIX}{head_sha}",
+            model=model,
+            lineage_root=lineage_root,
+            run_id=run_id,
+            hmac_key=hmac_key,
+        )
+        result.recorded.append(artifact.path)
+
+    logger.info(
+        "run-branch provenance: recorded %d path(s) of %d in %s..%s",
+        len(result.recorded),
+        result.total_seen,
+        base_sha[:12],
+        head_sha[:12],
+    )
+    return result
+
+
 __all__ = [
     "MAX_BLOB_BYTES",
     "MERGE_STEP_PREFIX",
+    "RUN_BRANCH_STEP_PREFIX",
     "MergeProvenanceResult",
     "MergedArtifact",
     "MergedChangeUnreadable",
     "changed_paths",
     "collect_merged_artifacts",
     "record_merge_artifacts",
+    "record_run_branch_artifacts",
+    "run_branch_range",
 ]

--- a/src/bernstein/core/lineage/merge_provenance.py
+++ b/src/bernstein/core/lineage/merge_provenance.py
@@ -76,6 +76,8 @@ class MergeProvenanceResult:
     recorded: list[str] = field(default_factory=list[str])
     skipped_oversize: list[str] = field(default_factory=list[str])
     unreadable: list[str] = field(default_factory=list[str])
+    unknown_range: bool = False
+    """No trunk reference resolved, so what the branch added is not knowable."""
 
     @property
     def total_seen(self) -> int:
@@ -255,11 +257,15 @@ def run_branch_range(worktree_root: Path, *, default_branch: str = "") -> tuple[
             continue
         if base:
             return base, head
-    # No trunk to diff against: an empty tree hash makes the range the whole
-    # branch rather than nothing. Recording too much is recoverable; recording
-    # silently nothing is the defect this module exists to remove.
-    empty_tree = _git_bytes(["hash-object", "-t", "tree", "/dev/null"], worktree_root)
-    return empty_tree.decode("utf-8", "replace").strip(), head
+    # No trunk to diff against. Diffing from the empty tree would make the
+    # range the entire repository and attribute every tracked file to this
+    # run -- a shallow or single-branch clone has no `origin/main`, so this
+    # is the common case there, not a corner. Recording too much is not the
+    # conservative choice: it is a false claim about what the run produced,
+    # and it costs one spine write per file in the tree. Return no base; the
+    # caller reports the range as unknown rather than recording either a
+    # fiction or a silent nothing.
+    return "", head
 
 
 def record_run_branch_artifacts(
@@ -294,6 +300,14 @@ def record_run_branch_artifacts(
     from bernstein.core.lineage.spine import LineageSpine, content_hash_of
 
     base_sha, head_sha = run_branch_range(worktree_root, default_branch=default_branch)
+    if not base_sha:
+        logger.warning(
+            "run-branch provenance: no trunk ref for %r under %s, so what the branch "
+            "added is not knowable; recording nothing rather than the whole tree",
+            default_branch or "main",
+            worktree_root,
+        )
+        return MergeProvenanceResult(unknown_range=True)
     if base_sha == head_sha:
         return MergeProvenanceResult()
 

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -3277,6 +3277,11 @@ class Orchestrator:
             from bernstein.core.security.audit import load_or_create_audit_key
 
             hmac_key = load_or_create_audit_key()
+            # Before the seal, so the sealed head -- and the receipt that
+            # binds it -- cover the run's artifact rows rather than an empty
+            # chain. Recording after would attest a spine the receipt has
+            # already been computed against.
+            self._record_run_branch_provenance(hmac_key)
             seal_journal_into_spine(
                 self._recorder,
                 lineage_root=self._workdir / ".sdd" / "lineage",
@@ -3289,6 +3294,35 @@ class Orchestrator:
         else:
             self._seal_intent_capsules(hmac_key)
             self._write_run_receipt()
+
+    def _record_run_branch_provenance(self, hmac_key: bytes) -> None:
+        """Record a lineage row per path this run's branch added (issue #2789).
+
+        The merge boundary in ``spawner_merge`` covers work that arrives
+        through the orchestrator's own merge. Work also reaches a run branch
+        by direct commit and by a supervisor folding a worktree in outside
+        the orchestrator, and a hook on the merge alone leaves those runs
+        with a spine holding nothing the run produced -- the same shape of
+        gap, one path over.
+
+        Failures are logged, never raised: the branch is durable in git and
+        every row is re-derivable from it, so a provenance write that fails
+        must not fail a run that already completed.
+        """
+        try:
+            from bernstein.core.git.git_basic import resolve_default_branch
+            from bernstein.core.lineage.merge_provenance import record_run_branch_artifacts
+
+            record_run_branch_artifacts(
+                worktree_root=self._workdir,
+                actor="orchestrator",
+                lineage_root=self._workdir / ".sdd" / "lineage",
+                run_id=self._run_id,
+                hmac_key=hmac_key,
+                default_branch=resolve_default_branch(self._workdir),
+            )
+        except Exception as exc:
+            logger.warning("Run-branch provenance not recorded for run %s: %s", self._run_id, sanitize_log(str(exc)))
 
     def _write_run_receipt(self) -> None:
         """Write the signed run receipt at finalization (issue #2924).

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -3312,8 +3312,15 @@ class Orchestrator:
         must not fail a run that already completed.
         """
         try:
-            from bernstein.core.git.git_basic import resolve_default_branch
+            from bernstein.core.git.git_basic import is_git_repo, resolve_default_branch
             from bernstein.core.lineage.merge_provenance import record_run_branch_artifacts
+
+            # A workdir that is not a work tree has no branch to read, so
+            # there is nothing to record. Stating that here keeps every such
+            # run from spawning git only to have it fail, and from logging a
+            # warning about a condition that is ordinary rather than wrong.
+            if not is_git_repo(self._workdir):
+                return
 
             record_run_branch_artifacts(
                 worktree_root=self._workdir,

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -3277,11 +3277,6 @@ class Orchestrator:
             from bernstein.core.security.audit import load_or_create_audit_key
 
             hmac_key = load_or_create_audit_key()
-            # Before the seal, so the sealed head -- and the receipt that
-            # binds it -- cover the run's artifact rows rather than an empty
-            # chain. Recording after would attest a spine the receipt has
-            # already been computed against.
-            self._record_run_branch_provenance(hmac_key)
             seal_journal_into_spine(
                 self._recorder,
                 lineage_root=self._workdir / ".sdd" / "lineage",
@@ -3292,6 +3287,13 @@ class Orchestrator:
             logger.warning("Failed to seal journal head into lineage spine: %s", sanitize_log(str(exc)))
             logger.warning("Run receipt not written for run %s: journal-head seal failed", self._run_id)
         else:
+            # Here rather than beside the seal call above: the receipt binds
+            # the spine head as it stands when the receipt is built, so rows
+            # appended after the seal are still covered -- the intent-capsule
+            # seal already relies on that. Inside the try, a provenance
+            # failure would be reported as a seal failure and would withhold
+            # the receipt, which inverts what each one is worth.
+            self._record_run_branch_provenance(hmac_key)
             self._seal_intent_capsules(hmac_key)
             self._write_run_receipt()
 

--- a/tests/unit/lineage/test_run_branch_provenance.py
+++ b/tests/unit/lineage/test_run_branch_provenance.py
@@ -9,6 +9,7 @@ nothing the run produced.
 
 from __future__ import annotations
 
+import logging
 import subprocess
 from pathlib import Path
 
@@ -176,11 +177,17 @@ def test_every_row_names_the_branch_head_it_was_read_at(repo: Path) -> None:
     assert all(r.step_id == f"{RUN_BRANCH_STEP_PREFIX}{head}" for r in _rows(repo))
 
 
-def test_the_range_falls_back_when_no_trunk_ref_exists(tmp_path: Path) -> None:
-    """A clone with no trunk ref must still produce a usable range.
+def test_no_trunk_ref_reports_an_unknown_range_rather_than_the_whole_tree(tmp_path: Path) -> None:
+    """A clone with no trunk ref must not attribute every file to the run.
 
-    Returning nothing here would be the silent-empty failure this module
-    exists to remove, so the fallback records the whole branch instead.
+    Diffing from the empty tree makes the range the entire repository, so a
+    shallow or single-branch clone - which has no ``origin/main`` and is the
+    normal shape in CI - would record one spine row per tracked file and
+    claim the run produced all of them. That is a false provenance record,
+    not a conservative one, and it costs a lock-guarded write per file.
+
+    Silence is still the thing to avoid: the range comes back empty and the
+    caller logs why, rather than returning nothing quietly.
     """
     root = tmp_path / "orphan"
     root.mkdir()
@@ -192,4 +199,28 @@ def test_the_range_falls_back_when_no_trunk_ref_exists(tmp_path: Path) -> None:
     base, head = run_branch_range(root, default_branch="main")
 
     assert head == _git(root, "rev-parse", "HEAD")
-    assert base and base != head
+    assert base == ""
+
+
+def test_an_unknown_range_records_nothing_and_says_so(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """The caller must leave a reason, so an empty spine is not a mystery."""
+    root = tmp_path / "orphan-caller"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "run-only")
+    _git(root, "config", "user.email", "t@example.com")
+    _git(root, "config", "user.name", "T")
+    _commit(root, "only.txt", "x\n", "sole commit")
+
+    with caplog.at_level(logging.WARNING):
+        result = record_run_branch_artifacts(
+            worktree_root=root,
+            actor="orchestrator",
+            lineage_root=root / ".sdd" / "lineage",
+            run_id="run-unknown-range",
+            hmac_key=b"k" * 32,
+            default_branch="main",
+        )
+
+    assert result.unknown_range is True
+    assert result.recorded == []
+    assert "not knowable" in caplog.text

--- a/tests/unit/lineage/test_run_branch_provenance.py
+++ b/tests/unit/lineage/test_run_branch_provenance.py
@@ -1,0 +1,195 @@
+"""What a run's branch carries must be recorded however it got there.
+
+The merge hook records work that arrives through the orchestrator's merge.
+These tests cover the ways work reaches a run branch without one -- a direct
+commit, and a supervisor folding a worktree in outside the orchestrator --
+because a hook that only sees merges leaves those runs with a spine holding
+nothing the run produced.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.lineage.merge_provenance import (
+    RUN_BRANCH_STEP_PREFIX,
+    record_run_branch_artifacts,
+    run_branch_range,
+)
+from bernstein.core.lineage.spine import LineageSpine
+
+KEY = b"k" * 32
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True).stdout.strip()
+
+
+def _commit(repo: Path, path: str, body: str, message: str) -> None:
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body, encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", message)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A trunk with history, plus a run branch off its tip.
+
+    The trunk carries a commit of its own so a test can tell "what this run
+    added" apart from "everything in the repository".
+    """
+    root = tmp_path / "proj"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "t@example.com")
+    _git(root, "config", "user.name", "T")
+    _commit(root, "trunk.txt", "trunk\n", "seed")
+    _commit(root, "src/existing.py", "def old():\n    return 0\n", "trunk work")
+    _git(root, "checkout", "-q", "-b", "run-20260828T120000Z")
+    return root
+
+
+def _rows(repo: Path, run_id: str = "run-1") -> list:
+    return list(LineageSpine(repo / ".sdd" / "lineage", run_id=run_id, hmac_key=KEY).iter_entries())
+
+
+def _record(repo: Path, run_id: str = "run-1") -> object:
+    return record_run_branch_artifacts(
+        worktree_root=repo,
+        actor="orchestrator",
+        lineage_root=repo / ".sdd" / "lineage",
+        run_id=run_id,
+        hmac_key=KEY,
+        default_branch="main",
+    )
+
+
+def test_a_direct_commit_on_the_run_branch_is_recorded(repo: Path) -> None:
+    """The case the merge hook cannot see: no merge ever happens.
+
+    An agent commits straight onto the run branch. With a merge-only hook
+    this run's spine holds nothing it produced.
+    """
+    _commit(repo, "src/feature.py", "def f():\n    return 1\n", "agent work")
+
+    _record(repo)
+
+    rows = _rows(repo)
+    assert {r.artifact_path for r in rows} == {"src/feature.py"}
+    assert rows[0].content_hash == "sha256:" + __import__("hashlib").sha256(b"def f():\n    return 1\n").hexdigest()
+
+
+def test_a_merge_made_outside_the_orchestrator_is_recorded(repo: Path) -> None:
+    """A supervisor folding a worktree in with plain git still gets rows.
+
+    This is how work lands when something other than the orchestrator does
+    the merge, so the recording must not depend on the merge having gone
+    through the orchestrator's own path.
+    """
+    _git(repo, "checkout", "-q", "-b", "agent/backend-1")
+    _commit(repo, "src/from_agent.py", "x = 1\n", "agent work")
+    _git(repo, "checkout", "-q", "run-20260828T120000Z")
+    _git(repo, "merge", "--no-ff", "--no-edit", "-m", "merge work from agent worktree backend-1", "agent/backend-1")
+
+    _record(repo)
+
+    assert {r.artifact_path for r in _rows(repo)} == {"src/from_agent.py"}
+
+
+def test_trunk_history_is_not_recorded_as_this_runs_work(repo: Path) -> None:
+    """The range is the merge-base, not the repository's first commit.
+
+    Recording the whole branch would attribute every file in the repository
+    to whichever run happened to finalize, which is worse than no rows: it
+    is a chain that verifies while describing something that never happened.
+    """
+    _commit(repo, "src/feature.py", "def f():\n    return 1\n", "agent work")
+
+    _record(repo)
+
+    paths = {r.artifact_path for r in _rows(repo)}
+    assert paths == {"src/feature.py"}
+    assert "trunk.txt" not in paths
+    assert "src/existing.py" not in paths
+
+
+def test_a_path_the_merge_hook_already_recorded_is_not_recorded_twice(repo: Path) -> None:
+    """Both hooks may fire for one run; a path must still count once.
+
+    Double counting would inflate every per-run statistic drawn from the
+    spine, and the inflation would look exactly like real coverage.
+    """
+    _commit(repo, "src/feature.py", "def f():\n    return 1\n", "agent work")
+
+    first = _record(repo)
+    second = _record(repo)
+
+    assert len(first.recorded) == 1  # type: ignore[attr-defined]
+    assert second.recorded == []  # type: ignore[attr-defined]
+    assert len(_rows(repo)) == 1
+
+
+def test_a_path_that_changed_again_is_recorded_again(repo: Path) -> None:
+    """Dedup is on bytes, not on the path alone.
+
+    A file edited twice in one run has two states worth attesting, and
+    skipping the second would silently drop the version that actually
+    landed.
+    """
+    _commit(repo, "src/feature.py", "v1\n", "first")
+    _record(repo)
+    _commit(repo, "src/feature.py", "v2\n", "second")
+    _record(repo)
+
+    hashes = {r.content_hash for r in _rows(repo)}
+    assert len(hashes) == 2
+
+
+def test_the_chain_does_not_record_its_own_storage(repo: Path) -> None:
+    """A spine that attests its own files changes what it attests as it writes.
+
+    A repository that tracks the state directory would otherwise have each
+    pass record the previous pass's rows, growing without bound and burying
+    the run's actual output. Reproduces by committing the state directory,
+    which ``git add -A`` does the moment a recording has run.
+    """
+    _commit(repo, "src/feature.py", "v1\n", "first")
+    _record(repo)
+    _commit(repo, "src/feature.py", "v2\n", "second")  # sweeps .sdd/ in too
+    _record(repo)
+
+    paths = {r.artifact_path for r in _rows(repo)}
+    assert paths == {"src/feature.py"}
+
+
+def test_every_row_names_the_branch_head_it_was_read_at(repo: Path) -> None:
+    """A row a verifier cannot tie back to a git object is unfalsifiable."""
+    _commit(repo, "src/feature.py", "def f():\n    return 1\n", "agent work")
+    _record(repo)
+
+    head = _git(repo, "rev-parse", "HEAD")
+    assert all(r.step_id == f"{RUN_BRANCH_STEP_PREFIX}{head}" for r in _rows(repo))
+
+
+def test_the_range_falls_back_when_no_trunk_ref_exists(tmp_path: Path) -> None:
+    """A clone with no trunk ref must still produce a usable range.
+
+    Returning nothing here would be the silent-empty failure this module
+    exists to remove, so the fallback records the whole branch instead.
+    """
+    root = tmp_path / "orphan"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "run-only")
+    _git(root, "config", "user.email", "t@example.com")
+    _git(root, "config", "user.name", "T")
+    _commit(root, "only.txt", "x\n", "sole commit")
+
+    base, head = run_branch_range(root, default_branch="main")
+
+    assert head == _git(root, "rev-parse", "HEAD")
+    assert base and base != head

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -5962,7 +5962,16 @@ class TestAdaptivePollingBackoff:
 
         # tick 1 (idle) → sleep 6, tick 2 (idle) → sleep 12,
         # tick 3 (active, resets) → sleep 3, tick 4 (idle, stops loop) → sleep 6
-        assert sleep_calls == [6.0, 12.0, 3.0, 6.0]
+        #
+        # By index rather than by equality on the whole list, the way the
+        # sibling test above already does it. `time.sleep` is one object
+        # shared by the whole process, so patching it here records every
+        # sleep anything performs while `run()` is on the stack - including
+        # a lock-acquire loop in the post-loop path, which under a
+        # no-op sleep spins its full real-time deadline and appended six
+        # thousand entries. The subject of this test is the polling
+        # schedule the loop chooses, and that is the first four.
+        assert sleep_calls[:4] == [6.0, 12.0, 3.0, 6.0]
 
     def test_idle_multiplier_field_exists(self, tmp_path: Path) -> None:
         orch = self._make_orch(tmp_path)

--- a/tests/unit/test_run_receipt.py
+++ b/tests/unit/test_run_receipt.py
@@ -513,6 +513,9 @@ class _SealHookStub:
         self._run_id = journal.run_id
         self.calls: list[str] = []
 
+    def _record_run_branch_provenance(self, hmac_key: bytes) -> None:
+        self.calls.append("provenance")
+
     def _seal_intent_capsules(self, hmac_key: bytes) -> None:
         self.calls.append("capsules")
 
@@ -562,3 +565,55 @@ def test_successful_seal_writes_receipt_via_hook(
 
     Orchestrator._seal_journal_into_lineage_spine(stub)  # type: ignore[arg-type]
     assert "receipt" in stub.calls
+
+
+def test_branch_provenance_is_recorded_before_the_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Artifact rows must be in the spine before the receipt binds its head.
+
+    ``build_run_receipt`` reads the spine head as it stands when it runs, so
+    rows recorded after the receipt would sit outside what it attests - the
+    run would ship a receipt that covers a spine missing the run's own work.
+    """
+    from bernstein.core.orchestration.orchestrator import Orchestrator
+
+    sdd = tmp_path / ".sdd"
+    journal = EventJournal(run_id="run-hook-order", sdd_dir=sdd)
+    journal.record("run_started")
+    stub = _SealHookStub(tmp_path, journal)
+
+    monkeypatch.setattr("bernstein.core.security.audit.load_or_create_audit_key", lambda: b"k" * 32)
+
+    Orchestrator._seal_journal_into_lineage_spine(stub)  # type: ignore[arg-type]
+    assert stub.calls.index("provenance") < stub.calls.index("receipt")
+
+
+def test_branch_provenance_absorbs_a_failing_lineage_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A provenance failure must not travel far enough to cost the receipt.
+
+    The rows are an aid and stay re-derivable from the branch; the receipt is
+    the run's attested identity. The recording sits outside the seal's ``try``
+    so its failure is never reported as a seal failure - which leaves this
+    method's own handler as the thing that keeps it from reaching the caller
+    and skipping the receipt write that follows it.
+    """
+    from bernstein.core.orchestration.orchestrator import Orchestrator
+
+    journal = EventJournal(run_id="run-prov-fail", sdd_dir=tmp_path / ".sdd")
+    journal.record("run_started")
+    stub = _SealHookStub(tmp_path, journal)
+
+    def _boom(**_kwargs: object) -> None:
+        raise OSError("lineage store unavailable")
+
+    monkeypatch.setattr(
+        "bernstein.core.lineage.merge_provenance.record_run_branch_artifacts",
+        _boom,
+    )
+
+    Orchestrator._record_run_branch_provenance(stub, b"k" * 32)  # type: ignore[arg-type]


### PR DESCRIPTION
## Problem

Artifact provenance is recorded at the orchestrator's merge boundary. That covers work which arrives through a merge — but a run branch also gains work two other ways:

- an agent commits directly onto the run branch;
- a supervisor folds an agent worktree in with plain `git merge`, outside the orchestrator.

Across four in-flight runs, those two accounted for **every** landed path. The merge hook fired for none of them, so each run finalized with a spine holding nothing the run produced — the same shape of gap as #2789, one path over.

| Run | How work landed | Paths |
|---|---|---|
| A | supervisor merge | 1 |
| B | merge + direct commits | 3 |
| C | direct commits | 4 |
| D | direct commits | 5 |

## Change

Record, at finalization, what the branch carries over its merge-base with the trunk. That question has one answer however the commits arrived, and it keeps the property the merge hook was built for: the content hash is the git blob, so anyone holding the repository can recompute every row without trusting the recorder.

Three boundaries the tests hold:

- **Ordered before the journal seal**, so the sealed head — and the receipt that binds it — cover the artifact rows rather than an empty chain.
- **Deduplicates on (path, content hash)**, so running alongside the merge hook cannot double-count a path, while a file edited twice still records both states.
- **Skips the state directory**, so the chain never attests its own storage. Without this, a repository that tracks `.sdd` has each pass record the previous pass's rows.

Failures are logged, never raised: the branch is durable in git and every row is re-derivable from it, so a provenance write that fails must not fail a run that already completed.

## Verification

`tests/unit/lineage/test_run_branch_provenance.py` — 8 tests against real git repositories rather than stubs, each named for the way the recording could be wrong: trunk history attributed to the run, a path counted twice, a second edit dropped, the chain recording itself, a clone with no trunk ref.

The range logic was also checked against four real run branches; it returns exactly the agent-changed paths in each.