### PR TITLE
fix(tests): restore two suites the trigger-sources audit deleted by filename

### DIFF
--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -93,7 +93,7 @@ The table below is a selection of the most load-bearing sub-packages, not the fu
 | `core/storage/` | Pluggable artifact storage sinks (local FS, S3, GCS, Azure Blob, R2) |
 | `core/tasks/` | Task models, lifecycle FSM, store, batch, dead-letter queue |
 | `core/tokens/` | Token monitor, context compression, prompt caching |
-| `core/trigger_sources/` | GitHub, GitLab, Slack, Discord, file watch, webhook triggers |
+| `core/trigger_sources/` | Slack, Discord, schedule, SLA, OData, file watch, webhook triggers |
 
 A few standalone files remain at `core/` top level: `defaults.py` (all configurable constants), `credential_scoping.py`, `streaming_merge.py`, `compat_redirect_ledger.py`, `dataclass_helpers.py`, `instrumentation.py`, `parallel_admission.py`, and `run_auth_token.py`.
 

--- a/docs/architecture/DESIGN.md
+++ b/docs/architecture/DESIGN.md
@@ -79,14 +79,11 @@ Trigger orchestration is implemented and centered on:
 
 Current source adapters:
 
-- `src/bernstein/core/trigger_sources/github.py`
-- `src/bernstein/core/trigger_sources/gitlab.py`
 - `src/bernstein/core/trigger_sources/slack.py`
 - `src/bernstein/core/trigger_sources/discord.py`
 - `src/bernstein/core/trigger_sources/file_watch.py`
 - `src/bernstein/core/trigger_sources/webhook.py`
 - `src/bernstein/core/trigger_sources/webhook_node.py`
-- `src/bernstein/core/trigger_sources/routine.py`
 - `src/bernstein/core/trigger_sources/schedule.py`
 
 Configuration source:

--- a/docs/operations/trigger-sources.md
+++ b/docs/operations/trigger-sources.md
@@ -102,17 +102,13 @@ aspiration:
 | OData | `trigger_sources/odata_poll.py` | A polled system-of-record row change | **Yes**, own poll loop. See [OData integration](odata.md). |
 | Generic webhook | `trigger_sources/receipt.py` (`automation_platforms.py`) | n8n / Zapier / Workato-style inbound payloads | **Yes** — `POST /webhook`. See [Automation bridge](../integrations/automation-bridge.md). |
 | Discord | `trigger_sources/discord.py` | Slash-command interactions | **Partial** — `POST /webhooks/discord/interactions` uses `verify_discord_signature` from this module for request verification; command handling builds its response directly rather than through `normalize_discord_interaction`, which is unused in production. |
-| GitHub | `trigger_sources/github.py` | Push / workflow_run / issues webhooks | **No** — the production route (`POST /webhooks/github`) maps events to tasks through the separate `bernstein.github_app.mapper` module instead. `github.py`'s `normalize_push` / `normalize_workflow_run` / `normalize_issues` are not called from any route; they are available to a custom `TriggerManager`-based rule if you feed them events yourself. |
-| GitLab | `trigger_sources/gitlab.py` | Pipeline / job webhooks | **No** — same situation as GitHub: `POST /webhooks/gitlab` builds tasks directly, not through this module. |
 | Generic HTTP | `trigger_sources/webhook.py` (`normalize_webhook`) | Arbitrary path/method/headers/payload | **No** — not called from any route in this codebase; the live generic-webhook endpoint (`POST /webhook`) creates a task from a task-shaped payload instead of normalizing through this function. |
 | File watch | `trigger_sources/file_watch.py` (`FileWatchSource`) | Debounced filesystem change events (via `watchdog`) | **No** — the class is defined but never instantiated outside its own module; no orchestrator loop drains its queue. The unrelated `bernstein watch` CLI command does not use it either. |
-| Claude Code Routine | `trigger_sources/routine.py` | A Routine session webhook | **No** — `normalize_routine_webhook` is defined but not called from any route. |
 
 ## Limitations
 
-Roughly half of the named adapters (GitHub, GitLab, generic HTTP webhook,
-file watch, Routine) are normalization functions with no production caller
-in this codebase — they are usable if you wire them into a custom route or
+Some of the named adapters (generic HTTP webhook, file watch) are
+normalization functions with no production caller in this codebase — they are usable if you wire them into a custom route or
 a `TriggerManager` rule yourself, but out of the box nothing invokes them.
 Treat the "wired" column above as authoritative over the module list; it
 will drift as routes change, so re-check the call sites (`grep -rn

--- a/tests/unit/test_github.py
+++ b/tests/unit/test_github.py
@@ -1,0 +1,677 @@
+"""Unit tests for bernstein.core.github - GitHub Issues integration."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from bernstein.core.github import (
+    _HASH_LABEL_PREFIX,
+    _LABEL_AUTO,
+    _LABEL_CLAIMED,
+    _LABEL_EVOLVE,
+    GitHubClient,
+    GitHubIssue,
+    _hash_title,
+    _label_color,
+)
+
+# ---------------------------------------------------------------------------
+# _hash_title
+# ---------------------------------------------------------------------------
+
+
+def test_hash_title_is_8_chars() -> None:
+    h = _hash_title("Some proposal title")
+    assert len(h) == 8
+    assert h.isalnum()
+
+
+def test_hash_title_case_insensitive() -> None:
+    assert _hash_title("Foo Bar") == _hash_title("foo bar")
+    assert _hash_title("FOO BAR") == _hash_title("foo bar")
+
+
+def test_hash_title_strip_whitespace() -> None:
+    assert _hash_title("  foo  ") == _hash_title("foo")
+
+
+def test_hash_title_different_titles_differ() -> None:
+    assert _hash_title("Add caching layer") != _hash_title("Remove dead code")
+
+
+# ---------------------------------------------------------------------------
+# GitHubIssue
+# ---------------------------------------------------------------------------
+
+
+def test_issue_is_claimed_true() -> None:
+    issue = GitHubIssue(
+        number=42,
+        title="Improve test coverage",
+        url="https://github.com/o/r/issues/42",
+        labels=[_LABEL_EVOLVE, _LABEL_CLAIMED],
+    )
+    assert issue.is_claimed is True
+
+
+def test_issue_is_claimed_false() -> None:
+    issue = GitHubIssue(
+        number=7,
+        title="Fix import order",
+        url="https://github.com/o/r/issues/7",
+        labels=[_LABEL_EVOLVE],
+    )
+    assert issue.is_claimed is False
+
+
+def test_issue_hash_label_present() -> None:
+    h = _hash_title("Add caching")
+    issue = GitHubIssue(
+        number=10,
+        title="Add caching",
+        url="",
+        labels=[_LABEL_EVOLVE, f"{_HASH_LABEL_PREFIX}{h}"],
+    )
+    assert issue.hash_label == f"{_HASH_LABEL_PREFIX}{h}"
+
+
+def test_issue_hash_label_absent() -> None:
+    issue = GitHubIssue(number=1, title="x", url="", labels=[_LABEL_EVOLVE])
+    assert issue.hash_label is None
+
+
+def test_issue_from_gh_json() -> None:
+    raw = {
+        "number": 99,
+        "title": "Auto-tune config",
+        "url": "https://github.com/o/r/issues/99",
+        "labels": [
+            {"name": _LABEL_EVOLVE},
+            {"name": _LABEL_AUTO},
+        ],
+        "state": "open",
+    }
+    issue = GitHubIssue.from_gh_json(raw)
+    assert issue.number == 99
+    assert issue.title == "Auto-tune config"
+    assert _LABEL_EVOLVE in issue.labels
+    assert _LABEL_AUTO in issue.labels
+    assert issue.state == "open"
+
+
+# ---------------------------------------------------------------------------
+# _label_color
+# ---------------------------------------------------------------------------
+
+
+def test_label_color_known_labels() -> None:
+    assert _label_color(_LABEL_EVOLVE) == "0075ca"
+    assert _label_color(_LABEL_CLAIMED) == "e4e669"
+    assert _label_color(_LABEL_AUTO) == "cfd3d7"
+
+
+def test_label_color_hash_label() -> None:
+    color = _label_color(f"{_HASH_LABEL_PREFIX}abc12345")
+    assert color == "d4edda"
+
+
+def test_label_color_unknown() -> None:
+    color = _label_color("some-random-label")
+    assert color == "ededed"
+
+
+# ---------------------------------------------------------------------------
+# GitHubClient.available
+# ---------------------------------------------------------------------------
+
+
+def test_available_true_when_gh_exits_zero() -> None:
+    client = GitHubClient()
+    with patch("bernstein.core.git.github.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        assert client.available is True
+
+
+def test_available_false_when_gh_exits_nonzero() -> None:
+    client = GitHubClient()
+    client._available = None  # reset cache
+    with patch("bernstein.core.git.github.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=1)
+        assert client.available is False
+
+
+def test_available_false_when_gh_not_found() -> None:
+    client = GitHubClient()
+    client._available = None
+    with patch(
+        "bernstein.core.github.subprocess.run",
+        side_effect=FileNotFoundError,
+    ):
+        assert client.available is False
+
+
+def test_available_cached_after_first_check() -> None:
+    client = GitHubClient()
+    client._available = None
+    with patch("bernstein.core.git.github.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        # First call: checks subprocess
+        assert client.available is True
+        # Second call: uses cached value, no extra subprocess call
+        assert client.available is True
+        assert mock_run.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# GitHubClient.fetch_open_evolve_issues
+# ---------------------------------------------------------------------------
+
+
+def _mock_run_ok(data: object) -> MagicMock:
+    """Return a mock subprocess.run result with returncode=0 and JSON stdout."""
+    m = MagicMock()
+    m.returncode = 0
+    m.stdout = json.dumps(data)
+    m.stderr = ""
+    return m
+
+
+def _mock_run_fail(stderr: str = "error") -> MagicMock:
+    m = MagicMock()
+    m.returncode = 1
+    m.stdout = ""
+    m.stderr = stderr
+    return m
+
+
+def test_fetch_open_evolve_issues_returns_list() -> None:
+    client = GitHubClient()
+    client._available = True
+
+    raw = [
+        {
+            "number": 1,
+            "title": "Proposal A",
+            "url": "https://github.com/o/r/issues/1",
+            "labels": [{"name": _LABEL_EVOLVE}],
+            "state": "open",
+        },
+        {
+            "number": 2,
+            "title": "Proposal B",
+            "url": "https://github.com/o/r/issues/2",
+            "labels": [{"name": _LABEL_EVOLVE}, {"name": _LABEL_CLAIMED}],
+            "state": "open",
+        },
+    ]
+    with patch("bernstein.core.git.github.subprocess.run", return_value=_mock_run_ok(raw)):
+        issues = client.fetch_open_evolve_issues()
+
+    assert len(issues) == 2
+    assert issues[0].number == 1
+    assert issues[1].is_claimed is True
+
+
+def test_fetch_open_evolve_issues_empty_when_unavailable() -> None:
+    client = GitHubClient()
+    client._available = False
+    issues = client.fetch_open_evolve_issues()
+    assert issues == []
+
+
+def test_fetch_open_evolve_issues_empty_on_gh_error() -> None:
+    client = GitHubClient()
+    client._available = True
+    with patch("bernstein.core.git.github.subprocess.run", return_value=_mock_run_fail()):
+        issues = client.fetch_open_evolve_issues()
+    assert issues == []
+
+
+def test_fetch_open_evolve_issues_empty_on_bad_json() -> None:
+    client = GitHubClient()
+    client._available = True
+    m = MagicMock(returncode=0, stdout="not json", stderr="")
+    with patch("bernstein.core.git.github.subprocess.run", return_value=m):
+        issues = client.fetch_open_evolve_issues()
+    assert issues == []
+
+
+# ---------------------------------------------------------------------------
+# GitHubClient.find_unclaimed
+# ---------------------------------------------------------------------------
+
+
+def test_find_unclaimed_filters_claimed() -> None:
+    client = GitHubClient()
+    client._available = True
+
+    raw = [
+        {
+            "number": 1,
+            "title": "A",
+            "url": "",
+            "state": "open",
+            "labels": [{"name": _LABEL_EVOLVE}],
+        },
+        {
+            "number": 2,
+            "title": "B",
+            "url": "",
+            "state": "open",
+            "labels": [{"name": _LABEL_EVOLVE}, {"name": _LABEL_CLAIMED}],
+        },
+        {
+            "number": 3,
+            "title": "C",
+            "url": "",
+            "state": "open",
+            "labels": [{"name": _LABEL_EVOLVE}],
+        },
+    ]
+    with patch("bernstein.core.git.github.subprocess.run", return_value=_mock_run_ok(raw)):
+        unclaimed = client.find_unclaimed()
+
+    assert len(unclaimed) == 2
+    assert all(not i.is_claimed for i in unclaimed)
+    # Sorted by number ascending (oldest first)
+    assert unclaimed[0].number == 1
+    assert unclaimed[1].number == 3
+
+
+# ---------------------------------------------------------------------------
+# GitHubClient.find_by_hash
+# ---------------------------------------------------------------------------
+
+
+def test_find_by_hash_matches_correct_issue() -> None:
+    client = GitHubClient()
+    client._available = True
+
+    title = "Optimise cache eviction"
+    h = _hash_title(title)
+    hash_label = f"{_HASH_LABEL_PREFIX}{h}"
+
+    raw = [
+        {
+            "number": 5,
+            "title": "Unrelated",
+            "url": "",
+            "state": "open",
+            "labels": [{"name": _LABEL_EVOLVE}],
+        },
+        {
+            "number": 6,
+            "title": title,
+            "url": "",
+            "state": "open",
+            "labels": [{"name": _LABEL_EVOLVE}, {"name": hash_label}],
+        },
+    ]
+    with patch("bernstein.core.git.github.subprocess.run", return_value=_mock_run_ok(raw)):
+        found = client.find_by_hash(title)
+
+    assert found is not None
+    assert found.number == 6
+
+
+def test_find_by_hash_returns_none_when_no_match() -> None:
+    client = GitHubClient()
+    client._available = True
+
+    raw = [
+        {"number": 1, "title": "Other", "url": "", "state": "open", "labels": [{"name": _LABEL_EVOLVE}]},
+    ]
+    with patch("bernstein.core.git.github.subprocess.run", return_value=_mock_run_ok(raw)):
+        found = client.find_by_hash("Non-existent proposal")
+
+    assert found is None
+
+
+# ---------------------------------------------------------------------------
+# GitHubClient.create_issue
+# ---------------------------------------------------------------------------
+
+
+def test_create_issue_returns_issue_on_success() -> None:
+    client = GitHubClient()
+    client._available = True
+
+    url = "https://github.com/owner/repo/issues/42"
+
+    def side_effect(args, **kwargs):
+        # _ensure_labels calls: gh label create x3, gh issue create
+        if "label" in args and "create" in args:
+            return MagicMock(returncode=0, stdout="", stderr="")
+        # gh issue create
+        return MagicMock(returncode=0, stdout=url, stderr="")
+
+    with patch("bernstein.core.git.github.subprocess.run", side_effect=side_effect):
+        issue = client.create_issue(title="Improve error messages", body="Some body")
+
+    assert issue is not None
+    assert issue.number == 42
+    assert issue.url == url
+    assert _LABEL_EVOLVE in issue.labels
+    assert _LABEL_AUTO in issue.labels
+
+
+def test_create_issue_returns_none_when_unavailable() -> None:
+    client = GitHubClient()
+    client._available = False
+    issue = client.create_issue(title="X", body="Y")
+    assert issue is None
+
+
+def test_create_issue_returns_none_on_gh_failure() -> None:
+    client = GitHubClient()
+    client._available = True
+
+    with patch("bernstein.core.git.github.subprocess.run", return_value=_mock_run_fail("permission denied")):
+        issue = client.create_issue(title="X", body="Y")
+
+    assert issue is None
+
+
+# ---------------------------------------------------------------------------
+# GitHubClient.claim_issue / unclaim_issue
+# ---------------------------------------------------------------------------
+
+
+def test_claim_issue_returns_true_on_success() -> None:
+    client = GitHubClient()
+    client._available = True
+
+    def side_effect(args, **kwargs):
+        # _ensure_labels + gh issue edit
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("bernstein.core.git.github.subprocess.run", side_effect=side_effect):
+        result = client.claim_issue(10)
+
+    assert result is True
+
+
+def test_claim_issue_returns_false_when_unavailable() -> None:
+    client = GitHubClient()
+    client._available = False
+    assert client.claim_issue(1) is False
+
+
+def test_unclaim_issue_returns_true_on_success() -> None:
+    client = GitHubClient()
+    client._available = True
+    with patch("bernstein.core.git.github.subprocess.run", return_value=MagicMock(returncode=0, stdout="")):
+        assert client.unclaim_issue(5) is True
+
+
+def test_unclaim_issue_returns_false_when_unavailable() -> None:
+    client = GitHubClient()
+    client._available = False
+    assert client.unclaim_issue(5) is False
+
+
+# ---------------------------------------------------------------------------
+# GitHubClient.close_issue
+# ---------------------------------------------------------------------------
+
+
+def test_close_issue_posts_comment_then_closes() -> None:
+    client = GitHubClient()
+    client._available = True
+
+    calls_made: list[list[str]] = []
+
+    def side_effect(args, **kwargs):
+        calls_made.append(args)
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("bernstein.core.git.github.subprocess.run", side_effect=side_effect):
+        result = client.close_issue(3, comment="Applied via PR #7")
+
+    assert result is True
+    # Should have called: gh issue comment, then gh issue close
+    comment_call = next((c for c in calls_made if "comment" in c), None)
+    close_call = next((c for c in calls_made if "close" in c), None)
+    assert comment_call is not None
+    assert close_call is not None
+
+
+def test_close_issue_no_comment_skips_comment_call() -> None:
+    client = GitHubClient()
+    client._available = True
+
+    calls_made: list[list[str]] = []
+
+    def side_effect(args, **kwargs):
+        calls_made.append(args)
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("bernstein.core.git.github.subprocess.run", side_effect=side_effect):
+        result = client.close_issue(3, comment=None)
+
+    assert result is True
+    comment_calls = [c for c in calls_made if "comment" in c]
+    assert len(comment_calls) == 0
+
+
+def test_close_issue_returns_false_when_unavailable() -> None:
+    client = GitHubClient()
+    client._available = False
+    assert client.close_issue(1) is False
+
+
+# ---------------------------------------------------------------------------
+# GitHubClient - repo parameter forwarded
+# ---------------------------------------------------------------------------
+
+
+def test_repo_forwarded_to_gh_commands() -> None:
+    client = GitHubClient(repo="myorg/myrepo")
+    client._available = True
+
+    raw: list[dict] = []
+    captured: list[list[str]] = []
+
+    def side_effect(args, **kwargs):
+        captured.append(args)
+        return MagicMock(returncode=0, stdout=json.dumps(raw), stderr="")
+
+    with patch("bernstein.core.git.github.subprocess.run", side_effect=side_effect):
+        client.fetch_open_evolve_issues()
+
+    cmd = captured[0]
+    assert "--repo" in cmd
+    assert "myorg/myrepo" in cmd
+
+
+# ---------------------------------------------------------------------------
+# Pagination - audit-098
+# ---------------------------------------------------------------------------
+
+
+def test_github_pagination_page_limit_default(monkeypatch) -> None:
+    """Default cap is the module constant when env is unset."""
+    from bernstein.core.git.github import _DEFAULT_PAGE_LIMIT, _page_limit
+
+    monkeypatch.delenv("BERNSTEIN_GITHUB_PAGE_LIMIT", raising=False)
+    assert _page_limit() == _DEFAULT_PAGE_LIMIT
+
+
+def test_github_pagination_page_limit_env_override(monkeypatch) -> None:
+    """Env var overrides the page cap."""
+    from bernstein.core.git.github import _page_limit
+
+    monkeypatch.setenv("BERNSTEIN_GITHUB_PAGE_LIMIT", "250")
+    assert _page_limit() == 250
+
+
+def test_github_pagination_page_limit_invalid_env_uses_default(monkeypatch) -> None:
+    """Non-integer or non-positive env values fall back to the default."""
+    from bernstein.core.git.github import _DEFAULT_PAGE_LIMIT, _page_limit
+
+    monkeypatch.setenv("BERNSTEIN_GITHUB_PAGE_LIMIT", "not-a-number")
+    assert _page_limit() == _DEFAULT_PAGE_LIMIT
+
+    monkeypatch.setenv("BERNSTEIN_GITHUB_PAGE_LIMIT", "0")
+    assert _page_limit() == _DEFAULT_PAGE_LIMIT
+
+    monkeypatch.setenv("BERNSTEIN_GITHUB_PAGE_LIMIT", "-5")
+    assert _page_limit() == _DEFAULT_PAGE_LIMIT
+
+
+def test_github_pagination_fetch_open_evolve_passes_high_limit(monkeypatch) -> None:
+    """``fetch_open_evolve_issues`` passes the configured cap (not 100)."""
+    from bernstein.core.git.github import _DEFAULT_PAGE_LIMIT
+
+    monkeypatch.delenv("BERNSTEIN_GITHUB_PAGE_LIMIT", raising=False)
+    client = GitHubClient()
+    client._available = True
+
+    captured: list[list[str]] = []
+
+    def side_effect(args, **kwargs):
+        captured.append(args)
+        return MagicMock(returncode=0, stdout="[]", stderr="")
+
+    with patch("bernstein.core.git.github.subprocess.run", side_effect=side_effect):
+        client.fetch_open_evolve_issues()
+
+    assert captured, "expected gh to be invoked"
+    cmd = captured[0]
+    assert "--limit" in cmd
+    assert cmd[cmd.index("--limit") + 1] == str(_DEFAULT_PAGE_LIMIT)
+    # Regression: old hardcoded value must not appear as the limit.
+    assert cmd[cmd.index("--limit") + 1] != "100"
+
+
+def test_github_pagination_fetch_community_passes_high_limit(monkeypatch) -> None:
+    """``fetch_community_issues`` passes the configured cap (not 50)."""
+    from bernstein.core.git.github import _DEFAULT_PAGE_LIMIT
+
+    monkeypatch.delenv("BERNSTEIN_GITHUB_PAGE_LIMIT", raising=False)
+    client = GitHubClient()
+    client._available = True
+
+    captured: list[list[str]] = []
+
+    def side_effect(args, **kwargs):
+        captured.append(args)
+        return MagicMock(returncode=0, stdout="[]", stderr="")
+
+    with patch("bernstein.core.git.github.subprocess.run", side_effect=side_effect):
+        client.fetch_community_issues()
+
+    # One call per community label.
+    assert len(captured) >= 1
+    for cmd in captured:
+        assert "--limit" in cmd
+        assert cmd[cmd.index("--limit") + 1] == str(_DEFAULT_PAGE_LIMIT)
+        assert cmd[cmd.index("--limit") + 1] != "50"
+
+
+def test_github_pagination_backlog_sync_passes_high_limit(monkeypatch, tmp_path) -> None:
+    """``_fetch_gh_issues`` used by backlog sync passes the cap (not 500)."""
+    from bernstein.core.git.github import _DEFAULT_PAGE_LIMIT, _fetch_gh_issues
+
+    monkeypatch.delenv("BERNSTEIN_GITHUB_PAGE_LIMIT", raising=False)
+
+    captured: list[list[str]] = []
+
+    def side_effect(args, **kwargs):
+        captured.append(args)
+        return MagicMock(returncode=0, stdout="[]", stderr="")
+
+    with patch("bernstein.core.git.github.subprocess.run", side_effect=side_effect):
+        _fetch_gh_issues(tmp_path)
+
+    assert captured
+    cmd = captured[0]
+    assert "--limit" in cmd
+    assert cmd[cmd.index("--limit") + 1] == str(_DEFAULT_PAGE_LIMIT)
+    # Regression: original hardcoded cap of 500 must be gone.
+    assert cmd[cmd.index("--limit") + 1] != "500"
+
+
+def test_github_pagination_returns_full_multi_page_result(monkeypatch) -> None:
+    """Concatenated multi-page result from ``gh`` is returned intact.
+
+    ``gh issue list`` paginates internally and hands us a single JSON array
+    containing every page concatenated. This test simulates that behaviour
+    with 650 issues (exceeding the old 500-cap) and asserts the caller
+    receives all of them.
+    """
+    monkeypatch.delenv("BERNSTEIN_GITHUB_PAGE_LIMIT", raising=False)
+    client = GitHubClient()
+    client._available = True
+
+    full_payload = [
+        {
+            "number": n,
+            "title": f"Proposal {n}",
+            "url": f"https://github.com/o/r/issues/{n}",
+            "labels": [{"name": _LABEL_EVOLVE}],
+            "state": "open",
+        }
+        for n in range(1, 651)
+    ]
+
+    with patch(
+        "bernstein.core.git.github.subprocess.run",
+        return_value=_mock_run_ok(full_payload),
+    ):
+        issues = client.fetch_open_evolve_issues()
+
+    assert len(issues) == 650
+    assert issues[0].number == 1
+    assert issues[-1].number == 650
+
+
+def test_github_pagination_truncation_warning_emitted(monkeypatch, caplog) -> None:
+    """When the returned count equals the cap, a WARNING is logged."""
+    import logging
+
+    monkeypatch.setenv("BERNSTEIN_GITHUB_PAGE_LIMIT", "3")
+    client = GitHubClient()
+    client._available = True
+
+    payload = [
+        {"number": n, "title": f"t{n}", "url": "", "state": "open", "labels": [{"name": _LABEL_EVOLVE}]}
+        for n in (1, 2, 3)
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="bernstein.core.git.github"):
+        with patch(
+            "bernstein.core.git.github.subprocess.run",
+            return_value=_mock_run_ok(payload),
+        ):
+            issues = client.fetch_open_evolve_issues()
+
+    assert len(issues) == 3
+    assert any(
+        "truncated" in rec.getMessage().lower() or "page cap" in rec.getMessage().lower() for rec in caplog.records
+    )
+
+
+def test_github_pagination_no_truncation_warning_below_cap(monkeypatch, caplog) -> None:
+    """When count is below the cap, no truncation warning is emitted."""
+    import logging
+
+    monkeypatch.setenv("BERNSTEIN_GITHUB_PAGE_LIMIT", "100")
+    client = GitHubClient()
+    client._available = True
+
+    payload = [
+        {"number": n, "title": f"t{n}", "url": "", "state": "open", "labels": [{"name": _LABEL_EVOLVE}]}
+        for n in range(1, 11)  # 10 issues, well below cap of 100
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="bernstein.core.git.github"):
+        with patch(
+            "bernstein.core.git.github.subprocess.run",
+            return_value=_mock_run_ok(payload),
+        ):
+            issues = client.fetch_open_evolve_issues()
+
+    assert len(issues) == 10
+    assert not any("truncated" in rec.getMessage().lower() for rec in caplog.records)

--- a/tests/unit/test_gitlab_app.py
+++ b/tests/unit/test_gitlab_app.py
@@ -1,0 +1,162 @@
+"""Unit tests for ``bernstein.gitlab_app.app`` - config + URL helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.gitlab_app.app import (
+    DEFAULT_GITLAB_URL,
+    GitLabAppConfig,
+    build_api_url,
+    build_auth_headers,
+    fetch_job_trace,
+    get_gitlab_base_url,
+)
+
+
+class TestGetGitlabBaseUrl:
+    """``get_gitlab_base_url`` reads BERNSTEIN_GITLAB_URL with sane defaults."""
+
+    def test_default_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BERNSTEIN_GITLAB_URL", raising=False)
+        assert get_gitlab_base_url() == DEFAULT_GITLAB_URL
+
+    def test_https_url_passes_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_GITLAB_URL", "https://gitlab.example.com")
+        assert get_gitlab_base_url() == "https://gitlab.example.com"
+
+    def test_trailing_slash_stripped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_GITLAB_URL", "https://gitlab.example.com/")
+        assert get_gitlab_base_url() == "https://gitlab.example.com"
+
+    def test_http_localhost_allowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_GITLAB_URL", "http://localhost:8080")
+        assert get_gitlab_base_url() == "http://localhost:8080"
+
+    def test_invalid_scheme_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_GITLAB_URL", "ftp://gitlab.example.com")
+        assert get_gitlab_base_url() == DEFAULT_GITLAB_URL
+
+    def test_garbage_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_GITLAB_URL", "not-a-url")
+        assert get_gitlab_base_url() == DEFAULT_GITLAB_URL
+
+    def test_empty_string_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_GITLAB_URL", "   ")
+        assert get_gitlab_base_url() == DEFAULT_GITLAB_URL
+
+
+class TestGitLabAppConfig:
+    """``GitLabAppConfig.from_env`` validation."""
+
+    def test_from_env_happy_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_GITLAB_URL", "https://gitlab.example.com")
+        monkeypatch.setenv("GITLAB_TOKEN", "glpat-test")
+        monkeypatch.setenv("GITLAB_WEBHOOK_TOKEN", "secret-hook")
+        cfg = GitLabAppConfig.from_env()
+        assert cfg.base_url == "https://gitlab.example.com"
+        assert cfg.token == "glpat-test"
+        assert cfg.webhook_token == "secret-hook"
+
+    def test_from_env_pat_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GITLAB_TOKEN", raising=False)
+        monkeypatch.setenv("GITLAB_PAT", "glpat-pat")
+        monkeypatch.setenv("GITLAB_WEBHOOK_TOKEN", "hook")
+        cfg = GitLabAppConfig.from_env()
+        assert cfg.token == "glpat-pat"
+
+    def test_from_env_missing_token_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GITLAB_TOKEN", raising=False)
+        monkeypatch.delenv("GITLAB_PAT", raising=False)
+        monkeypatch.setenv("GITLAB_WEBHOOK_TOKEN", "hook")
+        with pytest.raises(ValueError, match="GITLAB_TOKEN"):
+            GitLabAppConfig.from_env()
+
+    def test_from_env_missing_hook_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GITLAB_TOKEN", "x")
+        monkeypatch.delenv("GITLAB_WEBHOOK_TOKEN", raising=False)
+        with pytest.raises(ValueError, match="GITLAB_WEBHOOK_TOKEN"):
+            GitLabAppConfig.from_env()
+
+    def test_config_is_frozen(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        cfg = GitLabAppConfig(base_url="https://gitlab.com", token="t", webhook_token="w")
+        with pytest.raises(FrozenInstanceError):
+            cfg.token = "other"  # type: ignore[misc]
+
+
+class TestBuildApiUrl:
+    """``build_api_url`` path handling."""
+
+    def test_simple_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BERNSTEIN_GITLAB_URL", raising=False)
+        assert build_api_url("/projects/1") == "https://gitlab.com/api/v4/projects/1"
+
+    def test_missing_leading_slash_added(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BERNSTEIN_GITLAB_URL", raising=False)
+        assert build_api_url("projects/1") == "https://gitlab.com/api/v4/projects/1"
+
+    def test_custom_base(self) -> None:
+        assert build_api_url("/projects/1", "https://gitlab.acme.com") == "https://gitlab.acme.com/api/v4/projects/1"
+
+    def test_base_trailing_slash(self) -> None:
+        assert build_api_url("/x", "https://gitlab.acme.com/") == "https://gitlab.acme.com/api/v4/x"
+
+
+class TestBuildAuthHeaders:
+    def test_token_set(self) -> None:
+        assert build_auth_headers("abc") == {"PRIVATE-TOKEN": "abc"}
+
+    def test_empty_token(self) -> None:
+        assert build_auth_headers("") == {}
+
+
+class TestFetchJobTrace:
+    """``fetch_job_trace`` graceful degradation."""
+
+    def test_no_token_returns_empty(self) -> None:
+        assert fetch_job_trace(1, 2, token="") == ""
+
+    def test_httpx_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class _Response:
+            status_code = 200
+            text = "trace body"
+
+        class _FakeHttpx:
+            @staticmethod
+            def get(url: str, headers: dict[str, str], timeout: float) -> _Response:
+                assert "api/v4/projects/1/jobs/2/trace" in url
+                assert headers["PRIVATE-TOKEN"] == "t"
+                return _Response()
+
+        import sys
+
+        monkeypatch.setitem(sys.modules, "httpx", _FakeHttpx)
+        assert fetch_job_trace(1, 2, token="t") == "trace body"
+
+    def test_httpx_non_200(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class _Response:
+            status_code = 404
+            text = ""
+
+        class _FakeHttpx:
+            @staticmethod
+            def get(url: str, headers: dict[str, str], timeout: float) -> _Response:
+                return _Response()
+
+        import sys
+
+        monkeypatch.setitem(sys.modules, "httpx", _FakeHttpx)
+        assert fetch_job_trace(1, 2, token="t") == ""
+
+    def test_httpx_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class _FakeHttpx:
+            @staticmethod
+            def get(*_args: object, **_kwargs: object) -> object:
+                raise RuntimeError("boom")
+
+        import sys
+
+        monkeypatch.setitem(sys.modules, "httpx", _FakeHttpx)
+        assert fetch_job_trace(1, 2, token="t") == ""


### PR DESCRIPTION
#4716 merged while this was being written. Its module deletions were right; two of the five test files it removed were not, and the doc mentions it was meant to remove are still on `main`. This restores the coverage and finishes the doc half.

## Two test suites were matched to modules by filename

Neither imported anything the audit removed:

| Restored file | What it actually tests |
|---|---|
| `tests/unit/test_github.py` (677 lines, 43 tests) | `bernstein.core.github` and `bernstein.core.git.github` — the live helpers, `_page_limit`, `_fetch_gh_issues` |
| `tests/unit/test_gitlab_app.py` (162 lines) | `bernstein.gitlab_app.app`, the GitLab webhook application routed from `src/bernstein/core/routes/webhooks.py` |

839 lines of coverage came off live code, and no gate could have caught it: **a deletion cannot fail the suite it deletes**, so the branch went green precisely because the assertions were gone.

Both files are restored unchanged, and they pass with `trigger_sources/{github,gitlab,routine}.py` absent — that is the proof they never depended on them.

The other three deletions (`test_gitlab_trigger.py`, `test_routine_trigger.py`, and the 54 lines from `test_trigger_manager.py`) do import the removed modules and stay deleted.

## The doc mentions

The audit asks for module, tests and doc mentions in one change; the merged diff touched no docs file, so three documents still point operators at modules that are gone — the same defect the audit exists to remove, moved into the docs:

- `docs/architecture/DESIGN.md` — three entries under "Current source adapters".
- `docs/operations/trigger-sources.md` — three rows of the wiring table, and the Limitations paragraph that counted the unwired adapters.
- `docs/architecture/ARCHITECTURE.md` — the `core/trigger_sources/` package row still led with "GitHub, GitLab".

## Checked by

`tests/unit/test_github.py tests/unit/test_gitlab_app.py`: 65 passed against `main` with the three modules absent.