### PR TITLE
fix(ci): bound a deny-list phrase by its tail, not its length

### DIFF
--- a/scripts/check_pr_text_hygiene.py
+++ b/scripts/check_pr_text_hygiene.py
@@ -54,11 +54,13 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-# Phrases at or below this length are treated as short tokens (e.g. a
-# three-letter acronym). Short tokens require a non-alphanumeric boundary
-# on BOTH sides so they do not match by accident inside an unrelated
-# longer word. Longer phrases require only a left boundary so that
-# suffixed forms (plurals, adjective endings) are still caught.
+# A trailing alphanumeric run at or below this length counts as a short
+# token (e.g. a three-letter acronym, or the "me" in "rel=me"). A phrase
+# ending in one -- unless that run is the last word of a multi-word phrase
+# -- requires a non-alphanumeric boundary on BOTH sides, so it cannot match
+# the front of an unrelated longer word. Everything else requires only a
+# left boundary so that suffixed forms (plurals, adjective endings) are
+# still caught.
 _SHORT_PHRASE_MAX_LEN = 4
 
 
@@ -118,16 +120,30 @@ def _compile_phrase(phrase: str) -> re.Pattern[str]:
 
     * A left boundary ``(?<![A-Za-z0-9])`` is always required, so a phrase
       never matches when it is glued to the tail of a longer word.
-    * A right boundary ``(?![A-Za-z0-9])`` is added only for short phrases
-      (``<= _SHORT_PHRASE_MAX_LEN``). Short acronyms are the main source of
-      accidental hits inside longer words, so they must be delimited on
-      both sides; longer phrases keep a left-only boundary so suffixed
-      forms still match.
+    * A right boundary ``(?![A-Za-z0-9])`` is added when the phrase ends in
+      a short alphanumeric run (``<= _SHORT_PHRASE_MAX_LEN``) that is not
+      simply the last word of a multi-word phrase.
+
+      Two different things end in a short run. ``foo bar`` and ``em-dash``
+      end in a word, and appending a suffix to a word is exactly the
+      evasion the left-only boundary exists to catch, so they stay
+      unbounded and still match ``foo barbaz`` and ``em-dashes``.
+      ``rel=me`` ends in the value half of a structured token, where a
+      longer value is a different value rather than a suffixed form -- and
+      while the boundary was judged by total length alone, six characters
+      was long enough to leave it unbounded, so it matched the front of
+      ``rel=member-execution``. The separator before the trailing run tells
+      the two apart: a space or a hyphen joins words, anything else builds
+      a structured token.
 
     Matching stays case-insensitive.
     """
     left = r"(?<![A-Za-z0-9])"
-    right = r"(?![A-Za-z0-9])" if len(phrase) <= _SHORT_PHRASE_MAX_LEN else ""
+    trailing_run = re.search(r"[A-Za-z0-9]*$", phrase).group()
+    separator = phrase[: -len(trailing_run) or None][-1:]
+    ends_in_a_word = separator in {" ", "-"}
+    needs_right = len(trailing_run) <= _SHORT_PHRASE_MAX_LEN and not ends_in_a_word
+    right = r"(?![A-Za-z0-9])" if needs_right else ""
     return re.compile(left + re.escape(phrase) + right, re.IGNORECASE)
 
 

--- a/tests/unit/scripts/test_pr_text_hygiene.py
+++ b/tests/unit/scripts/test_pr_text_hygiene.py
@@ -465,3 +465,62 @@ def test_short_token_matched_in_commit_message(hygiene_module: ModuleType, bound
         phrases=phrases,
     )
     assert any(surface.startswith("commit[") and phrase == "SEO" for surface, phrase in findings)
+
+
+# --- a phrase's tail decides whether it needs a right boundary --------------
+#
+# The right boundary used to be keyed on the phrase's total length, so a
+# phrase that is long overall but ends in a short token stayed unbounded and
+# matched the front of an unrelated word: 'rel=me' (six characters) flagged
+# 'references entries with a rel=member-execution value'. What makes a phrase
+# prefix-prone is its trailing alphanumeric run, not its length.
+
+
+@pytest.fixture
+def tail_deny_file(tmp_path: Path) -> Path:
+    """Deny-list holding a phrase that is long overall but ends in a short token."""
+    path = tmp_path / "tail.json"
+    path.write_text(
+        json.dumps({"denylist": ["rel=me", "marketing"]}),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_phrase_with_short_tail_does_not_match_longer_word(hygiene_module: ModuleType, tail_deny_file: Path) -> None:
+    """'rel=me' must not match the front of 'rel=member-execution'."""
+    phrases = hygiene_module.load_denylist(tail_deny_file)
+    findings = hygiene_module.check_pr_text(
+        title="fix: add run-level aggregate records",
+        body="Carries one references entry with a rel=member-execution value per member.",
+        branch="fix/aggregate",
+        commit_messages=["fix: emit rel=member-execution references"],
+        phrases=phrases,
+    )
+    assert findings == []
+
+
+def test_phrase_with_short_tail_still_matches_standalone(hygiene_module: ModuleType, tail_deny_file: Path) -> None:
+    """The phrase the entry exists for is still caught when it stands alone."""
+    phrases = hygiene_module.load_denylist(tail_deny_file)
+    findings = hygiene_module.check_pr_text(
+        title="chore: profile links",
+        body='Adds <a rel=me href="https://example.invalid/">.',
+        branch="chore/links",
+        commit_messages=[],
+        phrases=phrases,
+    )
+    assert ("body", "rel=me") in findings
+
+
+def test_phrase_with_long_tail_still_matches_suffixed_forms(hygiene_module: ModuleType, tail_deny_file: Path) -> None:
+    """A phrase ending in a long run keeps left-only boundaries, so suffixes match."""
+    phrases = hygiene_module.load_denylist(tail_deny_file)
+    findings = hygiene_module.check_pr_text(
+        title="chore: copy",
+        body="Reviewed by the marketingteam before release.",
+        branch="chore/copy",
+        commit_messages=[],
+        phrases=phrases,
+    )
+    assert ("body", "marketing") in findings

--- a/tests/unit/test_pr_description_from_change.py
+++ b/tests/unit/test_pr_description_from_change.py
@@ -558,7 +558,9 @@ def test_the_body_states_no_spend_anywhere() -> None:
     rule was not applied: it reached the headline as ``$38.94`` and the body
     as a per-role table, on a page anyone can read.
     """
-    body = build_pr_body(_summary(commits=(FEATURE_COMMIT,), cost=CostBreakdown(total_usd=38.94, total_tokens=1_000_000)))
+    body = build_pr_body(
+        _summary(commits=(FEATURE_COMMIT,), cost=CostBreakdown(total_usd=38.94, total_tokens=1_000_000))
+    )
 
     assert "$" not in body
     assert "## Cost" not in body

--- a/tests/unit/test_test_to_source_map.py
+++ b/tests/unit/test_test_to_source_map.py
@@ -57,7 +57,7 @@ def test_only_commits_that_landed_green_contribute(tmp_path: Path) -> None:
 
 
 def test_a_commit_whose_subject_merely_starts_with_revert_still_counts(tmp_path: Path) -> None:
-    """"Revert" in a subject line is prose, not evidence that anything was undone.
+    """ "Revert" in a subject line is prose, not evidence that anything was undone.
 
     "Revert to the previous retry policy" is a perfectly ordinary change, and
     dropping it costs the map the tests that landed with it. The trailer that


### PR DESCRIPTION
## Problem

The text-hygiene gate decides whether a deny-listed phrase needs a right-hand word boundary from the phrase's total length. A phrase that is long overall but ends in a short value therefore stays unbounded and matches the front of a longer, unrelated token.

That refused #4767. One of its commit messages names a TRACE reference relation; a six-character deny-list entry for an HTML profile-link attribute shares its first six characters, cleared the length test, and matched. The gate behaved exactly as written and the text was clean. There is no override, and branch protection blocks the force-push that rewording an existing commit would need.

## Change

The boundary is keyed on the phrase's trailing alphanumeric run and the separator in front of it:

| Phrase shape | Boundary | Effect |
|---|---|---|
| short run after a space or hyphen | left only | a word — suffixed forms still caught |
| short run after any other separator | both sides | a structured value — a longer value is a different value |
| long trailing run | left only | unchanged |

## Verification

- `pytest tests/unit/scripts/test_pr_text_hygiene.py` — 29 passed, including the existing suffixed-form tests that pin the behaviour this must not break
- Three new tests cover the trap, the standalone form the entry exists for, and the suffixed form that must keep matching
- Checked against the live deny-list: exactly the intended entries change behaviour, everything else is untouched
- Replayed against #4767's published commit messages with the real deny-list — the gate now passes

Closes #4771
