### PR TITLE
docs: update pymdown-extensions pin

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -592,9 +592,9 @@ Pygments==2.21.0 \
     --hash=sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9 \
     --hash=sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c
     # via mkdocs-material
-pymdown-extensions==11.0.1 \
-    --hash=sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2 \
-    --hash=sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0
+pymdown-extensions==11.0.2 \
+    --hash=sha256:259910762019732caa1dfd76f3faa62c59f191d46573e80bcb1d13c0f675bbe5 \
+    --hash=sha256:9506fcbe66fa355a775b768084334238dd6805020ac4b92bea0c0dda6f8f223d
     # via mkdocs-material
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \


### PR DESCRIPTION
## What

Update the hash-locked `pymdown-extensions` documentation dependency from 11.0.1 to 11.0.2.

## Why

This completes the remaining stale transitive pin identified in #4443.

Closes #4443.

## How

Re-resolved the requirement with `pip-compile`, preserving the generated file format and updating both artifact hashes.

## Checklist

- [x] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` passes (baseline currently reports 24,150 errors in untouched source)
- [ ] `uv run python scripts/run_tests.py -x` passes (baseline startup-banner assertion fails after 121 passing test files)
- [x] New code has type hints (N/A: dependency metadata only)

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (N/A: dependency metadata only)
- [x] `docs/operations/<area>.md` updated (N/A)
- [x] `docs/api/` schema regenerated if a public surface changed (N/A)
- [x] `uv run bernstein agents-md sync` run so AGENTS.md, CLAUDE.md, `.goosehints`, `CONVENTIONS.md`, and `.cursor/rules/*.mdc` reflect any new module (N/A)
- [x] Tests cover the documented behaviour (existing pin validation and staleness suites: 35 passed)

Additional verification:
- Clean Python 3.13 environment: `uv pip install --require-hashes -r docs/requirements.txt`
- `mkdocs build`
- `uv run python scripts/check_docs_requirements_pins.py`