### PR TITLE
fix(tests): run the volunteer gate through the running interpreter

### DIFF
--- a/tests/unit/volunteer/test_task_finish.py
+++ b/tests/unit/volunteer/test_task_finish.py
@@ -467,7 +467,7 @@ def test_the_signed_envelope_verifies_against_the_worker_identity_the_bundle_nam
 
 
 def test_the_signed_receipt_contains_budget_line_items(tmp_path: Path) -> None:
-    manifest = _manifest(allowed_paths=["src/**"], gates=[["python", "-c", "pass"]])
+    manifest = _manifest(allowed_paths=["src/**"], gates=[[sys.executable, "-c", "pass"]])
     line_items = [
         {
             "dimension": "tasks",


### PR DESCRIPTION
## Problem

`main` is red: `Test (macos-latest, Python 3.13, shard 1)` fails on
`tests/unit/volunteer/test_task_finish.py::test_the_signed_receipt_contains_budget_line_items`.

The test declares its manifest gate as `python -c pass`. The macOS runner
image exposes `python3` but no bare `python`, so the gate cannot be executed:
`task_finish` returns `VolunteerRefusal(reason='gate_not_executable')` rather
than a `SignedResultBundle`, and the `isinstance` assertion fails. The Linux
runners provide a `python` shim, so only the macOS shard goes red.

The macOS cells run on `push` and on diffs marked macos-sensitive, not on
every pull request, which is why this reached `main` before it was seen.

## Change

Use `sys.executable`, which names the interpreter actually running the test
instead of one the runner image may or may not expose. This is already the
convention across the suite, including `tests/unit/volunteer/test_runner.py`
in the same directory; line 470 was the only place naming a bare `python`.

## Verification

Reproduced on macOS before the change (same refusal and assertion as CI), and
`tests/unit/volunteer/test_task_finish.py` passes 24/24 after it. `ruff check`
clean on the file.