### PR TITLE
feat(tasks): map tests from green co-change history

### DIFF
--- a/src/bernstein/core/tasks/context_extractors.py
+++ b/src/bernstein/core/tasks/context_extractors.py
@@ -1,3 +1,5 @@
+import subprocess
+from collections import Counter
 from pathlib import Path
 
 from bernstein.core.quality.flaky_detector import FlakyDetector
@@ -38,3 +40,36 @@ def get_known_flaky_tests(workdir: Path) -> list[str]:
     over the same quarantine must produce the same bytes.
     """
     return sorted(FlakyDetector(workdir).get_quarantined())
+
+
+def extract_test_to_source_map(repo_root: Path, targets: list[str], *, limit: int = 20) -> dict[str, list[str]]:
+    """Map source targets to tests co-changed by commits explicitly marked green.
+
+    The marker is deliberately conservative: only commit subjects containing
+    ``green`` count as landed-green evidence.  This makes the result
+    deterministic and avoids treating an unverified local commit as evidence.
+    """
+    result: dict[str, list[str]] = {}
+    for target in sorted(set(targets)):
+        counts: Counter[str] = Counter()
+        try:
+            commits = _git(repo_root, "log", "--format=%H%x00%s", "--", target).splitlines()
+            for record in commits:
+                sha, subject = record.split("\x00", 1)
+                if "green" not in subject.casefold():
+                    continue
+                changed = _git(
+                    repo_root, "diff-tree", "--root", "--no-commit-id", "--name-only", "-r", sha
+                ).splitlines()
+                for path in changed:
+                    if path.startswith(("test/", "tests/")) and path.endswith(".py"):
+                        counts[path] += 1
+        except (OSError, subprocess.CalledProcessError, ValueError):
+            result[target] = []
+            continue
+        result[target] = sorted(counts, key=lambda path: (-counts[path], path))[:limit]
+    return result
+
+
+def _git(repo_root: Path, *args: str) -> str:
+    return subprocess.check_output(("git", "-C", str(repo_root), *args), text=True)

--- a/src/bernstein/core/tasks/context_extractors.py
+++ b/src/bernstein/core/tasks/context_extractors.py
@@ -1,8 +1,12 @@
+import logging
+import re
 import subprocess
 from collections import Counter
 from pathlib import Path
 
 from bernstein.core.quality.flaky_detector import FlakyDetector
+
+logger = logging.getLogger(__name__)
 
 
 def find_nearest_agents_md(target_path: Path, repo_root: Path) -> str | None:
@@ -43,20 +47,22 @@ def get_known_flaky_tests(workdir: Path) -> list[str]:
 
 
 def extract_test_to_source_map(repo_root: Path, targets: list[str], *, limit: int = 20) -> dict[str, list[str]]:
-    """Map source targets to tests co-changed by commits explicitly marked green.
+    """Map source targets to tests co-changed by unreverted commits.
 
-    The marker is deliberately conservative: only commit subjects containing
-    ``green`` count as landed-green evidence.  This makes the result
-    deterministic and avoids treating an unverified local commit as evidence.
+    The commit graph is the available landed-green evidence: commits reachable
+    from the checked-out history are candidates, while an explicit Git revert
+    removes the reverted commit from the map.  This is deterministic and does
+    not infer CI status from commit-message wording.
     """
     result: dict[str, list[str]] = {}
     for target in sorted(set(targets)):
         counts: Counter[str] = Counter()
         try:
-            commits = _git(repo_root, "log", "--format=%H%x00%s", "--", target).splitlines()
-            for record in commits:
-                sha, subject = record.split("\x00", 1)
-                if "green" not in subject.casefold():
+            history = _git(repo_root, "log", "--format=%H%x00%B", "--", target)
+            reverted = _reverted_commits(history)
+            records = re.findall(r"(?ms)([0-9a-f]{40})\x00(.*?)(?=\n?[0-9a-f]{40}\x00|\Z)", history)
+            for sha, _message in records:
+                if sha in reverted or _message.lstrip().startswith("Revert "):
                     continue
                 changed = _git(
                     repo_root, "diff-tree", "--root", "--no-commit-id", "--name-only", "-r", sha
@@ -64,12 +70,20 @@ def extract_test_to_source_map(repo_root: Path, targets: list[str], *, limit: in
                 for path in changed:
                     if path.startswith(("test/", "tests/")) and path.endswith(".py"):
                         counts[path] += 1
-        except (OSError, subprocess.CalledProcessError, ValueError):
+        except (OSError, subprocess.CalledProcessError, ValueError) as exc:
+            logger.warning("could not derive test-to-source history for %s: %s", target, exc)
             result[target] = []
             continue
+        if len(counts) > limit:
+            logger.info("test-to-source map truncated for %s: kept %d of %d tests", target, limit, len(counts))
         result[target] = sorted(counts, key=lambda path: (-counts[path], path))[:limit]
     return result
 
 
 def _git(repo_root: Path, *args: str) -> str:
     return subprocess.check_output(("git", "-C", str(repo_root), *args), text=True)
+
+
+def _reverted_commits(history: str) -> set[str]:
+    """Return commits explicitly reverted in a ``git log --format=%B`` result."""
+    return set(re.findall(r"This reverts commit ([0-9a-f]{40})", history))

--- a/src/bernstein/core/tasks/context_extractors.py
+++ b/src/bernstein/core/tasks/context_extractors.py
@@ -59,10 +59,10 @@ def extract_test_to_source_map(repo_root: Path, targets: list[str], *, limit: in
         counts: Counter[str] = Counter()
         try:
             history = _git(repo_root, "log", "--format=%H%x00%B", "--", target)
-            reverted = _reverted_commits(history)
             records = re.findall(r"(?ms)([0-9a-f]{40})\x00(.*?)(?=\n?[0-9a-f]{40}\x00|\Z)", history)
+            excluded = _revert_pairs(records)
             for sha, _message in records:
-                if sha in reverted or _message.lstrip().startswith("Revert "):
+                if sha in excluded:
                     continue
                 changed = _git(
                     repo_root, "diff-tree", "--root", "--no-commit-id", "--name-only", "-r", sha
@@ -84,6 +84,23 @@ def _git(repo_root: Path, *args: str) -> str:
     return subprocess.check_output(("git", "-C", str(repo_root), *args), text=True)
 
 
-def _reverted_commits(history: str) -> set[str]:
-    """Return commits explicitly reverted in a ``git log --format=%B`` result."""
-    return set(re.findall(r"This reverts commit ([0-9a-f]{40})", history))
+def _revert_pairs(records: list[tuple[str, str]]) -> set[str]:
+    """Return the shas of every revert commit and the commit each one undid.
+
+    The evidence is the ``This reverts commit <sha>`` trailer that ``git
+    revert`` writes into the commit it creates -- a property of the record,
+    not of how someone worded a subject line. Matching on a ``Revert `` prefix
+    instead would drop an ordinary commit called "Revert to the previous retry
+    policy" and keep a revert whose message was rewritten by hand.
+
+    A revert that does not itself touch the target never appears in that
+    target's log, so the commit it undid still counts here. Narrowing that
+    needs the full history rather than the per-target one.
+    """
+    excluded: set[str] = set()
+    for sha, message in records:
+        undone = re.search(r"This reverts commit ([0-9a-f]{40})", message)
+        if undone is not None:
+            excluded.add(sha)
+            excluded.add(undone.group(1))
+    return excluded

--- a/tests/unit/test_test_to_source_map.py
+++ b/tests/unit/test_test_to_source_map.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from bernstein.core.tasks.context_extractors import extract_test_to_source_map
+
+
+def _commit(repo: Path, message: str, *paths: str) -> None:
+    for path in paths:
+        target = repo / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(message, encoding="utf-8")
+    subprocess.run(("git", "-C", str(repo), "add", "."), check=True)
+    subprocess.run(
+        ("git", "-C", str(repo), "-c", "user.name=test", "-c", "user.email=test@example.com", "commit", "-m", message),
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
+
+
+def test_a_test_that_never_co_changed_is_not_offered(tmp_path: Path) -> None:
+    subprocess.run(("git", "-C", str(tmp_path), "init"), check=True, stdout=subprocess.DEVNULL)
+    _commit(tmp_path, "green source change", "src/a.py", "tests/test_a.py")
+    _commit(tmp_path, "green unrelated test", "tests/test_never.py")
+    assert extract_test_to_source_map(tmp_path, ["src/a.py"]) == {"src/a.py": ["tests/test_a.py"]}
+
+
+def test_only_commits_that_landed_green_contribute(tmp_path: Path) -> None:
+    subprocess.run(("git", "-C", str(tmp_path), "init"), check=True, stdout=subprocess.DEVNULL)
+    _commit(tmp_path, "red source change", "src/a.py", "tests/test_red.py")
+    _commit(tmp_path, "green source change", "src/a.py", "tests/test_green.py")
+    assert extract_test_to_source_map(tmp_path, ["src/a.py"]) == {"src/a.py": ["tests/test_green.py"]}
+
+
+def test_the_map_is_stable_under_input_reordering(tmp_path: Path) -> None:
+    subprocess.run(("git", "-C", str(tmp_path), "init"), check=True, stdout=subprocess.DEVNULL)
+    _commit(tmp_path, "green source change", "src/a.py", "tests/test_a.py")
+    _commit(tmp_path, "green source change", "src/b.py", "tests/test_b.py")
+    assert extract_test_to_source_map(tmp_path, ["src/a.py", "src/b.py"]) == extract_test_to_source_map(
+        tmp_path, ["src/b.py", "src/a.py"]
+    )
+
+
+def test_a_target_with_no_history_yields_an_empty_map_and_no_error(tmp_path: Path) -> None:
+    subprocess.run(("git", "-C", str(tmp_path), "init"), check=True, stdout=subprocess.DEVNULL)
+    assert extract_test_to_source_map(tmp_path, ["src/missing.py"]) == {"src/missing.py": []}

--- a/tests/unit/test_test_to_source_map.py
+++ b/tests/unit/test_test_to_source_map.py
@@ -6,37 +6,70 @@ from pathlib import Path
 from bernstein.core.tasks.context_extractors import extract_test_to_source_map
 
 
-def _commit(repo: Path, message: str, *paths: str) -> None:
-    for path in paths:
-        target = repo / path
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(message, encoding="utf-8")
-    subprocess.run(("git", "-C", str(repo), "add", "."), check=True)
+def _git(repo: Path, *args: str) -> None:
+    """Run git in *repo* with an identity, whatever the host is configured with.
+
+    Every command that writes a commit goes through here. A runner with no
+    global ``user.email`` fails ``git revert`` with "unable to auto-detect
+    email address" and exit 128, which is a fixture problem wearing the
+    costume of a product failure -- and it only shows up off the developer's
+    own machine, where the global identity happens to exist.
+    """
     subprocess.run(
-        ("git", "-C", str(repo), "-c", "user.name=test", "-c", "user.email=test@example.com", "commit", "-m", message),
+        (
+            "git",
+            "-C",
+            str(repo),
+            "-c",
+            "user.name=test",
+            "-c",
+            "user.email=test@example.com",
+            *args,
+        ),
         check=True,
         stdout=subprocess.DEVNULL,
     )
 
 
+def _commit(repo: Path, message: str, *paths: str) -> None:
+    for path in paths:
+        target = repo / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(message, encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", message)
+
+
 def test_a_test_that_never_co_changed_is_not_offered(tmp_path: Path) -> None:
-    subprocess.run(("git", "-C", str(tmp_path), "init"), check=True, stdout=subprocess.DEVNULL)
+    _git(tmp_path, "init")
     _commit(tmp_path, "source change", "src/a.py", "tests/test_a.py")
     _commit(tmp_path, "unrelated test", "tests/test_never.py")
     assert extract_test_to_source_map(tmp_path, ["src/a.py"]) == {"src/a.py": ["tests/test_a.py"]}
 
 
 def test_only_commits_that_landed_green_contribute(tmp_path: Path) -> None:
-    subprocess.run(("git", "-C", str(tmp_path), "init"), check=True, stdout=subprocess.DEVNULL)
+    _git(tmp_path, "init")
     _commit(tmp_path, "source change", "src/a.py", "tests/test_reverted.py")
     reverted = subprocess.check_output(("git", "-C", str(tmp_path), "rev-parse", "HEAD"), text=True).strip()
-    subprocess.run(("git", "-C", str(tmp_path), "revert", "--no-edit", reverted), check=True, stdout=subprocess.DEVNULL)
+    _git(tmp_path, "revert", "--no-edit", reverted)
     _commit(tmp_path, "another source change", "src/a.py", "tests/test_kept.py")
     assert extract_test_to_source_map(tmp_path, ["src/a.py"]) == {"src/a.py": ["tests/test_kept.py"]}
 
 
+def test_a_commit_whose_subject_merely_starts_with_revert_still_counts(tmp_path: Path) -> None:
+    """"Revert" in a subject line is prose, not evidence that anything was undone.
+
+    "Revert to the previous retry policy" is a perfectly ordinary change, and
+    dropping it costs the map the tests that landed with it. The trailer that
+    ``git revert`` writes is the thing that actually records an undo.
+    """
+    _git(tmp_path, "init")
+    _commit(tmp_path, "Revert to the previous retry policy", "src/a.py", "tests/test_policy.py")
+    assert extract_test_to_source_map(tmp_path, ["src/a.py"]) == {"src/a.py": ["tests/test_policy.py"]}
+
+
 def test_the_map_is_stable_under_input_reordering(tmp_path: Path) -> None:
-    subprocess.run(("git", "-C", str(tmp_path), "init"), check=True, stdout=subprocess.DEVNULL)
+    _git(tmp_path, "init")
     _commit(tmp_path, "green source change", "src/a.py", "tests/test_a.py")
     _commit(tmp_path, "green source change", "src/b.py", "tests/test_b.py")
     assert extract_test_to_source_map(tmp_path, ["src/a.py", "src/b.py"]) == extract_test_to_source_map(
@@ -45,5 +78,5 @@ def test_the_map_is_stable_under_input_reordering(tmp_path: Path) -> None:
 
 
 def test_a_target_with_no_history_yields_an_empty_map_and_no_error(tmp_path: Path) -> None:
-    subprocess.run(("git", "-C", str(tmp_path), "init"), check=True, stdout=subprocess.DEVNULL)
+    _git(tmp_path, "init")
     assert extract_test_to_source_map(tmp_path, ["src/missing.py"]) == {"src/missing.py": []}

--- a/tests/unit/test_test_to_source_map.py
+++ b/tests/unit/test_test_to_source_map.py
@@ -21,16 +21,18 @@ def _commit(repo: Path, message: str, *paths: str) -> None:
 
 def test_a_test_that_never_co_changed_is_not_offered(tmp_path: Path) -> None:
     subprocess.run(("git", "-C", str(tmp_path), "init"), check=True, stdout=subprocess.DEVNULL)
-    _commit(tmp_path, "green source change", "src/a.py", "tests/test_a.py")
-    _commit(tmp_path, "green unrelated test", "tests/test_never.py")
+    _commit(tmp_path, "source change", "src/a.py", "tests/test_a.py")
+    _commit(tmp_path, "unrelated test", "tests/test_never.py")
     assert extract_test_to_source_map(tmp_path, ["src/a.py"]) == {"src/a.py": ["tests/test_a.py"]}
 
 
 def test_only_commits_that_landed_green_contribute(tmp_path: Path) -> None:
     subprocess.run(("git", "-C", str(tmp_path), "init"), check=True, stdout=subprocess.DEVNULL)
-    _commit(tmp_path, "red source change", "src/a.py", "tests/test_red.py")
-    _commit(tmp_path, "green source change", "src/a.py", "tests/test_green.py")
-    assert extract_test_to_source_map(tmp_path, ["src/a.py"]) == {"src/a.py": ["tests/test_green.py"]}
+    _commit(tmp_path, "source change", "src/a.py", "tests/test_reverted.py")
+    reverted = subprocess.check_output(("git", "-C", str(tmp_path), "rev-parse", "HEAD"), text=True).strip()
+    subprocess.run(("git", "-C", str(tmp_path), "revert", "--no-edit", reverted), check=True, stdout=subprocess.DEVNULL)
+    _commit(tmp_path, "another source change", "src/a.py", "tests/test_kept.py")
+    assert extract_test_to_source_map(tmp_path, ["src/a.py"]) == {"src/a.py": ["tests/test_kept.py"]}
 
 
 def test_the_map_is_stable_under_input_reordering(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes #4648.

This adds the first test-to-source map extractor for the task context pack. For each target path, it reads the repository's git history, excludes commits explicitly reverted by later Git revert commits, and collects co-changed Python test paths.

## Implementation

- Reuses the existing task context extractor module and git CLI surface.
- Sorts targets and ranks test paths by co-change frequency with a deterministic path tie-breaker.
- Uses `git diff-tree --root` so root commits are handled correctly.
- Reports truncation and history-read failures through the existing logger while failing open with an empty map.
- No model calls, new storage, or test execution from the extracted map.

The landed-green decision is based on the commit graph: reachable commits are candidates, while an explicit `This reverts commit <sha>.` record and its revert commit are excluded. This uses durable repository evidence rather than commit-message wording or a model inference.

## Tests

- `uv run --python 3.12 pytest -q --basetemp .pytest-tmp/revision4 tests/unit/test_test_to_source_map.py tests/unit/test_task_pack.py` — 8 passed
- `uv run --python 3.12 ruff check src/bernstein/core/tasks/context_extractors.py tests/unit/test_test_to_source_map.py` — passed
- `uv run --python 3.12 ruff format --check src/bernstein/core/tasks/context_extractors.py tests/unit/test_test_to_source_map.py` — passed
- `uv run --python 3.12 pyright src/bernstein/core/tasks/context_extractors.py tests/unit/test_test_to_source_map.py` — 0 errors
- `git diff --check` — passed

The test run used a worktree-local pytest temporary directory because the host's default Windows temporary directory is not writable.
