### PR TITLE
feat(lineage): classify foreign attestations fail-closed

### DIFF
--- a/docs/lineage.md
+++ b/docs/lineage.md
@@ -149,6 +149,21 @@ make -C examples/lineage demo-healthcare
 make -C examples/lineage demo-eu-mfg
 ```
 
+## Foreign attestations
+
+An external attestation is typed metadata beside a lineage record, never an
+entry in Bernstein's HMAC chain.  The first verifier slice accepts a
+protocol-neutral envelope containing an issuer, issuer key id, content hash,
+claimed subject, trust class, format, and payload hash.  It preserves the
+foreign trust class and reports a structurally valid envelope as
+`unverifiable` until an issuer- and format-specific verifier is available.
+
+`unverifiable` does not mean Bernstein rejected the foreign claim, and it
+does not mean Bernstein verified it.  A malformed envelope fails closed at
+`public` trust.  Unknown formats remain `unverifiable` rather than being
+parsed as Bernstein data.  Neither result changes whether Bernstein's own
+lineage chain verifies or upgrades a foreign claim into a Bernstein finding.
+
 ## Failure modes you should know
 
 | Symptom | Likely cause | Action |

--- a/src/bernstein/core/lineage/__init__.py
+++ b/src/bernstein/core/lineage/__init__.py
@@ -37,6 +37,11 @@ from bernstein.core.lineage.entry import (
     canonicalise,
     entry_hash,
 )
+from bernstein.core.lineage.foreign_attestation import (
+    ForeignAttestationResult,
+    ForeignAttestationVerdict,
+    verify_foreign_attestation,
+)
 from bernstein.core.lineage.gate import GateResult
 from bernstein.core.lineage.gate import check as gate_check
 from bernstein.core.lineage.identity import (
@@ -100,6 +105,8 @@ __all__ = [
     "AuditingTrackerAdapter",
     "ChildBody",
     "FirstWriterPolicy",
+    "ForeignAttestationResult",
+    "ForeignAttestationVerdict",
     "Fork",
     "GateResult",
     "HumanPolicy",
@@ -145,5 +152,6 @@ __all__ = [
     "seal_write",
     "sign_detached",
     "verify_detached",
+    "verify_foreign_attestation",
     "wrap_adapter",
 ]

--- a/src/bernstein/core/lineage/foreign_attestation.py
+++ b/src/bernstein/core/lineage/foreign_attestation.py
@@ -1,0 +1,106 @@
+"""Classify foreign attestations without adopting their authority.
+
+This module deliberately handles only the safe first slice of foreign
+attestation support.  It validates the protocol-neutral envelope shape and
+reports a foreign claim as ``unverifiable`` until Bernstein has a native
+verifier for that issuer and format.  It never parses the foreign signature,
+adds the claim to Bernstein's HMAC chain, or upgrades its trust class.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import cast
+
+from bernstein.core.lineage.provenance import LOWEST_TRUST_CLASS, TrustClass
+
+_SHA256_DIGEST = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_REQUIRED_KEYS = frozenset({"issuer", "issuer_key_id", "content_hash", "claimed_subject", "trust_class", "envelope"})
+
+
+class ForeignAttestationVerdict(StrEnum):
+    """Outcome of checking a foreign attestation envelope."""
+
+    UNVERIFIABLE = "unverifiable"
+    MALFORMED = "malformed"
+
+
+@dataclass(frozen=True, slots=True)
+class ForeignAttestationResult:
+    """Fail-closed classification of an attestation Bernstein did not issue."""
+
+    verdict: ForeignAttestationVerdict
+    verified: bool
+    taint: TrustClass
+    reason: str
+
+
+def _non_empty_string(value: object) -> bool:
+    return isinstance(value, str) and bool(value)
+
+
+def _trust_class(value: object) -> TrustClass | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        return TrustClass(value)
+    except ValueError:
+        return None
+
+
+def _malformed(reason: str, taint: TrustClass = LOWEST_TRUST_CLASS) -> ForeignAttestationResult:
+    return ForeignAttestationResult(
+        verdict=ForeignAttestationVerdict.MALFORMED,
+        verified=False,
+        taint=taint,
+        reason=reason,
+    )
+
+
+def verify_foreign_attestation(attestation: Mapping[str, object]) -> ForeignAttestationResult:
+    """Classify one protocol-neutral foreign attestation without verifying it.
+
+    Args:
+        attestation: The typed metadata attached beside a Bernstein lineage
+            record.  Its foreign envelope remains opaque to this function.
+
+    Returns:
+        A result that is never ``verified`` in this initial slice.  A
+        structurally valid foreign envelope is ``unverifiable`` because no
+        issuer- and format-specific verifier was invoked.  Invalid metadata is
+        ``malformed`` and fails closed at the lowest trust class.
+    """
+    if frozenset(attestation) != _REQUIRED_KEYS:
+        return _malformed("foreign attestation has unsupported or missing fields")
+
+    for field in ("issuer", "issuer_key_id", "claimed_subject"):
+        if not _non_empty_string(attestation[field]):
+            return _malformed(f"foreign attestation requires a non-empty {field}")
+
+    content_hash = attestation["content_hash"]
+    if not isinstance(content_hash, str) or _SHA256_DIGEST.fullmatch(content_hash) is None:
+        return _malformed("foreign attestation requires a sha256 content_hash")
+
+    taint = _trust_class(attestation["trust_class"])
+    if taint is None:
+        return _malformed("foreign attestation has an unknown trust_class")
+
+    envelope = attestation["envelope"]
+    if not isinstance(envelope, Mapping):
+        return _malformed("foreign attestation requires an envelope", taint)
+    typed_envelope = cast(Mapping[str, object], envelope)
+    if not _non_empty_string(typed_envelope.get("format")):
+        return _malformed("foreign attestation envelope requires a format", taint)
+    payload_hash = typed_envelope.get("payload_hash")
+    if not isinstance(payload_hash, str) or _SHA256_DIGEST.fullmatch(payload_hash) is None:
+        return _malformed("foreign attestation envelope requires a sha256 payload_hash", taint)
+
+    return ForeignAttestationResult(
+        verdict=ForeignAttestationVerdict.UNVERIFIABLE,
+        verified=False,
+        taint=taint,
+        reason="no native verifier is registered for the foreign issuer and envelope format",
+    )

--- a/tests/unit/lineage/test_foreign_attestation_contract.py
+++ b/tests/unit/lineage/test_foreign_attestation_contract.py
@@ -19,8 +19,6 @@ import json
 import re
 from pathlib import Path
 
-import pytest
-
 _FIXTURE_PATH = Path(__file__).with_name("fixtures") / "foreign_attestation_unverifiable.json"
 
 #: Every key a foreign attestation may carry.  An allowlist rather than a
@@ -83,22 +81,8 @@ def test_foreign_attestation_fixture_is_protocol_neutral_and_unlinked() -> None:
     assert expected["derived_taint"] == "third_party"
 
 
-@pytest.mark.xfail(
-    raises=ImportError,
-    strict=True,
-    reason="issue #3133: foreign-attestation verification is not implemented yet",
-)
 def test_unverifiable_foreign_attestation_fails_closed_without_changing_local_chain() -> None:
-    """Specify the verifier contract before its implementation exists.
-
-    The import intentionally fails on current main, and ``raises=ImportError``
-    keeps that the only tolerated failure.  A verifier that lands and reports
-    the wrong verdict raises ``AssertionError``, which this marker does not
-    absorb, so the suite turns red instead of reporting a green xfail over a
-    contract it never actually checked.  A verifier that lands and is correct
-    turns this into a strict xpass, red as well, which forces whoever
-    implements it to convert this into an ordinary contract test.
-    """
+    """A valid but unknown foreign format remains explicitly unverifiable."""
     from bernstein.core.lineage.foreign_attestation import verify_foreign_attestation
 
     fixture = _fixture()
@@ -121,3 +105,39 @@ def test_unverifiable_foreign_attestation_fails_closed_without_changing_local_ch
         "expected_verdict": "verified",
         "evidence_source": "bernstein-lineage-only",
     }
+
+
+def test_malformed_foreign_attestation_fails_closed_at_public_trust() -> None:
+    from bernstein.core.lineage.foreign_attestation import verify_foreign_attestation
+
+    fixture = _fixture()
+    record = fixture["lineage_record"]
+    assert isinstance(record, dict)
+    original = record["external_attestation"]
+    assert isinstance(original, dict)
+    malformed = {**original, "trust_class": "operator_hmac"}
+
+    result = verify_foreign_attestation(malformed)
+
+    assert result.verdict == "malformed"
+    assert result.verified is False
+    assert result.taint.value == "public"
+
+
+def test_unknown_envelope_format_is_unverifiable_not_a_parse_error() -> None:
+    from bernstein.core.lineage.foreign_attestation import verify_foreign_attestation
+
+    fixture = _fixture()
+    record = fixture["lineage_record"]
+    assert isinstance(record, dict)
+    original = record["external_attestation"]
+    assert isinstance(original, dict)
+    envelope = original["envelope"]
+    assert isinstance(envelope, dict)
+    unknown_format = {**original, "envelope": {**envelope, "format": "future-foreign-format-v9"}}
+
+    result = verify_foreign_attestation(unknown_format)
+
+    assert result.verdict == "unverifiable"
+    assert result.verified is False
+    assert result.taint.value == "third_party"


### PR DESCRIPTION
## What

Implements the first fail-closed verifier slice for the protocol-neutral foreign-attestation fixture in #3133.

## Why

A foreign issuer claim needs a typed place beside a Bernstein lineage record without being confused with material Bernstein evaluated or added to its HMAC chain.

## How

- Validate the established protocol-neutral envelope shape only.
- Return `unverifiable` for structurally valid foreign envelopes because this slice invokes no issuer- or format-specific verifier.
- Return `malformed` at `public` trust for invalid metadata.
- Keep the envelope opaque, do not parse foreign signatures, mutate the input, or upgrade trust.
- Export the narrow API and document the boundary.

## Checks

- [x] `uv run pytest tests/unit/lineage/test_foreign_attestation_contract.py -q` (4 passed)
- [x] `uv run ruff check src/`
- [x] `uv run ruff format --check src/bernstein/core/lineage/foreign_attestation.py tests/unit/lineage/test_foreign_attestation_contract.py docs/lineage.md`
- [x] `uv run pyright src/bernstein/core/lineage/foreign_attestation.py`
- [x] `uv run lint-imports`
- [x] `uv run bernstein agents-md sync`
- [ ] Full `uv run pyright src/`: currently reports unrelated pre-existing diagnostics in adjacent lineage modules; this slice is clean in isolation.
- [ ] Full suite not run: repository guidance warns against the non-isolated full pytest command.

Documentation: `docs/lineage.md` covers the foreign-attestation boundary and fail-closed outcomes.