### PR TITLE
docs: regenerate adapter last-green table from canary receipts

### DIFF
--- a/docs/adapters/conformance-canary.md
+++ b/docs/adapters/conformance-canary.md
@@ -214,15 +214,15 @@ covered under *Chronic-skip handling*.
 | Adapter | Binary | Last-green version | Verified | Receipt |
 |---|---|---|---|---|
 | agy | `agy` | 1.0.0 | 2026-07-11T05:57:23Z (not probed) | `006fb946868d` |
-| aider | `aider` | 0.86.2 | 2026-08-28T16:58:22Z | `e27126a41c41` |
-| claude | `claude` | 2.1.250 | 2026-08-28T16:58:22Z | `c5bb6395cf73` |
-| codex | `codex` | 0.150.1 | 2026-08-28T16:58:22Z | `dbaba31a8881` |
-| copilot | `copilot` | 1.0.81 | 2026-08-28T16:58:22Z | `8a91752801c2` |
-| gemini | `gemini` | 0.57.0 | 2026-08-28T16:58:22Z | `1780bbae392c` |
-| kimi | `kimi` | 1.49.0 | 2026-08-28T16:58:22Z | `80ae2f114663` |
-| opencode | `opencode` | 1.18.25 | 2026-08-28T16:58:22Z | `180c2cccba55` |
-| pydantic_ai | `clai` | 2.35.3 | 2026-08-28T16:58:22Z | `a2148dd9124e` |
-| qwen | `qwen` | 0.22.2 | 2026-08-28T16:58:22Z | `b14522297509` |
+| aider | `aider` | 0.86.2 | 2026-08-29T11:23:38Z | `7cf04d2c7f12` |
+| claude | `claude` | 2.1.251 | 2026-08-29T11:23:38Z | `620ddf212dbf` |
+| codex | `codex` | 0.151.0 | 2026-08-29T11:23:38Z | `764d072cf400` |
+| copilot | `copilot` | 1.0.81 | 2026-08-29T11:23:38Z | `4a817ded148a` |
+| gemini | `gemini` | 0.57.0 | 2026-08-29T11:23:38Z | `e56fcb0657a4` |
+| kimi | `kimi` | 1.49.0 | 2026-08-29T11:23:38Z | `88bc11837712` |
+| opencode | `opencode` | 1.18.25 | 2026-08-29T11:23:38Z | `ba3c967c0c15` |
+| pydantic_ai | `clai` | 2.36.0 | 2026-08-29T11:23:38Z | `57f498ddd288` |
+| qwen | `qwen` | 0.22.3 | 2026-08-29T11:23:38Z | `362afcdb722e` |
 <!-- last-green:end -->
 
 ## Operator knobs

--- a/src/bernstein/adapters/last_green.json
+++ b/src/bernstein/adapters/last_green.json
@@ -8,57 +8,57 @@
     },
     "aider": {
       "binary": "aider",
-      "receipt_sha256": "e27126a41c41869038ef554fc4da9490ed617c52bc1d1f99a4ce20bcc4885025",
-      "recorded_at": "2026-08-28T16:58:22Z",
+      "receipt_sha256": "7cf04d2c7f122e6f83704f6467768a1b6ab716d3f65e74153bcbc3a799f6bad9",
+      "recorded_at": "2026-08-29T11:23:38Z",
       "version": "0.86.2"
     },
     "claude": {
       "binary": "claude",
-      "receipt_sha256": "c5bb6395cf73c545f2ac5ec84e43846f795e610b31696f0b99ceff87c3dfc0d8",
-      "recorded_at": "2026-08-28T16:58:22Z",
-      "version": "2.1.250"
+      "receipt_sha256": "620ddf212dbf2e9db2ac8a06039c07f60df806c7bac611f588531415388894f1",
+      "recorded_at": "2026-08-29T11:23:38Z",
+      "version": "2.1.251"
     },
     "codex": {
       "binary": "codex",
-      "receipt_sha256": "dbaba31a8881ed63bc966b534f5f2fedb5783054d8afcc47627fdd1fb35ceb39",
-      "recorded_at": "2026-08-28T16:58:22Z",
-      "version": "0.150.1"
+      "receipt_sha256": "764d072cf4007aab9b4079833ec9aa9f85d6c228317716662cb4bd5b570f9a25",
+      "recorded_at": "2026-08-29T11:23:38Z",
+      "version": "0.151.0"
     },
     "copilot": {
       "binary": "copilot",
-      "receipt_sha256": "8a91752801c2224657cd1f69ab5dc853d5085304312ab61d4b2f20435acff859",
-      "recorded_at": "2026-08-28T16:58:22Z",
+      "receipt_sha256": "4a817ded148aa728bbf86b7531333483e4470952cc89c33883e1edeb534dd339",
+      "recorded_at": "2026-08-29T11:23:38Z",
       "version": "1.0.81"
     },
     "gemini": {
       "binary": "gemini",
-      "receipt_sha256": "1780bbae392c6e47782da0bc6a885262ee28abedca8159f1eeae02aaa4bee0dd",
-      "recorded_at": "2026-08-28T16:58:22Z",
+      "receipt_sha256": "e56fcb0657a4b3307d62466610c47e295422c4a26f3bc3f991bb935a2d5314a7",
+      "recorded_at": "2026-08-29T11:23:38Z",
       "version": "0.57.0"
     },
     "kimi": {
       "binary": "kimi",
-      "receipt_sha256": "80ae2f114663bc407c181688a6f97c7bbf36301ccb097008322b4287fb0e3e8d",
-      "recorded_at": "2026-08-28T16:58:22Z",
+      "receipt_sha256": "88bc11837712cf3c2eac70d4caee140d5835bbb0c3b38633702c168ab099cbb3",
+      "recorded_at": "2026-08-29T11:23:38Z",
       "version": "1.49.0"
     },
     "opencode": {
       "binary": "opencode",
-      "receipt_sha256": "180c2cccba55508db77539b0dbebfac3f5e8877c2d15a01c2ce5ce64ea21d1cb",
-      "recorded_at": "2026-08-28T16:58:22Z",
+      "receipt_sha256": "ba3c967c0c15121546bf059d9d532a1d69dfddbdd1fadbd2b8e7597c85ec0b41",
+      "recorded_at": "2026-08-29T11:23:38Z",
       "version": "1.18.25"
     },
     "pydantic_ai": {
       "binary": "clai",
-      "receipt_sha256": "a2148dd9124e5f9ee8b5335d94abc884279f9a1ee52659a2c93bfb9fff098214",
-      "recorded_at": "2026-08-28T16:58:22Z",
-      "version": "2.35.3"
+      "receipt_sha256": "57f498ddd28884fbcb332fbb6a39d935bcdbf6e2a0e6dd192cf8b309beb1cb6e",
+      "recorded_at": "2026-08-29T11:23:38Z",
+      "version": "2.36.0"
     },
     "qwen": {
       "binary": "qwen",
-      "receipt_sha256": "b14522297509b08bb33c092a8c6742b8fbb8ff9d705ca0c815b5a691a7bfb948",
-      "recorded_at": "2026-08-28T16:58:22Z",
-      "version": "0.22.2"
+      "receipt_sha256": "362afcdb722e6c1220904d5a45cec7f7cc14f04d4887bbd3ca4c88efe3350e64",
+      "recorded_at": "2026-08-29T11:23:38Z",
+      "version": "0.22.3"
     }
   },
   "schema_version": 1

--- a/tests/unit/test_pr_description_from_change.py
+++ b/tests/unit/test_pr_description_from_change.py
@@ -558,7 +558,9 @@ def test_the_body_states_no_spend_anywhere() -> None:
     rule was not applied: it reached the headline as ``$38.94`` and the body
     as a per-role table, on a page anyone can read.
     """
-    body = build_pr_body(_summary(commits=(FEATURE_COMMIT,), cost=CostBreakdown(total_usd=38.94, total_tokens=1_000_000)))
+    body = build_pr_body(
+        _summary(commits=(FEATURE_COMMIT,), cost=CostBreakdown(total_usd=38.94, total_tokens=1_000_000))
+    )
 
     assert "$" not in body
     assert "## Cost" not in body

--- a/tests/unit/test_test_to_source_map.py
+++ b/tests/unit/test_test_to_source_map.py
@@ -57,7 +57,7 @@ def test_only_commits_that_landed_green_contribute(tmp_path: Path) -> None:
 
 
 def test_a_commit_whose_subject_merely_starts_with_revert_still_counts(tmp_path: Path) -> None:
-    """"Revert" in a subject line is prose, not evidence that anything was undone.
+    """ "Revert" in a subject line is prose, not evidence that anything was undone.
 
     "Revert to the previous retry policy" is a perfectly ordinary change, and
     dropping it costs the map the tests that landed with it. The trailer that


### PR DESCRIPTION
Nightly adapter conformance canary regeneration of the per-adapter last-green projection (packaged last_green.json + the docs table). Every row is anchored to the receipt that attested it; receipts for this run are attached to the workflow run as artifacts.

Workflow run: https://github.com/sipyourdrink-ltd/bernstein/actions/runs/33249972776