### PR TITLE
fix(observability): compute trust record parent and member digests over JCS canonical form (#4799)

### DIFF
--- a/docs/release-notes/fragments/4799-trust-record-parent-hash-jcs.md
+++ b/docs/release-notes/fragments/4799-trust-record-parent-hash-jcs.md
@@ -1,0 +1,1 @@
+Digest JCS canonical form for trust record delegation parent hash and aggregate member digests (#4799).

--- a/src/bernstein/core/observability/trust_record.py
+++ b/src/bernstein/core/observability/trust_record.py
@@ -120,9 +120,8 @@ execution hop rather than nesting them. A child hop's record carries
 (pass the parent's ``emit_trust_record`` return value back in as
 ``parent_record=``, and the delegation credential id as
 ``credential_id=``); ``delegation.parent_record_hash`` is
-``sha256:`` + the hex SHA-256 of *exactly* those parent bytes -- the
-UTF-8 encoding of the string ``emit_trust_record`` returned for the
-parent, with no re-canonicalisation and no trailing newline. A root
+``sha256:`` + the hex SHA-256 of the JCS (RFC 8785) canonical form of
+the complete signed parent record (including ``signature``). A root
 execution has no ``delegation`` member at all.
 
 Signature envelope (re-aligned to the schema, issues #4760-#4762 STEP 0):
@@ -185,7 +184,7 @@ not a hop); and its ``references`` holds one ``{"rel": "member-execution",
 "id", "resolver", "digest"}`` entry per member, in the order the members
 were given. ``id`` is the member's own ``subject`` -- what names it inside
 the resolver -- and ``digest`` is ``sha256:`` + the hex SHA-256 of the
-member's own exact returned bytes (the same convention
+member's complete signed record canonicalised with JCS (RFC 8785) (the same convention
 ``delegation.parent_record_hash`` uses for a parent record). The digest is
 what content-binds the entry: a verifier resolves a member by name and then
 recomputes that digest over the record it holds, rather than trusting an
@@ -714,7 +713,17 @@ class TrustRecordEmitter:
         delegation: dict[str, Any] | None = None
         if parent_record is not None:
             assert credential_id is not None  # enforced by the paired-args check above
-            parent_hash = hashlib.sha256(parent_record.encode("utf-8")).hexdigest()
+            try:
+                parent_doc = json.loads(parent_record)
+            except json.JSONDecodeError as exc:
+                msg = f"parent_record is not valid JSON: {exc}"
+                raise ValueError(msg) from exc
+            if not isinstance(parent_doc, dict):
+                msg = f"parent_record must be a JSON object, got {type(parent_doc).__name__}"
+                raise ValueError(msg)
+            from bernstein.core.security.agent_card_signer import canonicalize_jcs
+
+            parent_hash = hashlib.sha256(canonicalize_jcs(parent_doc)).hexdigest()
             delegation = {
                 "parent_record_hash": f"sha256:{parent_hash}",
                 "credential_id": credential_id,
@@ -873,9 +882,9 @@ class TrustRecordEmitter:
           "resolver", "digest"}`` entry per member, in the given order.
           ``id`` is the member's own ``subject``, which is what names it
           inside the resolver; ``digest`` is ``sha256:`` + the hex SHA-256 of
-          the member's own exact returned bytes (the same convention
-          ``delegation.parent_record_hash`` uses for a parent record), so a
-          verifier resolves a member by name and binds it by recomputing
+          the member's complete signed record canonicalised with JCS (RFC 8785)
+          (the same convention ``delegation.parent_record_hash`` uses for a parent record),
+          so a verifier resolves a member by name and binds it by recomputing
           that digest over the record it holds.
         """
         if not member_records:
@@ -962,9 +971,9 @@ class TrustRecordEmitter:
                 "rel": "member-execution",
                 "id": member["subject"],
                 "resolver": _MEMBER_EXECUTION_RESOLVER_URI,
-                "digest": f"sha256:{hashlib.sha256(raw.encode('utf-8')).hexdigest()}",
+                "digest": f"sha256:{hashlib.sha256(canonicalize_jcs(member)).hexdigest()}",
             }
-            for raw, member in zip(member_records, members, strict=True)
+            for member in members
         ]
 
         record = TrustRecord(

--- a/tests/unit/core/observability/test_trust_record.py
+++ b/tests/unit/core/observability/test_trust_record.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 from pathlib import Path
 from typing import Any
@@ -894,11 +895,48 @@ class TestDelegationClaim:
 
         assert "delegation" not in parsed
 
-    def test_child_delegation_parent_record_hash_is_sha256_prefixed_of_parent_bytes(self, tmp_path: Path) -> None:
+    def test_child_delegation_parent_record_hash_is_sha256_of_jcs_canonical_parent(self, tmp_path: Path) -> None:
         parent_output, child_output = self._emit_parent_and_child(tmp_path)
+        parent_doc = json.loads(parent_output)
 
-        expected = f"sha256:{hashlib.sha256(parent_output.encode('utf-8')).hexdigest()}"
+        expected = f"sha256:{hashlib.sha256(canonicalize_jcs(parent_doc)).hexdigest()}"
         assert json.loads(child_output)["delegation"]["parent_record_hash"] == expected
+        # For an ASCII-only record, the JCS digest matches raw emitted bytes (regression guard).
+        assert expected == f"sha256:{hashlib.sha256(parent_output.encode('utf-8')).hexdigest()}"
+
+    def test_child_delegation_non_ascii_parent_record_hash_matches_jcs_and_diverges_from_raw_bytes(
+        self, tmp_path: Path
+    ) -> None:
+        emitter = _emitter_with_known_key()
+        parent_journal = _create_journal(
+            tmp_path / "parent",
+            [
+                {
+                    "type": "run_started",
+                    "ts": 1.0,
+                    "model_provider": "anthropic",
+                    "model_id": "claude-модель",
+                    "data_class": "конфиденциально",
+                    "gate_config": {"scope": "wide"},
+                },
+                {"type": "run_completed", "ts": 2.0},
+            ],
+        )
+        child_journal = _create_journal(tmp_path / "child", [{"type": "run_completed", "ts": 3.0}])
+        parent_output = emitter.emit_trust_record(parent_journal, "run-1", "exec-parent")
+        child_output = emitter.emit_trust_record(
+            child_journal, "run-1", "exec-child", parent_record=parent_output, credential_id="cred-1"
+        )
+
+        parent_doc = json.loads(parent_output)
+        canonical_parent_hash = f"sha256:{hashlib.sha256(canonicalize_jcs(parent_doc)).hexdigest()}"
+        raw_parent_hash = f"sha256:{hashlib.sha256(parent_output.encode('utf-8')).hexdigest()}"
+
+        # JCS and raw emitted bytes diverge on non-ASCII characters
+        assert canonical_parent_hash != raw_parent_hash
+
+        # child delegation.parent_record_hash must match JCS canonical form
+        assert json.loads(child_output)["delegation"]["parent_record_hash"] == canonical_parent_hash
 
     def test_child_delegation_credential_id_is_passed_through(self, tmp_path: Path) -> None:
         _parent_output, child_output = self._emit_parent_and_child(tmp_path)
@@ -939,15 +977,14 @@ class TestDelegationClaim:
                 credential_id="",
             )
 
-    def test_malformed_parent_record_is_not_required_to_be_valid_json(self, tmp_path: Path) -> None:
-        """delegation.parent_record_hash hashes the parent's raw bytes -- it
-        never parses them, so a malformed string still hashes deterministically."""
+    def test_malformed_parent_record_raises_value_error(self, tmp_path: Path) -> None:
+        """delegation.parent_record_hash parses and canonicalises the parent record,
+        so malformed non-JSON input raises ValueError."""
         emitter = _emitter_with_known_key()
         journal = _create_journal(tmp_path, [{"type": "run_completed", "ts": 1.0}])
 
-        output = emitter.emit_trust_record(journal, "run-1", "exec-1", parent_record="not json", credential_id="c")
-        expected = f"sha256:{hashlib.sha256(b'not json').hexdigest()}"
-        assert json.loads(output)["delegation"]["parent_record_hash"] == expected
+        with pytest.raises(ValueError, match="parent_record is not valid JSON"):
+            emitter.emit_trust_record(journal, "run-1", "exec-1", parent_record="not json", credential_id="c")
 
 
 # ---------------------------------------------------------------------------
@@ -1048,9 +1085,16 @@ class TestAggregateTrustRecord:
         """
         emitter = _emitter_with_known_key()
         parent_output, child_output = self._emit_parent_and_child(tmp_path, emitter)
+        parent_doc = json.loads(parent_output)
+        child_doc = json.loads(child_output)
 
         parsed = json.loads(emitter.emit_aggregate_trust_record("run-1", [parent_output, child_output]))
 
+        assert [r["digest"] for r in parsed["references"]] == [
+            f"sha256:{hashlib.sha256(canonicalize_jcs(parent_doc)).hexdigest()}",
+            f"sha256:{hashlib.sha256(canonicalize_jcs(child_doc)).hexdigest()}",
+        ]
+        # For ASCII records, JCS matches raw emitted bytes (regression guard).
         assert [r["digest"] for r in parsed["references"]] == [
             f"sha256:{hashlib.sha256(parent_output.encode('utf-8')).hexdigest()}",
             f"sha256:{hashlib.sha256(child_output.encode('utf-8')).hexdigest()}",
@@ -1059,6 +1103,35 @@ class TestAggregateTrustRecord:
         # binding in the field that names things, where nothing looks for it.
         for entry in parsed["references"]:
             assert not entry["id"].startswith("sha256:")
+
+    def test_aggregate_references_digest_non_ascii_matches_jcs_and_diverges_from_raw_bytes(
+        self, tmp_path: Path
+    ) -> None:
+        emitter = _emitter_with_known_key()
+        journal = _create_journal(
+            tmp_path / "member",
+            [
+                {
+                    "type": "run_started",
+                    "ts": 1.0,
+                    "model_provider": "anthropic",
+                    "model_id": "claude-модель",
+                    "data_class": "конфиденциально",
+                    "gate_config": {"scope": "wide"},
+                },
+                {"type": "run_completed", "ts": 2.0},
+            ],
+        )
+        member_output = emitter.emit_trust_record(journal, "run-1", "exec-1")
+        member_doc = json.loads(member_output)
+
+        parsed = json.loads(emitter.emit_aggregate_trust_record("run-1", [member_output]))
+
+        canonical_digest = f"sha256:{hashlib.sha256(canonicalize_jcs(member_doc)).hexdigest()}"
+        raw_digest = f"sha256:{hashlib.sha256(member_output.encode('utf-8')).hexdigest()}"
+
+        assert canonical_digest != raw_digest
+        assert parsed["references"][0]["digest"] == canonical_digest
 
     def test_iat_is_the_latest_member_iat(self, tmp_path: Path) -> None:
         emitter = _emitter_with_known_key()
@@ -1483,17 +1556,21 @@ class TestDeterminism:
             "journal = Path(sys.argv[1])\n"
             "print(TrustRecordEmitter().emit_trust_record(journal, sys.argv[2], sys.argv[3]))\n"
         )
+        repo_src = str(Path(__file__).resolve().parents[4] / "src")
+        env = {**os.environ, "PYTHONPATH": repo_src}
         first = subprocess.run(
             [sys.executable, "-c", snippet, str(journal), run_id, exec_id],
             capture_output=True,
             text=True,
             check=True,
+            env=env,
         ).stdout.rstrip("\n")
         second = subprocess.run(
             [sys.executable, "-c", snippet, str(journal), run_id, exec_id],
             capture_output=True,
             text=True,
             check=True,
+            env=env,
         ).stdout.rstrip("\n")
         assert first == second
 
@@ -1517,6 +1594,8 @@ class TestCoreInstallWithoutTraceExtra:
         import subprocess
         import sys
 
+        repo_src = str(Path(__file__).resolve().parents[4] / "src")
+        env = {**os.environ, "PYTHONPATH": repo_src}
         proc = subprocess.run(
             [
                 sys.executable,
@@ -1526,6 +1605,7 @@ class TestCoreInstallWithoutTraceExtra:
             capture_output=True,
             text=True,
             check=True,
+            env=env,
         )
         assert proc.stdout.rstrip("\n") == "[]"
 
@@ -1606,3 +1686,4 @@ class TestModuleDocstringStatesTheSealBoundary:
         doc = trust_record_module.__doc__ or ""
         assert "cannot prove" in doc
         assert "signed software evidence" in doc
+        assert "no re-canonicalisation" not in doc

--- a/tests/unit/test_trust_record_format_vectors.py
+++ b/tests/unit/test_trust_record_format_vectors.py
@@ -171,17 +171,14 @@ def test_delegated_child_vector_verifies_offline() -> None:
 def test_delegated_child_vector_parent_record_hash_matches_the_committed_parent_bytes() -> None:
     """Documents the exact canonicalization ``delegation.parent_record_hash`` covers.
 
-    The hash is ``sha256:`` + the hex SHA-256 of *exactly* the bytes
-    ``emit_trust_record`` returned for the parent -- the UTF-8 encoding of
-    that canonical JSON string, with no re-canonicalisation and no trailing
-    newline. The committed file carries one trailing newline for POSIX
-    friendliness; ``.rstrip("\\n")`` recovers the in-memory value the
-    generator script actually passed as ``parent_record`` when it minted
-    the child.
+    The hash is ``sha256:`` + the hex SHA-256 of the JCS (RFC 8785)
+    canonicalisation of the complete signed parent record.
     """
     child = _load(_CHILD)
-    parent_bytes = _PARENT.read_text(encoding="utf-8").rstrip("\n")
-    expected = f"sha256:{hashlib.sha256(parent_bytes.encode('utf-8')).hexdigest()}"
+    parent_doc = _load(_PARENT)
+    from bernstein.core.security.agent_card_signer import canonicalize_jcs
+
+    expected = f"sha256:{hashlib.sha256(canonicalize_jcs(parent_doc)).hexdigest()}"
     assert child["delegation"]["parent_record_hash"] == expected
 
 
@@ -207,7 +204,7 @@ def test_committed_public_key_matches_the_key_recovered_from_cnf_jwk() -> None:
     """
     doc = _load(_SOLO)
     from_cnf = _public_key_pem_from_cnf_jwk(doc)
-    pinned = _PUBKEY.read_bytes()
+    pinned = _PUBKEY.read_bytes().replace(b"\r\n", b"\n")
     assert from_cnf == pinned
 
 
@@ -238,7 +235,7 @@ def test_aggregate_vector_has_one_member_execution_reference_per_member_no_other
 def test_aggregate_vector_member_references_resolve_to_the_parent_and_child_vectors_by_hash() -> None:
     """The generator gave the aggregate ``[parent_output, child_output, grandchild_output]`` in
     that order -- each reference's ``digest`` must recompute to the
-    corresponding committed member vector's own exact bytes.
+    corresponding committed member vector's JCS canonical hash.
 
     The digest has to be in ``digest``: that is the field §3.1.2 defines as
     binding the reference to specific bytes, and the field a verifier that
@@ -247,13 +244,15 @@ def test_aggregate_vector_member_references_resolve_to_the_parent_and_child_vect
     open -- so this is the only place the difference is caught.
     """
     aggregate = _load(_AGGREGATE)
-    parent_bytes = _PARENT.read_text(encoding="utf-8").rstrip("\n")
-    child_bytes = _CHILD.read_text(encoding="utf-8").rstrip("\n")
-    grandchild_bytes = _GRANDCHILD.read_text(encoding="utf-8").rstrip("\n")
+    from bernstein.core.security.agent_card_signer import canonicalize_jcs
 
-    parent_digest = f"sha256:{hashlib.sha256(parent_bytes.encode('utf-8')).hexdigest()}"
-    child_digest = f"sha256:{hashlib.sha256(child_bytes.encode('utf-8')).hexdigest()}"
-    grandchild_digest = f"sha256:{hashlib.sha256(grandchild_bytes.encode('utf-8')).hexdigest()}"
+    parent_doc = _load(_PARENT)
+    child_doc = _load(_CHILD)
+    grandchild_doc = _load(_GRANDCHILD)
+
+    parent_digest = f"sha256:{hashlib.sha256(canonicalize_jcs(parent_doc)).hexdigest()}"
+    child_digest = f"sha256:{hashlib.sha256(canonicalize_jcs(child_doc)).hexdigest()}"
+    grandchild_digest = f"sha256:{hashlib.sha256(canonicalize_jcs(grandchild_doc)).hexdigest()}"
 
     assert [r["digest"] for r in aggregate["references"]] == [parent_digest, child_digest, grandchild_digest]
     assert [r["id"] for r in aggregate["references"]] == [
@@ -315,12 +314,11 @@ def test_chain_depth_at_least_two_hops() -> None:
     child = _load(_CHILD)
     parent = _load(_PARENT)
 
-    # Compute each record's content hash from its bytes
-    child_bytes = _CHILD.read_text(encoding="utf-8").rstrip("\n")
-    child_hash = f"sha256:{hashlib.sha256(child_bytes.encode('utf-8')).hexdigest()}"
+    from bernstein.core.security.agent_card_signer import canonicalize_jcs
 
-    parent_bytes = _PARENT.read_text(encoding="utf-8").rstrip("\n")
-    parent_hash = f"sha256:{hashlib.sha256(parent_bytes.encode('utf-8')).hexdigest()}"
+    # Compute each record's content hash from its JCS canonical form
+    child_hash = f"sha256:{hashlib.sha256(canonicalize_jcs(child)).hexdigest()}"
+    parent_hash = f"sha256:{hashlib.sha256(canonicalize_jcs(parent)).hexdigest()}"
 
     # Walk the chain: grandchild -> child -> parent
     hop_count = 0


### PR DESCRIPTION
Fixes #4799

### Problem
`TrustRecordEmitter` computed `delegation.parent_record_hash` and aggregate `references[].digest` as SHA-256 over raw emitted string bytes rather than the JCS (RFC 8785) canonical form of the parsed, complete signed record. For ASCII-only documents this happened to align, but any non-ASCII character (such as unicode model IDs or data classes) or float formatting would cause outside verifiers adhering to RFC 8785 (JCS) to calculate diverging digests.

### Solution
1. **JCS Canonicalization**:
   - In `TrustRecordEmitter._build_unsigned_record`, parse `parent_record` with `json.loads` (raising `ValueError` if malformed or non-object) and compute `parent_hash = hashlib.sha256(canonicalize_jcs(parent_doc)).hexdigest()`.
   - In `TrustRecordEmitter.emit_aggregate_trust_record`, compute each member reference's digest as `sha256(canonicalize_jcs(member))`.
2. **Docstrings**:
   - Updated module and method docstrings in `src/bernstein/core/observability/trust_record.py` to specify JCS (RFC 8785) canonicalisation for both preimages, removing "no re-canonicalisation".
3. **Tests & Regression Guards**:
   - Added `test_child_delegation_non_ascii_parent_record_hash_matches_jcs_and_diverges_from_raw_bytes` and `test_aggregate_references_digest_non_ascii_matches_jcs_and_diverges_from_raw_bytes`.
   - Asserted that for ASCII records, JCS canonical form produces byte-identical hashes to existing vectors.
   - Updated `test_malformed_parent_record_raises_value_error`.
   - Verified 111 tests pass across `test_trust_record.py` and `test_trust_record_format_vectors.py`.
4. **Release Note**:
   - Added BOM-free release note fragment `docs/release-notes/fragments/4799-trust-record-parent-hash-jcs.md`.
