### PR TITLE
feat(tasks): add co-change neighbours extractor

### DIFF
--- a/src/bernstein/core/tasks/context_extractors.py
+++ b/src/bernstein/core/tasks/context_extractors.py
@@ -112,8 +112,8 @@ def extract_test_to_source_map(repo_root: Path, targets: list[str], *, limit: in
                 if sha in excluded:
                     continue
                 changed = _git(
-                    repo_root, "diff-tree", "--root", "--no-commit-id", "--name-only", "-r", sha
-                ).splitlines()
+                    repo_root, "diff-tree", "--root", "--no-commit-id", "--name-only", "-r", "-z", sha
+                ).split("\0")
                 for path in changed:
                     if path.startswith(("test/", "tests/")) and path.endswith(".py"):
                         counts[path] += 1

--- a/src/bernstein/core/tasks/context_extractors.py
+++ b/src/bernstein/core/tasks/context_extractors.py
@@ -46,6 +46,53 @@ def get_known_flaky_tests(workdir: Path) -> list[str]:
     return sorted(FlakyDetector(workdir).get_quarantined())
 
 
+def extract_co_change_neighbours(repo_root: Path, targets: list[str], *, limit: int = 20) -> dict[str, list[str]]:
+    """Return files that co-change with each target in the repository history.
+
+    Frequency is the primary ranking signal. When files have the same
+    frequency, the file seen in the more recent target commit wins, followed
+    by a path tie-breaker. The commit graph is the source of truth, so files
+    in unrelated directories are included and same-directory files are not
+    preferred implicitly. History failures fail open with an empty result.
+    """
+    result: dict[str, list[str]] = {}
+    for target in sorted(set(targets)):
+        counts: Counter[str] = Counter()
+        latest: dict[str, int] = {}
+        try:
+            commits = _git(repo_root, "log", "--format=%H", "--", target).splitlines()
+            for position, commit in enumerate(commits):
+                changed = _git(
+                    repo_root,
+                    "diff-tree",
+                    "--root",
+                    "--no-commit-id",
+                    "--name-only",
+                    "-r",
+                    "-z",
+                    commit,
+                ).split("\0")
+                for path in changed:
+                    if path and path != target:
+                        counts[path] += 1
+                        latest[path] = max(latest.get(path, 0), len(commits) - position)
+        except (OSError, subprocess.SubprocessError, ValueError) as exc:
+            logger.warning("could not derive co-change neighbours for %s: %s", target, exc)
+            result[target] = []
+            continue
+
+        ranked = sorted(counts, key=lambda path: (-counts[path], -latest[path], path))
+        if len(ranked) > limit:
+            logger.info(
+                "co-change neighbours truncated for %s: kept %d of %d",
+                target,
+                limit,
+                len(ranked),
+            )
+        result[target] = ranked[:limit]
+    return result
+
+
 def extract_test_to_source_map(repo_root: Path, targets: list[str], *, limit: int = 20) -> dict[str, list[str]]:
     """Map source targets to tests co-changed by unreverted commits.
 

--- a/src/bernstein/core/tasks/context_extractors.py
+++ b/src/bernstein/core/tasks/context_extractors.py
@@ -128,9 +128,7 @@ def extract_test_to_source_map(repo_root: Path, targets: list[str], *, limit: in
 
 
 def _git(repo_root: Path, *args: str) -> str:
-    return subprocess.check_output(
-        ("git", "-C", str(repo_root), *args), text=True, encoding="utf-8"
-    )
+    return subprocess.check_output(("git", "-C", str(repo_root), *args), text=True, encoding="utf-8")
 
 
 def _revert_pairs(records: list[tuple[str, str]]) -> set[str]:

--- a/src/bernstein/core/tasks/context_extractors.py
+++ b/src/bernstein/core/tasks/context_extractors.py
@@ -128,7 +128,9 @@ def extract_test_to_source_map(repo_root: Path, targets: list[str], *, limit: in
 
 
 def _git(repo_root: Path, *args: str) -> str:
-    return subprocess.check_output(("git", "-C", str(repo_root), *args), text=True)
+    return subprocess.check_output(
+        ("git", "-C", str(repo_root), *args), text=True, encoding="utf-8"
+    )
 
 
 def _revert_pairs(records: list[tuple[str, str]]) -> set[str]:

--- a/tests/unit/test_co_change_neighbours.py
+++ b/tests/unit/test_co_change_neighbours.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.tasks.context_extractors import extract_co_change_neighbours
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        (
+            "git",
+            "-C",
+            str(repo),
+            "-c",
+            "user.name=test",
+            "-c",
+            "user.email=test@example.com",
+            *args,
+        ),
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
+
+
+def _commit(repo: Path, message: str, *paths: str) -> None:
+    for path in paths:
+        target = repo / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(message, encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", message)
+
+
+def test_neighbours_come_from_the_commit_graph_not_the_directory(tmp_path: Path) -> None:
+    _git(tmp_path, "init")
+    _commit(tmp_path, "first change", "src/model.py", "schemas/model.json")
+    _commit(tmp_path, "same directory only", "src/other.py")
+    assert extract_co_change_neighbours(tmp_path, ["src/model.py"]) == {
+        "src/model.py": ["schemas/model.json"],
+    }
+
+
+def test_the_ranking_is_stable_under_input_reordering(tmp_path: Path) -> None:
+    _git(tmp_path, "init")
+    _commit(tmp_path, "shared change again", "src/a.py", "config/shared.toml")
+    _commit(tmp_path, "shared change", "src/a.py", "config/shared.toml")
+    _commit(tmp_path, "other change", "src/b.py", "config/other.toml")
+    assert extract_co_change_neighbours(tmp_path, ["src/a.py", "src/b.py"]) == extract_co_change_neighbours(
+        tmp_path, ["src/b.py", "src/a.py"]
+    )
+
+
+def test_the_cap_is_reported_not_silently_applied(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    _git(tmp_path, "init")
+    _commit(tmp_path, "many co-changes", "src/a.py", "one.txt", "two.txt", "three.txt")
+    with caplog.at_level("INFO"):
+        result = extract_co_change_neighbours(tmp_path, ["src/a.py"], limit=2)
+    assert len(result["src/a.py"]) == 2
+    assert "co-change neighbours truncated for src/a.py: kept 2 of 3" in caplog.text
+
+
+def test_a_repository_with_one_commit_yields_no_neighbours_and_no_error(tmp_path: Path) -> None:
+    _git(tmp_path, "init")
+    _commit(tmp_path, "only target", "src/a.py")
+    assert extract_co_change_neighbours(tmp_path, ["src/a.py"]) == {"src/a.py": []}

--- a/tests/unit/test_test_to_source_map.py
+++ b/tests/unit/test_test_to_source_map.py
@@ -80,3 +80,17 @@ def test_the_map_is_stable_under_input_reordering(tmp_path: Path) -> None:
 def test_a_target_with_no_history_yields_an_empty_map_and_no_error(tmp_path: Path) -> None:
     _git(tmp_path, "init")
     assert extract_test_to_source_map(tmp_path, ["src/missing.py"]) == {"src/missing.py": []}
+
+
+def test_a_test_whose_path_git_would_quote_is_still_found(tmp_path: Path) -> None:
+    """Plain ``--name-only`` hands back C-quoted paths for anything non-ASCII.
+
+    ``tests/test_ünïcode.py`` comes out as ``"tests/test_\\303\\274n..."`` --
+    a string that starts with a double quote, so a ``tests/`` prefix check
+    silently drops it and the map claims the file has no covering test. The
+    map is read as "these are the tests that cover this", which makes a
+    missing row a wrong answer rather than a thin one.
+    """
+    _git(tmp_path, "init")
+    _commit(tmp_path, "source change", "src/a.py", "tests/test_ünïcode.py")
+    assert extract_test_to_source_map(tmp_path, ["src/a.py"]) == {"src/a.py": ["tests/test_ünïcode.py"]}


### PR DESCRIPTION
## Issue

Fixes #4647.

## Summary

Adds the co-change neighbours extractor for the task context pack. For each target path, it reads the repository commit graph and returns files that changed in the same commits, including files in unrelated directories.

## Implementation

- Reuses the existing task context extractor's Git CLI surface; no model calls or new storage are introduced.
- Sorts and de-duplicates target paths so input ordering cannot affect the result.
- Ranks neighbours by co-change frequency, then by the most recent target commit, with a deterministic path tie-breaker.
- Fails open with an empty result when history cannot be read and logs when the configured cap truncates a result.
- Adds the four regression tests specified by the issue, including commit-graph locality, reordered inputs, cap reporting, and a one-commit repository.
- Decodes Git output as UTF-8 so non-ASCII paths remain intact on Windows as well as Unix hosts.

The ranking keeps frequency as the primary signal because repeated co-change is the strongest repository-local evidence; recency breaks ties so equally frequent files that were used more recently are preferred. The extractor intentionally uses the raw co-change history: a commit and its revert both count because both commits genuinely changed the files together. This differs from `extract_test_to_source_map`, where `_revert_pairs` excludes reverted commits because that map is specifically about tests covering changes that remain in the source history; the two extractors therefore have different, deliberate semantics.

## Compatibility

This is an additive extractor API. Existing task-pack serialization, callers, and public behavior are unchanged.

## Validation

- `python -m pytest tests/unit/test_co_change_neighbours.py tests/unit/test_test_to_source_map.py tests/unit/test_task_pack.py -q --basetemp .pytest-tmp-post-fix` — 14 passed.
- `uv run lint-imports` with UTF-8 console settings — 3 contracts kept, 0 broken.
- `ruff check` on changed Python files — passed.
- `ruff format --check` on the original changed files — passed; after the maintainer's follow-up changed the existing test-to-source map file, the Windows checkout reports a repository-wide CRLF/LF rewrite, so no formatting-only rewrite was included.
- `pyright` on changed Python files — 0 errors.
- `scripts/check_routes_broad_except.py` — passed.
- `git diff --check` — passed.

## Checks not run

The full repository test suite and full-repository type check were not run; the focused tests and changed-file checks cover this additive extractor, while the repository documents the isolated runner for the full suite.