### PR TITLE
fix(spawn): one relay section name, and a log when it cannot be built

### DIFF
--- a/src/bernstein/core/agents/spawn_prompt.py
+++ b/src/bernstein/core/agents/spawn_prompt.py
@@ -949,14 +949,20 @@ def _render_prompt(
     # entirely when the store is absent, empty, or chain verification fails.
     if role == "manager":
         try:
-            from bernstein.core.orchestration.consensus_relay import build_spawn_section
+            from bernstein.core.orchestration.consensus_relay import (
+                MANAGER_RELAY_SECTION,
+                spawn_section_for_workdir,
+            )
 
-            relay_block = build_spawn_section(relay_root=workdir / ".sdd" / "runtime" / "consensus")
+            relay_block = spawn_section_for_workdir(workdir)
             if relay_block:
-                named_sections.append(("consensus relay", relay_block))
-        except Exception:
-            # Never block a spawn because of relay problems.
-            pass
+                named_sections.append((MANAGER_RELAY_SECTION, relay_block))
+        except Exception as exc:
+            # Never block a spawn because of relay problems - but a section
+            # that silently stops appearing is indistinguishable from a store
+            # that is simply empty, which is how this feature would die
+            # unnoticed.
+            logger.warning("Consensus relay section omitted from manager spawn: %s", exc)
     # KV-cache locality: lessons go AFTER the stable header (role,
     # git_safety, specialists) but BEFORE the variable goal/task body
     # so the cacheable prefix stays byte-stable across spawns.

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -1256,13 +1256,20 @@ def _render_prompt_with_receipt(
     # entirely when the store is absent, empty, or chain verification fails.
     if role == "manager":
         try:
-            from bernstein.core.orchestration.consensus_relay import build_spawn_section
+            from bernstein.core.orchestration.consensus_relay import (
+                MANAGER_RELAY_SECTION,
+                spawn_section_for_workdir,
+            )
 
-            relay_block = build_spawn_section(relay_root=workdir / ".sdd" / "runtime" / "consensus")
+            relay_block = spawn_section_for_workdir(workdir)
             if relay_block:
-                named_sections.append(("consensus_relay", relay_block))
-        except Exception:
-            pass
+                named_sections.append((MANAGER_RELAY_SECTION, relay_block))
+        except Exception as exc:
+            # Never block a spawn because of relay problems - but a section
+            # that silently stops appearing is indistinguishable from a store
+            # that is simply empty, which is how this feature would die
+            # unnoticed.
+            logger.warning("Consensus relay section omitted from manager spawn: %s", exc)
     named_sections.append(("tasks", f"\n## Assigned tasks\n{task_block}"))
     # Artifact contract (#4539): surface the kind/path/criteria an
     # artifact-mode task is judged by. Empty for the git path, so a plain

--- a/src/bernstein/core/orchestration/consensus_relay.py
+++ b/src/bernstein/core/orchestration/consensus_relay.py
@@ -73,6 +73,7 @@ from bernstein.core.persistence.atomic_write import write_atomic_json
 __all__ = [
     "DEFAULT_RELAY_DIR",
     "GENESIS_PREV_HASH",
+    "MANAGER_RELAY_SECTION",
     "RELAY_VERSION",
     "RelayChainError",
     "RelayDecision",
@@ -86,6 +87,7 @@ __all__ = [
     "compute_relay_hmac",
     "default_relay_key",
     "load_relay_key",
+    "spawn_section_for_workdir",
     "verify_chain",
 ]
 
@@ -711,6 +713,19 @@ class RelayStore:
 
 _SPAWN_SECTION_CAP = 4_000
 """Maximum rendered bytes for the consensus section in a manager spawn prompt."""
+
+MANAGER_RELAY_SECTION = "consensus_relay"
+"""Section name both spawn paths must use, so one prompt does not differ from the other."""
+
+
+def spawn_section_for_workdir(workdir: Path) -> str:
+    """Return the manager relay section for ``workdir``, or ``""`` if there is none.
+
+    The two spawn paths resolve the same store and must not disagree about
+    where it lives or what the section is called, so the resolution lives
+    here rather than being spelled out at each call site.
+    """
+    return build_spawn_section(relay_root=workdir / ".sdd" / "runtime" / "consensus")
 
 
 def build_spawn_section(*, relay_root: Path | None = None, key: bytes | None = None) -> str:

--- a/tests/unit/core/agents/test_manager_relay_spawn.py
+++ b/tests/unit/core/agents/test_manager_relay_spawn.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
+import pytest
 from bernstein.core.spawn_prompt import _render_prompt
 
 
@@ -150,3 +152,55 @@ class TestManagerRelaySpawnPrompt:
             )
 
         assert "Prior cycle consensus" not in prompt
+
+
+def test_both_spawn_paths_name_the_relay_section_identically() -> None:
+    """One manager must not get a differently-named section than another.
+
+    The two render paths built the block independently, one calling it
+    "consensus relay" and the other "consensus_relay", so which name a
+    manager saw depended on which path spawned it - and section names are
+    what budget-aware compression and dedup key on.
+    """
+    import inspect
+
+    from bernstein.core.agents import spawn_prompt as sp_mod
+    from bernstein.core.agents import spawner_core as sc_mod
+
+    for module in (sp_mod, sc_mod):
+        source = inspect.getsource(module)
+        assert "MANAGER_RELAY_SECTION" in source, f"{module.__name__} spells the section name itself"
+        assert '"consensus relay"' not in source
+
+
+def test_a_broken_relay_is_reported_rather_than_swallowed(
+    tmp_path: Path,
+    make_task: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A relay that stops appearing must not look like a relay that is empty.
+
+    The injection is guarded so a relay problem can never block a spawn.
+    With a bare ``pass`` that same guard made the feature's death silent:
+    no section, no log, indistinguishable from a store with nothing in it.
+    """
+    task = make_task(id="T-9", role="manager", title="Plan next iteration")
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+
+    def _boom(_workdir: Path) -> str:
+        raise RuntimeError("relay store exploded")
+
+    with (
+        patch("bernstein.core.orchestration.consensus_relay.spawn_section_for_workdir", _boom),
+        caplog.at_level(logging.WARNING),
+    ):
+        prompt = _render_prompt(
+            [task],
+            templates_dir=templates_dir,
+            workdir=tmp_path,
+            session_id="mgr-boom",
+        )
+
+    assert "Consensus relay section omitted" in caplog.text
+    assert prompt, "a relay failure must not cost the spawn its prompt"


### PR DESCRIPTION
Follow-up to #4678 / #4717, which had already entered the merge queue when these came up.

## Two defects in the injection added there

**The two spawn paths disagree on the section name.** `spawn_prompt.py` appends it as `"consensus relay"`, `spawner_core.py` as `"consensus_relay"`, so which name a manager sees depends on which path spawned it. Section names are what budget-aware compression and `deduplicate_section` key on, so the same content is treated as two different sections.

**The guard is silent.** Both call sites wrap the injection in `except Exception: pass`. Guarding is right - a relay problem must never block a spawn. Swallowing without a word is not: a section that stops appearing then looks exactly like a store with nothing in it, which is how this would stop working without anyone noticing.

## Change

Path resolution and the section name move into `consensus_relay`, beside the store they describe, as `spawn_section_for_workdir` and `MANAGER_RELAY_SECTION`. Both call sites use them and log a warning instead of passing.

## Tests

- `test_both_spawn_paths_name_the_relay_section_identically` - neither module spells the name itself any more.
- `test_a_broken_relay_is_reported_rather_than_swallowed` - a raising relay leaves a warning and still returns a working prompt.

Both fail against the code as merged.