### PR TITLE
chore: keep trust record vectors byte-exact across checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,8 @@ docs/assets/demo-run/run-receipt.pub.pem -text linguist-generated
 # evidence that tests/unit/test_*_receipt_format_vectors.py compares against.
 tests/fixtures/receipt-vectors/*.json -text
 tests/fixtures/receipt-vectors/*.pem -text
+# Trust record vectors are the same byte-exact artefacts as the receipt
+# vectors above: a signature is over the bytes, and the committed public key
+# is compared byte-for-byte, so no checkout may translate their line endings.
+tests/fixtures/trust-record-vectors/*.json -text
+tests/fixtures/trust-record-vectors/*.pem -text


### PR DESCRIPTION
`.gitattributes` already exempts `tests/fixtures/receipt-vectors` from EOL translation, and states the reason in place: a signature is over the bytes, so a checkout that rewrites line endings silently invalidates the committed evidence.

`tests/fixtures/trust-record-vectors` holds the same class of artefact — signed records plus a public key that `tests/unit/test_trust_record_format_vectors.py` compares byte-for-byte — and was never added to that rule.

Verified with `git check-attr text --` on the vector files: `text: unset` after the change.

Without this, a CRLF checkout mangles the committed key, and a test comparing it against bytes recovered from the vector has to strip line endings to pass — weakening the check instead of fixing its cause.