### PR TITLE
fix(github-app): post check runs under token auth without an installation id

### DIFF
--- a/src/bernstein/github_app/check_runs.py
+++ b/src/bernstein/github_app/check_runs.py
@@ -60,10 +60,14 @@ class ComparisonCheckRunResult:
 class CheckRunClient:
     """Thin wrapper around the GitHub Check Runs API via ``gh`` CLI.
 
+    Authentication is delegated entirely to ``gh`` (its token environment),
+    so the client itself needs only the repository slug to operate.
+
     Args:
-        repo: ``owner/repo`` slug.  Required for all API calls.
-        installation_id: GitHub App installation ID.  Required; if ``None``
-            or empty all operations are no-ops.
+        repo: ``owner/repo`` slug.  Required; if empty all operations are
+            no-ops.
+        installation_id: GitHub App installation ID, kept for callers that
+            track one.  Not used for API calls.
     """
 
     def __init__(self, repo: str, installation_id: str | None = None) -> None:
@@ -73,7 +77,7 @@ class CheckRunClient:
     @property
     def _configured(self) -> bool:
         """True if the client has enough config to make API calls."""
-        return bool(self._repo and self._installation_id)
+        return bool(self._repo)
 
     def create(
         self,

--- a/tests/unit/test_check_runs.py
+++ b/tests/unit/test_check_runs.py
@@ -40,16 +40,26 @@ def test_check_run_result_fields() -> None:
 
 
 class TestCheckRunClientCreate:
-    def test_create_not_configured_returns_none(self) -> None:
-        """No installation ID → silent no-op."""
-        client = CheckRunClient(repo="acme/widgets", installation_id=None)
+    def test_create_empty_repo_returns_none(self) -> None:
+        """No repo slug → silent no-op."""
+        client = CheckRunClient(repo="", installation_id="42")
         result = client.create(head_sha="abc123", task_title="Fix the bug")
         assert result is None
 
-    def test_create_empty_installation_returns_none(self) -> None:
-        client = CheckRunClient(repo="acme/widgets", installation_id="")
-        result = client.create(head_sha="abc123", task_title="Fix the bug")
-        assert result is None
+    def test_create_without_installation_id_calls_gh_api(self) -> None:
+        """Auth is delegated to gh; token-authenticated callers pass no installation ID."""
+        client = CheckRunClient(repo="acme/widgets", installation_id=None)
+        response_data = {"id": 999, "html_url": "https://github.com/checks/999"}
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps(response_data).encode()
+        mock_result.stderr = b""
+
+        with patch("subprocess.run", return_value=mock_result):
+            result = client.create(head_sha="abc123", task_title="Fix the bug")
+
+        assert result is not None
+        assert result.check_run_id == 999
 
     def test_create_calls_gh_api(self) -> None:
         client = CheckRunClient(repo="acme/widgets", installation_id="42")
@@ -113,8 +123,8 @@ class TestCheckRunClientCreate:
 
 
 class TestCheckRunClientUpdate:
-    def test_update_not_configured_returns_none(self) -> None:
-        client = CheckRunClient(repo="acme/widgets", installation_id=None)
+    def test_update_empty_repo_returns_none(self) -> None:
+        client = CheckRunClient(repo="", installation_id="42")
         result = client.update(check_run_id=123, conclusion="success", summary="All good")
         assert result is None
 
@@ -185,8 +195,8 @@ class TestCheckRunClientUpdate:
 
 
 class TestCheckRunClientCreateVerificationCheckRun:
-    def test_not_configured_returns_none(self) -> None:
-        client = CheckRunClient(repo="acme/widgets", installation_id=None)
+    def test_empty_repo_returns_none(self) -> None:
+        client = CheckRunClient(repo="", installation_id="42")
         result = client.create_verification_check_run(
             head_sha="abc123",
             summary="summary",
@@ -194,6 +204,26 @@ class TestCheckRunClientCreateVerificationCheckRun:
             conclusion="success",
         )
         assert result is None
+
+    def test_without_installation_id_posts_check_run(self) -> None:
+        """The receipt verification workflow authenticates via gh and passes no installation ID."""
+        client = CheckRunClient(repo="acme/widgets", installation_id=None)
+        response_data = {"id": 200, "html_url": "https://github.com/checks/200"}
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps(response_data).encode()
+        mock_result.stderr = b""
+
+        with patch("subprocess.run", return_value=mock_result):
+            result = client.create_verification_check_run(
+                head_sha="abc123",
+                summary="summary",
+                details="details",
+                conclusion="neutral",
+            )
+
+        assert result is not None
+        assert result.check_run_id == 200
 
     def test_success_returns_comparison_check_run_result(self) -> None:
         client = CheckRunClient(repo="acme/widgets", installation_id="42")
@@ -241,8 +271,8 @@ class TestCheckRunClientCreateVerificationCheckRun:
 
 
 class TestCheckRunClientUpdateVerificationCheckRun:
-    def test_not_configured_returns_none(self) -> None:
-        client = CheckRunClient(repo="acme/widgets", installation_id=None)
+    def test_empty_repo_returns_none(self) -> None:
+        client = CheckRunClient(repo="", installation_id="42")
         result = client.update_verification_check_run(
             check_run_id=123,
             summary="summary",


### PR DESCRIPTION
## Problem

`CheckRunClient._configured` requires an installation id, but no API call uses it — authentication is delegated to the `gh` CLI. The receipt verification workflow constructs the client as `CheckRunClient(repo_slug, None)` (token auth), so every check-run POST returned `None` and the posting step exited 1 on every PR the workflow ran on (e.g. [this run](https://github.com/sipyourdrink-ltd/bernstein/actions/runs/33311762523)).

## Fix

`_configured` now requires only the repo slug. The installation id stays accepted for callers that track one and is documented as unused for API calls.

## Tests

- `test_create_without_installation_id_calls_gh_api` / `test_without_installation_id_posts_check_run` pin the token-auth caller shape (red before the fix).
- Empty-repo no-op coverage retained.