### PR TITLE
fix(cluster): key REST node re-registration on name+url, not a fresh id

### DIFF
--- a/src/bernstein/core/routes/task_cluster.py
+++ b/src/bernstein/core/routes/task_cluster.py
@@ -85,7 +85,7 @@ def _verify_cluster_auth(request: Request, required_scope: str) -> None:
 
 @router.post("/cluster/nodes", status_code=201, responses=_AUTH_RESPONSES)
 def register_node(body: NodeRegisterRequest, request: Request) -> NodeResponse:
-    """Register a new node in the cluster."""
+    """Register a node, or update the entry of one that is re-registering."""
     from bernstein.core.cluster_auth import SCOPE_NODE_REGISTER
 
     _verify_cluster_auth(request, SCOPE_NODE_REGISTER)
@@ -97,6 +97,15 @@ def register_node(body: NodeRegisterRequest, request: Request) -> NodeResponse:
         gpu_available=body.capacity.gpu_available,
         supported_models=body.capacity.supported_models,
     )
+    # Re-registration is keyed on the node's operator-visible identity
+    # (name + url), not on a per-call id -- the same rule the gRPC
+    # RegisterNode handler follows (grpc_server.py). A worker that restarts
+    # has no memory of the id the server gave it, so minting a fresh NodeInfo
+    # per call left the old entry behind: the registry carried one row per
+    # restart, and cluster_summary counted that worker's capacity once per
+    # row. The request already carries the whole identity, so this is a
+    # lookup before the register call rather than a schema change.
+    existing = node_registry.find_by_identity(body.name, body.url)
     node = NodeInfo(
         name=body.name,
         url=body.url,
@@ -104,6 +113,8 @@ def register_node(body: NodeRegisterRequest, request: Request) -> NodeResponse:
         labels=body.labels,
         cell_ids=body.cell_ids,
     )
+    if existing is not None:
+        node.id = existing.id
     registered = node_registry.register(node)
     return node_to_response(registered)
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2095,6 +2095,94 @@ async def test_register_node(cluster_client: AsyncClient) -> None:
 
 
 @pytest.mark.anyio
+async def test_re_registering_the_same_node_updates_its_entry(cluster_client: AsyncClient) -> None:
+    """A worker that restarts must not become a second node (#3803).
+
+    ``register_node`` minted a fresh ``NodeInfo`` -- and so a fresh random id
+    -- on every call, so a worker that restarted three times left three
+    entries and ``cluster_summary`` counted its slots three times. The gRPC
+    handler already keys on name+url (#3796); this is the REST surface
+    catching up.
+
+    Asserted on the registry count *and* the capacity total, because a test
+    that only checked the second call returned 201 passes on the broken code.
+    """
+    first = await cluster_client.post("/cluster/nodes", json=NODE_PAYLOAD)
+    assert first.status_code == 201
+    first_id = first.json()["id"]
+
+    second = await cluster_client.post("/cluster/nodes", json=NODE_PAYLOAD)
+    assert second.status_code == 201
+    # The same worker, so the same entry: the id it was first given survives.
+    assert second.json()["id"] == first_id
+
+    listed = await cluster_client.get("/cluster/nodes")
+    assert len(listed.json()) == 1, "a restarting worker left a second entry"
+
+    status = await cluster_client.get("/cluster/status")
+    body = status.json()
+    assert body["total_nodes"] == 1
+    # The point of the bug: capacity counted once, not once per registration.
+    assert body["total_capacity"] == NODE_PAYLOAD["capacity"]["max_agents"]
+    assert body["available_slots"] == NODE_PAYLOAD["capacity"]["available_slots"]
+
+
+@pytest.mark.anyio
+async def test_a_different_node_still_registers_separately(cluster_client: AsyncClient) -> None:
+    """Only the *same* identity collapses -- two workers stay two entries.
+
+    Guards the over-correction: keying on name+url must not merge distinct
+    workers, which would under-report capacity instead of over-reporting it.
+    """
+    await cluster_client.post("/cluster/nodes", json=NODE_PAYLOAD)
+    other = {**NODE_PAYLOAD, "name": "worker-2", "url": "http://worker2:8052"}
+    await cluster_client.post("/cluster/nodes", json=other)
+
+    listed = await cluster_client.get("/cluster/nodes")
+    assert len(listed.json()) == 2
+
+    status = await cluster_client.get("/cluster/status")
+    assert status.json()["total_capacity"] == NODE_PAYLOAD["capacity"]["max_agents"] * 2
+
+
+@pytest.mark.anyio
+async def test_same_name_on_a_different_url_is_a_different_node(cluster_client: AsyncClient) -> None:
+    """Identity is name *and* url, so a redeployed worker on a new address is new.
+
+    Two hosts running a worker that shares a name is the ordinary case in a
+    cluster; collapsing them on name alone would hide one of them.
+    """
+    await cluster_client.post("/cluster/nodes", json=NODE_PAYLOAD)
+    moved = {**NODE_PAYLOAD, "url": "http://worker1-relocated:8052"}
+    await cluster_client.post("/cluster/nodes", json=moved)
+
+    listed = await cluster_client.get("/cluster/nodes")
+    assert len(listed.json()) == 2
+
+
+@pytest.mark.anyio
+async def test_re_registering_refreshes_the_reported_capacity(cluster_client: AsyncClient) -> None:
+    """The updated entry carries the *new* capacity, not the stale one.
+
+    Re-registration exists so a worker can report what it can do now; keeping
+    the id but also keeping the old capacity would trade one wrong total for
+    another.
+    """
+    await cluster_client.post("/cluster/nodes", json=NODE_PAYLOAD)
+    grown = {
+        **NODE_PAYLOAD,
+        "capacity": {**NODE_PAYLOAD["capacity"], "max_agents": 8, "available_slots": 8},
+    }
+    await cluster_client.post("/cluster/nodes", json=grown)
+
+    status = await cluster_client.get("/cluster/status")
+    body = status.json()
+    assert body["total_nodes"] == 1
+    assert body["total_capacity"] == 8
+    assert body["available_slots"] == 8
+
+
+@pytest.mark.anyio
 async def test_list_nodes_empty(cluster_client: AsyncClient) -> None:
     """GET /cluster/nodes returns [] when no nodes registered."""
     resp = await cluster_client.get("/cluster/nodes")


### PR DESCRIPTION
Fixes #3803. Written against your corrections in the issue thread rather than the original body — identity lookup, no schema change.

## The change

`register_node` minted a fresh `NodeInfo`, and so a fresh random id, on every call. A worker that restarted three times left three registry entries and `cluster_summary` counted its slots three times.

It now mirrors what #3796 landed for gRPC: `find_by_identity(name, url)` before the register call, carrying the existing id onto the new record. `NodeRegisterRequest` is untouched — it already carries the whole identity.

## Your question about the status reset

**I think the reset is wrong, so per your instruction this PR is the identity fix only and the status question is filed separately as #4820.**

The reasoning, for the record. `NodeInfo.status` defaults to `NodeStatus.ONLINE`, so rebuilding the record silently returns a `CORDONED` or `DRAINING` worker to `ONLINE`. Three things make me think that is a surprise rather than a correct default:

1. **It inverts the safety property.** An operator cordons a node to stop scheduling onto it, and the common reason to cordon is that the node is misbehaving. A misbehaving node restarts more often than a healthy one — so the worse a worker behaves, the more often it escapes the cordon. The failure mode selects for exactly the nodes the operator was protecting against.
2. **It is the same bug class as this issue.** Un-cordoning silently puts a node's slots back into `total_capacity`, which is over-reporting capacity by a different route. Fixing the row count while leaving that open only closes half of it.
3. **The domain convention is the other way.** A kubelet restart does not clear `spec.unschedulable`; cordon survives node restart, and operators carry that expectation across.

The counter-argument is real — a restarted worker is a new process, and the operator can re-cordon — but it requires the operator to notice, and nothing surfaces the transition.

I have deliberately **not** acted on that here. It affects the gRPC handler identically, so it wants one decision applied to both surfaces, and folding it in would make this PR the thing you said you did not want: two surfaces disagreeing, or a scope creep that is harder to review than either half.

## Tests

Four, through the HTTP surface rather than the registry:

| test | on `main` |
| --- | --- |
| same name+url twice → one entry, capacity counted once | **fails** — `assert 2 == 1` on `total_nodes` |
| re-registering refreshes reported capacity | **fails** |
| two different workers stay two entries | passes (guards the over-correction) |
| same name, different url stays two entries | passes (identity is both fields) |

The first fails on the entry count before it reaches the capacity assertion, as you predicted. The two guards passing on both old and new code is the point of including them — they would catch a fix that collapsed distinct workers and under-reported capacity instead.

## Verify

Your commands, via `.venv` (no `uv` on this machine):

- `pytest tests/unit/routes/` — 8 passed
- `pytest tests/unit/test_server.py` — 126 passed
- `pytest tests/unit -k "cluster or node"` — 503 passed, 1 skipped
- `ruff check src/bernstein/core/routes/` — clean; `ruff format --check` — 72 files already formatted
- `mypy src/bernstein/core/routes/` — no issues in 71 source files

Out of scope as the issue asks: the missing `_verify_cluster_auth()` on `steal_tasks` in the same file.

