### PR TITLE
fix(pr-gen): judge a WIP commit by its churn, not by its prefix

### DIFF
--- a/src/bernstein/core/integrations/pr_gen.py
+++ b/src/bernstein/core/integrations/pr_gen.py
@@ -149,7 +149,8 @@ _HOUSEKEEPING_TYPES = frozenset({"style", "chore"})
 _CC_SUBJECT_RE = re.compile(r"^(?P<type>[a-z]+)(?:\([^)]*\))?!?:\s", re.IGNORECASE)
 
 # Markers for a commit that was never meant to describe anything.
-_WIP_SUBJECT_RE = re.compile(r"^\s*(?:\[wip\]|wip\b|fixup!|squash!|amend!)", re.IGNORECASE)
+_REBASE_MARKER_RE = re.compile(r"^\s*(?:fixup!|squash!|amend!)", re.IGNORECASE)
+_WIP_MARKER_RE = re.compile(r"^\s*(?:\[wip\]|wip\b)", re.IGNORECASE)
 
 # The wording a repair commit uses whatever conventional-commit type it
 # claims. ``fix: resolve lint gate failures`` is typed ``fix`` and is still
@@ -440,8 +441,11 @@ def is_housekeeping_commit(commit: CommitRecord) -> bool:
     A commit is housekeeping when any of the following holds:
 
     * it is a merge commit, or it touches no files at all;
-    * its subject is a work-in-progress or rebase marker (``[WIP]``,
-      ``fixup!``, ``squash!``, ``amend!``);
+    * its subject is a rebase marker (``fixup!``, ``squash!``, ``amend!``);
+    * its subject carries a work-in-progress marker (``[WIP]``, ``wip``) *and*
+      it changes nothing under ``src/`` - the marker records when the commit
+      was made, not that it is upkeep, and a worktree fold routinely lands
+      real work behind it;
     * its conventional-commit type is ``style`` or ``chore``;
     * its subject names a formatter, a linter or a regeneration - the wording
       a repair commit uses whatever type it claims, which is how ``fix:
@@ -463,7 +467,16 @@ def is_housekeeping_commit(commit: CommitRecord) -> bool:
         return True
 
     subject = commit.subject.strip()
-    if not subject or _WIP_SUBJECT_RE.match(subject):
+    if not subject or _REBASE_MARKER_RE.match(subject):
+        return True
+
+    # A WIP marker records when the commit was made, not that it is upkeep.
+    # Folding an agent worktree in lands substantive work behind that prefix
+    # as a matter of course, so classifying on the marker alone drops the one
+    # commit that touched src/ out of the ranking entirely and hands the pull
+    # request's name to whatever small follow-up came after it. Judge it by
+    # what it changed: a WIP commit that alters no source is a checkpoint.
+    if _WIP_MARKER_RE.match(subject) and commit.src_churn == 0:
         return True
 
     conventional = _CC_SUBJECT_RE.match(subject)

--- a/tests/unit/test_pr_description_from_change.py
+++ b/tests/unit/test_pr_description_from_change.py
@@ -90,7 +90,7 @@ FORMAT_COMMIT = _commit(
     "style: reformat storage package",
     [("src/bernstein/core/storage/store.py", 40, 40)],
 )
-WIP_COMMIT = _commit("dddddddddddd", "[WIP] key derivation", [("src/bernstein/core/storage/keys.py", 10, 0)])
+WIP_COMMIT = _commit("dddddddddddd", "[WIP] key derivation", [("notes/scratch.md", 10, 0)])
 MERGE_COMMIT = _commit("eeeeeeeeeeee", "Merge branch 'main' into agent/run-1", is_merge=True)
 CONTEXT_SYNC_COMMIT = _commit("ffffffffffff", "docs: refresh agent context", [("AGENTS.md", 12, 3)])
 
@@ -162,7 +162,7 @@ def test_a_docs_only_run_still_gets_a_real_title() -> None:
     ("commit", "why"),
     [
         (MERGE_COMMIT, "merge commit"),
-        (WIP_COMMIT, "work-in-progress marker"),
+        (WIP_COMMIT, "work-in-progress marker over no source change"),
         (FORMAT_COMMIT, "style: type"),
         (LINT_COMMIT, "lint-repair wording under a fix: type"),
         (CONTEXT_SYNC_COMMIT, "generated agent-context file only"),
@@ -557,3 +557,56 @@ def test_a_session_with_no_cost_says_so_in_one_line() -> None:
 
     assert "No cost was recorded" in cost
     assert "Effective rate" not in cost
+
+
+# ---------------------------------------------------------------------------
+# A WIP marker is not a claim about what the commit did
+# ---------------------------------------------------------------------------
+
+
+WIP_FEATURE_COMMIT = _commit(
+    "dddddddddddd",
+    "[WIP] feat(review): add ApprovalBinding data model and emit/verify functions",
+    files=(("src/bernstein/core/review/receipt.py", 227, 0),),
+)
+TEST_FIX_COMMIT = _commit(
+    "ffffffffffff",
+    "fix(tests): detect real openai-agents SDK in _sdk_installed()",
+    files=(("tests/integration/adapters/test_openai_agents_smoke.py", 23, 1),),
+)
+
+
+def test_a_wip_commit_that_adds_source_can_still_name_the_pull_request() -> None:
+    """The incident: 227 lines of new source were filed under housekeeping.
+
+    Folding an agent worktree in commits substantive work behind a ``[WIP]``
+    prefix. Classifying on the marker dropped that commit from the ranking
+    entirely, so the description named the branch after a test fix that came
+    after it and listed the feature under "not what this pull request is
+    about" - while the header's own file count said six files and 300 lines.
+    """
+    assert is_housekeeping_commit(WIP_FEATURE_COMMIT) is False
+
+    ranked = rank_commits((TEST_FIX_COMMIT, WIP_FEATURE_COMMIT))
+
+    assert ranked[0] is WIP_FEATURE_COMMIT
+
+
+def test_a_wip_commit_that_touches_no_source_is_still_housekeeping() -> None:
+    """The marker keeps its meaning for the checkpoints it was written for."""
+    assert is_housekeeping_commit(WIP_COMMIT) is True
+
+
+def test_rebase_markers_are_housekeeping_whatever_they_touch() -> None:
+    """``fixup!`` names a commit destined to be squashed into another one.
+
+    Unlike ``[WIP]`` it says what will happen to the commit, not when it was
+    written, so churn does not redeem it.
+    """
+    fixup = _commit(
+        "cccccccccccc",
+        "fixup! feat(storage): derive a per-store key with HKDF-SHA256",
+        files=(("src/bernstein/core/storage/keys.py", 140, 12),),
+    )
+
+    assert is_housekeeping_commit(fixup) is True


### PR DESCRIPTION
## Problem

A published pull-request description named the branch after a 23-line test fix and filed a 227-line new module under *"Housekeeping, not what this pull request is about"* — while its own header counted six files and ~300 lines. The header and the body disagreed about the same branch.

The cause is in the classifier, not the renderer. `is_housekeeping_commit` treated a `[WIP]` subject prefix as proof of upkeep, so the commit was dropped out of `rank_commits` entirely and could neither name the change nor appear in the Change section.

Folding an agent worktree in commits substantive work behind that prefix as a matter of course, so this is the ordinary case for those runs, not a corner.

## Change

`[WIP]`/`wip` now describes *when* a commit was written, so the classifier judges it by what it changed: a WIP commit with no `src/` churn stays housekeeping, one that adds source is eligible to name the pull request.

`fixup!` / `squash!` / `amend!` keep the old unconditional treatment — those name what will *happen* to the commit (it gets squashed away), so churn does not redeem them. The two marker kinds now live in separate patterns rather than one alternation.

## Tests

- `test_a_wip_commit_that_adds_source_can_still_name_the_pull_request` — the reported shape: a 227-line WIP commit ranks above the test fix that followed it. Fails on the old classifier.
- `test_a_wip_commit_that_touches_no_source_is_still_housekeeping` — the marker keeps its meaning for real checkpoints.
- `test_rebase_markers_are_housekeeping_whatever_they_touch` — pins the asymmetry between the two marker kinds.

`tests/unit/test_pr_description_from_change.py` + `tests/unit/test_pr_gen.py`: 71 passed.