### PR TITLE
fix(pr-gen): describe uninformative WIP commits by what they changed

### DIFF
--- a/src/bernstein/core/integrations/pr_gen.py
+++ b/src/bernstein/core/integrations/pr_gen.py
@@ -1014,8 +1014,8 @@ def describe_commit(commit: CommitRecord) -> str:
         only = commit.files[0]
         return f"work in `{only.path}` (+{only.added} / -{only.removed})"
     scope = _scope_of([f.path for f in commit.files])
-    where = f"`{scope}`" if scope else "across the tree"
-    return f"work in {where} ({len(commit.files)} files, +{added} / -{removed})"
+    where = f"in `{scope}`" if scope else "across the tree"
+    return f"work {where} ({len(commit.files)} files, +{added} / -{removed})"
 
 
 def _format_commit_changes(commits: tuple[CommitRecord, ...]) -> str:

--- a/src/bernstein/core/integrations/pr_gen.py
+++ b/src/bernstein/core/integrations/pr_gen.py
@@ -44,7 +44,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping
+    from collections.abc import Iterable, Mapping, Sequence
 
     from bernstein.core.review.receipt import ReviewReceipt
 
@@ -76,6 +76,7 @@ __all__ = [
     "build_pr_body",
     "build_pr_title",
     "build_provenance",
+    "describe_commit",
     "dominant_commit",
     "is_housekeeping_commit",
     "load_session_summary",
@@ -151,6 +152,25 @@ _CC_SUBJECT_RE = re.compile(r"^(?P<type>[a-z]+)(?:\([^)]*\))?!?:\s", re.IGNORECA
 # Markers for a commit that was never meant to describe anything.
 _REBASE_MARKER_RE = re.compile(r"^\s*(?:fixup!|squash!|amend!)", re.IGNORECASE)
 _WIP_MARKER_RE = re.compile(r"^\s*(?:\[wip\]|wip\b)", re.IGNORECASE)
+
+# Subjects that provably say nothing about the change, so the renderer
+# describes the commit by what it touched instead of quoting them.
+#
+# The standing case is the fold-in commit an agent worktree writes,
+# ``[WIP] <session-id> partial work`` (agent_lifecycle.py). Its subject names
+# a session, not a change, and a squash merge copies the pull request body
+# onto the default branch — so the session identifier became the permanent
+# description of 71 commits on ``main`` in two weeks.
+#
+# Deliberately narrow. It matches that shape and a bare marker with nothing
+# after it, and nothing else: a WIP commit whose author wrote a real subject
+# still renders verbatim, because the subject is better than anything derived
+# from a diff. This is the rendering half only — ``is_housekeeping_commit``
+# still judges WIP commits by their churn (#4726), and this never consults it.
+_UNINFORMATIVE_SUBJECT_RE = re.compile(
+    r"^\s*(?:\[wip\]|wip)\s*(?::|-)?\s*(?:\S+\s+)?partial work\s*$|^\s*(?:\[wip\]|wip)\s*$",
+    re.IGNORECASE,
+)
 
 # The wording a repair commit uses whatever conventional-commit type it
 # claims. ``fix: resolve lint gate failures`` is typed ``fix`` and is still
@@ -950,6 +970,54 @@ def _format_file_lines(files: Iterable[FileChange]) -> list[str]:
     return lines
 
 
+def _scope_of(paths: Sequence[str]) -> str:
+    """The deepest directory every one of ``paths`` sits under.
+
+    ``""`` when they share nothing but the repository root, which reads
+    better as "across the tree" than as an empty backtick pair.
+    """
+    if not paths:
+        return ""
+    split = [p.split("/")[:-1] for p in paths]
+    common: list[str] = []
+    # strict=False is the point: paths sit at different depths, and the common
+    # scope ends at the shallowest one.
+    for parts in zip(*split, strict=False):
+        if len(set(parts)) != 1:
+            break
+        common.append(parts[0])
+    return "/".join(common)
+
+
+def describe_commit(commit: CommitRecord) -> str:
+    """How a commit is named in the rendered body.
+
+    Its subject, unless the subject provably says nothing about the change —
+    then what it actually touched: scope plus churn. A reader of ``git log``
+    on the default branch gets "the agents package, 3 files, +120 / -8"
+    instead of a session identifier and the word "partial".
+
+    Ranking is untouched: which commit names the pull request is
+    ``rank_commits``' decision and stays exactly as #4726 left it. This only
+    changes how the chosen commits are written down.
+    """
+    subject = commit.subject.strip()
+    if not _UNINFORMATIVE_SUBJECT_RE.match(subject):
+        return subject
+    if not commit.files:
+        # Nothing to describe it by. Say so rather than fall back to the
+        # subject, which is what leaked the session identifier.
+        return "checkpoint, no file changes"
+    added = sum(f.added for f in commit.files)
+    removed = sum(f.removed for f in commit.files)
+    if len(commit.files) == 1:
+        only = commit.files[0]
+        return f"work in `{only.path}` (+{only.added} / -{only.removed})"
+    scope = _scope_of([f.path for f in commit.files])
+    where = f"`{scope}`" if scope else "across the tree"
+    return f"work in {where} ({len(commit.files)} files, +{added} / -{removed})"
+
+
 def _format_commit_changes(commits: tuple[CommitRecord, ...]) -> str:
     """Render the Change section from the branch's commits.
 
@@ -974,19 +1042,19 @@ def _format_commit_changes(commits: tuple[CommitRecord, ...]) -> str:
     lines: list[str] = []
     if ranked:
         lead, *rest = ranked
-        lines.append(f"{lead.subject.strip()} (`{lead.short_sha}`)")
+        lines.append(f"{describe_commit(lead)} (`{lead.short_sha}`)")
         lines.append("")
         lines.extend(_format_file_lines(lead.files))
         if rest:
             lines.append("")
             lines.append("Also in this branch:")
-            lines.extend(f"- {commit.subject.strip()} (`{commit.short_sha}`)" for commit in rest)
+            lines.extend(f"- {describe_commit(commit)} (`{commit.short_sha}`)" for commit in rest)
 
     if housekeeping:
         if lines:
             lines.append("")
         lines.append("Housekeeping, not what this pull request is about:")
-        lines.extend(f"- {commit.subject.strip()} (`{commit.short_sha}`)" for commit in housekeeping)
+        lines.extend(f"- {describe_commit(commit)} (`{commit.short_sha}`)" for commit in housekeeping)
 
     return "\n".join(lines)
 

--- a/tests/unit/test_pr_description_from_change.py
+++ b/tests/unit/test_pr_description_from_change.py
@@ -687,7 +687,7 @@ def test_files_sharing_no_directory_are_described_as_across_the_tree() -> None:
         "[WIP] backend-5 partial work",
         [("src/a.py", 3, 1), ("docs/b.md", 2, 0)],
     )
-    assert describe_commit(spread) == "work in across the tree (2 files, +5 / -1)"
+    assert describe_commit(spread) == "work across the tree (2 files, +5 / -1)"
 
 
 def test_the_rendered_body_never_carries_a_session_identifier() -> None:

--- a/tests/unit/test_pr_description_from_change.py
+++ b/tests/unit/test_pr_description_from_change.py
@@ -35,6 +35,7 @@ from bernstein.core.integrations.pr_gen import (
     build_pr_body,
     build_pr_title,
     build_provenance,
+    describe_commit,
     dominant_commit,
     is_housekeeping_commit,
     load_session_summary,
@@ -627,3 +628,80 @@ def test_rebase_markers_are_housekeeping_whatever_they_touch() -> None:
     )
 
     assert is_housekeeping_commit(fixup) is True
+
+
+# ---------------------------------------------------------------------------
+# Uninformative subjects are described, not quoted (#4766)
+# ---------------------------------------------------------------------------
+
+WIP_FOLD_IN_COMMIT = _commit(
+    "dddddddddddd",
+    "[WIP] backend-3c1d21a5 partial work",
+    [
+        ("src/bernstein/core/agents/agent_lifecycle.py", 100, 5),
+        ("src/bernstein/core/agents/in_process_agent.py", 20, 3),
+    ],
+)
+WIP_BUT_DESCRIPTIVE_COMMIT = _commit(
+    "eeeeeeeeeeee",
+    "[WIP] rework the lease reaper's expiry sweep",
+    [("src/bernstein/core/agents/reaper.py", 40, 10)],
+)
+
+
+def test_an_uninformative_wip_subject_renders_as_what_it_changed() -> None:
+    """A squash merge copies the body onto main, so the session id became the
+    permanent description of the change. Describe the diff instead."""
+    rendered = describe_commit(WIP_FOLD_IN_COMMIT)
+    assert "backend-3c1d21a5" not in rendered
+    assert "partial work" not in rendered
+    assert "src/bernstein/core/agents" in rendered
+    assert "+120 / -8" in rendered
+
+
+def test_a_wip_commit_with_a_real_subject_renders_unchanged() -> None:
+    """The author's own words beat anything derived from a diff."""
+    assert describe_commit(WIP_BUT_DESCRIPTIVE_COMMIT) == "[WIP] rework the lease reaper's expiry sweep"
+
+
+def test_a_descriptive_subject_renders_unchanged() -> None:
+    assert describe_commit(FEATURE_COMMIT) == FEATURE_COMMIT.subject
+
+
+def test_a_single_file_uninformative_commit_names_the_file() -> None:
+    one = _commit("ffffffffffff", "[WIP] qa-9 partial work", [("src/bernstein/core/x.py", 7, 2)])
+    assert describe_commit(one) == "work in `src/bernstein/core/x.py` (+7 / -2)"
+
+
+def test_an_uninformative_commit_touching_nothing_says_so() -> None:
+    """Falling back to the subject here is what leaked the identifier."""
+    empty = _commit("111111111111", "[WIP] backend-77 partial work")
+    rendered = describe_commit(empty)
+    assert "backend-77" not in rendered
+    assert rendered == "checkpoint, no file changes"
+
+
+def test_files_sharing_no_directory_are_described_as_across_the_tree() -> None:
+    spread = _commit(
+        "222222222222",
+        "[WIP] backend-5 partial work",
+        [("src/a.py", 3, 1), ("docs/b.md", 2, 0)],
+    )
+    assert describe_commit(spread) == "work in across the tree (2 files, +5 / -1)"
+
+
+def test_the_rendered_body_never_carries_a_session_identifier() -> None:
+    """The end-to-end shape from the issue: a branch carrying both kinds."""
+    body = build_pr_body(_summary(commits=(WIP_FOLD_IN_COMMIT, WIP_BUT_DESCRIPTIVE_COMMIT)))
+    assert "backend-3c1d21a5" not in body
+    assert "partial work" not in body
+    # The descriptive one survives verbatim in the same body.
+    assert "rework the lease reaper's expiry sweep" in body
+
+
+def test_ranking_is_untouched_by_the_rendering_change() -> None:
+    """#4726's behaviour still holds: a WIP commit with src/ churn is
+    eligible to name the pull request, and outranks a smaller one."""
+    assert not is_housekeeping_commit(WIP_FOLD_IN_COMMIT)
+    ranked = rank_commits((WIP_BUT_DESCRIPTIVE_COMMIT, WIP_FOLD_IN_COMMIT))
+    assert ranked[0] is WIP_FOLD_IN_COMMIT


### PR DESCRIPTION
Fixes #4766.

## The change

Where a commit's subject provably says nothing about the change, the Change table renders what it actually touched instead of quoting the subject:

| commit | before | after |
| --- | --- | --- |
| two files under one package | `[WIP] backend-3c1d21a5 partial work` | ``work in `src/bernstein/core/agents` (2 files, +120 / -8)`` |
| one file | `[WIP] qa-9 partial work` | ``work in `src/bernstein/core/x.py` (+7 / -2)`` |
| files sharing no directory | `[WIP] backend-5 partial work` | `work in across the tree (2 files, +5 / -1)` |
| no files at all | `[WIP] backend-77 partial work` | `checkpoint, no file changes` |
| a WIP commit with a real subject | `[WIP] rework the lease reaper's expiry sweep` | *unchanged* |

The empty-files case matters more than it looks: falling back to the subject there is exactly what leaked the identifier, so it says what it knows instead.

## Two deliberate narrownesses

**The match, not the marker.** `_UNINFORMATIVE_SUBJECT_RE` matches the generated shape and a bare marker with nothing after it — it does not reuse `_WIP_MARKER_RE`. A WIP commit whose author wrote a real subject renders verbatim, because their words beat anything derived from a diff.

**Ranking is untouched.** `is_housekeeping_commit` still judges a WIP commit by its `src/` churn exactly as #4726 left it, and `describe_commit` never consults it. `test_ranking_is_untouched_by_the_rendering_change` pins both halves: the fold-in commit is still not housekeeping, and it still outranks a smaller descriptive commit for naming the PR.

`agent_lifecycle.py` is not touched — the internal subject stays useful in the worktree, and existing history is left alone.

## Against the acceptance list

- [x] uninformative shape renders by what it changed; the session identifier does not appear
- [x] a WIP commit with a descriptive subject renders unchanged
- [x] ranking and housekeeping classification untouched, with a test asserting #4726 still holds
- [x] a test builds a body from a range containing **both** shapes and asserts the output — `test_the_rendered_body_never_carries_a_session_identifier` checks the identifier is gone *and* that the descriptive subject survives in the same body
- [x] no change to the subject `agent_lifecycle.py` writes

## Verification

Eight tests added to `tests/unit/test_pr_description_from_change.py`. To check they test the behaviour rather than the existence of a function, I stubbed `describe_commit` back to `return subject` — the five behavioural ones fail, and the three "renders unchanged" guards stay green, which is the split you want.

- `test_pr_description_from_change.py` — 64 passed
- `test_pr_gen.py` + `test_pr_goal_and_run_identity.py` — 32 passed
- `ruff check` and `ruff format --check` clean

One note on `_scope_of`: the `zip(..., strict=False)` is load-bearing rather than a lint appeasement — paths sit at different depths and the common scope has to end at the shallowest one.
