### PR TITLE
fix(ci): quote the volunteer-verify check-run heredoc and gate the pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,6 +457,12 @@ jobs:
         # and this job passed all three. Pure stdlib and git, so it runs here
         # ahead of the bootstrap step rather than waiting on the toolchain.
         run: python3 scripts/check_bom.py
+      - name: Reject an unquoted Python heredoc in a workflow
+        # A workflow step assembled its Python source by shell substitution
+        # and died on NameError the first time it ran after merge, leaving a
+        # red check on every pull request opened afterwards. Pure stdlib, so
+        # it runs here ahead of the bootstrap step.
+        run: python3 scripts/check_workflow_heredocs.py
       - name: Check Python syntax in scripts/
         run: |
           ERRORS=""

--- a/.github/workflows/volunteer-verify.yml
+++ b/.github/workflows/volunteer-verify.yml
@@ -215,33 +215,31 @@ jobs:
           # Determine conclusion based on overall pass/fail
           if echo "$RESULT_JSON" | grep -q '"overall_passed": true'; then
             CONCLUSION="success"
-            SUMMARY="Volunteer receipt verification passed"
           else
             CONCLUSION="failure"
-            SUMMARY="Volunteer receipt verification failed"
           fi
+          export CONCLUSION
 
           # Create check run client and post/update check run
-          uv run python << EOF
+          uv run python << 'PYEOF'
           import os
           import json
           import sys
-          from pathlib import Path
           from bernstein.github_app.check_runs import CheckRunClient
 
           # Load result
-          with open('$VERIFICATION_RESULT_PATH') as f:
+          with open(os.environ["VERIFICATION_RESULT_PATH"]) as f:
               result = json.load(f)
 
           # Create check run client
-          check_run_client = CheckRunClient('$REPO_SLUG', None)
+          check_run_client = CheckRunClient(os.environ["REPO_SLUG"], None)
 
           # Post new verification check run
           check_run_result = check_run_client.create_verification_check_run(
-              head_sha='$HEAD_SHA',
+              head_sha=os.environ["HEAD_SHA"],
               summary=result['summary'],
               details=result['details'],
-              conclusion=CONCLUSION,
+              conclusion=os.environ["CONCLUSION"],
           )
 
           if check_run_result is None:
@@ -249,4 +247,4 @@ jobs:
               sys.exit(1)
 
           print(f"Posted verification check run: {check_run_result.check_run_id}")
-          EOF
+          PYEOF

--- a/docs/release-notes/fragments/volunteer-verify-heredoc.md
+++ b/docs/release-notes/fragments/volunteer-verify-heredoc.md
@@ -1,0 +1,3 @@
+Fixed the volunteer receipt verification workflow, whose check-run step built
+its Python source by shell substitution and failed on every pull request. A
+repo-hygiene gate now rejects an unquoted Python heredoc in any workflow.

--- a/scripts/check_workflow_heredocs.py
+++ b/scripts/check_workflow_heredocs.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+"""Repo-hygiene gate: a Python heredoc in a workflow must use a quoted delimiter.
+
+``volunteer-verify.yml`` fed its check-run script through ``python << EOF``.
+An unquoted delimiter makes the shell expand the body before Python sees it,
+so the step's source was assembled by string substitution: values landed
+inside Python string literals, and one call argument was written as a bare
+``CONCLUSION`` rather than ``'$CONCLUSION'``. The step died on ``NameError``
+the first time it ran after merge, and every pull request opened afterwards
+carried the red check until the workflow was corrected.
+
+The quoted form (``python << 'PYEOF'``) passes the body through untouched and
+forces the script to read its inputs from ``os.environ``, where a value
+containing a quote or a newline cannot rewrite the program. Both surviving
+heredocs in that workflow already did this; the broken step was the only one
+that deviated.
+
+Scans the workflow directory and fails on any heredoc that *is* a Python
+program and whose delimiter is unquoted. A heredoc handed to a script as
+stdin data (``python tool.py log <<JSON``) is left alone: there the shell
+substitution is the point, and the body is never parsed as Python.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# ``uv run python << 'PYEOF'``, ``PYTEST_EXIT_CODE="$rc" python3 <<-EOF`` and
+# the like: an interpreter word carrying no script argument, so the heredoc
+# body is the program itself, then the operator, then a delimiter that is
+# quoted only when the body is meant to survive the shell verbatim.
+HEREDOC = re.compile(r"(?:^|[\s;|&(])(?:python[0-9.]*)(?:\s+-\S+)*\s*<<-?\s*(?P<delim>\S+)")
+
+WORKFLOW_SUFFIXES = (".yml", ".yaml")
+
+
+def unquoted_heredocs(text: str) -> list[tuple[int, str]]:
+    """Return ``(line number, delimiter)`` for each unquoted Python heredoc."""
+    found: list[tuple[int, str]] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        match = HEREDOC.search(line)
+        if match is None:
+            continue
+        delim = match.group("delim")
+        if delim[:1] in {"'", '"'}:
+            continue
+        found.append((lineno, delim))
+    return found
+
+
+def workflow_files(root: Path) -> list[Path]:
+    workflows = root / ".github" / "workflows"
+    if not workflows.is_dir():
+        return []
+    return sorted(p for p in workflows.iterdir() if p.suffix in WORKFLOW_SUFFIXES)
+
+
+def check(root: Path) -> int:
+    violations: list[str] = []
+    for path in workflow_files(root):
+        for lineno, delim in unquoted_heredocs(path.read_text(encoding="utf-8")):
+            rel = path.relative_to(root)
+            violations.append(f"{rel}:{lineno}: python heredoc delimiter {delim} is not quoted")
+
+    if not violations:
+        return 0
+
+    print("Unquoted Python heredoc in a workflow:", file=sys.stderr)
+    for violation in violations:
+        print(f"  {violation}", file=sys.stderr)
+    print(
+        "\nThe shell expands an unquoted heredoc body before Python parses it, so the "
+        "step's source is built by substitution. Quote the delimiter (<< 'PYEOF') and "
+        "read the values from os.environ instead.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path("."),
+        help="Repository to scan (default: the current directory).",
+    )
+    args = parser.parse_args(argv)
+    return check(args.root)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_check_workflow_heredocs.py
+++ b/tests/unit/scripts/test_check_workflow_heredocs.py
@@ -1,0 +1,101 @@
+"""The workflow-heredoc gate catches the line that actually broke.
+
+Every fixture here is a line lifted from ``volunteer-verify.yml``: the
+unquoted heredoc as it was merged, and the quoted forms that the same file
+already used in its other steps.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
+
+from check_workflow_heredocs import check, unquoted_heredocs
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# The line as merged, which made the shell expand the body and left a bare
+# ``CONCLUSION`` in the Python source.
+BROKEN = "          uv run python << EOF"
+# The two forms the same workflow already used elsewhere.
+FIXED = "          uv run python << 'PYEOF'"
+PUBLISH = "          PYTEST_EXIT_CODE=\"$pytest_exit_code\" python << 'EOF'"
+
+
+def test_flags_the_heredoc_that_broke_the_check_run() -> None:
+    assert unquoted_heredocs(BROKEN) == [(1, "EOF")]
+
+
+def test_accepts_the_quoted_form_the_workflow_now_uses() -> None:
+    assert unquoted_heredocs(FIXED) == []
+
+
+def test_accepts_a_quoted_heredoc_behind_an_env_assignment() -> None:
+    """``publish.yml`` prefixes the interpreter with an assignment."""
+    assert unquoted_heredocs(PUBLISH) == []
+
+
+def test_accepts_a_dash_heredoc_when_quoted() -> None:
+    assert unquoted_heredocs("  python3 <<-'EOF'") == []
+
+
+def test_flags_a_dash_heredoc_when_unquoted() -> None:
+    assert unquoted_heredocs("  python3 <<-EOF") == [(1, "EOF")]
+
+
+def test_ignores_a_heredoc_that_feeds_something_other_than_python() -> None:
+    """The gate speaks to Python bodies; ``cat`` and friends are not its business."""
+    assert unquoted_heredocs("          cat << EOF") == []
+
+
+def test_ignores_a_data_heredoc_piped_into_a_script() -> None:
+    """``auto-heal.yml`` builds a JSON payload for a script's stdin.
+
+    The body is data, never parsed as Python, and the substitution is the
+    whole point of writing it that way.
+    """
+    line = "          uv run python scripts/auto_heal_v2_run.py log <<JSON"
+    assert unquoted_heredocs(line) == []
+
+
+def test_still_flags_an_unquoted_body_behind_interpreter_flags() -> None:
+    assert unquoted_heredocs("          python3 -u << EOF") == [(1, "EOF")]
+
+
+def test_reports_the_line_number_within_a_file() -> None:
+    text = "\n".join(["steps:", "  run: |", BROKEN])
+    assert unquoted_heredocs(text) == [(3, "EOF")]
+
+
+def test_repository_workflows_are_clean(capsys: pytest.CaptureFixture[str]) -> None:
+    """The invariant holds on the tree as committed."""
+    assert check(REPO_ROOT) == 0, capsys.readouterr().err
+
+
+def test_check_fails_on_a_workflow_directory_holding_the_broken_line(tmp_path: Path) -> None:
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "volunteer-verify.yml").write_text(f"steps:\n  run: |\n{BROKEN}\n")
+
+    assert check(tmp_path) == 1
+
+
+def test_runs_as_a_script(tmp_path: Path) -> None:
+    """CI invokes it as ``python3 scripts/check_workflow_heredocs.py``."""
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "ok.yml").write_text(f"steps:\n  run: |\n{FIXED}\n")
+
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "check_workflow_heredocs.py"), "--root", str(tmp_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
The `Verify volunteer receipt` workflow ran its check-run step as `uv run python << EOF`. An unquoted delimiter makes the shell expand the heredoc before Python parses it, so the step's source was assembled by substitution — and one call argument was written as a bare `CONCLUSION` instead of an interpolated value:

```
Traceback (most recent call last):
  File "<stdin>", line 19, in <module>
NameError: name 'CONCLUSION' is not defined
```

The step failed the first time it ran after merge, and every pull request opened afterwards carried the red check.

## Change

- The step now uses the form the same workflow already uses in its other Python step: a quoted delimiter (`<< 'PYEOF'`) with the values read from `os.environ`. A value containing a quote or a newline can no longer rewrite the program.
- New `scripts/check_workflow_heredocs.py` fails repo hygiene on any workflow heredoc that *is* a Python program and whose delimiter is unquoted. A heredoc carrying stdin data for a script (`python tool.py log <<JSON` in `auto-heal.yml`) is left alone: there the substitution is the point and the body is never parsed as Python.
- Wired into the CI hygiene job next to the BOM check, ahead of the toolchain bootstrap.

## Checks

`tests/unit/scripts/test_check_workflow_heredocs.py` — 12 cases, every fixture lifted from the workflows themselves: the line as it was merged, the two quoted forms already in the tree, the flagged and unflagged dash-heredoc forms, and the data heredoc. Run against the pre-fix file from `main`, the gate reports `volunteer-verify.yml:225`; against this branch it is clean.