### PR TITLE
feat(lineage): render a sealed fan-out and sweep it for tampering

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -1313,9 +1313,18 @@ bernstein completions --shell zsh > ~/.zsh/completion/_bernstein
 | `clone` | Clone all missing repos defined in the workspace. |
 | `validate` | Check workspace health: all repos exist and are valid git checkouts. |
 
-For worktree lifecycle (inspection / reaping) use `bernstein worktrees list` / `bernstein worktrees gc`.
+For worktree lifecycle (inspection / reaping) use the `bernstein worktrees` group below.
 
-#### `bernstein worktrees graph`
+#### `bernstein worktrees`
+
+| Subcommand | Purpose |
+|---|---|
+| `list` | Tabular dump of every worktree, with its classified state. |
+| `gc` | Reap orphan worktrees. `--dry` to preview, `--yes` to skip the prompt. |
+| `unlock` | Release a stale GC lock left by an interrupted run. |
+| `graph` | Render one fan-out's sealed run graph, branch by branch (below). |
+
+##### `bernstein worktrees graph`
 
 Render one fan-out's sealed run graph, branch by branch, from the receipt under `.sdd/run-graph/`.
 

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -1315,6 +1315,22 @@ bernstein completions --shell zsh > ~/.zsh/completion/_bernstein
 
 For worktree lifecycle (inspection / reaping) use `bernstein worktrees list` / `bernstein worktrees gc`.
 
+#### `bernstein worktrees graph`
+
+Render one fan-out's sealed run graph, branch by branch, from the receipt under `.sdd/run-graph/`.
+
+| Argument / flag | Purpose |
+|---|---|
+| `FANOUT_ID` | The receipt hash, or any unique prefix of it. An ambiguous prefix lists its candidates rather than choosing one. |
+| `--run-id SESSION=RUN` | Pair a branch's session id with the run whose spine recorded it. Repeatable. |
+| `--verify` | Re-derive the whole receipt and report the verdict. Needs `--public-key`. |
+| `--json` | Emit the signed receipt verbatim and nothing else. |
+| `--public-key FILE` | PEM public key the receipt was signed with. |
+| `--workdir DIRECTORY` | Project root holding `.sdd` (default: the current directory). |
+
+Exits non-zero when a branch's spine no longer verifies, or when `--verify` refuses the receipt.
+A branch with no `--run-id` is reported as unresolved, not as failing: it was not checked, so it did not fail.
+
 #### `bernstein session`
 
 | Subcommand | Purpose |

--- a/docs/release-notes/fragments/3761-run-graph-cli-and-sweep.md
+++ b/docs/release-notes/fragments/3761-run-graph-cli-and-sweep.md
@@ -1,0 +1,3 @@
+## A sealed fan-out can be read on the command line, and the tamper sweep now covers one
+
+`bernstein worktrees graph <fanout-id>` renders every branch of a sealed fan-out with its verify status, `--verify` re-derives the whole receipt, and `--json` emits the signed artifact verbatim. `verify_lineage_chains` gained the matching coverage: a tampered branch inside a fan-out now trips the same `lineage_tamper_detected` event and `bernstein_lineage_tamper_total` counter that a tampered single-run spine already did. A fan-out whose worktrees have been reaped, or whose branches have no run id supplied, is reported as not checked rather than as tampered (#3761).

--- a/src/bernstein/cli/commands/run_graph_cmd.py
+++ b/src/bernstein/cli/commands/run_graph_cmd.py
@@ -1,0 +1,236 @@
+"""``bernstein worktrees graph`` - show one fan-out's sealed run graph.
+
+A fan-out's branches are sealed into a single receipt under
+``.sdd/run-graph/``, but until now nothing rendered one: an operator holding a
+receipt hash had a file of hashes and no way to see which branches it covers
+or whether they still agree with it.
+
+Three things this command is careful about, because each has a wrong answer
+that looks like a right one:
+
+* **A fan-out is named by its receipt hash.** There is no separate id to
+  invent - the receipt is content-addressed and its hash *is* the fan-out's
+  identity, so a hand-edited fan-out is a different fan-out and says so. A
+  unique prefix is accepted the way git accepts a short sha; an ambiguous one
+  names its candidates instead of picking the first.
+
+* **A missing input is not a failing branch.** A branch with no ``run_id`` in
+  the supplied mapping cannot be paired with a spine, so nothing can be said
+  about it. It renders as *unresolved*, never as failing, and it does not set
+  the exit status. Reporting "cannot check" as "failed" would train an
+  operator to ignore the one line that matters.
+
+* **The receipt does not name its own branches.** It seals opaque node
+  hashes, so the branch names have to come from re-deriving the graph off the
+  tree. That is also what makes the rendering meaningful: what you see is the
+  tree as it is now, checked against what was sealed, not a replay of the
+  receipt's own fields.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+from rich.tree import Tree
+
+from bernstein.cli.helpers import console
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from bernstein.core.lineage.run_graph import RunGraph
+
+__all__ = ["parse_run_ids", "resolve_receipt_path", "run_graph_cmd"]
+
+#: Where ``build_run_graph_receipt`` writes each sealed fan-out.
+RECEIPT_RELDIR = Path(".sdd") / "run-graph"
+
+_HASH_PREFIX = "sha256:"
+
+
+def _load_hmac_key() -> bytes:
+    from bernstein.core.security.audit import load_or_create_audit_key
+
+    return load_or_create_audit_key()
+
+
+def parse_run_ids(pairs: tuple[str, ...]) -> dict[str, str]:
+    """Turn repeated ``SESSION=RUN`` options into the mapping the graph needs."""
+    mapping: dict[str, str] = {}
+    for pair in pairs:
+        session, separator, run_id = pair.partition("=")
+        if not separator or not session or not run_id:
+            msg = f"expected SESSION=RUN, got {pair!r}"
+            raise click.BadParameter(msg)
+        mapping[session] = run_id
+    return mapping
+
+
+def resolve_receipt_path(receipt_dir: Path, fanout_id: str) -> Path:
+    """Find the one receipt ``fanout_id`` names.
+
+    Accepts the full receipt hash with or without its ``sha256:`` prefix, or
+    any prefix of the hex that matches exactly one receipt. An ambiguous
+    prefix is an error that lists what it matched: picking the first match
+    would render a different fan-out than the operator asked for, and the
+    output gives no hint that it happened.
+    """
+    if not receipt_dir.is_dir():
+        msg = f"no sealed fan-outs: {receipt_dir} does not exist"
+        raise click.ClickException(msg)
+
+    wanted = fanout_id.removeprefix(_HASH_PREFIX)
+    if not wanted:
+        msg = "a fan-out id is required (the receipt hash, or a unique prefix of it)"
+        raise click.ClickException(msg)
+
+    matches = sorted(
+        path for path in receipt_dir.glob("*.json") if path.stem.removeprefix(_HASH_PREFIX).startswith(wanted)
+    )
+    if not matches:
+        msg = f"no sealed fan-out matches {fanout_id!r} under {receipt_dir}"
+        raise click.ClickException(msg)
+    if len(matches) > 1:
+        listed = ", ".join(path.stem for path in matches)
+        msg = f"{fanout_id!r} matches {len(matches)} fan-outs: {listed}"
+        raise click.ClickException(msg)
+    return matches[0]
+
+
+def _branch_rows(graph: RunGraph, lineage_root: Path, hmac_key: bytes) -> list[tuple[str, str, str]]:
+    """One ``(session_id, state, detail)`` row per branch, in graph order.
+
+    ``state`` is one of ``ok``, ``FAILED`` or ``unresolved``. The walk is the
+    point: a node hash carries the spine's *stored* head, and editing the
+    journal rows does not rewrite that head, so a tampered branch still hashes
+    the same. Only walking the chain sees it.
+    """
+    from bernstein.core.lineage.run_graph import RunGraphNodeStatus
+    from bernstein.core.lineage.spine import LineageSpine
+
+    rows: list[tuple[str, str, str]] = []
+    for node in graph.nodes:
+        head = "no head sha" if node.head_sha is None else node.head_sha[:12]
+        if node.status is RunGraphNodeStatus.UNRESOLVED or node.run_id is None:
+            rows.append((node.session_id, "unresolved", f"{head} - no run id supplied for this branch"))
+            continue
+        spine = LineageSpine(lineage_root, run_id=node.run_id, hmac_key=hmac_key)
+        verified = spine.verify()
+        state = "ok" if verified.ok else "FAILED"
+        detail = f"{head} - run {node.run_id}"
+        if not verified.ok:
+            detail = f"{detail} - spine no longer verifies"
+        rows.append((node.session_id, state, detail))
+    return rows
+
+
+_STATE_STYLE = {"ok": "green", "FAILED": "red", "unresolved": "yellow"}
+
+
+def _render(receipt_path: Path, receipt_body: Mapping[str, object], rows: list[tuple[str, str, str]]) -> None:
+    tree = Tree(f"[bold]{receipt_path.stem}[/bold]")
+    tree.add(f"graph root  {receipt_body.get('graph_root_hash', '?')}")
+    tree.add(f"anchored at {receipt_body.get('journal_entry_hash') or '[red]nothing[/red]'}")
+    branches = tree.add(f"branches ({len(rows)} on the tree, {len(receipt_body.get('node_hashes', []) or [])} sealed)")
+    for session_id, state, detail in rows:
+        style = _STATE_STYLE[state]
+        branches.add(f"[{style}]{state:<10}[/{style}] {session_id}  {detail}")
+    console.print(tree)
+
+
+@click.command("graph")
+@click.argument("fanout_id")
+@click.option(
+    "--run-id",
+    "run_id_pairs",
+    multiple=True,
+    metavar="SESSION=RUN",
+    help="Pair a branch's session id with the run whose spine recorded it. Repeatable.",
+)
+@click.option("--verify", "do_verify", is_flag=True, help="Re-derive the whole receipt and report the verdict.")
+@click.option("--json", "as_json", is_flag=True, help="Emit the signed receipt verbatim and nothing else.")
+@click.option(
+    "--public-key",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="PEM public key the receipt was signed with. Required by --verify.",
+)
+@click.option(
+    "--workdir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Project root holding .sdd (default: the current directory).",
+)
+def run_graph_cmd(
+    fanout_id: str,
+    run_id_pairs: tuple[str, ...],
+    do_verify: bool,
+    as_json: bool,
+    public_key: Path | None,
+    workdir: Path | None,
+) -> None:
+    """Render one fan-out's sealed run graph, branch by branch.
+
+    \b
+      bernstein worktrees graph <fanout-id>
+      bernstein worktrees graph <fanout-id> --run-id sess-a=run-a --verify --public-key key.pem
+      bernstein worktrees graph <fanout-id> --json
+
+    Exits non-zero when a branch's spine no longer verifies, or when --verify
+    refuses the receipt. A branch with no --run-id is reported as unresolved,
+    not as failing: nothing was checked, so nothing failed.
+    """
+    from bernstein.core.lineage.run_graph import build_run_graph, verify_run_graph_receipt
+
+    root = Path.cwd() if workdir is None else workdir
+    receipt_path = resolve_receipt_path(root / RECEIPT_RELDIR, fanout_id)
+
+    if as_json:
+        # Verbatim: this file is the signed artifact, and re-encoding it would
+        # change the bytes the signature covers.
+        click.echo(receipt_path.read_text(encoding="utf-8").strip())
+        return
+
+    try:
+        receipt_body = json.loads(receipt_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        msg = f"{receipt_path.name} could not be read as a receipt: {exc}"
+        raise click.ClickException(msg) from exc
+
+    run_ids = parse_run_ids(run_id_pairs)
+    hmac_key = _load_hmac_key()
+    lineage_root = root / ".sdd" / "lineage"
+    graph = build_run_graph(root, run_ids=run_ids, lineage_root=lineage_root, hmac_key=hmac_key)
+    rows = _branch_rows(graph, lineage_root, hmac_key)
+    _render(receipt_path, receipt_body, rows)
+
+    failed = [session_id for session_id, state, _ in rows if state == "FAILED"]
+    if failed:
+        console.print(f"[red]{len(failed)} branch(es) failed:[/red] {', '.join(failed)}")
+
+    if not do_verify:
+        if failed:
+            raise SystemExit(1)
+        return
+
+    if public_key is None:
+        # Refusing beats verifying with no key and reporting the refusal as a
+        # bad signature, which reads as tampering.
+        msg = "--verify needs --public-key: the receipt's signature cannot be checked without it"
+        raise click.ClickException(msg)
+
+    result = verify_run_graph_receipt(
+        receipt_path=receipt_path,
+        repo_root=root,
+        run_ids=run_ids,
+        lineage_root=lineage_root,
+        hmac_key=hmac_key,
+        public_key_pem=public_key.read_bytes(),
+    )
+    style = "green" if result.ok else "red"
+    console.print(f"[{style}]{result.status}[/{style}]: {result.reason}")
+    if not result.ok or failed:
+        raise SystemExit(1)

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -83,6 +83,7 @@ from bernstein.cli.commands.pool_cmd import pool_group
 from bernstein.cli.commands.receipt_cmd import receipt_group
 from bernstein.cli.commands.resume_cmd import resume_cmd
 from bernstein.cli.commands.role_adapter_policy_cmd import security_group as _role_adapter_security_group
+from bernstein.cli.commands.run_graph_cmd import run_graph_cmd
 from bernstein.cli.commands.run_names_cmd import run_lookup_cmd
 from bernstein.cli.commands.skills_cmd import skills_group
 from bernstein.cli.commands.spec_cmd import spec_group
@@ -1162,6 +1163,12 @@ cli.add_command(self_group, "self")
 cli.add_command(undo_cmd, "undo")
 cli.add_command(worker, "worker")
 cli.add_command(worktrees_group, "worktrees")
+# `bernstein worktrees graph <fanout-id>`: a fan-out's branches *are*
+# worktrees, and this group already owns the classifier surface they are read
+# through. The alternative reading, `bernstein run graph`, is not available:
+# `run` is a command (`bernstein run plan.yaml`), not a group, and turning it
+# into one would change how every existing invocation parses.
+worktrees_group.add_command(run_graph_cmd, "graph")
 cli.add_command(diff_cmd, "diff")
 cli.add_command(merge_cmd, "merge")
 cli.add_command(migrate_cmd, "migrate")

--- a/src/bernstein/core/quality/janitor.py
+++ b/src/bernstein/core/quality/janitor.py
@@ -15,6 +15,7 @@ import re
 import shlex
 import subprocess
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -41,6 +42,8 @@ from bernstein.core.quality.verifier_ladder import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from bernstein.core.lineage.gate import GateResult
     from bernstein.core.persistence.lineage import LineageVerificationResult
     from bernstein.core.security.audit_chain import AuditChainStore
@@ -597,12 +600,40 @@ def compact_lineage_logs(workdir: Path) -> list[str]:
     return compress_rotated_lineage(workdir / ".sdd")
 
 
+@dataclass(frozen=True, slots=True)
+class RunGraphSweepInputs:
+    """Everything a sealed fan-out needs before it can be re-derived.
+
+    A run-graph receipt seals opaque node hashes, so checking one means
+    rebuilding the graph off the tree and the spines -- which needs the repo,
+    the session-to-run mapping the fan-out was sealed with, the spine root,
+    and both keys. None of that is recoverable from the receipt file, so it is
+    supplied by the caller or the sweep does not run. That is the same opt-in
+    boundary :func:`verify_lineage_tool_call_gate` uses: without it the pass
+    is byte-for-byte what it was.
+
+    Attributes:
+        repo_root: Repository whose worktrees are the fan-out's branches.
+        run_ids: ``session_id -> run_id``, as used when the fan-out was sealed.
+        lineage_root: Root under which each run's spine lives.
+        hmac_key: Key the spines were written with.
+        public_key_pem: PEM public key the receipts were signed with.
+    """
+
+    repo_root: Path
+    run_ids: Mapping[str, str]
+    lineage_root: Path
+    hmac_key: bytes
+    public_key_pem: bytes
+
+
 def verify_lineage_chains(
     workdir: Path,
     *,
     audit_log: Any = None,
     sink: Any = None,
     verifier: Any = None,
+    run_graph: RunGraphSweepInputs | None = None,
 ) -> list[LineageVerificationResult]:
     """Re-verify every run's lineage chain and surface tampering loudly.
 
@@ -624,9 +655,16 @@ def verify_lineage_chains(
             ``LineageTamperEvent`` is delivered for each failed run.
         verifier: Optional :class:`LineageVerifier`. When set, customer
             signatures are checked alongside the WAL hash chain.
+        run_graph: Optional :class:`RunGraphSweepInputs`. When set, every
+            sealed fan-out under ``.sdd/run-graph`` is re-derived too, and a
+            tampered branch inside one surfaces exactly as a tampered
+            single-run spine already does. A fan-out the inputs cannot
+            account for is logged and skipped, never alerted on.
 
     Returns:
-        One :class:`LineageVerificationResult` per run inspected.
+        One :class:`LineageVerificationResult` per run inspected. Fan-out
+        receipts are not runs and do not appear here; they surface through
+        the alert path only.
     """
     from bernstein.core.persistence.lineage import LineageReader, verify_run_chain
 
@@ -644,7 +682,99 @@ def verify_lineage_chains(
         if result.ok:
             continue
         _surface_tamper(run_id, result, audit_log=audit_log, sink=sink)
+    if run_graph is not None:
+        _sweep_run_graph_receipts(workdir, run_graph, audit_log=audit_log, sink=sink)
     return results
+
+
+def _sweep_run_graph_receipts(
+    workdir: Path,
+    inputs: RunGraphSweepInputs,
+    *,
+    audit_log: Any,
+    sink: Any,
+) -> None:
+    """Re-derive every sealed fan-out and alert on the ones that disagree.
+
+    The sweep that already catches a tampered single-run spine had no
+    knowledge of fan-outs, so a branch edited inside one was invisible to it.
+    This closes that, through the same alert path -- one
+    ``lineage_tamper_detected`` event and one counter increment per receipt,
+    keyed on the receipt hash, which is the fan-out's identity.
+    """
+    from bernstein.core.lineage.run_graph import verify_run_graph_receipt
+    from bernstein.core.persistence.lineage import LineageVerificationResult
+
+    receipt_dir = workdir / ".sdd" / "run-graph"
+    if not receipt_dir.is_dir():
+        return
+    for receipt_path in sorted(receipt_dir.glob("*.json")):
+        try:
+            result = verify_run_graph_receipt(
+                receipt_path=receipt_path,
+                repo_root=inputs.repo_root,
+                run_ids=inputs.run_ids,
+                lineage_root=inputs.lineage_root,
+                hmac_key=inputs.hmac_key,
+                public_key_pem=inputs.public_key_pem,
+            )
+        except Exception:
+            logger.warning("run-graph: verification raised for %s", receipt_path.name, exc_info=True)
+            continue
+        if result.ok:
+            continue
+        unverifiable = _run_graph_unverifiable_reason(result, inputs)
+        if unverifiable is not None:
+            logger.info("run-graph: %s not checked -- %s", receipt_path.stem, unverifiable)
+            continue
+        sealed = 0 if result.receipt is None else len(result.receipt.node_hashes)
+        _surface_tamper(
+            receipt_path.stem,
+            LineageVerificationResult(ok=False, errors=[result.reason], record_count=sealed),
+            audit_log=audit_log,
+            sink=sink,
+        )
+
+
+def _run_graph_unverifiable_reason(
+    result: Any,
+    inputs: RunGraphSweepInputs,
+) -> str | None:
+    """Why this fan-out cannot be judged, or ``None`` when the failure is real.
+
+    Two states are refused by verification and are not evidence of anything.
+
+    A receipt stops verifying once its worktrees are reaped: from the
+    filesystem, a branch removed by routine cleanup and a branch removed to
+    hide what it held are the same observation. Alerting on the first would
+    fire on every fan-out the moment the janitor's own cleanup ran, and an
+    alert that fires on healthy state stops being read -- which costs more
+    than the coverage is worth.
+
+    A branch with no ``run_id`` in the supplied mapping is the same shape:
+    the caller did not give the sweep enough to pair that branch with a
+    spine, so the disagreement is in the inputs, not in the tree.
+
+    Everything else -- an edited body, a bad signature, a branch whose spine
+    no longer walks, a missing anchor -- is a real finding and is alerted on.
+    """
+    from bernstein.core.lineage.run_graph import RunGraphNodeStatus, build_run_graph
+
+    if result.status != "diverged" or result.receipt is None:
+        return None
+    graph = build_run_graph(
+        inputs.repo_root,
+        run_ids=inputs.run_ids,
+        lineage_root=inputs.lineage_root,
+        hmac_key=inputs.hmac_key,
+    )
+    sealed = len(result.receipt.node_hashes)
+    if len(graph.nodes) < sealed:
+        return f"the tree holds {len(graph.nodes)} of the {sealed} branches it sealed"
+    unresolved = sorted(node.session_id for node in graph.nodes if node.status is RunGraphNodeStatus.UNRESOLVED)
+    if unresolved:
+        return f"no run id supplied for branch(es) {', '.join(unresolved)}"
+    return None
 
 
 def verify_lineage_tool_call_gate(

--- a/tests/integration/test_lineage_tamper_detection.py
+++ b/tests/integration/test_lineage_tamper_detection.py
@@ -15,6 +15,7 @@ Asserts that:
 from __future__ import annotations
 
 import json
+import shutil
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -282,3 +283,220 @@ def _counter_value(counter: Any, **labels: str) -> float:
         return float(counter.labels(**labels)._value.get())
     except AttributeError:
         return 0.0
+
+
+# ---------------------------------------------------------------------------
+# The same sweep, applied to a fan-out (#3761)
+#
+# A fan-out's branches are sealed into one run-graph receipt, and the sweep
+# above had no knowledge of those: a branch edited inside a fan-out was
+# invisible to the same pass that catches an edited single-run spine. These
+# assert the parity -- same event, same counter -- and, just as importantly,
+# the two states where the sweep must stay quiet, because an alert that fires
+# on healthy state is one an operator learns to skip.
+# ---------------------------------------------------------------------------
+
+_FANOUT_HMAC_KEY = b"k" * 32
+_FANOUT_TIMESTAMP = 1_700_000_000
+_FANOUT_SESSIONS = ("sess-alpha", "sess-beta")
+_FANOUT_RUN_IDS = {session: f"run-{session.split('-')[1]}" for session in _FANOUT_SESSIONS}
+
+
+def _git(cwd: Path, *args: str) -> None:
+    import subprocess
+
+    subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        env={
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@example.invalid",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@example.invalid",
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "HOME": str(cwd),
+        },
+    )
+
+
+def _seal_fanout(workdir: Path) -> tuple[str, bytes]:
+    """Two branches, their spines, and one sealed receipt on disk.
+
+    The branches are real git repositories because the head sha is one of the
+    three things the graph root commits to, and it is resolved through git
+    both when sealing and when checking. A fixture that stubbed it would seal
+    a head nothing could re-derive, and every receipt would then look
+    tampered -- which is a fixture failing, dressed as the finding under test.
+
+    Returns ``(receipt_hash, public_key_pem)``.
+    """
+    from bernstein.core.lineage.run_graph import build_run_graph, build_run_graph_receipt
+    from bernstein.core.lineage.spine import LineageSpine
+    from bernstein.core.security.agent_card_signer import generate_ed25519_keypair
+
+    worktrees = workdir / ".sdd" / "runtime" / "worktrees"
+    worktrees.mkdir(parents=True, exist_ok=True)
+    lineage_root = workdir / ".sdd" / "lineage"
+    for session in _FANOUT_SESSIONS:
+        branch = worktrees / session
+        branch.mkdir(exist_ok=True)
+        _git(branch, "init", "-q", "-b", "main")
+        (branch / "out.txt").write_text(session, encoding="utf-8")
+        _git(branch, "add", "out.txt")
+        _git(branch, "commit", "-q", "-m", f"work in {session}")
+        LineageSpine(lineage_root, run_id=_FANOUT_RUN_IDS[session], hmac_key=_FANOUT_HMAC_KEY).record(
+            artifact_path=f"out/{session}.txt",
+            content=session.encode(),
+            actor="tester",
+            step_id="step-1",
+            model="test-model",
+            timestamp=_FANOUT_TIMESTAMP,
+        )
+
+    private_key_pem, public_key_pem = generate_ed25519_keypair()
+    graph = build_run_graph(
+        workdir,
+        run_ids=_FANOUT_RUN_IDS,
+        lineage_root=lineage_root,
+        hmac_key=_FANOUT_HMAC_KEY,
+    )
+    receipt = build_run_graph_receipt(
+        graph=graph,
+        workdir=workdir,
+        lineage_root=lineage_root,
+        hmac_key=_FANOUT_HMAC_KEY,
+        timestamp=_FANOUT_TIMESTAMP,
+        private_key_pem=private_key_pem,
+        chain=None,
+    )
+    return receipt.receipt_hash, public_key_pem
+
+
+def _fanout_inputs(workdir: Path, public_key_pem: bytes, *, run_ids: dict[str, str] | None = None) -> Any:
+    from bernstein.core.quality.janitor import RunGraphSweepInputs
+
+    return RunGraphSweepInputs(
+        repo_root=workdir,
+        run_ids=_FANOUT_RUN_IDS if run_ids is None else run_ids,
+        lineage_root=workdir / ".sdd" / "lineage",
+        hmac_key=_FANOUT_HMAC_KEY,
+        public_key_pem=public_key_pem,
+    )
+
+
+def _tamper_branch(workdir: Path, session: str) -> None:
+    """Edit a row inside one branch's spine, leaving its stored head alone.
+
+    The stored head is what a node hash carries, so this edit is invisible to
+    the hash comparison and only the chain walk sees it.
+    """
+    journal = next((workdir / ".sdd" / "lineage" / _FANOUT_RUN_IDS[session]).rglob("*.jsonl"))
+    raw = journal.read_bytes()
+    assert b'"actor":"tester"' in raw, "fixture no longer carries the field this test edits"
+    journal.write_bytes(raw.replace(b'"actor":"tester"', b'"actor":"testeR"'))
+
+
+def _tamper_counter(receipt_hash: str) -> float:
+    """The same counter the single-run tests read, keyed on the fan-out."""
+    from bernstein.core.observability.prometheus import lineage_tamper_total
+
+    return _counter_value(lineage_tamper_total, run_id=receipt_hash)
+
+
+def test_janitor_detects_a_tampered_fan_out_branch(tmp_path: Path) -> None:
+    """A branch edited inside a fan-out reaches the same alert as a run does."""
+    receipt_hash, public_key_pem = _seal_fanout(tmp_path)
+    _tamper_branch(tmp_path, "sess-beta")
+    before = _tamper_counter(receipt_hash)
+
+    audit = _FakeAuditLog()
+    verify_lineage_chains(
+        tmp_path,
+        audit_log=audit,
+        sink=NullAlertSink(),
+        run_graph=_fanout_inputs(tmp_path, public_key_pem),
+    )
+
+    tamper_events = [e for e in audit.events if e["event_type"] == "lineage_tamper_detected"]
+    assert len(tamper_events) == 1
+    assert tamper_events[0]["resource_id"] == receipt_hash
+    assert "sess-beta" in tamper_events[0]["details"]["errors"][0]
+    assert _tamper_counter(receipt_hash) == before + 1
+
+
+def test_janitor_leaves_an_intact_fan_out_alone(tmp_path: Path) -> None:
+    """No finding on a healthy fan-out, or the alert means nothing."""
+    _receipt_hash, public_key_pem = _seal_fanout(tmp_path)
+
+    audit = _FakeAuditLog()
+    verify_lineage_chains(
+        tmp_path,
+        audit_log=audit,
+        sink=NullAlertSink(),
+        run_graph=_fanout_inputs(tmp_path, public_key_pem),
+    )
+
+    assert audit.events == []
+
+
+def test_janitor_does_not_call_a_reaped_fan_out_tampering(tmp_path: Path) -> None:
+    """A receipt stops verifying once its worktrees are reaped.
+
+    From the filesystem a branch removed by routine cleanup and a branch
+    removed to hide what it held are the same observation -- and the janitor
+    is the process that does the reaping, so alerting on this would fire on
+    every fan-out it cleans up after.
+    """
+    receipt_hash, public_key_pem = _seal_fanout(tmp_path)
+    shutil.rmtree(tmp_path / ".sdd" / "runtime" / "worktrees" / "sess-beta")
+    before = _tamper_counter(receipt_hash)
+
+    audit = _FakeAuditLog()
+    verify_lineage_chains(
+        tmp_path,
+        audit_log=audit,
+        sink=NullAlertSink(),
+        run_graph=_fanout_inputs(tmp_path, public_key_pem),
+    )
+
+    assert audit.events == []
+    assert _tamper_counter(receipt_hash) == before
+
+
+def test_janitor_does_not_call_a_missing_run_id_tampering(tmp_path: Path) -> None:
+    """An incomplete mapping is a gap in the inputs, not in the tree."""
+    receipt_hash, public_key_pem = _seal_fanout(tmp_path)
+    before = _tamper_counter(receipt_hash)
+
+    audit = _FakeAuditLog()
+    verify_lineage_chains(
+        tmp_path,
+        audit_log=audit,
+        sink=NullAlertSink(),
+        run_graph=_fanout_inputs(tmp_path, public_key_pem, run_ids={"sess-alpha": "run-alpha"}),
+    )
+
+    assert audit.events == []
+    assert _tamper_counter(receipt_hash) == before
+
+
+def test_janitor_without_fan_out_inputs_sweeps_exactly_what_it_did_before(tmp_path: Path) -> None:
+    """The coupling is opt-in: no inputs, no fan-out sweep, same verdict.
+
+    A tampered fan-out sitting on disk must not change the answer for a caller
+    that never asked about fan-outs -- otherwise every existing janitor call
+    silently acquires a new failure mode.
+    """
+    _make_signed_run(tmp_path)
+    receipt_hash, _ = _seal_fanout(tmp_path)
+    _tamper_branch(tmp_path, "sess-beta")
+    before = _tamper_counter(receipt_hash)
+
+    audit = _FakeAuditLog()
+    results = verify_lineage_chains(tmp_path, audit_log=audit, sink=NullAlertSink())
+
+    assert [r.ok for r in results] == [True]
+    assert audit.events == []
+    assert _tamper_counter(receipt_hash) == before

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -137,7 +137,6 @@ UNDOCUMENTED_EXEMPTIONS: dict[str, str] = {
     "trend-scan": "Metric trend scanner (#2550)",
     "var": "Fleet configuration variable group (#2550)",
     "wheelhouse": "Wheelhouse package cache group (#2550)",
-    "worktrees": "Git worktree management group (#2550)",
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_run_graph_cmd.py
+++ b/tests/unit/test_run_graph_cmd.py
@@ -1,0 +1,291 @@
+"""``bernstein worktrees graph`` - what an operator can trust it to say (#3761).
+
+Each test is named for a property, because the failure that matters here is
+not "the command crashed" but "the command said something reassuring about a
+fan-out it could not actually check".
+
+The fixture builds real git repositories for the branches rather than
+injecting a head resolver: the command resolves heads through git in
+production, and a fan-out whose heads are stubbed would not exercise the path
+that actually runs.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.run_graph_cmd import resolve_receipt_path, run_graph_cmd
+from bernstein.core.lineage.run_graph import (
+    build_run_graph,
+    build_run_graph_receipt,
+    verify_run_graph_receipt,
+)
+from bernstein.core.lineage.spine import LineageSpine
+from bernstein.core.security.agent_card_signer import generate_ed25519_keypair
+
+TIMESTAMP = 1_700_000_000
+SESSIONS = ("sess-alpha", "sess-beta")
+RUN_IDS = {session: f"run-{session.split('-')[1]}" for session in SESSIONS}
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        env={
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@example.invalid",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@example.invalid",
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "HOME": str(cwd),
+        },
+    )
+
+
+@pytest.fixture
+def keypair() -> tuple[bytes, bytes]:
+    private, public = generate_ed25519_keypair()
+    return private, public
+
+
+@pytest.fixture
+def hmac_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> bytes:
+    """The key the command itself will resolve, not one chosen here.
+
+    The command opens spines with the audit key, so a fixture that sealed
+    them with some other key would have every branch fail for a reason that
+    has nothing to do with what these tests are about -- and one of them would
+    still pass, because a test asserting "this branch failed" cannot tell a
+    tampered branch from an unreadable one.
+    """
+    from bernstein.core.security.audit import load_or_create_audit_key
+
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(tmp_path / "audit.key"))
+    return load_or_create_audit_key()
+
+
+@pytest.fixture
+def sealed(tmp_path: Path, keypair: tuple[bytes, bytes], hmac_key: bytes) -> tuple[Path, Path, Path]:
+    """A workdir with two branches, their spines, and one sealed receipt.
+
+    Returns ``(workdir, receipt_path, public_key_path)``.
+    """
+    private_key_pem, public_key_pem = keypair
+    workdir = tmp_path / "repo"
+    worktrees = workdir / ".sdd" / "runtime" / "worktrees"
+    worktrees.mkdir(parents=True)
+    lineage_root = workdir / ".sdd" / "lineage"
+
+    for session in SESSIONS:
+        branch = worktrees / session
+        branch.mkdir()
+        _git(branch, "init", "-q", "-b", "main")
+        (branch / "out.txt").write_text(session, encoding="utf-8")
+        _git(branch, "add", "out.txt")
+        _git(branch, "commit", "-q", "-m", f"work in {session}")
+        spine = LineageSpine(lineage_root, run_id=RUN_IDS[session], hmac_key=hmac_key)
+        spine.record(
+            artifact_path=f"out/{session}.txt",
+            content=session.encode(),
+            actor="tester",
+            step_id="step-1",
+            model="test-model",
+            timestamp=TIMESTAMP,
+        )
+
+    graph = build_run_graph(workdir, run_ids=RUN_IDS, lineage_root=lineage_root, hmac_key=hmac_key)
+    receipt = build_run_graph_receipt(
+        graph=graph,
+        workdir=workdir,
+        lineage_root=lineage_root,
+        hmac_key=hmac_key,
+        timestamp=TIMESTAMP,
+        private_key_pem=private_key_pem,
+        chain=None,
+    )
+    receipt_path = workdir / ".sdd" / "run-graph" / f"{receipt.receipt_hash}.json"
+    public_key_path = tmp_path / "public.pem"
+    public_key_path.write_bytes(public_key_pem)
+    return workdir, receipt_path, public_key_path
+
+
+def _tamper(workdir: Path, session: str) -> None:
+    """Edit a row inside one branch's spine, leaving its stored head alone.
+
+    This is the edit a node-hash comparison cannot see: the hash carries the
+    spine's stored head, and rewriting a row does not rewrite that head.
+    """
+    lineage_root = workdir / ".sdd" / "lineage"
+    journal = next((lineage_root / RUN_IDS[session]).rglob("*.jsonl"))
+    raw = journal.read_bytes()
+    assert b'"actor":"tester"' in raw, "fixture no longer carries the field this test edits"
+    journal.write_bytes(raw.replace(b'"actor":"tester"', b'"actor":"testeR"'))
+
+
+def _run(args: list[str]) -> tuple[int, str]:
+    result = CliRunner().invoke(run_graph_cmd, args, catch_exceptions=False)
+    return result.exit_code, result.output
+
+
+def _run_id_args() -> list[str]:
+    return [arg for session, run_id in RUN_IDS.items() for arg in ("--run-id", f"{session}={run_id}")]
+
+
+# ---------------------------------------------------------------------------
+# What --json emits
+# ---------------------------------------------------------------------------
+
+
+def test_the_json_output_is_a_receipt_that_still_verifies(
+    sealed: tuple[Path, Path, Path], keypair: tuple[bytes, bytes], hmac_key: bytes, tmp_path: Path
+) -> None:
+    """--json emits the signed artifact, not a re-encoding of it.
+
+    Round-tripping it through verification is the check that matters: a
+    command that pretty-printed or reordered the JSON would still look right
+    and would no longer carry a signature anyone could check.
+    """
+    workdir, receipt_path, _ = sealed
+    _public = keypair[1]
+
+    code, output = _run([receipt_path.stem, "--json", "--workdir", str(workdir)])
+    assert code == 0
+
+    round_tripped = tmp_path / "round-tripped.json"
+    round_tripped.write_text(output.strip(), encoding="utf-8")
+    result = verify_run_graph_receipt(
+        receipt_path=round_tripped,
+        repo_root=workdir,
+        run_ids=RUN_IDS,
+        lineage_root=workdir / ".sdd" / "lineage",
+        hmac_key=hmac_key,
+        public_key_pem=_public,
+    )
+    assert result.ok, result.reason
+    assert result.status == "verified"
+
+
+# ---------------------------------------------------------------------------
+# What the default rendering says
+# ---------------------------------------------------------------------------
+
+
+def test_a_tampered_branch_is_named_in_the_default_rendering(sealed: tuple[Path, Path, Path]) -> None:
+    """The offending branch is named, and the command exits non-zero.
+
+    "Something in this fan-out is wrong" is not actionable; the session id is.
+    """
+    workdir, receipt_path, _ = sealed
+    _tamper(workdir, "sess-beta")
+
+    code, output = _run([receipt_path.stem, "--workdir", str(workdir), *_run_id_args()])
+    assert code == 1
+    assert "sess-beta" in output
+    assert "FAILED" in output
+
+
+def test_an_untampered_fan_out_renders_every_branch_as_ok(sealed: tuple[Path, Path, Path]) -> None:
+    """The healthy case has to be quiet, or the failing case says nothing."""
+    workdir, receipt_path, _ = sealed
+
+    code, output = _run([receipt_path.stem, "--workdir", str(workdir), *_run_id_args()])
+    assert code == 0
+    assert "FAILED" not in output
+    for session in SESSIONS:
+        assert session in output
+
+
+def test_a_branch_with_no_run_id_is_unresolved_rather_than_failing(sealed: tuple[Path, Path, Path]) -> None:
+    """A missing input is not evidence against the branch.
+
+    Called failing, it would put a red line next to a branch nobody has
+    checked -- and an operator who learns that red lines are often noise stops
+    reading the one that is not.
+    """
+    workdir, receipt_path, _ = sealed
+
+    code, output = _run([receipt_path.stem, "--workdir", str(workdir), "--run-id", "sess-alpha=run-alpha"])
+    assert code == 0
+    assert "unresolved" in output
+    assert "sess-beta" in output
+    assert "FAILED" not in output
+
+
+# ---------------------------------------------------------------------------
+# Naming a fan-out
+# ---------------------------------------------------------------------------
+
+
+def test_a_unique_prefix_names_the_fan_out(sealed: tuple[Path, Path, Path]) -> None:
+    """A full sha256 is not something an operator retypes."""
+    workdir, receipt_path, _ = sealed
+    prefix = receipt_path.stem.removeprefix("sha256:")[:8]
+
+    code, output = _run([prefix, "--json", "--workdir", str(workdir)])
+    assert code == 0
+    assert json.loads(output.strip())["receipt_hash"] == receipt_path.stem
+
+
+def test_an_ambiguous_prefix_lists_its_candidates_instead_of_choosing(sealed: tuple[Path, Path, Path]) -> None:
+    """Picking the first match would render a different fan-out silently."""
+    _workdir, receipt_path, _ = sealed
+    twin = receipt_path.with_name(f"{receipt_path.stem}0.json")
+    twin.write_text(receipt_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+    with pytest.raises(Exception, match="matches 2 fan-outs"):
+        resolve_receipt_path(receipt_path.parent, receipt_path.stem.removeprefix("sha256:")[:8])
+
+
+def test_an_unknown_id_says_so_rather_than_rendering_nothing(sealed: tuple[Path, Path, Path]) -> None:
+    """An empty render reads as an empty fan-out, which is a different fact."""
+    _workdir, receipt_path, _ = sealed
+
+    with pytest.raises(Exception, match="no sealed fan-out matches"):
+        resolve_receipt_path(receipt_path.parent, "deadbeef")
+
+
+# ---------------------------------------------------------------------------
+# --verify
+# ---------------------------------------------------------------------------
+
+
+def test_verify_confirms_a_receipt_against_the_tree_it_sealed(sealed: tuple[Path, Path, Path]) -> None:
+    workdir, receipt_path, public_key_path = sealed
+
+    code, output = _run(
+        [
+            receipt_path.stem,
+            "--verify",
+            "--public-key",
+            str(public_key_path),
+            "--workdir",
+            str(workdir),
+            *_run_id_args(),
+        ]
+    )
+    assert code == 0
+    assert "verified" in output
+
+
+def test_verify_without_a_public_key_refuses_rather_than_reporting_a_bad_signature(
+    sealed: tuple[Path, Path, Path],
+) -> None:
+    """No key means the signature was not checked, which is not the same as a
+    signature that failed -- and the second reads as tampering."""
+    workdir, receipt_path, _ = sealed
+
+    with pytest.raises(Exception, match="needs --public-key"):
+        CliRunner().invoke(
+            run_graph_cmd,
+            [receipt_path.stem, "--verify", "--workdir", str(workdir), *_run_id_args()],
+            catch_exceptions=False,
+            standalone_mode=False,
+        )


### PR DESCRIPTION
Closes #3761. Slice 4 of 4 of #2929.

## Problem

A fan-out could be assembled, sealed and verified (the earlier slices), and none of that was reachable. An operator holding a receipt hash had a file of opaque hashes and no command that showed which branches it covered. And the periodic sweep that catches a tampered single-run spine — `verify_lineage_chains`, the one that emits `lineage_tamper_detected` and increments `bernstein_lineage_tamper_total` — had no knowledge of run-graph receipts, so a branch edited inside a fan-out was invisible to it.

## Change

**`bernstein worktrees graph <fanout-id>`** renders every branch with its verify status; `--verify` re-derives the whole receipt and reports the verdict; `--json` emits the signed artifact verbatim.

**`verify_lineage_chains` gained the sweep**, through an opt-in `RunGraphSweepInputs`. A tampered branch inside a fan-out now reaches the same event, the same counter, and the same SIEM sink as a tampered spine, keyed on the receipt hash.

## The three decisions this slice had to make

### 1. Where the command lives — settled by fact, not taste

The issue offered `bernstein run graph` under a new top-level `run` group, or the existing `worktrees` group. `run` is already a **command** (`bernstein run plan.yaml`, `main.py:1115`), not a group; turning it into one would change how every existing invocation parses. So: `bernstein worktrees graph`. That group is also the closer home on its own merits — a fan-out's branches *are* worktrees, and `build_run_graph` iterates the very classifier this group renders.

### 2. What names a fan-out

There is no `fanout_id` anywhere in the tree, and this slice does not invent one. Receipts are written to `.sdd/run-graph/<receipt_hash>.json`, so the receipt hash **is** the fan-out's identity: a fan-out edited by hand is a different fan-out and says so. A unique prefix is accepted the way git accepts a short sha; an ambiguous one lists its candidates rather than picking the first, because picking the first renders a different fan-out and the output gives no hint that it happened.

### 3. Reaped worktrees — the scheduling question #3760 left to this slice

#3760's verification fails closed when a fan-out's worktrees are gone, and named the cost: *a receipt stops verifying once its worktrees are reaped; that is a scheduling decision for the janitor slice.* This is that slice, so here is the decision.

**A refusal to check is not a finding.** Two states are refused by verification and are not evidence of anything:

| State | Why it is not tampering |
| --- | --- |
| The tree holds fewer branches than the receipt sealed | From the filesystem, a branch removed by routine cleanup and a branch removed to hide what it held are the same observation — and **the janitor is the process that does the reaping**, so alerting here would fire on its own cleanup, every pass |
| A branch has no `run_id` in the supplied mapping | It was never paired with a spine, so nothing about it was checked; the gap is in the inputs |

Both are logged and skipped. Everything else — an edited body, a bad signature, a branch whose spine no longer walks, a missing anchor — is alerted on.

The predicate reads this off the re-derived graph (branch counts, node status), not off the reason string, so a reworded message cannot silently turn an alert into a skip.

The same rule holds on the CLI: an unresolved branch renders as `unresolved`, never as `FAILED`, and does not set the exit status. An alert that fires on healthy state is one an operator learns to skip — which costs more than the coverage is worth.

## Two smaller things worth naming

**The spine walk is what catches a tampered branch.** A node hash carries the spine's *stored* head, and editing the journal rows does not rewrite that head — so a tampered branch still hashes the same and a comparison sees nothing. The rendering walks each branch's chain for that reason.

**`--verify` without `--public-key` refuses.** Verifying with no key and reporting the result would present "the signature was not checked" as "the signature failed", which reads as tampering.

## Verification

Eight CLI tests and five janitor tests, each named for the property it protects. To confirm they test behaviour rather than the existence of a function, I removed each part in turn:

- sweep call stubbed to `if False:` → `test_janitor_detects_a_tampered_fan_out_branch` fails, alone.
- the unverifiable predicate short-circuited to `return None` → the reaped-fan-out and missing-run-id tests fail, and only those two.
- an unresolved branch rendered as `FAILED` → `test_a_branch_with_no_run_id_is_unresolved_rather_than_failing` fails, alone.

The fixtures use **real git repositories** for the branches and the command's **own** audit key, not stubs. Both matter: the head sha is one of the three things the graph root commits to and is resolved through git on both sides, and the command opens spines with the audit key — a fixture that sealed with some other key would have every branch fail for a reason unrelated to the test, while the tampered-branch test still passed, because "this branch failed" cannot tell a tampered branch from an unreadable one.

Runs on this branch:

- `tests/unit/test_run_graph_cmd.py tests/integration/test_lineage_tamper_detection.py tests/unit/test_janitor.py tests/unit/lineage/ tests/unit/test_worktrees_cmd.py` — 834 passed, 1 xfailed.
- CLI/docs parity guards (`test_cli_command_registration.py`, `test_readme_api_coverage.py`, `test_feature_matrix_drift.py`) — 712 passed, 1 skipped.
- `uv run mypy --config-file mypy.gate.ini` — no issues in 86 source files.
- `uv run ruff check src tests` and `ruff format --check src tests` — clean.

## Not in this branch

Per the issue's non-goals: no changes to how graphs are assembled, sealed, or verified. The sweep is opt-in at the caller boundary — the same pattern `verify_lineage_tool_call_gate` uses — so a caller that passes nothing gets the pass it had before, byte for byte, which `test_janitor_without_fan_out_inputs_sweeps_exactly_what_it_did_before` holds in place.
