### PR TITLE
test(runner): name the files that ran no tests

### DIFF
--- a/docs/operations/ci.md
+++ b/docs/operations/ci.md
@@ -87,7 +87,11 @@ opt-in `cluster_e2e` marker). Those files execute no assertions here.
 `scripts/run_tests.py` reports them as `NO TESTS` rather than `PASS`, and
 totals them separately (`Files: P passed, F failed, N ran no tests, T
 total`), so the passing count is a count of files that actually executed
-something. A file that ran nothing is not a failure - a credential-gated
+something. Each file in that bucket is then named on its own line
+(`  ran no tests: tests/...`): the per-file lines are printed only for
+failures, so on a green shard the totals are the whole record, and a bare
+count of several hundred files leaves no way to check which file executed
+nothing. A file that ran nothing is not a failure - a credential-gated
 suite and an empty impact-based selection are both legitimate - but it is
 not evidence either. A file that exits 0 without a pytest terminal summary
 *is* a failure: pytest prints one on every completed run, so its absence

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -404,16 +404,26 @@ def _report_file_result(label: str, code: int, duration: float, output: str) -> 
     return outcome
 
 
-def _print_totals(passed: int, failed: int, no_tests: int, total: int) -> None:
-    """Print the per-file totals with ran-nothing broken out."""
-    print(f"Files: {passed} passed, {failed} failed, {no_tests} ran no tests, {total} total")
+def _print_totals(passed: int, failed: int, no_tests: Collection[Path], total: int) -> None:
+    """Print the per-file totals with ran-nothing broken out, naming each file.
+
+    The per-file lines are printed only for failures, so on a green shard the
+    totals are the whole record. "1 ran no tests" out of several hundred names
+    nothing: a reader cannot tell which file executed nothing, and cannot check
+    whether the file they care about was among the ones that ran at all. The
+    names are cheap -- this bucket is a handful of files on a normal shard --
+    and they are what makes the count auditable.
+    """
+    print(f"Files: {passed} passed, {failed} failed, {len(no_tests)} ran no tests, {total} total")
+    for path in sorted(no_tests):
+        print(f"  ran no tests: {path}")
 
 
 def run_sequential(files: list[Path], extra_args: list[str], fail_fast: bool, coverage: bool = False) -> int:
     """Run test files one by one."""
     passed = 0
     failed = 0
-    no_tests = 0
+    no_tests: list[Path] = []
     total_duration = 0.0
 
     for i, path in enumerate(files, 1):
@@ -437,7 +447,7 @@ def run_sequential(files: list[Path], extra_args: list[str], fail_fast: bool, co
         if outcome == OUTCOME_PASSED:
             passed += 1
         elif outcome == OUTCOME_NO_TESTS:
-            no_tests += 1
+            no_tests.append(path)
         else:
             failed += 1
             if fail_fast:
@@ -457,7 +467,7 @@ def run_parallel(
 
     passed = 0
     failed = 0
-    no_tests = 0
+    no_tests: list[Path] = []
     done = 0
     total = len(files)
     abort = False
@@ -499,7 +509,7 @@ def run_parallel(
             if outcome == OUTCOME_PASSED:
                 passed += 1
             elif outcome == OUTCOME_NO_TESTS:
-                no_tests += 1
+                no_tests.append(fpath)
             else:
                 failed += 1
                 if fail_fast:
@@ -534,7 +544,7 @@ def run_parallel(
             if outcome == OUTCOME_PASSED:
                 passed += 1
             elif outcome == OUTCOME_NO_TESTS:
-                no_tests += 1
+                no_tests.append(fpath)
             else:
                 failed += 1
                 if fail_fast:

--- a/tests/unit/scripts/test_run_tests_zero_test_outcomes.py
+++ b/tests/unit/scripts/test_run_tests_zero_test_outcomes.py
@@ -189,6 +189,60 @@ def test_sequential_totals_count_ran_nothing_separately(
     assert code == 0
 
 
+def test_sequential_totals_name_the_files_that_ran_nothing(
+    run_tests_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Each ran-nothing file is named, so the count can be checked against paths.
+
+    The per-file lines only appear for failures, so a shard that reports
+    "1 ran no tests" out of several hundred gives a reader no way to tell
+    which file executed nothing -- or whether the file they care about was
+    among the ones that ran at all.
+    """
+    files = [Path("tests/unit/test_a.py"), Path("tests/unit/test_b.py"), Path("tests/unit/test_c.py")]
+    monkeypatch.setattr(
+        run_tests_module,
+        "run_file",
+        _stub_run_file(
+            {
+                "test_a.py": (0, "4 passed in 0.10s"),
+                "test_b.py": (0, "13 skipped in 3.10s"),
+                "test_c.py": (5, "no tests ran in 0.01s"),
+            }
+        ),
+    )
+
+    run_tests_module.run_sequential(files, [], fail_fast=False)
+
+    captured = capsys.readouterr().out
+    assert "ran no tests: tests/unit/test_b.py" in captured
+    assert "ran no tests: tests/unit/test_c.py" in captured
+    assert "ran no tests: tests/unit/test_a.py" not in captured
+
+
+def test_totals_name_the_files_in_a_deterministic_order(
+    run_tests_module: ModuleType,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Both runners report through this one function, so it is where the naming lives.
+
+    The parallel runner completes files in whatever order the pool returns
+    them; sorting here keeps two runs of the same shard byte-identical.
+    """
+    run_tests_module._print_totals(
+        1,
+        0,
+        [Path("tests/unit/test_z.py"), Path("tests/unit/test_b.py")],
+        3,
+    )
+
+    captured = capsys.readouterr().out
+    assert "Files: 1 passed, 0 failed, 2 ran no tests, 3 total" in captured
+    assert captured.index("test_b.py") < captured.index("test_z.py")
+
+
 def test_sequential_totals_fail_on_a_replaced_process(
     run_tests_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Problem

A test shard reports its result as one line:

```
Files: 295 passed, 0 failed, 1 ran no tests, 296 total
```

Per-file lines are printed only for failures, so on a green shard that line is the entire record. It names nothing. Reading it, you cannot tell which of the 296 files executed nothing, and you cannot tell whether the file you came to check was among the ones that ran at all.

That came up while working out why a branch whose own tests fail locally had a green rollup: the four shard logs contain no test-file names whatsoever, so there was no way to answer "did this shard run this file?" from the record CI keeps.

## Change

`_print_totals` now takes the ran-nothing paths rather than a count, and names each one under the totals:

```
Files: 295 passed, 0 failed, 1 ran no tests, 296 total
  ran no tests: tests/integration/test_e2b_sandbox.py
```

The bucket is a handful of files on a normal shard, so the cost is a few lines. The list is sorted because the parallel runner completes files in whatever order the pool returns them, and two runs of the same shard should print the same bytes.

Both runners report through this one function, so both lanes are covered.

## Tests

- `test_sequential_totals_name_the_files_that_ran_nothing` - end-to-end through `run_sequential`; the two ran-nothing files are named and the passing one is not.
- `test_totals_name_the_files_in_a_deterministic_order` - the shared reporting seam, pinning the sort.

Existing coverage in `tests/unit/scripts/test_run_tests_zero_test_outcomes.py` continues to pin the counts themselves.

`docs/operations/ci.md` documents the totals line and is updated with it.