### PR TITLE
fix(pr): stop publishing what the run spent

### DIFF
--- a/docs/release-notes/fragments/4735-pr-body-drops-spend.md
+++ b/docs/release-notes/fragments/4735-pr-body-drops-spend.md
@@ -1,0 +1,13 @@
+## Pull-request descriptions no longer carry what the run spent
+
+`build_pr_body` opened every description with the session's spend
+(`> 📝 4 files · +507 / -0 · $38.94`) and closed it with a `## Cost` section
+listing the total, the token count, an effective rate per million tokens and a
+per-role breakdown. All of it landed on a public page.
+
+The module already refuses to source a description from the session's own
+status text, on the grounds that it describes the run while a reader of the
+pull request is asking about the diff. Spend is the same kind of fact and was
+the one place the rule was not applied. Both the headline figure and the
+section are gone; the run's cost accounting is unchanged and still available
+where it belongs, in the run report and the retrospective.

--- a/src/bernstein/core/integrations/pr_gen.py
+++ b/src/bernstein/core/integrations/pr_gen.py
@@ -22,7 +22,7 @@ description belongs to this diff.
 The module reuses existing Bernstein state:
 
 * :class:`bernstein.core.persistence.session.SessionState` - run-level
-  goal, completed task ids and cumulative cost.
+  goal and completed task ids.
 * :class:`bernstein.core.persistence.session.WrapUpBrief` - per-session
   diff-stat and changes summary written on graceful stop.
 * :class:`bernstein.core.tasks.models.JanitorResult` - quality-gate
@@ -904,30 +904,6 @@ def _format_gates(gates: tuple[GateResult, ...]) -> str:
     return "\n".join(lines)
 
 
-def _format_cost(cost: CostBreakdown) -> str:
-    """Render the cost section as a markdown list."""
-    if cost.total_usd == 0 and cost.total_tokens == 0:
-        return "- _No cost was recorded for this session._"
-
-    lines: list[str] = [
-        f"- **Total:** ${cost.total_usd:.2f}",
-        f"- **Tokens:** {cost.total_tokens:,}",
-    ]
-
-    if cost.total_tokens > 0 and cost.total_usd > 0:
-        rate = (cost.total_usd / cost.total_tokens) * 1_000_000
-        lines.append(f"- **Effective rate:** ${rate:.2f} / 1M tokens")
-    else:
-        lines.append("- **Effective rate:** n/a")
-
-    if cost.by_role:
-        by_role_sorted = sorted(cost.by_role.items(), key=lambda kv: -kv[1])
-        role_fragments = ", ".join(f"{role} ${usd:.2f}" for role, usd in by_role_sorted)
-        lines.append(f"- **By role:** {role_fragments}")
-
-    return "\n".join(lines)
-
-
 def _format_diff_stat(diff_stat: str) -> str:
     """Render the diff-stat, folded away, or a fallback line."""
     stripped = diff_stat.strip()
@@ -1108,7 +1084,7 @@ def _format_headline(session: SessionSummary) -> str:
     """Render the one-line summary that opens the body.
 
     A reviewer opening a pull request asks three questions before any other:
-    how big is it, did the checks pass, what did it cost.  The line answers
+    how big is it and did the checks pass.  The line answers
     all three above the fold so the rest of the description is optional
     reading rather than a search.
     """
@@ -1124,9 +1100,6 @@ def _format_headline(session: SessionSummary) -> str:
     if session.gates:
         passed = len(session.gates) - len(failed)
         segments.append(f"**{passed}/{len(session.gates)} gates passed**")
-
-    if session.cost.total_usd > 0:
-        segments.append(f"**${session.cost.total_usd:.2f}**")
 
     if session.git_error:
         marker = "⚠️"
@@ -1148,8 +1121,11 @@ def build_pr_body(session: SessionSummary) -> str:
 
     The output is structured so downstream reviewers (and tooling) can
     reliably grep for section headers.  All core sections - Problem,
-    Change, Verification and Cost - are always present even when the
+    Change and Verification - are always present even when the
     underlying data is empty, so tests can rely on their presence.
+
+    What the run spent is deliberately absent, for the same reason the
+    status text is: it describes the run, and the page is public.
 
     Every section is projected from the change: the linked issue states the
     problem, the commits and their files state what the diff does, and the
@@ -1206,9 +1182,6 @@ def build_pr_body(session: SessionSummary) -> str:
             "",
         ]
     parts += [
-        "## Cost",
-        _format_cost(session.cost),
-        "",
         "---",
         f"_Generated from Bernstein session `{short_id}`._",
         "",

--- a/tests/unit/test_pr_description_from_change.py
+++ b/tests/unit/test_pr_description_from_change.py
@@ -517,7 +517,7 @@ def test_a_colon_lead_in_absorbs_the_block_it_introduces() -> None:
     assert "edge ships nightly" in problem
 
 
-def test_the_body_opens_with_the_size_the_gates_and_the_cost() -> None:
+def test_the_body_opens_with_the_size_and_the_gates() -> None:
     body = build_pr_body(_summary(commits=(FEATURE_COMMIT,)))
     headline = body.splitlines()[0]
 
@@ -525,7 +525,6 @@ def test_the_body_opens_with_the_size_the_gates_and_the_cost() -> None:
     assert "2 files" in headline
     assert "+210 / -4" in headline
     assert "2/2 gates passed" in headline
-    assert "$1.00" in headline
 
 
 def test_a_failed_gate_shows_in_the_headline() -> None:
@@ -539,7 +538,7 @@ def test_a_failed_gate_shows_in_the_headline() -> None:
 def test_a_run_without_a_journal_head_does_not_advertise_one() -> None:
     """``Journal head: unrecorded`` reads as a lost recording, not an absent one."""
     body = build_pr_body(_summary(provenance=build_provenance(diff=b"diff --git a/x b/x\n")))
-    provenance = body.split("## Provenance", 1)[1].split("## Cost", 1)[0]
+    provenance = body.split("## Provenance", 1)[1].split("\n---", 1)[0]
 
     assert "unrecorded" not in provenance
     assert "Journal head" not in provenance
@@ -551,12 +550,28 @@ def test_a_journal_head_is_shown_when_the_run_anchored_one() -> None:
     assert "**Journal head:** `deadbeef`" in body
 
 
-def test_a_session_with_no_cost_says_so_in_one_line() -> None:
-    body = build_pr_body(_summary(cost=CostBreakdown()))
-    cost = body.split("## Cost", 1)[1].split("---", 1)[0]
+def test_the_body_states_no_spend_anywhere() -> None:
+    """What a run cost describes the run, not the diff a reviewer is reading.
 
-    assert "No cost was recorded" in cost
-    assert "Effective rate" not in cost
+    The module already refuses to source the description from the session's
+    own status text for exactly this reason. Spend was the one place that
+    rule was not applied: it reached the headline as ``$38.94`` and the body
+    as a per-role table, on a page anyone can read.
+    """
+    body = build_pr_body(_summary(commits=(FEATURE_COMMIT,), cost=CostBreakdown(total_usd=38.94, total_tokens=1_000_000)))
+
+    assert "$" not in body
+    assert "## Cost" not in body
+    assert "Effective rate" not in body
+    assert "38.94" not in body
+
+
+def test_a_session_with_no_cost_recorded_renders_the_same_body() -> None:
+    """No branch on spend survives, so the two bodies cannot drift apart."""
+    priced = build_pr_body(_summary(commits=(FEATURE_COMMIT,), cost=CostBreakdown(total_usd=12.5, total_tokens=999)))
+    free = build_pr_body(_summary(commits=(FEATURE_COMMIT,), cost=CostBreakdown()))
+
+    assert priced == free
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4735

## Problem

Every pull request the tool opens carried the run spend in its headline
(`> 📝 **4 files** · +507 / -0 · **$38.94**`) and a `## Cost` section listing
the total, the token count, an effective rate per million tokens and a
per-role breakdown. All of it renders on a public page, and none of it helps
the person deciding whether the diff is correct.

`pr_gen` already states the rule for a different field: the session status
text is deliberately not a source, because it describes the run while a reader
of the pull request is asking about the diff. Spend is the same kind of fact
and was the one place the rule was not applied.

## Change

| File | Change |
| --- | --- |
| `src/bernstein/core/integrations/pr_gen.py` | headline spend segment and `## Cost` section removed, with the now-unused renderer; docstrings updated to match |
| `tests/unit/test_pr_description_from_change.py` | two new tests, one stale assertion dropped |
| `docs/release-notes/fragments/4735-pr-body-drops-spend.md` | release note |

`CostBreakdown` stays on `SessionSummary`. The run report, retrospective and
run export render cost for the artefacts where it belongs and are untouched.

## Checked by

Both new tests fail against the previous generator and pass against this one.
`test_the_body_states_no_spend_anywhere` builds a body from a session costing
$38.94 and asserts the markdown contains no `$`, no `## Cost` and not the
figure. `test_a_session_with_no_cost_recorded_renders_the_same_body` builds a
priced and an unpriced session and asserts the bodies are identical, so no
branch on spend can reappear unnoticed.

187 tests across every module that touches `build_pr_body` pass; ruff clean.
