### PR TITLE
test: make the cost-cache offset test independent of filesystem mtime granularity

### DIFF
--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1916,7 +1916,16 @@ def test_read_cost_by_role_incremental_offset(tmp_path: Path) -> None:
     with metrics_jsonl.open("ab") as fh:
         fh.write(record2.encode())
 
-    mtime2 = metrics_jsonl.stat().st_mtime + 1
+    # Derive the second mtime from mtime1, not from a fresh stat(). A fresh
+    # stat() only yields a *different* mtime when the filesystem stamped the
+    # two writes distinctly, and Linux stamps inodes from a coarse cached
+    # clock (tick granularity, 1-10ms), so two writes microseconds apart
+    # routinely share one mtime. When they do, mtime2 == mtime1,
+    # _read_cost_by_role() takes its cache-hit branch and never parses
+    # record2 - the KeyError: 'qa' seen on main. Whether the two writes
+    # straddle a tick boundary depends on where in the tick the test starts,
+    # which is what made the failure order-dependent.
+    mtime2 = mtime1 + 1
     os.utime(metrics_jsonl, (mtime2, mtime2))
     store._cost_cache_mtime = mtime1  # simulate prior cached mtime
 


### PR DESCRIPTION
Fixes #4750.

## Root cause

The test is not order-dependent on process state — it depends on the **filesystem clock**. It derived both mtimes from a `stat()` taken after each write:

```python
mtime1 = metrics_jsonl.stat().st_mtime + 1   # after record1
mtime2 = metrics_jsonl.stat().st_mtime + 1   # after record2
```

so `mtime2` differs from `mtime1` only when the filesystem stamped the two writes distinctly. Linux stamps inodes from a coarse cached clock at tick granularity (1–10 ms), so two writes microseconds apart routinely share one mtime. When they do, `mtime2 == mtime1`, `_read_cost_by_role()` returns on its cache-hit branch, `record2` is never parsed, and the assertion fails with `KeyError: 'qa'` — exactly as reported.

Whether the two writes straddle a tick boundary depends on where in the tick the test starts, which is why the failure moved with ordering: it survived the file running alone and appeared once a neighbouring file shifted the phase. On macOS/APFS, which has nanosecond mtimes and no coarse caching, it never reproduces at all.

## Confirming the mechanism

Forcing the two writes to share an mtime reproduces the reported failure, and the fixed form survives it:

```
                                     old test logic          fixed test logic
fine (APFS, ns)                      {'backend','qa'} PASS   {'backend','qa'} PASS
coarse (Linux tick granularity)      {'backend'} KeyError    {'backend','qa'} PASS
```

## The change

Derive `mtime2` from `mtime1` rather than from a fresh `stat()`, so the two mtimes are distinct by construction. The test then exercises the incremental-offset path it claims to exercise on any filesystem, in any order — no fixture or production-code change needed.

`test_read_cost_by_role_truncation_reset` uses the same `stat()`-derived idiom but sets `_cost_cache_mtime = 0.0` before its second read, forcing a miss, so it is not exposed to this and is left alone.

## Verification

- `pytest tests/unit/test_server.py` — 122 passed
- `pytest tests/unit/test_bulletin.py tests/unit/test_defaults.py tests/unit/test_server.py` — 143 passed (both neighbours named in the issue)
- `ruff check` and `ruff format --check` clean