### PR TITLE
feat(lineage): verify a run-graph receipt by re-deriving it

### DIFF
--- a/docs/release-notes/fragments/3760-verify-run-graph-receipt.md
+++ b/docs/release-notes/fragments/3760-verify-run-graph-receipt.md
@@ -1,0 +1,3 @@
+## A sealed run-graph receipt can be checked against the tree it sealed
+
+`verify_run_graph_receipt` rebuilds a fan-out's graph from the worktrees and walks every branch's lineage spine, then compares the result with the sealed receipt rather than replaying the receipt's own stored hashes. An edited receipt, a branch whose journal was altered, a missing branch, and a receipt with no spine anchor are each refused by name (#3760).

--- a/src/bernstein/core/lineage/run_graph.py
+++ b/src/bernstein/core/lineage/run_graph.py
@@ -321,13 +321,24 @@ def build_run_graph_receipt(
         kid="bernstein.run_graph",
     )
 
-    # Write signed receipt JSON under .sdd/run-graph/
+    # Write signed receipt JSON under .sdd/run-graph/, carrying the anchor.
+    # The anchor is what ties the file to the spine entry covering it; a file
+    # written from ``sealed_no_anchor`` carries an empty one, and a reader
+    # then has no way to find the entry that seals it.
+    anchored = RunGraphReceipt(
+        schema_version=sealed_no_anchor.schema_version,
+        graph_root_hash=sealed_no_anchor.graph_root_hash,
+        node_hashes=sealed_no_anchor.node_hashes,
+        timestamp=sealed_no_anchor.timestamp,
+        receipt_hash=receipt_hash,
+        journal_entry_hash=anchor,
+    )
     receipt_dir = workdir / ".sdd" / "run-graph"
     receipt_dir.mkdir(parents=True, exist_ok=True)
     receipt_path = receipt_dir / f"{receipt_hash}.json"
     receipt_path.write_text(
         json.dumps(
-            {**sealed_no_anchor.to_dict(), "signed_jws": signed_jws},
+            {**anchored.to_dict(), "signed_jws": signed_jws},
             ensure_ascii=False,
             separators=(",", ":"),
             sort_keys=True,
@@ -372,6 +383,193 @@ def _node_hash(node: RunGraphNode) -> str:
         "status": node.status.value,
     }
     return _hash_obj(payload)
+
+
+@dataclass(frozen=True, slots=True)
+class RunGraphVerifyResult:
+    """The outcome of checking one sealed receipt against the tree it claims.
+
+    Attributes:
+        ok: True only when every check below passed.
+        status: ``verified``, or which check refused: ``unreadable``,
+            ``empty``, ``tampered``, ``diverged``, ``unanchored``.
+        reason: One sentence naming what failed, and where. For a divergence
+            this names the branch, because "the graph changed" is not
+            actionable and "session X's head moved" is.
+        receipt: The receipt as read, or ``None`` when it could not be parsed.
+    """
+
+    ok: bool
+    status: str
+    reason: str
+    receipt: RunGraphReceipt | None = None
+
+
+def verify_run_graph_receipt(
+    *,
+    receipt_path: Path,
+    repo_root: Path,
+    run_ids: Mapping[str, str],
+    lineage_root: Path,
+    hmac_key: bytes,
+    public_key_pem: bytes,
+    head_sha_resolver: Callable[[Path], str | None] = _git_head_sha,
+) -> RunGraphVerifyResult:
+    """Check a sealed receipt by rebuilding what it claims, not by reading it.
+
+    A receipt that only replays its own stored fields proves nothing: every
+    hash inside it was written by the same pass that wrote the fields, so a
+    hand-edited receipt whose internals agree with each other passes such a
+    check. The sibling patterns in this package re-derive for that reason --
+    :meth:`LineageSpine.verify` walks the chain rather than trusting a cached
+    head -- and this does the same for a fan-out.
+
+    Five checks, in cost order so a cheap refusal never pays for an expensive
+    one, each fail-closed:
+
+    1. The receipt parses, and carries a signature.
+    2. It covers at least one branch. An empty fan-out is refused rather than
+       passing on nothing to disagree with.
+    3. ``receipt_hash`` recomputes from the body.
+    4. The detached JWS verifies over the canonical bytes.
+    5. The graph is rebuilt from the worktrees and the spines, and its root
+       hash and per-node hashes must equal the sealed ones.
+    6. The spine entry named by ``journal_entry_hash`` exists and covers those
+       same canonical bytes.
+
+    Checks 3 and 4 catch an edited receipt; check 5 is the one that catches an
+    edited *tree* -- a flipped byte in a branch's spine moves that branch's
+    head, so the rebuilt node hash stops matching and the branch is named.
+
+    Args:
+        receipt_path: The ``.sdd/run-graph/<hash>.json`` file to check.
+        repo_root: Repository root whose worktrees are re-classified.
+        run_ids: ``session_id -> run_id``, as passed when the graph was built.
+        lineage_root: Root under which the spines live.
+        hmac_key: Key the spines were written with.
+        public_key_pem: SPKI PEM of the Ed25519 public key that sealed it.
+        head_sha_resolver: Injection point for the git head lookup.
+
+    Returns:
+        A :class:`RunGraphVerifyResult`; ``ok`` is true only for ``verified``.
+    """
+    from bernstein.core.security.agent_card_signer import verify_detached_jws_over_canonical
+
+    try:
+        raw = json.loads(receipt_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        return RunGraphVerifyResult(
+            ok=False, status="unreadable", reason=f"receipt at {receipt_path} could not be read: {exc}"
+        )
+    if not isinstance(raw, dict):
+        return RunGraphVerifyResult(ok=False, status="unreadable", reason="receipt is not a JSON object")
+    signed_jws = raw.get("signed_jws")
+    if not isinstance(signed_jws, str) or not signed_jws:
+        return RunGraphVerifyResult(ok=False, status="unreadable", reason="receipt carries no signature")
+    try:
+        receipt = RunGraphReceipt.from_dict(raw)
+    except (KeyError, TypeError, ValueError) as exc:
+        return RunGraphVerifyResult(ok=False, status="unreadable", reason=f"receipt fields are malformed: {exc}")
+
+    # An empty fan-out has nothing to disagree with, so every check below would
+    # pass on it. Refuse instead: sealing zero branches is a defect at the
+    # sealing end, and reporting it as verified hides that.
+    if not receipt.node_hashes:
+        return RunGraphVerifyResult(ok=False, status="empty", reason="receipt seals no branches", receipt=receipt)
+
+    stored_hash = receipt.receipt_hash
+    if _hash_obj(receipt.body()) != stored_hash:
+        return RunGraphVerifyResult(
+            ok=False, status="tampered", reason="receipt_hash does not match the body it covers", receipt=receipt
+        )
+    if not verify_detached_jws_over_canonical(
+        canonical_body=receipt.canonical_bytes(),
+        detached_jws=signed_jws,
+        public_key_pem=public_key_pem,
+        expected_typ="run-graph-receipt+jws",
+    ):
+        return RunGraphVerifyResult(
+            ok=False, status="tampered", reason="signature does not verify over the receipt body", receipt=receipt
+        )
+
+    rederived = build_run_graph(
+        repo_root,
+        run_ids=run_ids,
+        lineage_root=lineage_root,
+        hmac_key=hmac_key,
+        head_sha_resolver=head_sha_resolver,
+    )
+    rederived_hashes = tuple(_node_hash(node) for node in rederived.nodes)
+    if rederived_hashes != receipt.node_hashes:
+        return RunGraphVerifyResult(
+            ok=False, status="diverged", reason=_diverged_reason(receipt, rederived, rederived_hashes), receipt=receipt
+        )
+    # A node hash carries the spine's *stored* head, so a branch whose journal
+    # was edited underneath it still hashes the same: the head file is not
+    # rewritten by an edit to the rows. Only walking the chain sees that, which
+    # is why this is a separate check and not folded into the comparison above.
+    for node in rederived.nodes:
+        if node.run_id is None:
+            continue
+        branch = LineageSpine(lineage_root, run_id=node.run_id, hmac_key=hmac_key)
+        if not branch.verify().ok:
+            return RunGraphVerifyResult(
+                ok=False,
+                status="diverged",
+                reason=f"branch {node.session_id} has a spine that no longer verifies",
+                receipt=receipt,
+            )
+
+    if rederived.root_hash != receipt.graph_root_hash:
+        # Every node agreed and the root did not, so the root covers something
+        # the nodes do not -- ordering. Worth its own sentence rather than
+        # being folded into the node message, which would misdescribe it.
+        return RunGraphVerifyResult(
+            ok=False,
+            status="diverged",
+            reason="every branch matches but the graph root does not; the sealed branch order differs",
+            receipt=receipt,
+        )
+
+    spine = LineageSpine(lineage_root, run_id=RUN_GRAPH_RUN_ID, hmac_key=hmac_key)
+    expected_content = content_hash_of(receipt.canonical_bytes())
+    anchored = any(
+        entry.entry_hash == receipt.journal_entry_hash and entry.content_hash == expected_content
+        for entry in spine.iter_entries()
+    )
+    if not anchored:
+        return RunGraphVerifyResult(
+            ok=False,
+            status="unanchored",
+            reason=f"no entry in the {RUN_GRAPH_RUN_ID} spine anchors this receipt",
+            receipt=receipt,
+        )
+
+    return RunGraphVerifyResult(
+        ok=True,
+        status="verified",
+        reason=f"{len(receipt.node_hashes)} branch(es) re-derived and matched",
+        receipt=receipt,
+    )
+
+
+def _diverged_reason(
+    receipt: RunGraphReceipt,
+    rederived: RunGraph,
+    rederived_hashes: tuple[str, ...],
+) -> str:
+    """Name the branch that moved, rather than reporting that something did.
+
+    The sealed side carries hashes, not nodes, so the session id has to come
+    from the re-derived side. When the counts differ there is no pairing to
+    read a name out of, and the count itself is the finding.
+    """
+    if len(rederived_hashes) != len(receipt.node_hashes):
+        return f"receipt seals {len(receipt.node_hashes)} branch(es), the tree now has {len(rederived_hashes)}"
+    for index, (sealed, current) in enumerate(zip(receipt.node_hashes, rederived_hashes, strict=True)):
+        if sealed != current:
+            return f"branch {rederived.nodes[index].session_id} no longer matches the sealed receipt"
+    return "branch hashes differ from the sealed receipt"
 
 
 def _record_run_graph_receipt(
@@ -421,9 +619,11 @@ __all__ = [
     "RunGraphNodeStatus",
     "RunGraphReceipt",
     "RunGraphReceiptSchema",
+    "RunGraphVerifyResult",
     "_node_hash",
     "_record_run_graph_receipt",
     "build_run_graph",
     "build_run_graph_receipt",
     "compute_root_hash",
+    "verify_run_graph_receipt",
 ]

--- a/tests/unit/lineage/test_run_graph_receipt.py
+++ b/tests/unit/lineage/test_run_graph_receipt.py
@@ -21,9 +21,11 @@ from bernstein.core.lineage.run_graph import (
     RunGraphNode,
     RunGraphNodeStatus,
     RunGraphReceipt,
+    RunGraphVerifyResult,
     _node_hash,
     build_run_graph,
     build_run_graph_receipt,
+    verify_run_graph_receipt,
 )
 from bernstein.core.security.agent_card_signer import generate_ed25519_keypair
 from bernstein.core.security.audit_chain import (
@@ -515,3 +517,243 @@ def test_run_graph_receipt_has_correct_run_id_constant() -> None:
     """Test RUN_GRAPH_RUN_ID constant exists and has expected value."""
     assert RUN_GRAPH_RUN_ID == "run-graph"
     assert RUN_GRAPH_RUN_ID != "eval-gate"  # Different from gate receipts
+
+
+# ---------------------------------------------------------------------------
+# verify_run_graph_receipt (#3760)
+# ---------------------------------------------------------------------------
+#
+# A receipt that only replays its own stored fields proves nothing: every hash
+# inside it was written by the pass that wrote the fields. These tests damage
+# the tree and the receipt in turn, and assert the verifier notices -- which is
+# the only way to tell re-derivation from a self-consistency check.
+
+
+def _seal(
+    repo_root: Path,
+    lineage_root: Path,
+    private_key_pem: bytes,
+    *,
+    sessions: tuple[str, ...] = SESSIONS,
+) -> tuple[RunGraphReceipt, Path]:
+    """Seal the fan-out and return the receipt with its on-disk path."""
+    graph = build_run_graph(
+        repo_root,
+        run_ids={s: RUN_IDS[s] for s in sessions},
+        lineage_root=lineage_root,
+        hmac_key=HMAC_KEY,
+        head_sha_resolver=lambda p: HEAD_SHAS.get(p.name),
+    )
+    receipt = build_run_graph_receipt(
+        graph=graph,
+        workdir=repo_root,
+        lineage_root=lineage_root,
+        hmac_key=HMAC_KEY,
+        timestamp=TIMESTAMP,
+        private_key_pem=private_key_pem,
+        chain=None,
+    )
+    return receipt, repo_root / ".sdd" / "run-graph" / f"{receipt.receipt_hash}.json"
+
+
+def _verify(path: Path, repo_root: Path, lineage_root: Path, public_key_pem: bytes) -> RunGraphVerifyResult:
+    return verify_run_graph_receipt(
+        receipt_path=path,
+        repo_root=repo_root,
+        run_ids=dict(RUN_IDS),
+        lineage_root=lineage_root,
+        hmac_key=HMAC_KEY,
+        public_key_pem=public_key_pem,
+        head_sha_resolver=lambda p: HEAD_SHAS.get(p.name),
+    )
+
+
+@pytest.fixture
+def keypair() -> tuple[bytes, bytes]:
+    private, public = generate_ed25519_keypair()
+    return private, public
+
+
+def test_a_sealed_receipt_verifies_against_the_tree_it_sealed(
+    fanout: tuple[Path, Path], keypair: tuple[bytes, bytes]
+) -> None:
+    repo_root, lineage_root = fanout
+    private, public = keypair
+    _receipt, path = _seal(repo_root, lineage_root, private)
+
+    result = _verify(path, repo_root, lineage_root, public)
+
+    assert result.ok is True
+    assert result.status == "verified"
+    assert "3 branch" in result.reason
+
+
+def test_a_flipped_byte_in_a_branch_spine_names_that_branch(
+    fanout: tuple[Path, Path], keypair: tuple[bytes, bytes]
+) -> None:
+    """The assertion #3760 exists for: damage the tree, not the receipt.
+
+    Nothing inside the receipt changes here. Only re-derivation can see it,
+    and the message has to name the branch or an operator has N places to look.
+    """
+    repo_root, lineage_root = fanout
+    private, public = keypair
+    _receipt, path = _seal(repo_root, lineage_root, private)
+
+    spine_file = next((lineage_root / RUN_IDS["sess-beta"]).rglob("*.jsonl"))
+    raw = spine_file.read_bytes()
+    assert b'"actor":"tester"' in raw
+    spine_file.write_bytes(raw.replace(b'"actor":"tester"', b'"actor":"testeR"'))
+
+    result = _verify(path, repo_root, lineage_root, public)
+
+    assert result.ok is False
+    assert result.status == "diverged"
+    assert "sess-beta" in result.reason
+
+
+def test_a_branch_that_disappeared_is_reported_as_a_count(
+    fanout: tuple[Path, Path], keypair: tuple[bytes, bytes]
+) -> None:
+    """With a branch gone there is no pairing to read a name out of."""
+    repo_root, lineage_root = fanout
+    private, public = keypair
+    _receipt, path = _seal(repo_root, lineage_root, private)
+
+    import shutil
+
+    shutil.rmtree(repo_root / ".sdd" / "runtime" / "worktrees" / "sess-gamma")
+
+    result = _verify(path, repo_root, lineage_root, public)
+
+    assert result.ok is False
+    assert result.status == "diverged"
+    assert "3 branch(es)" in result.reason
+    assert "2" in result.reason
+
+
+def test_an_edited_receipt_body_fails_before_any_re_derivation(
+    fanout: tuple[Path, Path], keypair: tuple[bytes, bytes]
+) -> None:
+    repo_root, lineage_root = fanout
+    private, public = keypair
+    _receipt, path = _seal(repo_root, lineage_root, private)
+
+    data = json.loads(path.read_text())
+    data["timestamp"] = TIMESTAMP + 1
+    path.write_text(json.dumps(data))
+
+    result = _verify(path, repo_root, lineage_root, public)
+
+    assert result.ok is False
+    assert result.status == "tampered"
+    assert "receipt_hash" in result.reason
+
+
+def test_a_receipt_signed_by_another_key_is_refused(fanout: tuple[Path, Path], keypair: tuple[bytes, bytes]) -> None:
+    """The body is intact and self-consistent; only the signer is wrong."""
+    repo_root, lineage_root = fanout
+    private, _public = keypair
+    _receipt, path = _seal(repo_root, lineage_root, private)
+    _other_private, other_public = generate_ed25519_keypair()
+
+    result = _verify(path, repo_root, lineage_root, other_public)
+
+    assert result.ok is False
+    assert result.status == "tampered"
+    assert "signature" in result.reason
+
+
+def test_a_receipt_stripped_of_its_signature_is_refused(
+    fanout: tuple[Path, Path], keypair: tuple[bytes, bytes]
+) -> None:
+    """Absent evidence must not read as satisfied evidence."""
+    repo_root, lineage_root = fanout
+    private, public = keypair
+    _receipt, path = _seal(repo_root, lineage_root, private)
+
+    data = json.loads(path.read_text())
+    del data["signed_jws"]
+    path.write_text(json.dumps(data))
+
+    result = _verify(path, repo_root, lineage_root, public)
+
+    assert result.ok is False
+    assert result.status == "unreadable"
+
+
+def test_an_empty_fan_out_is_refused_rather_than_passing_on_nothing(
+    tmp_path: Path, keypair: tuple[bytes, bytes]
+) -> None:
+    """Zero branches means zero disagreements, which is not the same as agreement."""
+    private, public = keypair
+    repo_root = tmp_path / "repo"
+    (repo_root / ".sdd" / "runtime" / "worktrees").mkdir(parents=True)
+    lineage_root = tmp_path / "lineage"
+
+    graph = build_run_graph(
+        repo_root,
+        run_ids={},
+        lineage_root=lineage_root,
+        hmac_key=HMAC_KEY,
+        head_sha_resolver=lambda p: None,
+    )
+    assert graph.nodes == ()
+    receipt = build_run_graph_receipt(
+        graph=graph,
+        workdir=repo_root,
+        lineage_root=lineage_root,
+        hmac_key=HMAC_KEY,
+        timestamp=TIMESTAMP,
+        private_key_pem=private,
+        chain=None,
+    )
+    path = repo_root / ".sdd" / "run-graph" / f"{receipt.receipt_hash}.json"
+
+    result = verify_run_graph_receipt(
+        receipt_path=path,
+        repo_root=repo_root,
+        run_ids={},
+        lineage_root=lineage_root,
+        hmac_key=HMAC_KEY,
+        public_key_pem=public,
+        head_sha_resolver=lambda p: None,
+    )
+
+    assert result.ok is False
+    assert result.status == "empty"
+
+
+def test_a_receipt_whose_spine_anchor_is_gone_is_refused(
+    fanout: tuple[Path, Path], keypair: tuple[bytes, bytes]
+) -> None:
+    """The receipt and the tree agree; only the anchor binding them is missing."""
+    repo_root, lineage_root = fanout
+    private, public = keypair
+    _receipt, path = _seal(repo_root, lineage_root, private)
+
+    anchor_spine = next((lineage_root / RUN_GRAPH_RUN_ID).rglob("*.jsonl"))
+    anchor_spine.write_bytes(b"")
+
+    result = _verify(path, repo_root, lineage_root, public)
+
+    assert result.ok is False
+    assert result.status == "unanchored"
+
+
+def test_an_unreadable_receipt_is_refused_rather_than_skipped(tmp_path: Path, keypair: tuple[bytes, bytes]) -> None:
+    _private, public = keypair
+    missing = tmp_path / "nope.json"
+
+    result = verify_run_graph_receipt(
+        receipt_path=missing,
+        repo_root=tmp_path,
+        run_ids={},
+        lineage_root=tmp_path / "lineage",
+        hmac_key=HMAC_KEY,
+        public_key_pem=public,
+    )
+
+    assert result.ok is False
+    assert result.status == "unreadable"
+    assert result.receipt is None


### PR DESCRIPTION
Closes #3760.

## Problem

A sealed run-graph receipt had nothing that checked it. Reading it back and confirming its fields agree with each other proves nothing: every hash inside it was written by the same pass that wrote the fields, so a hand-edited receipt whose internals are self-consistent passes such a check. The sibling patterns in this area re-derive for exactly that reason — `verify_verdict_receipt` recomputes the verdict from the embedded evidence, and `LineageSpine.verify` walks the chain instead of trusting a cached head.

## Change

`verify_run_graph_receipt` rebuilds the graph from the worktrees and the spines and compares that with what was sealed. Six checks, in cost order so a cheap refusal never pays for an expensive one, each fail-closed:

| # | Check | What it catches |
| --- | --- | --- |
| 1 | The receipt parses and carries a signature | A truncated or unsigned file, refused rather than skipped |
| 2 | It seals at least one branch | An empty fan-out, which has nothing to disagree with and would otherwise pass on that |
| 3 | `receipt_hash` recomputes from the body | An edited body |
| 4 | The detached JWS verifies | A body re-hashed after editing, or one signed by another key |
| 5 | Rebuilt node hashes and root match | A branch whose head moved, named individually |
| 6 | The spine entry named by the anchor covers the same bytes | A receipt with no anchoring entry behind it |

Checks 3 and 4 catch an edited *receipt*. Check 5 is the one that catches an edited *tree*.

**Walking each branch's spine is a separate step, not part of check 5.** A node hash carries the spine's stored head, and editing the journal rows does not rewrite that head — so a tampered branch still hashes the same and the comparison sees nothing. Only the walk sees it. This is the one thing here that would have been easy to write, easy to review, and wrong.

## The decision the issue left open

The issue asks what a diverged head sha is checked against when a fan-out's worktrees have been reaped, and names the two options: fail closed for that branch, or verify from the spine alone and let the receipt's recorded head stand unchecked.

**Fail closed.** From the filesystem, a worktree removed by routine cleanup and a worktree removed to hide what it contained are the same observation. Verifying from the spine alone would mean the head sha — one of the three things the root hash commits to — is never checked against anything, which is the trust this slice exists to remove. A receipt that says "verified" while a third of its content was taken on faith is worse than one that says it cannot tell.

The operational cost is real and worth naming: **a receipt stops verifying once its worktrees are reaped.** Verification belongs before cleanup, or cleanup has to keep enough to re-derive from. That is a scheduling decision for the janitor slice rather than something to paper over here.

The refusal reports it as a count (`receipt seals 3 branch(es), the tree now has 2`) rather than naming the missing branch, because the sealed side stores hashes and not session ids — there is no name to recover from a hash that no longer has a match.

## Also in this branch

`build_run_graph_receipt` wrote the on-disk receipt from the pre-anchor value, so the file carried `journal_entry_hash: ""` while the returned object carried the real anchor. A reader holding only the file had no way to find the spine entry sealing it, which made check 6 impossible against the artifact rather than against the return value. The file is now written from the anchored receipt. `test_a_sealed_receipt_verifies_against_the_tree_it_sealed` fails without this.

## Verification

Nine tests in `tests/unit/lineage/test_run_graph_receipt.py`, each named for the property it protects rather than for the function it calls. To confirm they test behaviour rather than the existence of a function, I removed each fix in turn:

- with the spine walk stubbed to `if False:` — `test_a_flipped_byte_in_a_branch_spine_names_that_branch` fails.
- with the anchor written back as `""` — `test_a_sealed_receipt_verifies_against_the_tree_it_sealed` fails.
- both removed — 2 failed, 24 passed.

Full runs on this branch:

- `tests/unit/lineage/` — 633 passed, 1 xfailed.
- `uv run mypy --config-file mypy.gate.ini` — no issues in 85 source files.
- `uv run ruff check` and `ruff format --check` — clean.

## Not in this branch

Per the issue's non-goals: no CLI surface and no janitor wiring. Those are slice 4 (#3761), which is now unblocked.
