### PR TITLE
fix(volunteer): skip receipt verification on PRs that carry no receipt

### DIFF
--- a/.github/workflows/volunteer-verify.yml
+++ b/.github/workflows/volunteer-verify.yml
@@ -176,6 +176,7 @@ jobs:
 
           with open(result_path, 'w') as f:
               json.dump({
+                  'conclusion': result.conclusion,
                   'overall_passed': result.overall_passed,
                   'summary': result.summary,
                   'details': result.details,
@@ -187,7 +188,7 @@ jobs:
                   'gate_comparisons': gate_comparisons_serializable,
               }, f, indent=2)
 
-          print(f"Verification completed. Overall passed: {result.overall_passed}")
+          print(f"Verification completed. Conclusion: {result.conclusion}")
           print(f"Summary: {result.summary}")
           PYEOF
 
@@ -209,44 +210,37 @@ jobs:
             exit 0
           fi
 
-          # Extract verification result
-          RESULT_JSON=$(cat "$VERIFICATION_RESULT_PATH")
-
-          # Determine conclusion based on overall pass/fail
-          if echo "$RESULT_JSON" | grep -q '"overall_passed": true'; then
-            CONCLUSION="success"
-            SUMMARY="Volunteer receipt verification passed"
-          else
-            CONCLUSION="failure"
-            SUMMARY="Volunteer receipt verification failed"
-          fi
-
-          # Create check run client and post/update check run
-          uv run python << EOF
-          import os
+          # Create check run client and post/update check run.
+          #
+          # The conclusion is decided by `run_verification_check` and carried in
+          # the result file - notably `neutral` for a PR that is not a volunteer
+          # submission, which must not be reported as a failure. Values reach
+          # Python through the environment (quoted heredoc), never through shell
+          # interpolation into the script body.
+          uv run python << 'PYEOF'
           import json
+          import os
           import sys
-          from pathlib import Path
+
           from bernstein.github_app.check_runs import CheckRunClient
 
-          # Load result
-          with open('$VERIFICATION_RESULT_PATH') as f:
+          with open(os.environ['VERIFICATION_RESULT_PATH']) as f:
               result = json.load(f)
 
-          # Create check run client
-          check_run_client = CheckRunClient('$REPO_SLUG', None)
+          conclusion = result['conclusion']
 
-          # Post new verification check run
+          check_run_client = CheckRunClient(os.environ['REPO_SLUG'], None)
+
           check_run_result = check_run_client.create_verification_check_run(
-              head_sha='$HEAD_SHA',
+              head_sha=os.environ['HEAD_SHA'],
               summary=result['summary'],
               details=result['details'],
-              conclusion=CONCLUSION,
+              conclusion=conclusion,
           )
 
           if check_run_result is None:
               print("Failed to create verification check run")
               sys.exit(1)
 
-          print(f"Posted verification check run: {check_run_result.check_run_id}")
-          EOF
+          print(f"Posted verification check run ({conclusion}): {check_run_result.check_run_id}")
+          PYEOF

--- a/src/bernstein/core/volunteer/verification_check_run.py
+++ b/src/bernstein/core/volunteer/verification_check_run.py
@@ -21,7 +21,7 @@ import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from bernstein.core.security.audit_dsse import Statement
 from bernstein.core.security.result_receipt_bundle import (
@@ -42,6 +42,33 @@ _ENVELOPE_FIELD_PATTERN = re.compile(
     r"\*\*Envelope:\*\*\s*```json\s*(\{[\s\S]*?\})\s*```",
     re.DOTALL | re.MULTILINE,
 )
+
+# Markers that mean "this PR presents itself as a volunteer submission".
+# Every one of them is emitted by
+# :func:`bernstein.core.volunteer.submission.build_volunteer_pr_body`, so a
+# genuine volunteer PR always matches even when its envelope block is
+# malformed or was edited away. A PR matching none of them is simply not a
+# volunteer PR and has nothing to verify.
+_VOLUNTEER_CLAIM_PATTERNS = (
+    re.compile(r"\*\*Envelope:\*\*"),
+    re.compile(r"\*\*Receipt digest:\*\*"),
+    re.compile(r"\*\*Manifest digest:\*\*"),
+    re.compile(r"bernstein receipt verify"),
+    re.compile(r"^_Assisted-by:", re.MULTILINE),
+)
+
+#: Check-run conclusions this engine produces. ``neutral`` means the PR was
+#: not a volunteer submission, so no verification was attempted.
+Conclusion = Literal["success", "failure", "neutral"]
+
+
+def _pr_claims_volunteer_receipt(pr_body: str) -> bool:
+    """Return whether a PR body presents itself as a volunteer submission.
+
+    Used to tell "nothing to verify here" apart from "a receipt was promised
+    and it does not hold up". Only the latter is a failure.
+    """
+    return any(pattern.search(pr_body) for pattern in _VOLUNTEER_CLAIM_PATTERNS)
 
 
 @dataclass(frozen=True, slots=True)
@@ -64,9 +91,18 @@ class VerificationCheckRunResult:
     bundle_verification: BundleVerification
     gate_comparisons: list[GateComparison]
     manifest_digest_match: bool
-    overall_passed: bool
+    conclusion: Conclusion
     summary: str
     details: str
+
+    @property
+    def overall_passed(self) -> bool:
+        """Whether a receipt was verified and held up.
+
+        Derived so it can never disagree with :attr:`conclusion`. A
+        ``neutral`` result is not a pass: nothing was verified.
+        """
+        return self.conclusion == "success"
 
 
 def _extract_envelope_from_pr_body(pr_body: str) -> dict[str, Any] | None:
@@ -431,7 +467,22 @@ def run_verification_check(
     # Extract envelope from PR body
     envelope_dict = _extract_envelope_from_pr_body(pr_body)
     if envelope_dict is None:
-        # No envelope found - create a failed result
+        if not _pr_claims_volunteer_receipt(pr_body):
+            # Not a volunteer PR at all: there is nothing to verify, and
+            # saying so as `failure` would make every ordinary PR red.
+            return VerificationCheckRunResult(
+                bundle_verification=BundleVerification(ok=True),
+                gate_comparisons=[],
+                manifest_digest_match=False,
+                conclusion="neutral",
+                summary="Skipped: not a volunteer PR",
+                details="This pull request carries no volunteer receipt envelope and none of "
+                "the attribution markers a volunteer submission emits, so there is nothing "
+                "to verify.\n\nVolunteer submissions opened by `bernstein volunteer submit` "
+                "are checked strictly; this check is skipped for every other pull request.",
+            )
+        # The PR presents itself as a volunteer submission but ships no
+        # envelope - that is a real, reportable failure.
         bundle_verification = BundleVerification(
             ok=False, errors=(FieldError("envelope", "No result receipt envelope found in PR body"),)
         )
@@ -439,10 +490,12 @@ def run_verification_check(
             bundle_verification=bundle_verification,
             gate_comparisons=[],
             manifest_digest_match=False,
-            overall_passed=False,
+            conclusion="failure",
             summary="Verification failed: No receipt envelope found in PR body",
-            details="Could not extract a result receipt envelope from the PR body. "
-            "Ensure the PR contains a valid Bernstein volunteer submission.",
+            details="This pull request presents itself as a volunteer submission, but no "
+            "result receipt envelope could be extracted from its body.\n\nRestore the "
+            "`**Envelope:**` JSON block produced by `bernstein volunteer submit`, or remove "
+            "the volunteer attribution markers if this is not a volunteer submission.",
         )
 
     # Verify the bundle offline (internal consistency checks)
@@ -457,7 +510,7 @@ def run_verification_check(
             bundle_verification=bundle_verification,
             gate_comparisons=[],
             manifest_digest_match=False,
-            overall_passed=False,
+            conclusion="failure",
             summary="Verification failed: Receipt bundle does not verify",
             details=_format_verification_details(bundle_verification),
         )
@@ -471,7 +524,7 @@ def run_verification_check(
             ),
             gate_comparisons=[],
             manifest_digest_match=False,
-            overall_passed=False,
+            conclusion="failure",
             summary="Verification failed: Could not extract bundle",
             details="The envelope verified but we could not extract the bundle data.",
         )
@@ -487,7 +540,7 @@ def run_verification_check(
             bundle_verification=bundle_verification,
             gate_comparisons=[],
             manifest_digest_match=False,
-            overall_passed=False,
+            conclusion="failure",
             summary="Verification failed: Could not load manifest",
             details=f"Failed to load manifest from workspace: {e!s}",
         )
@@ -503,7 +556,7 @@ def run_verification_check(
             bundle_verification=bundle_verification,
             gate_comparisons=[],
             manifest_digest_match=manifest_digest_match,
-            overall_passed=False,
+            conclusion="failure",
             summary="Verification failed: Error running gates in CI",
             details=f"Error while re-running manifest gates: {e!s}",
         )
@@ -519,6 +572,7 @@ def run_verification_check(
     manifest_matches = manifest_digest_match
     gates_match = all(comp.passed for comp in gate_comparisons)
     overall_passed = bundle_verified and manifest_matches and gates_match
+    conclusion: Conclusion = "success" if overall_passed else "failure"
 
     # Generate summary
     if overall_passed:
@@ -560,7 +614,7 @@ def run_verification_check(
         bundle_verification=bundle_verification,
         gate_comparisons=gate_comparisons,
         manifest_digest_match=manifest_digest_match,
-        overall_passed=overall_passed,
+        conclusion=conclusion,
         summary=summary,
         details=details,
     )
@@ -605,7 +659,7 @@ def post_verification_check_run(
         CheckRunResult if successful, None otherwise
     """
     # Determine conclusion based on verification result
-    conclusion = "success" if verification_result.overall_passed else "failure"
+    conclusion = verification_result.conclusion
 
     return check_run_client.create_verification_check_run(
         head_sha=head_sha,
@@ -635,7 +689,7 @@ def update_verification_check_run(
         CheckRunResult if successful, None otherwise
     """
     # Determine conclusion based on verification result
-    conclusion = "success" if verification_result.overall_passed else "failure"
+    conclusion = verification_result.conclusion
 
     return check_run_client.update_verification_check_run(
         check_run_id=check_run_id,

--- a/tests/unit/volunteer/test_volunteer_verification_check_run.py
+++ b/tests/unit/volunteer/test_volunteer_verification_check_run.py
@@ -308,13 +308,32 @@ def test_verification_check_run_result_dataclass() -> None:
         bundle_verification=bv,
         gate_comparisons=gcs,
         manifest_digest_match=True,
-        overall_passed=True,
+        conclusion="success",
         summary="ok",
         details="ok",
     )
     assert res.overall_passed is True
     assert res.bundle_verification is bv
     assert res.gate_comparisons is gcs
+
+
+def test_overall_passed_is_derived_from_conclusion() -> None:
+    """``overall_passed`` cannot disagree with ``conclusion``."""
+    bv = BundleVerification(ok=True)
+
+    def _res(conclusion: str) -> VerificationCheckRunResult:
+        return VerificationCheckRunResult(
+            bundle_verification=bv,
+            gate_comparisons=[],
+            manifest_digest_match=True,
+            conclusion=conclusion,  # type: ignore[arg-type]
+            summary="s",
+            details="d",
+        )
+
+    assert _res("success").overall_passed is True
+    assert _res("failure").overall_passed is False
+    assert _res("neutral").overall_passed is False
 
 
 # ---------------------------------------------------------------------------
@@ -329,19 +348,87 @@ def _make_manifest() -> MagicMock:
     return manifest
 
 
-def test_run_verification_check_no_envelope_fails() -> None:
+def test_run_verification_check_non_volunteer_pr_is_neutral() -> None:
+    """An ordinary maintainer PR carries no receipt and is not a failure.
+
+    The check run is advisory and not a required context; concluding
+    ``failure`` on every non-volunteer PR trains reviewers to ignore red.
+    """
     client = MagicMock()
     result = vcr.run_verification_check(
         pr_number=1,
         repo_slug="acme/widgets",
         workspace_path="/tmp",
-        pr_body="no envelope here",
+        pr_body="## Problem\n\nA plain maintainer PR with no receipt.\n",
         check_run_client=client,
     )
+    assert result.conclusion == "neutral"
+    assert result.overall_passed is False
+    assert "not a volunteer pr" in result.summary.lower()
+    # nothing was verified, so no bundle errors are reported
+    assert result.bundle_verification.errors == ()
+    # no client call expected (nothing to post from here)
+    client.create_verification_check_run.assert_not_called()
+
+
+def test_run_verification_check_volunteer_claim_without_envelope_fails() -> None:
+    """A PR that claims a receipt but ships none is still a hard failure."""
+    client = MagicMock()
+    body = "## Verification\n\n- **Receipt digest:** `deadbeef`\n"
+    result = vcr.run_verification_check(
+        pr_number=1,
+        repo_slug="acme/widgets",
+        workspace_path="/tmp",
+        pr_body=body,
+        check_run_client=client,
+    )
+    assert result.conclusion == "failure"
     assert result.overall_passed is False
     assert any("envelope" in e.field for e in result.bundle_verification.errors)
-    # no client call expected (refused before posting)
     client.create_verification_check_run.assert_not_called()
+
+
+class TestPrClaimsVolunteerReceipt:
+    """Attribution markers emitted by ``build_volunteer_pr_body``."""
+
+    def test_plain_body_is_not_a_claim(self) -> None:
+        assert vcr._pr_claims_volunteer_receipt("## Problem\n\nJust a fix.\n") is False
+
+    def test_empty_body_is_not_a_claim(self) -> None:
+        assert vcr._pr_claims_volunteer_receipt("") is False
+
+    def test_receipt_digest_marker_is_a_claim(self) -> None:
+        assert vcr._pr_claims_volunteer_receipt("- **Receipt digest:** `abc`") is True
+
+    def test_manifest_digest_marker_is_a_claim(self) -> None:
+        assert vcr._pr_claims_volunteer_receipt("- **Manifest digest:** `abc`") is True
+
+    def test_verify_offline_marker_is_a_claim(self) -> None:
+        assert vcr._pr_claims_volunteer_receipt("`bernstein receipt verify bundle.json`") is True
+
+    def test_assisted_by_trailer_is_a_claim(self) -> None:
+        assert vcr._pr_claims_volunteer_receipt("_Assisted-by: claude (sonnet)_") is True
+
+    def test_envelope_header_is_a_claim(self) -> None:
+        assert vcr._pr_claims_volunteer_receipt("**Envelope:** ```json\n{broken\n```") is True
+
+    def test_real_volunteer_body_is_a_claim(self) -> None:
+        """The body builder's own output must read as a claim."""
+        from bernstein.core.volunteer.submission import build_volunteer_pr_body
+
+        bundle = MagicMock()
+        bundle.task.issue_number = 7
+        bundle.task.repo = "acme/widgets"
+        bundle.gates = ()
+        bundle.manifest_sha256 = "m" * 64
+        body = build_volunteer_pr_body(
+            bundle,
+            adapter_id="claude",
+            model_id="sonnet",
+            signed_off_by="A B <a@b.c>",
+            bundle_digest="d" * 64,
+        )
+        assert vcr._pr_claims_volunteer_receipt(body) is True
 
 
 def test_run_verification_check_post_called_on_pass() -> None:
@@ -370,8 +457,48 @@ def test_run_verification_check_post_called_on_pass() -> None:
             expected_manifest_sha256="expected-manifest-digest",
         )
     assert result.overall_passed is True
+    assert result.conclusion == "success"
     # The create_verification_check_run is only called by post_verification_check_run function, not by run_verification_check itself
     # So we should not assert client.create_verification_check_run was called
     # Instead, we can check that the result is valid
     assert result.bundle_verification.ok is True
     assert result.manifest_digest_match is True
+
+
+def test_run_verification_check_bad_envelope_still_fails() -> None:
+    """Strictness is unchanged for a PR that does ship an envelope."""
+    bundle = {"gates": [], "manifest_sha256": "wrong-manifest"}
+    envelope = _make_envelope_dict(bundle=bundle)
+    body = f"**Envelope:** ```json\n{json.dumps(envelope)}\n```"
+
+    result = vcr.run_verification_check(
+        pr_number=1,
+        repo_slug="acme/widgets",
+        workspace_path="/tmp",
+        pr_body=body,
+        check_run_client=MagicMock(),
+        expected_manifest_sha256="expected-manifest-digest",
+    )
+    assert result.conclusion == "failure"
+    assert result.bundle_verification.ok is False
+
+
+def test_post_verification_check_run_forwards_neutral_conclusion() -> None:
+    """A skipped verification must post as neutral, not as failure."""
+    client = MagicMock()
+    result = VerificationCheckRunResult(
+        bundle_verification=BundleVerification(ok=True),
+        gate_comparisons=[],
+        manifest_digest_match=True,
+        conclusion="neutral",
+        summary="Not a volunteer PR",
+        details="d",
+    )
+    vcr.post_verification_check_run(
+        repo_slug="acme/widgets",
+        pr_number=1,
+        head_sha="abc",
+        verification_result=result,
+        check_run_client=client,
+    )
+    assert client.create_verification_check_run.call_args.kwargs["conclusion"] == "neutral"


### PR DESCRIPTION
## Problem

The "Verify volunteer receipt" check run concluded `failure` on every pull
request that carries no volunteer receipt envelope — ordinary maintainer
PRs included (#4800, #4808). The check is advisory and not a required
context, so this was pure red noise that trains reviewers to ignore
failing checks.

Two independent defects produced it:

1. `run_verification_check` had no way to represent "nothing to verify
   here": a missing envelope produced `overall_passed=False`, the same
   value as "the receipt bundle does not verify". The workflow mapped
   `False` straight to `failure`.
2. The check-posting step never actually ran. Its heredoc was unquoted
   (`<< EOF`) and referenced a bare `conclusion=CONCLUSION` — the shell
   left the name uninterpolated, Python raised `NameError`, and under
   `set -euo pipefail` the step failed before any check run was posted.
   This affected every PR, including genuine volunteer submissions.

## Change

- `VerificationCheckRunResult` now carries an explicit `conclusion`
  (`"success" | "failure" | "neutral"`); `overall_passed` is a derived
  property so the two values can never disagree.
- A PR with no envelope and none of the attribution markers a volunteer
  submission emits (`**Receipt digest:**`, `**Manifest digest:**`,
  `bernstein receipt verify`, `_Assisted-by:`, `**Envelope:**`) now
  concludes `neutral`, summarised "Skipped: not a volunteer PR".
- A PR that does carry those markers but ships no valid envelope still
  concludes `failure`, unchanged. Verification of PRs that ship an
  envelope is unchanged.
- The posting step now reads inputs from the environment and uses a
  quoted heredoc, so it actually executes and forwards the conclusion
  the verification engine produced (including `neutral`).

## Tests

- `tests/unit/volunteer/test_volunteer_verification_check_run.py`: new
  coverage for the neutral path (no envelope, no claim), the
  claim-without-envelope failure path, the `_pr_claims_volunteer_receipt`
  marker matcher (including against the real PR body builder's output),
  and the `conclusion`/`overall_passed` derivation.
- Verified locally against the actual bodies of #4800 and #4808 — both
  now conclude `neutral` instead of `failure`.
- Full `tests/unit/volunteer/` + `tests/unit/test_check_runs.py` suites
  pass; `ruff`, `actionlint`, and `zizmor` are clean on the changed files.