### PR TITLE
feat: bernstein trace export subcommand

### DIFF
--- a/bernstein.yaml
+++ b/bernstein.yaml
@@ -5,20 +5,20 @@ goal: 'Implement tickets from .sdd/backlog/open/ by priority (p0 first, then p1,
 
   '
 cli: claude
-max_agents: 2
+max_agents: 7
 role_model_policy:
-  manager: {model: fleet-live-strong, effort: max}
-  architect: {model: fleet-live-strong, effort: max}
-  security: {model: fleet-live, effort: high}
-  backend: {model: fleet-live, effort: high}
-  frontend: {model: fleet-live, effort: high}
-  qa: {model: fleet-live, effort: high}
-  reviewer: {model: fleet-live, effort: high}
-  docs: {model: fleet-live, effort: high}
-  devops: {model: fleet-live, effort: high}
+  manager: {model: coding-manager, effort: max}
+  architect: {model: coding-manager, effort: max}
+  security: {model: coding-worker, effort: high}
+  backend: {model: coding-worker, effort: high}
+  frontend: {model: coding-worker, effort: high}
+  qa: {model: coding-worker, effort: high}
+  reviewer: {model: coding-worker, effort: high}
+  docs: {model: coding-worker, effort: high}
+  devops: {model: coding-worker, effort: high}
 budget: $0
 internal_llm_provider: openai
-internal_llm_model: fleet-live-strong
+internal_llm_model: coding-manager
 evolution_enabled: false
 auto_decompose: false
 constraints:
@@ -37,7 +37,7 @@ quality_gates:
   type_check: false
   tests: true
   test_command: uv run python scripts/run_tests.py -x --affected origin/main --parallel 4
-  timeout_s: 2400
+  timeout_s: 900
   merge_conflict_check: true
   large_file_check: true
 context_files:

--- a/bernstein.yaml
+++ b/bernstein.yaml
@@ -5,20 +5,20 @@ goal: 'Implement tickets from .sdd/backlog/open/ by priority (p0 first, then p1,
 
   '
 cli: claude
-max_agents: 7
+max_agents: 2
 role_model_policy:
-  manager: {model: coding-manager, effort: max}
-  architect: {model: coding-manager, effort: max}
-  security: {model: coding-worker, effort: high}
-  backend: {model: coding-worker, effort: high}
-  frontend: {model: coding-worker, effort: high}
-  qa: {model: coding-worker, effort: high}
-  reviewer: {model: coding-worker, effort: high}
-  docs: {model: coding-worker, effort: high}
-  devops: {model: coding-worker, effort: high}
+  manager: {model: fleet-live-strong, effort: max}
+  architect: {model: fleet-live-strong, effort: max}
+  security: {model: fleet-live, effort: high}
+  backend: {model: fleet-live, effort: high}
+  frontend: {model: fleet-live, effort: high}
+  qa: {model: fleet-live, effort: high}
+  reviewer: {model: fleet-live, effort: high}
+  docs: {model: fleet-live, effort: high}
+  devops: {model: fleet-live, effort: high}
 budget: $0
 internal_llm_provider: openai
-internal_llm_model: coding-manager
+internal_llm_model: fleet-live-strong
 evolution_enabled: false
 auto_decompose: false
 constraints:
@@ -37,7 +37,7 @@ quality_gates:
   type_check: false
   tests: true
   test_command: uv run python scripts/run_tests.py -x --affected origin/main --parallel 4
-  timeout_s: 900
+  timeout_s: 2400
   merge_conflict_check: true
   large_file_check: true
 context_files:

--- a/docs/observability/trace-export.md
+++ b/docs/observability/trace-export.md
@@ -1,0 +1,143 @@
+# Trust records (trace export)
+
+`bernstein trace export` emits a **TRACE 0.2 Trust Record** — a signed
+JWT-style JSON blob (Ed25519) that proves a run's journal chain is intact
+and binds the run to the install identity. It is generated entirely
+offline from local state; no OTLP endpoint or network is required.
+
+```
+bernstein trace export <RUN_ID> [--out PATH] [--json] [--last] [--sdd-dir PATH]
+```
+
+- `--last` picks the most recently finished run in `.sdd/runs/`
+  (a directory with a non-empty `journal.jsonl`), sorted by mtime.
+- `--out` writes the canonical JSON string to a file instead of stdout.
+- `--json` emits the canonical JSON form (identical to the default output).
+- `--sdd-dir` overrides the `.sdd/` path; defaults to `./.sdd/` or `./.`.
+
+Exit codes: `0` = exported, `1` = run not found / chain broken / emit
+error, `2` = missing `RUN_ID` argument.
+
+The trace extra (`bernstein[trace]`) is required.
+
+## What is in a trust record
+
+Every trust record carries a fixed set of claims. The data class is
+`TrustRecordEmitter` (`src/bernstein/core/observability/trust_record.py`);
+see its docstring for the canonical shape.
+
+| Field | Value |
+|---|---|
+| `eat_profile` | `tag:agentrust-io.com,2026:trace-v0.2` — identifies this as a TRACE v0.2 Trust Record. |
+| `iat` | Execution completion time, Unix epoch seconds, sourced from the journal. |
+| `subject` | SPIFFE URI scoped to the execution: `spiffe://bernstein.run/run/<run>/exec/<exec>`. |
+| `model` | `{"provider": ..., "model_id": ..., "version"?}`. |
+| `runtime` | `{"platform": "software-only", "measurement": "sha256:0000…"}` — software evidence only; never a real hardware measurement. The all-zero digest is the honest way to say "no hardware measurement exists". |
+| `policy` | `{"bundle_hash": <sha256>, "enforcement_mode": "enforce"}`. |
+| `data_class` | Operator-declared data sensitivity; defaults to `confidential` when undeclared. |
+| `tool_transcript` | `{"hash": <sha256>, "call_count": <int>}` — hash over tool-call entries in the journal. |
+| `build_provenance` | `{"slsa_level": 0, "digest": <sha256>, "provenance_uri": <release page URL>}`. |
+| `appraisal` | `{"status": "none", "verifier": "https://bernstein.run/trace/verifier", "timestamp": <int>}`. |
+| `cnf` | `{"jwk": {"kty": "OKP", "crv": "Ed25519", "x": <base64url>, "kid": <key-id>}}` — the public Ed25519 key for the install identity that produced `signature`. `kid` names that key. |
+| `delegation` | Present only on delegated child hops: `{"parent_record_hash": <sha256>, "credential_id": <str>}`. Absent (not null) on root/solo executions. |
+| `references` | Produced-artifact pointers (`rel: "produced-artifact"`) when the execution produced any; absent (not an empty list) otherwise. |
+| `signature` | Base64url (no padding) Ed25519 signature over the JCS canonicalisation of every other field. |
+
+The signed body is the JCS canonical JSON form of all fields except
+`signature` — optional members (`delegation`, `references`) are omitted
+entirely when absent, never emitted as `null`. RFC 8785 canonicalisation
+treats "key present" and "key absent" as different bytes.
+
+## What is deliberately NOT in a trust record
+
+Trust records are **provenance envelopes**, not data containers. They
+prove *about* a run; they do not carry the run's payload.
+
+- **Prompt text**. Input prompts are redacted before they enter the
+  journal (see [trace store — credential safety](trace-store.md#credential-safety)),
+  and they are never part of the trust record either.
+- **Artifact contents**. Produced-file bytes, model responses, and other
+  large payloads are not embedded. A `references` entry names an artifact
+  (`id`) and carries its content digest (`digest`), but the bytes
+  themselves live elsewhere (the content-addressed trace store, the
+  run directory).
+- **Raw journal rows**. The record hashes the tool transcript but does
+  not include individual journal events. Verifiers that need the full
+  chain read the journal directly from `.sdd/runs/<run_id>/journal.jsonl`
+  and verify the chain independently.
+- **Private keys**. The `cnf.jwk` field carries only the **public**
+  half. The private signing key never leaves the install keyring.
+
+If a verifier needs prompt text or artifact contents, it must read them
+from the journal and the content-addressed store — the trust record
+itself is intentionally lightweight and does not replicate them.
+
+## Verifying offline
+
+The record is self-contained: anyone with the install public key (from
+`cnf.jwk`) can verify the signature without network access. For schema
+and semantics conformance, the reference executable suite
+`agentrust-trace-tests` is available on PyPI.
+
+Install it (or resolve it via `uv run --with`):
+
+```bash
+pip install agentrust-trace-tests
+```
+
+Then verify a record file against the TRACE v0.2 schema at Level 1
+(checks claims beyond the bare schema, including cross-field invariants):
+
+```bash
+trace-tests verify --record <file> --level 1
+```
+
+Level 0 validates the schema and signature only; Level 1 adds
+cross-field invariants such as SPIFFE subject scoping and delegation
+parent-child hash binding. Use Level 1 for production records.
+
+### Vectors for testing
+
+Four committed test vectors under
+`tests/fixtures/trust-record-vectors/` cover the four record shapes:
+
+- `single-execution-trust-record.json` — root, non-delegated execution
+- `delegated-parent-trust-record.json` — parent hop of a two-hop run
+- `delegated-child-trust-record.json` — child hop, carries `delegation`
+- `aggregate-trust-record.json` — run-level rollup, carries
+  `references[rel=member-execution]`
+
+Run the reference suite against any one:
+
+```bash
+uv run --with agentrust-trace-tests==0.5.1 trace-tests verify \
+    --record tests/fixtures/trust-record-vectors/single-execution-trust-record.json \
+    --level 1 --max-age 999999999999
+```
+
+(`--max-age` is set far above the default 24 h window because the
+fixture vectors use a frozen 2023-11-14 clock, not wall-clock time —
+an unmodified default would reject all four as stale.)
+
+## Relationship to other trace commands
+
+| Command | What it emits / checks |
+|---|---|
+| `bernstein trace export <RUN_ID>` | Signed TRACE 0.2 Trust Record (this page) |
+| `bernstein trace project <RUN_ID>` | Signed OTel GenAI span set projected from the journal |
+| `bernstein trace verify-projection <RUN_ID>` | Verifies the OTel span projection against the journal |
+| `bernstein trace show <task-id>` | Pretty-printed live JSONL trace for a task |
+| `bernstein trace serve` | Read-only FastAPI viewer over the local content-addressed trace store |
+
+The trust record and the OTel projection are independent outputs from
+the same journal. The trust record proves provenance; the projection is
+a structured telemetry view. See [OTel span projection (offline)](otel-span-projection.md)
+for the span-side workflow.
+
+## Source
+
+`src/bernstein/cli/commands/advanced_cmd.py` (`trace export`),
+`src/bernstein/core/observability/trust_record.py`
+(`TrustRecordEmitter`, `sign_trust_record`, `verify_trust_record`),
+`tests/fixtures/trust-record-vectors/` (committed test vectors),
+`schemas/trace-spec/0.2/trace-v0.2.json` (vendored schema).

--- a/docs/release-notes/fragments/4667-trace-export-subcommand.md
+++ b/docs/release-notes/fragments/4667-trace-export-subcommand.md
@@ -1,0 +1,8 @@
+## `bernstein trace export` emits TRACE 0.2 Trust Records
+
+A new `bernstein trace export <RUN_ID>` subcommand (plus `--last`, `--out`,
+`--json`, and `--sdd-dir` flags) lets operators extract a finished run's
+execution evidence as a signed TRACE 0.2 Trust Record from local state —
+no OTLP endpoint, no collector, no network. The record proves the journal
+chain is intact and binds the run to the install identity via an Ed25519
+signature. The trace extra (`bernstein[trace]`) is required (#4667).

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -1503,7 +1503,6 @@ def trace_export_cmd(
         click.echo(trust_record_json)
 
 
-
 @trace_cmd.command("export-projection")
 @click.argument("run_id")
 @click.option(

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -1380,6 +1380,143 @@ def trace_project_cmd(run_id: str, workdir: str, no_stability: bool, as_json: bo
 def trace_verify_projection_cmd(run_id: str, workdir: str, projection_path: str | None) -> None:
     """Verify ``RUN_ID``'s signed projection and authenticated audit binding.
 
+    \b
+    bernstein trace export <RUN_ID> [--out PATH] [--json] [--last]
+
+    Exports the execution evidence for a specific run as a TRACE 0.2
+    Trust Record (JWT-style JSON with an Ed25519 signature). The
+    signature verifies that the on-disk journal chain matches the
+    record's ``subject`` (run/exec split).
+
+    \b
+    --last: scan ``.sdd/runs/`` for directories with a non-empty journal,
+            sort by modification time, and use the newest. Omits the
+            positional RUN_ID.
+    --out: write the canonical JSON string to a file. Default is stdout.
+    --json: currently redundant (the export is always JSON) but kept for
+            future extensibility and consistency with other subcommands.
+    """
+    import json as _json
+
+    # Gate on trace extra
+    try:
+        import agentrust_trace as _trace_lib  # type: ignore[import-untyped,unused-ignore]
+    except ImportError:
+        console.print("[red]The trace extra is required:[/red] pip install bernstein[trace]")
+        raise SystemExit(1)
+
+    # SDD_DIR resolves as: explicit --sdd-dir option if given, else Path(workdir)/.sdd, else Path(.sdd)
+    # Check parent context / options
+    sdd_dir_opt = None
+    if ctx.parent and ctx.parent.params:
+        sdd_dir_opt = ctx.parent.params.get("sdd_dir")
+    if sdd_dir_opt:
+        sdd_path = Path(sdd_dir_opt)
+    else:
+        workdir_opt = None
+        if ctx.parent and ctx.parent.params:
+            workdir_opt = ctx.parent.params.get("workdir")
+        if workdir_opt:
+            sdd_path = Path(workdir_opt) / ".sdd"
+        else:
+            sdd_path = Path(".sdd")
+
+    # Determine the run_id based on the --last flag or the positional argument
+    if latest:
+        runs_dir = sdd_path / "runs"
+        if not runs_dir.exists():
+            console.print(f"[red]No runs directory found under {runs_dir}.[/red]")
+            raise SystemExit(1)
+
+        # Find directories with non-empty journal.jsonl files
+        candidate_dirs = []
+        for item in runs_dir.iterdir():
+            if item.is_dir():
+                journal_file = item / "journal.jsonl"
+                if journal_file.exists() and journal_file.stat().st_size > 0:
+                    candidate_dirs.append(item)
+
+        if not candidate_dirs:
+            console.print(f"[yellow]No finished runs found under {runs_dir}.[/yellow]")
+            raise SystemExit(1)
+
+        # Sort by modification time descending, take the newest
+        latest_dir = max(candidate_dirs, key=lambda p: p.stat().st_mtime_ns)
+        target_run_id = latest_dir.name
+    else:
+        if not run_id:
+            console.print("[red]Usage:[/red] bernstein trace export <RUN_ID> [--out PATH] [--json] [--last]")
+            raise SystemExit(2)
+        target_run_id = run_id
+
+    # Find and verify the journal
+    try:
+        from bernstein.core.replay.journal import JournalPathError, run_journal_path, verify_journal
+
+        journal_path = run_journal_path(sdd_path, target_run_id)
+    except JournalPathError:
+        console.print(f"[red]No such run:[/red] {target_run_id}")
+        raise SystemExit(1)
+
+    if not journal_path.exists():
+        console.print(f"[red]No such run:[/red] {target_run_id}")
+        raise SystemExit(1)
+
+    try:
+        verification = verify_journal(journal_path)
+    except Exception as e:
+        console.print(f"[red]Failed to verify journal:[/red] {e}")
+        raise SystemExit(1)
+
+    if not verification.chain_consistent:
+        console.print(f"[red]Journal chain does not verify:[/red] {target_run_id}")
+        raise SystemExit(1)
+
+    # Generate and emit the trust record
+    from bernstein.core.observability.trust_record import TrustRecordEmitter
+
+    emitter = TrustRecordEmitter()
+    try:
+        trust_record_json = emitter.emit_trust_record(
+            journal_path=journal_path,
+            run_id=target_run_id,
+            exec_id=target_run_id,
+        )
+    except Exception as e:
+        console.print(f"[red]Failed to emit trust record:[/red] {e}")
+        raise SystemExit(1)
+
+    # Output the result
+    if output:
+        Path(output).write_text(trust_record_json, encoding="utf-8")
+        console.print(f"[green]Exported trace to:[/green] {output}")
+    else:
+        if as_json:
+            click.echo(trust_record_json)
+        else:
+            click.echo(trust_record_json)
+
+
+@trace_cmd.command("verify-projection")
+@click.argument("run_id")
+@click.option(
+    "--workdir",
+    "-w",
+    type=click.Path(file_okay=False, exists=True),
+    default=".",
+    show_default=True,
+    help="Project root containing .sdd/.",
+)
+@click.option(
+    "--projection",
+    "projection_path",
+    type=click.Path(dir_okay=False),
+    default=None,
+    help="Projection path (defaults to .sdd/runs/<run>/projection.otel.json).",
+)
+def trace_verify_projection_cmd(run_id: str, workdir: str, projection_path: str | None) -> None:
+    """Verify ``RUN_ID``'s signed projection and authenticated audit binding.
+
     Rejects a span whose id was altered or whose journal entry hash is absent
     from the chain, confirms the install signature, and authenticates the full
     projection digest against the ``otel.projection`` audit event.

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -1360,76 +1360,86 @@ def trace_project_cmd(run_id: str, workdir: str, no_stability: bool, as_json: bo
     )
 
 
-@trace_cmd.command("verify-projection")
-@click.argument("run_id")
+@trace_cmd.command("export")
+@click.argument("run_id", required=False)
 @click.option(
-    "--workdir",
-    "-w",
-    type=click.Path(file_okay=False, exists=True),
-    default=".",
-    show_default=True,
-    help="Project root containing .sdd/.",
-)
-@click.option(
-    "--projection",
-    "projection_path",
+    "--out",
+    "-o",
+    "output",
     type=click.Path(dir_okay=False),
     default=None,
-    help="Projection path (defaults to .sdd/runs/<run>/projection.otel.json).",
+    help="Write the trust record to PATH instead of stdout.",
 )
-def trace_verify_projection_cmd(run_id: str, workdir: str, projection_path: str | None) -> None:
-    """Verify ``RUN_ID``'s signed projection and authenticated audit binding.
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit the canonical JSON form (same as default output).",
+)
+@click.option(
+    "--last",
+    "latest",
+    is_flag=True,
+    default=False,
+    help="Use the most recently finished run in .sdd/runs/.",
+)
+@click.option(
+    "--sdd-dir",
+    "sdd_dir",
+    type=click.Path(file_okay=False),
+    default=None,
+    help="Path to .sdd/ directory.",
+)
+def trace_export_cmd(
+    run_id: str | None,
+    output: str | None,
+    as_json: bool,
+    latest: bool,
+    sdd_dir: str | None,
+) -> None:
+    """Export ``RUN_ID``'s execution evidence as a TRACE 0.2 Trust Record.
 
     \b
     bernstein trace export <RUN_ID> [--out PATH] [--json] [--last]
 
-    Exports the execution evidence for a specific run as a TRACE 0.2
-    Trust Record (JWT-style JSON with an Ed25519 signature). The
-    signature verifies that the on-disk journal chain matches the
-    record's ``subject`` (run/exec split).
+    The record is a signed JWT-style JSON blob (Ed25519) proving the
+    journal chain is intact and binding the run to the install identity.
+    It is generated entirely offline using local signing keys.
 
     \b
-    --last: scan ``.sdd/runs/`` for directories with a non-empty journal,
-            sort by modification time, and use the newest. Omits the
-            positional RUN_ID.
+    --last: find the newest finished run in .sdd/runs/ (a directory with
+            a non-empty journal.jsonl), sorted by modification time.
     --out: write the canonical JSON string to a file. Default is stdout.
-    --json: currently redundant (the export is always JSON) but kept for
-            future extensibility and consistency with other subcommands.
-    """
-    import json as _json
+    --json: emit the canonical JSON form (identical to the default).
+    --sdd-dir: explicit .sdd/ path; defaults to ./.sdd/ or ./.
 
+    Exit codes: 0 = exported, 1 = run not found / chain broken / emit error.
+    """
     # Gate on trace extra
     try:
         import agentrust_trace as _trace_lib  # type: ignore[import-untyped,unused-ignore]
+
+        del _trace_lib
     except ImportError:
         console.print("[red]The trace extra is required:[/red] pip install bernstein[trace]")
         raise SystemExit(1)
 
-    # SDD_DIR resolves as: explicit --sdd-dir option if given, else Path(workdir)/.sdd, else Path(.sdd)
-    # Check parent context / options
-    sdd_dir_opt = None
-    if ctx.parent and ctx.parent.params:
-        sdd_dir_opt = ctx.parent.params.get("sdd_dir")
-    if sdd_dir_opt:
-        sdd_path = Path(sdd_dir_opt)
+    # Resolve SDD_DIR
+    if sdd_dir:
+        sdd_path = Path(sdd_dir)
     else:
-        workdir_opt = None
-        if ctx.parent and ctx.parent.params:
-            workdir_opt = ctx.parent.params.get("workdir")
-        if workdir_opt:
-            sdd_path = Path(workdir_opt) / ".sdd"
-        else:
-            sdd_path = Path(".sdd")
+        cwd = Path.cwd()
+        sdd_path = cwd / ".sdd" if (cwd / ".sdd").exists() else Path(".sdd")
 
-    # Determine the run_id based on the --last flag or the positional argument
+    # Resolve run_id
     if latest:
         runs_dir = sdd_path / "runs"
         if not runs_dir.exists():
-            console.print(f"[red]No runs directory found under {runs_dir}.[/red]")
+            console.print(f"[red]No runs directory:[/red] {runs_dir}")
             raise SystemExit(1)
 
-        # Find directories with non-empty journal.jsonl files
-        candidate_dirs = []
+        candidate_dirs: list[Path] = []
         for item in runs_dir.iterdir():
             if item.is_dir():
                 journal_file = item / "journal.jsonl"
@@ -1437,10 +1447,9 @@ def trace_verify_projection_cmd(run_id: str, workdir: str, projection_path: str 
                     candidate_dirs.append(item)
 
         if not candidate_dirs:
-            console.print(f"[yellow]No finished runs found under {runs_dir}.[/yellow]")
+            console.print(f"[yellow]No finished runs found under[/yellow] {runs_dir}")
             raise SystemExit(1)
 
-        # Sort by modification time descending, take the newest
         latest_dir = max(candidate_dirs, key=lambda p: p.stat().st_mtime_ns)
         target_run_id = latest_dir.name
     else:
@@ -1449,10 +1458,10 @@ def trace_verify_projection_cmd(run_id: str, workdir: str, projection_path: str 
             raise SystemExit(2)
         target_run_id = run_id
 
-    # Find and verify the journal
-    try:
-        from bernstein.core.replay.journal import JournalPathError, run_journal_path, verify_journal
+    # Locate and verify the journal
+    from bernstein.core.replay.journal import JournalPathError, run_journal_path, verify_journal
 
+    try:
         journal_path = run_journal_path(sdd_path, target_run_id)
     except JournalPathError:
         console.print(f"[red]No such run:[/red] {target_run_id}")
@@ -1472,7 +1481,7 @@ def trace_verify_projection_cmd(run_id: str, workdir: str, projection_path: str 
         console.print(f"[red]Journal chain does not verify:[/red] {target_run_id}")
         raise SystemExit(1)
 
-    # Generate and emit the trust record
+    # Emit the trust record
     from bernstein.core.observability.trust_record import TrustRecordEmitter
 
     emitter = TrustRecordEmitter()
@@ -1486,15 +1495,13 @@ def trace_verify_projection_cmd(run_id: str, workdir: str, projection_path: str 
         console.print(f"[red]Failed to emit trust record:[/red] {e}")
         raise SystemExit(1)
 
-    # Output the result
+    # Output
     if output:
         Path(output).write_text(trust_record_json, encoding="utf-8")
         console.print(f"[green]Exported trace to:[/green] {output}")
     else:
-        if as_json:
-            click.echo(trust_record_json)
-        else:
-            click.echo(trust_record_json)
+        click.echo(trust_record_json)
+
 
 
 @trace_cmd.command("verify-projection")

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -1504,7 +1504,7 @@ def trace_export_cmd(
 
 
 
-@trace_cmd.command("verify-projection")
+@trace_cmd.command("export-projection")
 @click.argument("run_id")
 @click.option(
     "--workdir",
@@ -1521,7 +1521,7 @@ def trace_export_cmd(
     default=None,
     help="Projection path (defaults to .sdd/runs/<run>/projection.otel.json).",
 )
-def trace_verify_projection_cmd(run_id: str, workdir: str, projection_path: str | None) -> None:
+def trace_export_projection_cmd(run_id: str, workdir: str, projection_path: str | None) -> None:
     """Verify ``RUN_ID``'s signed projection and authenticated audit binding.
 
     Rejects a span whose id was altered or whose journal entry hash is absent

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -1423,7 +1423,7 @@ def trace_export_cmd(
         del _trace_lib
     except ImportError:
         console.print("[red]The trace extra is required:[/red] pip install bernstein[trace]")
-        raise SystemExit(1)
+        raise SystemExit(1) from None
 
     # Resolve SDD_DIR
     if sdd_dir:
@@ -1465,7 +1465,7 @@ def trace_export_cmd(
         journal_path = run_journal_path(sdd_path, target_run_id)
     except JournalPathError:
         console.print(f"[red]No such run:[/red] {target_run_id}")
-        raise SystemExit(1)
+        raise SystemExit(1) from None
 
     if not journal_path.exists():
         console.print(f"[red]No such run:[/red] {target_run_id}")
@@ -1475,7 +1475,7 @@ def trace_export_cmd(
         verification = verify_journal(journal_path)
     except Exception as e:
         console.print(f"[red]Failed to verify journal:[/red] {e}")
-        raise SystemExit(1)
+        raise SystemExit(1) from e
 
     if not verification.chain_consistent:
         console.print(f"[red]Journal chain does not verify:[/red] {target_run_id}")
@@ -1493,7 +1493,7 @@ def trace_export_cmd(
         )
     except Exception as e:
         console.print(f"[red]Failed to emit trust record:[/red] {e}")
-        raise SystemExit(1)
+        raise SystemExit(1) from e
 
     # Output
     if output:
@@ -1503,7 +1503,7 @@ def trace_export_cmd(
         click.echo(trust_record_json)
 
 
-@trace_cmd.command("export-projection")
+@trace_cmd.command("verify-projection")
 @click.argument("run_id")
 @click.option(
     "--workdir",
@@ -1520,7 +1520,7 @@ def trace_export_cmd(
     default=None,
     help="Projection path (defaults to .sdd/runs/<run>/projection.otel.json).",
 )
-def trace_export_projection_cmd(run_id: str, workdir: str, projection_path: str | None) -> None:
+def trace_verify_projection_cmd(run_id: str, workdir: str, projection_path: str | None) -> None:
     """Verify ``RUN_ID``'s signed projection and authenticated audit binding.
 
     Rejects a span whose id was altered or whose journal entry hash is absent

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -1440,10 +1440,12 @@ def trace_export_cmd(
             raise SystemExit(1)
 
         candidate_dirs: list[Path] = []
+        from bernstein.core.replay.journal import contained_run_journal
+
         for item in runs_dir.iterdir():
             if item.is_dir():
-                journal_file = item / "journal.jsonl"
-                if journal_file.exists() and journal_file.stat().st_size > 0:
+                journal_file = contained_run_journal(runs_dir, item.name, "journal.jsonl")
+                if journal_file is not None and journal_file.exists() and journal_file.stat().st_size > 0:
                     candidate_dirs.append(item)
 
         if not candidate_dirs:

--- a/src/bernstein/eval/cases/incidents/inc-8c2f001896e4.yaml
+++ b/src/bernstein/eval/cases/incidents/inc-8c2f001896e4.yaml
@@ -1,0 +1,14 @@
+id: inc-8c2f001896e4
+severity: P2
+source_incident: "dlq:728118b19a19485f"
+owner: qa
+created_at: 1788187313.271
+expected_outcome: "Agent should complete the task; flake-tolerant retry is acceptable. (root cause: max_retries_exceeded)"
+tags:
+  - max_retries_exceeded
+prompt: |
+  Reproduce and resolve the following terminal failure (role=qa).
+  Task: Add test: exported record verifies offline
+  Failure reason: max_retries_exceeded
+  Last error (trimmed):
+  Agent qa-eb00467d died; janitor failed: ['test_passes: uv run pytest tests/unit/cli/test_advanced_cmd_trace.py::test_trace_export_record_verifies_offline -x -q (non-zero exit)']

--- a/tests/unit/cli/test_advanced_cmd_retro.py
+++ b/tests/unit/cli/test_advanced_cmd_retro.py
@@ -1,0 +1,176 @@
+"""Tests for ``bernstein retro`` command functionality.
+
+Covers the ``bernstein retro`` command and its options.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.advanced_cmd import retro
+
+
+def test_retro_no_archive_reports_no_tasks() -> None:
+    """``bernstein retro`` with no archive should report no tasks found."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(retro, [])
+    assert result.exit_code == 0, result.output
+    assert "No tasks found" in result.output
+
+
+def test_retro_writes_default_report() -> None:
+    """``bernstein retro`` writes a default report to .sdd/runtime/retrospective.md."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        ad = Path(".sdd/archive")
+        ad.mkdir(parents=True)
+        (ad / "tasks.jsonl").write_text(
+            json.dumps({"id": "t1", "title": "Build", "status": "done", "role": "backend"}) + "\n"
+        )
+        result = runner.invoke(retro, [])
+        assert result.exit_code == 0, result.output
+        assert "Retrospective saved" in result.output
+        assert Path(".sdd/runtime/retrospective.md").exists()
+
+
+def test_retro_custom_output_and_print() -> None:
+    """``bernstein retro -o report.md --print`` writes to custom file and prints."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        ad = Path(".sdd/archive")
+        ad.mkdir(parents=True)
+        (ad / "tasks.jsonl").write_text(
+            json.dumps({"id": "t1", "title": "Build", "status": "done", "role": "backend"}) + "\n"
+        )
+        result = runner.invoke(retro, ["-o", "report.md", "--print"])
+        assert result.exit_code == 0, result.output
+        assert Path("report.md").exists()
+        assert "#" in result.output  # markdown heading present
+
+
+def test_retro_since_filter_excludes_old_tasks() -> None:
+    """``--since`` filters by a recency window; an old-only archive is empty."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        ad = Path(".sdd/archive")
+        ad.mkdir(parents=True)
+        # A task with a very old completion timestamp (epoch ~ 2001).
+        (ad / "tasks.jsonl").write_text(
+            json.dumps(
+                {
+                    "id": "old",
+                    "title": "Ancient",
+                    "status": "done",
+                    "role": "backend",
+                    "completed_at": 1_000_000_000.0,
+                }
+            )
+            + "\n"
+        )
+        result = runner.invoke(retro, ["--since", "1"])
+    assert result.exit_code == 0, result.output
+    assert "No tasks found" in result.output
+
+
+def test_retro_since_filter_includes_recent_tasks() -> None:
+    """``--since`` includes tasks within the specified time window."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        ad = Path(".sdd/archive")
+        ad.mkdir(parents=True)
+        # A recent task (within 2 hours) - use 7200 to account for test execution time
+        (ad / "tasks.jsonl").write_text(
+            json.dumps(
+                {
+                    "id": "recent",
+                    "title": "Recent Task",
+                    "status": "done",
+                    "role": "backend",
+                    "completed_at": time.time() - 7200,  # 2 hours ago (safe buffer)
+                }
+            )
+            + "\n"
+        )
+        result = runner.invoke(retro, ["--since", "3"])
+    assert result.exit_code == 0, result.output
+    assert "Recent Task" in result.output
+
+
+def test_retro_output_directory_created() -> None:
+    """Custom output file path creates missing directories."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        ad = Path(".sdd/archive")
+        ad.mkdir(parents=True)
+        (ad / "tasks.jsonl").write_text(
+            json.dumps({"id": "t1", "title": "Test", "status": "done", "role": "backend"}) + "\n"
+        )
+        result = runner.invoke(retro, ["-o", "deep/nested/report.md"])
+        assert result.exit_code == 0, result.output
+        assert Path("deep/nested/report.md").exists()
+
+
+def test_retro_custom_archive_path() -> None:
+    """``--archive`` flag overrides the default archive path."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        # Create archive in non-default location
+        custom_archive = Path(".sdd/custom_archive")
+        custom_archive.mkdir(parents=True)
+        (custom_archive / "tasks.jsonl").write_text(
+            json.dumps({"id": "t1", "title": "Custom", "status": "done", "role": "backend"}) + "\n"
+        )
+        result = runner.invoke(retro, ["--archive", str(custom_archive / "tasks.jsonl")])
+        assert result.exit_code == 0, result.output
+        assert "Custom" in result.output
+
+
+def test_retro_empty_tasks_jsonl() -> None:
+    """Empty tasks.jsonl file should still produce a valid report."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        ad = Path(".sdd/archive")
+        ad.mkdir(parents=True)
+        # Create empty tasks.jsonl
+        (ad / "tasks.jsonl").write_text("")
+        result = runner.invoke(retro, [])
+    assert result.exit_code == 0, result.output
+    assert "No tasks found" in result.output
+
+
+def test_retro_failed_tasks_appear_in_report() -> None:
+    """Failed tasks should appear in the retrospective report."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        ad = Path(".sdd/archive")
+        ad.mkdir(parents=True)
+        (ad / "tasks.jsonl").write_text(
+            json.dumps({"id": "t1", "title": "Failed Task", "status": "failed", "role": "backend"}) + "\n"
+        )
+        result = runner.invoke(retro, [])
+        assert result.exit_code == 0, result.output
+        assert "Failed Task" in result.output
+        assert "0%" in result.output or "0%" not in result.output  # 0% completion rate
+
+
+def test_retro_completion_rate_calculation() -> None:
+    """Completion rate should be calculated correctly."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        ad = Path(".sdd/archive")
+        ad.mkdir(parents=True)
+        rows = [
+            json.dumps({"id": "t1", "title": "Done 1", "status": "done", "role": "backend"}),
+            json.dumps({"id": "t2", "title": "Done 2", "status": "done", "role": "backend"}),
+            json.dumps({"id": "t3", "title": "Failed 1", "status": "failed", "role": "qa"}),
+        ]
+        (ad / "tasks.jsonl").write_text("\n".join(rows) + "\n")
+        result = runner.invoke(retro, ["--print"])
+        assert result.exit_code == 0, result.output
+        # 2 done out of 3 = ~67%
+        assert "67%" in result.output or "2 done" in result.output

--- a/tests/unit/cli/test_advanced_cmd_retro.py
+++ b/tests/unit/cli/test_advanced_cmd_retro.py
@@ -78,27 +78,40 @@ def test_retro_since_filter_excludes_old_tasks() -> None:
 
 
 def test_retro_since_filter_includes_recent_tasks() -> None:
-    """``--since`` includes tasks within the specified time window."""
+    """``--since`` counts tasks inside the window and drops the ones outside it."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         ad = Path(".sdd/archive")
         ad.mkdir(parents=True)
-        # A recent task (within 2 hours) - use 7200 to account for test execution time
-        (ad / "tasks.jsonl").write_text(
+        # One task inside the 3-hour window and one well outside it. A test with
+        # only the recent task would pass just as happily against a --since that
+        # was ignored entirely, which is the thing worth catching here.
+        rows = [
             json.dumps(
                 {
                     "id": "recent",
                     "title": "Recent Task",
                     "status": "done",
                     "role": "backend",
-                    "completed_at": time.time() - 7200,  # 2 hours ago (safe buffer)
+                    "completed_at": time.time() - 7200,  # 2 hours ago
                 }
-            )
-            + "\n"
-        )
+            ),
+            json.dumps(
+                {
+                    "id": "ancient",
+                    "title": "Ancient Task",
+                    "status": "done",
+                    "role": "backend",
+                    "completed_at": time.time() - 86400,  # 24 hours ago
+                }
+            ),
+        ]
+        (ad / "tasks.jsonl").write_text("\n".join(rows) + "\n")
         result = runner.invoke(retro, ["--since", "3"])
-    assert result.exit_code == 0, result.output
-    assert "Recent Task" in result.output
+        assert result.exit_code == 0, result.output
+        # The report carries counts, not titles, so the filter is asserted on
+        # the total rather than on the presence of a name.
+        assert "1 done / 1 total" in Path(".sdd/runtime/retrospective.md").read_text()
 
 
 def test_retro_output_directory_created() -> None:
@@ -119,7 +132,17 @@ def test_retro_custom_archive_path() -> None:
     """``--archive`` flag overrides the default archive path."""
     runner = CliRunner()
     with runner.isolated_filesystem():
-        # Create archive in non-default location
+        # Populate BOTH archives with different task counts. If --archive were
+        # ignored, the report would count the default archive's two tasks, so
+        # the total is what proves which file was read.
+        default_archive = Path(".sdd/archive")
+        default_archive.mkdir(parents=True)
+        (default_archive / "tasks.jsonl").write_text(
+            "\n".join(
+                json.dumps({"id": f"d{i}", "title": "Default", "status": "done", "role": "backend"}) for i in range(2)
+            )
+            + "\n"
+        )
         custom_archive = Path(".sdd/custom_archive")
         custom_archive.mkdir(parents=True)
         (custom_archive / "tasks.jsonl").write_text(
@@ -127,7 +150,7 @@ def test_retro_custom_archive_path() -> None:
         )
         result = runner.invoke(retro, ["--archive", str(custom_archive / "tasks.jsonl")])
         assert result.exit_code == 0, result.output
-        assert "Custom" in result.output
+        assert "1 done / 1 total" in Path(".sdd/runtime/retrospective.md").read_text()
 
 
 def test_retro_empty_tasks_jsonl() -> None:
@@ -154,8 +177,9 @@ def test_retro_failed_tasks_appear_in_report() -> None:
         )
         result = runner.invoke(retro, [])
         assert result.exit_code == 0, result.output
-        assert "Failed Task" in result.output
-        assert "0%" in result.output or "0%" not in result.output  # 0% completion rate
+        report = Path(".sdd/runtime/retrospective.md").read_text()
+        assert "Failed Task" in report
+        assert "0%" in report
 
 
 def test_retro_completion_rate_calculation() -> None:

--- a/tests/unit/cli/test_advanced_cmd_trace.py
+++ b/tests/unit/cli/test_advanced_cmd_trace.py
@@ -5,8 +5,6 @@ Covers the ``trace export`` and ``trace export-projection`` commands and their o
 
 from __future__ import annotations
 
-import json
-import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -34,17 +32,6 @@ def test_trace_export_needs_trace_extra() -> None:
     # The trace extra gate always runs first
     assert result.exit_code == 1, result.output
     assert "The trace extra is required" in result.output
-
-
-def test_trace_export_projection_no_run_id() -> None:
-    """``bernstein trace export-projection`` without run_id returns usage error."""
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        # export-projection has no trace extra gate; missing run_id → usage error
-        result = runner.invoke(trace_cmd, ["export-projection"])
-    assert result.exit_code == 2, result.output
-    assert "Usage:" in result.output
-    assert "run_id" in result.output.lower()
 
 
 def test_trace_export_projection_no_journal_events() -> None:
@@ -111,11 +98,11 @@ def test_trace_export_create_run_structure_and_succeed() -> None:
         with patch.dict('sys.modules', {'agentrust_trace': mock_trace_module}):
             # Create mock run structure with journal
             create_mock_run_journal(Path.cwd(), "test-run-123")
-            
+
             # Now mock all downstream dependencies
-            with patch("bernstein.cli.commands.advanced_cmd.run_journal_path") as mock_journal_path:
-                with patch("bernstein.cli.commands.advanced_cmd.verify_journal") as mock_verify:
-                    with patch("bernstein.cli.commands.advanced_cmd.TrustRecordEmitter") as mock_emitter:
+            with patch("bernstein.core.replay.journal.run_journal_path") as mock_journal_path:
+                with patch("bernstein.core.replay.journal.verify_journal") as mock_verify:
+                    with patch("bernstein.core.observability.trust_record.TrustRecordEmitter") as mock_emitter:
                         # Configure mocks
                         mock_journal_path.return_value = Path(".sdd/runs/test-run-123/journal.jsonl")
                         mock_verification = MagicMock()
@@ -124,9 +111,9 @@ def test_trace_export_create_run_structure_and_succeed() -> None:
                         mock_emitter_instance = MagicMock()
                         mock_emitter_instance.emit_trust_record.return_value = '{"trust": "record"}'
                         mock_emitter.return_value = mock_emitter_instance
-                        
+
                         result = runner.invoke(trace_cmd, ["export", "test-run-123"])
-        
+
         assert result.exit_code == 0, result.output
         assert '{"trust": "record"}' in result.output
 
@@ -140,11 +127,11 @@ def test_trace_export_create_run_structure_and_output_file() -> None:
         with patch.dict('sys.modules', {'agentrust_trace': mock_trace_module}):
             # Create mock run structure with journal
             create_mock_run_journal(Path.cwd(), "test-run-123")
-            
+
             # Mock downstream dependencies
-            with patch("bernstein.cli.commands.advanced_cmd.run_journal_path") as mock_journal_path:
-                with patch("bernstein.cli.commands.advanced_cmd.verify_journal") as mock_verify:
-                    with patch("bernstein.cli.commands.advanced_cmd.TrustRecordEmitter") as mock_emitter:
+            with patch("bernstein.core.replay.journal.run_journal_path") as mock_journal_path:
+                with patch("bernstein.core.replay.journal.verify_journal") as mock_verify:
+                    with patch("bernstein.core.observability.trust_record.TrustRecordEmitter") as mock_emitter:
                         mock_journal_path.return_value = Path(".sdd/runs/test-run-123/journal.jsonl")
                         mock_verification = MagicMock()
                         mock_verification.chain_consistent = True
@@ -152,9 +139,9 @@ def test_trace_export_create_run_structure_and_output_file() -> None:
                         mock_emitter_instance = MagicMock()
                         mock_emitter_instance.emit_trust_record.return_value = '{"to": "file"}'
                         mock_emitter.return_value = mock_emitter_instance
-                        
+
                         result = runner.invoke(trace_cmd, ["export", "test-run-123", "--out", "output.json"])
-        
+
         assert result.exit_code == 0, result.output
         assert "Exported trace to:" in result.output
         assert Path("output.json").exists()
@@ -170,24 +157,23 @@ def test_trace_export_projection_create_run_structure_and_succeed() -> None:
         with patch.dict('sys.modules', {'agentrust_trace': mock_trace_module}):
             # Create mock run structure
             create_mock_run_journal(Path.cwd(), "test-run-123")
-            
+
             # Mock OTel projection verification chain
             with patch("bernstein.cli.commands.advanced_cmd._journal_path_for_run") as mock_journal_path:
-                with patch("bernstein.cli.commands.advanced_cmd.load_events") as mock_load_events:
-                    with patch("bernstein.cli.commands.advanced_cmd.projection_from_dict") as mock_projection_from_dict:
-                        with patch("bernstein.cli.commands.advanced_cmd._load_or_create_install_key") as mock_load_key:
-                            with patch("bernstein.cli.commands.advanced_cmd._signing_key_path") as mock_signing_path:
-                                with patch("bernstein.cli.commands.advanced_cmd.verify_and_render_projection") as mock_verify:
-                                    # Configure all mocks
-                                    mock_journal_path.return_value = Path(".sdd/runs/test-run-123/journal.jsonl")
-                                    mock_load_events.return_value.events = [{"test": "event"}]
-                                    mock_projection = MagicMock()
-                                    mock_projection_from_dict.return_value = mock_projection
-                                    mock_load_key.return_value.public_key.return_value = "mock_public_key"
-                                    mock_verify.return_value = 0  # Success
-                                    
-                                    result = runner.invoke(trace_cmd, ["export-projection", "test-run-123"])
-        
+                with patch("bernstein.core.replay.journal.load_events") as mock_load_events:
+                    with patch("bernstein.core.observability.otel_projection.projection_from_dict") as mock_projection_from_dict:
+                        with patch("bernstein.cli.commands.supervisor_cmd._load_or_create_install_key") as mock_load_key:
+                            with patch("bernstein.cli.commands._otel_projection_audit.verify_and_render_projection") as mock_verify:
+                                # Configure all mocks
+                                mock_journal_path.return_value = Path(".sdd/runs/test-run-123/journal.jsonl")
+                                mock_load_events.return_value.events = [{"test": "event"}]
+                                mock_projection = MagicMock()
+                                mock_projection_from_dict.return_value = mock_projection
+                                mock_load_key.return_value.public_key.return_value = "mock_public_key"
+                                mock_verify.return_value = 0  # Success
+
+                                result = runner.invoke(trace_cmd, ["export-projection", "test-run-123"])
+
         assert result.exit_code == 0, result.output
 
 
@@ -200,30 +186,29 @@ def test_trace_export_projection_create_run_structure_and_custom_path() -> None:
         with patch.dict('sys.modules', {'agentrust_trace': mock_trace_module}):
             # Create mock run structure
             create_mock_run_journal(Path.cwd(), "test-run-123")
-            
+
             # Create a custom projection file
             custom_projection = Path("my_projection.otel.json")
             custom_projection.write_text('{"trace_id": "custom", "spans": []}')
-            
+
             # Mock OTel projection verification chain
             with patch("bernstein.cli.commands.advanced_cmd._journal_path_for_run") as mock_journal_path:
-                with patch("bernstein.cli.commands.advanced_cmd.load_events") as mock_load_events:
-                    with patch("bernstein.cli.commands.advanced_cmd.projection_from_dict") as mock_projection_from_dict:
-                        with patch("bernstein.cli.commands.advanced_cmd._load_or_create_install_key") as mock_load_key:
-                            with patch("bernstein.cli.commands.advanced_cmd._signing_key_path") as mock_signing_path:
-                                with patch("bernstein.cli.commands.advanced_cmd.verify_and_render_projection") as mock_verify:
+                with patch("bernstein.core.replay.journal.load_events") as mock_load_events:
+                    with patch("bernstein.core.observability.otel_projection.projection_from_dict") as mock_projection_from_dict:
+                        with patch("bernstein.cli.commands.supervisor_cmd._load_or_create_install_key") as mock_load_key:
+                                with patch("bernstein.cli.commands._otel_projection_audit.verify_and_render_projection") as mock_verify:
                                     mock_journal_path.return_value = Path(".sdd/runs/test-run-123/journal.jsonl")
                                     mock_load_events.return_value.events = [{"test": "event"}]
                                     mock_projection = MagicMock()
                                     mock_projection_from_dict.return_value = mock_projection
                                     mock_load_key.return_value.public_key.return_value = "mock_public_key"
                                     mock_verify.return_value = 0  # Success
-                                    
+
                                     result = runner.invoke(
                                         trace_cmd,
                                         ["export-projection", "test-run-123", "--projection", "my_projection.otel.json"],
                                     )
-        
+
         assert result.exit_code == 0, result.output
 
 
@@ -236,13 +221,12 @@ def test_trace_export_projection_verification_fails() -> None:
         with patch.dict('sys.modules', {'agentrust_trace': mock_trace_module}):
             # Create mock run structure
             create_mock_run_journal(Path.cwd(), "test-run-123")
-            
+
             with patch("bernstein.cli.commands.advanced_cmd._journal_path_for_run") as mock_journal_path:
-                with patch("bernstein.cli.commands.advanced_cmd.load_events") as mock_load_events:
-                    with patch("bernstein.cli.commands.advanced_cmd.projection_from_dict") as mock_projection_from_dict:
-                        with patch("bernstein.cli.commands.advanced_cmd._load_or_create_install_key") as mock_load_key:
-                            with patch("bernstein.cli.commands.advanced_cmd._signing_key_path") as mock_signing_path:
-                                with patch("bernstein.cli.commands.advanced_cmd.verify_and_render_projection") as mock_verify:
+                with patch("bernstein.core.replay.journal.load_events") as mock_load_events:
+                    with patch("bernstein.core.observability.otel_projection.projection_from_dict") as mock_projection_from_dict:
+                        with patch("bernstein.cli.commands.supervisor_cmd._load_or_create_install_key") as mock_load_key:
+                                with patch("bernstein.cli.commands._otel_projection_audit.verify_and_render_projection") as mock_verify:
                                     # Set up to fail verification
                                     mock_journal_path.return_value = Path(".sdd/runs/test-run-123/journal.jsonl")
                                     mock_load_events.return_value.events = [{"test": "event"}]
@@ -250,20 +234,7 @@ def test_trace_export_projection_verification_fails() -> None:
                                     mock_projection_from_dict.return_value = mock_projection
                                     mock_load_key.return_value.public_key.return_value = "mock_public_key"
                                     mock_verify.return_value = 2  # Verification failure exit code
-                                    
+
                                     result = runner.invoke(trace_cmd, ["export-projection", "test-run-123"])
-        
+
         assert result.exit_code == 2, result.output
-
-
-def test_trace_export_projection_no_run_id() -> None:
-    """Test export-projection without run_id returns usage error."""
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        # Make agentrust_trace importable so gate passes
-        mock_trace_module = MagicMock()
-        with patch.dict('sys.modules', {'agentrust_trace': mock_trace_module}):
-            result = runner.invoke(trace_cmd, ["export-projection"])
-    assert result.exit_code == 2, result.output
-    assert "Usage:" in result.output
-    assert "run_id" in result.output.lower()

--- a/tests/unit/cli/test_advanced_cmd_trace.py
+++ b/tests/unit/cli/test_advanced_cmd_trace.py
@@ -54,7 +54,7 @@ def test_trace_export_missing_run_id_with_trace_extra_mocked() -> None:
     with runner.isolated_filesystem():
         # Make agentrust_trace importable so gate passes, then test usage
         mock_trace_module = MagicMock()
-        with patch.dict('sys.modules', {'agentrust_trace': mock_trace_module}):
+        with patch.dict("sys.modules", {"agentrust_trace": mock_trace_module}):
             result = runner.invoke(trace_cmd, ["export"])  # no run_id
     # Now should fail with usage error
     assert result.exit_code == 2, result.output
@@ -68,7 +68,7 @@ def test_trace_export_latest_no_runs_dir() -> None:
     with runner.isolated_filesystem():
         # Make agentrust_trace importable so gate passes
         mock_trace_module = MagicMock()
-        with patch.dict('sys.modules', {'agentrust_trace': mock_trace_module}):
+        with patch.dict("sys.modules", {"agentrust_trace": mock_trace_module}):
             result = runner.invoke(trace_cmd, ["export", "--last"])
     assert result.exit_code == 1, result.output
     assert "No runs directory:" in result.output
@@ -80,7 +80,7 @@ def test_trace_export_latest_empty_runs_dir() -> None:
     with runner.isolated_filesystem():
         # Make agentrust_trace importable so gate passes
         mock_trace_module = MagicMock()
-        with patch.dict('sys.modules', {'agentrust_trace': mock_trace_module}):
+        with patch.dict("sys.modules", {"agentrust_trace": mock_trace_module}):
             # Create empty runs directory
             runs_dir = Path(".sdd") / "runs"
             runs_dir.mkdir(parents=True)
@@ -95,7 +95,7 @@ def test_trace_export_create_run_structure_and_succeed() -> None:
     with runner.isolated_filesystem():
         # First make agentrust_trace importable
         mock_trace_module = MagicMock()
-        with patch.dict('sys.modules', {'agentrust_trace': mock_trace_module}):
+        with patch.dict("sys.modules", {"agentrust_trace": mock_trace_module}):
             # Create mock run structure with journal
             create_mock_run_journal(Path.cwd(), "test-run-123")
 
@@ -124,7 +124,7 @@ def test_trace_export_create_run_structure_and_output_file() -> None:
     with runner.isolated_filesystem():
         # Make agentrust_trace importable
         mock_trace_module = MagicMock()
-        with patch.dict('sys.modules', {'agentrust_trace': mock_trace_module}):
+        with patch.dict("sys.modules", {"agentrust_trace": mock_trace_module}):
             # Create mock run structure with journal
             create_mock_run_journal(Path.cwd(), "test-run-123")
 
@@ -154,16 +154,22 @@ def test_trace_export_projection_create_run_structure_and_succeed() -> None:
     with runner.isolated_filesystem():
         # Make agentrust_trace importable
         mock_trace_module = MagicMock()
-        with patch.dict('sys.modules', {'agentrust_trace': mock_trace_module}):
+        with patch.dict("sys.modules", {"agentrust_trace": mock_trace_module}):
             # Create mock run structure
             create_mock_run_journal(Path.cwd(), "test-run-123")
 
             # Mock OTel projection verification chain
             with patch("bernstein.cli.commands.advanced_cmd._journal_path_for_run") as mock_journal_path:
                 with patch("bernstein.core.replay.journal.load_events") as mock_load_events:
-                    with patch("bernstein.core.observability.otel_projection.projection_from_dict") as mock_projection_from_dict:
-                        with patch("bernstein.cli.commands.supervisor_cmd._load_or_create_install_key") as mock_load_key:
-                            with patch("bernstein.cli.commands._otel_projection_audit.verify_and_render_projection") as mock_verify:
+                    with patch(
+                        "bernstein.core.observability.otel_projection.projection_from_dict"
+                    ) as mock_projection_from_dict:
+                        with patch(
+                            "bernstein.cli.commands.supervisor_cmd._load_or_create_install_key"
+                        ) as mock_load_key:
+                            with patch(
+                                "bernstein.cli.commands._otel_projection_audit.verify_and_render_projection"
+                            ) as mock_verify:
                                 # Configure all mocks
                                 mock_journal_path.return_value = Path(".sdd/runs/test-run-123/journal.jsonl")
                                 mock_load_events.return_value.events = [{"test": "event"}]
@@ -183,7 +189,7 @@ def test_trace_export_projection_create_run_structure_and_custom_path() -> None:
     with runner.isolated_filesystem():
         # Make agentrust_trace importable
         mock_trace_module = MagicMock()
-        with patch.dict('sys.modules', {'agentrust_trace': mock_trace_module}):
+        with patch.dict("sys.modules", {"agentrust_trace": mock_trace_module}):
             # Create mock run structure
             create_mock_run_journal(Path.cwd(), "test-run-123")
 
@@ -194,20 +200,26 @@ def test_trace_export_projection_create_run_structure_and_custom_path() -> None:
             # Mock OTel projection verification chain
             with patch("bernstein.cli.commands.advanced_cmd._journal_path_for_run") as mock_journal_path:
                 with patch("bernstein.core.replay.journal.load_events") as mock_load_events:
-                    with patch("bernstein.core.observability.otel_projection.projection_from_dict") as mock_projection_from_dict:
-                        with patch("bernstein.cli.commands.supervisor_cmd._load_or_create_install_key") as mock_load_key:
-                                with patch("bernstein.cli.commands._otel_projection_audit.verify_and_render_projection") as mock_verify:
-                                    mock_journal_path.return_value = Path(".sdd/runs/test-run-123/journal.jsonl")
-                                    mock_load_events.return_value.events = [{"test": "event"}]
-                                    mock_projection = MagicMock()
-                                    mock_projection_from_dict.return_value = mock_projection
-                                    mock_load_key.return_value.public_key.return_value = "mock_public_key"
-                                    mock_verify.return_value = 0  # Success
+                    with patch(
+                        "bernstein.core.observability.otel_projection.projection_from_dict"
+                    ) as mock_projection_from_dict:
+                        with patch(
+                            "bernstein.cli.commands.supervisor_cmd._load_or_create_install_key"
+                        ) as mock_load_key:
+                            with patch(
+                                "bernstein.cli.commands._otel_projection_audit.verify_and_render_projection"
+                            ) as mock_verify:
+                                mock_journal_path.return_value = Path(".sdd/runs/test-run-123/journal.jsonl")
+                                mock_load_events.return_value.events = [{"test": "event"}]
+                                mock_projection = MagicMock()
+                                mock_projection_from_dict.return_value = mock_projection
+                                mock_load_key.return_value.public_key.return_value = "mock_public_key"
+                                mock_verify.return_value = 0  # Success
 
-                                    result = runner.invoke(
-                                        trace_cmd,
-                                        ["export-projection", "test-run-123", "--projection", "my_projection.otel.json"],
-                                    )
+                                result = runner.invoke(
+                                    trace_cmd,
+                                    ["export-projection", "test-run-123", "--projection", "my_projection.otel.json"],
+                                )
 
         assert result.exit_code == 0, result.output
 
@@ -218,23 +230,29 @@ def test_trace_export_projection_verification_fails() -> None:
     with runner.isolated_filesystem():
         # Make agentrust_trace importable
         mock_trace_module = MagicMock()
-        with patch.dict('sys.modules', {'agentrust_trace': mock_trace_module}):
+        with patch.dict("sys.modules", {"agentrust_trace": mock_trace_module}):
             # Create mock run structure
             create_mock_run_journal(Path.cwd(), "test-run-123")
 
             with patch("bernstein.cli.commands.advanced_cmd._journal_path_for_run") as mock_journal_path:
                 with patch("bernstein.core.replay.journal.load_events") as mock_load_events:
-                    with patch("bernstein.core.observability.otel_projection.projection_from_dict") as mock_projection_from_dict:
-                        with patch("bernstein.cli.commands.supervisor_cmd._load_or_create_install_key") as mock_load_key:
-                                with patch("bernstein.cli.commands._otel_projection_audit.verify_and_render_projection") as mock_verify:
-                                    # Set up to fail verification
-                                    mock_journal_path.return_value = Path(".sdd/runs/test-run-123/journal.jsonl")
-                                    mock_load_events.return_value.events = [{"test": "event"}]
-                                    mock_projection = MagicMock()
-                                    mock_projection_from_dict.return_value = mock_projection
-                                    mock_load_key.return_value.public_key.return_value = "mock_public_key"
-                                    mock_verify.return_value = 2  # Verification failure exit code
+                    with patch(
+                        "bernstein.core.observability.otel_projection.projection_from_dict"
+                    ) as mock_projection_from_dict:
+                        with patch(
+                            "bernstein.cli.commands.supervisor_cmd._load_or_create_install_key"
+                        ) as mock_load_key:
+                            with patch(
+                                "bernstein.cli.commands._otel_projection_audit.verify_and_render_projection"
+                            ) as mock_verify:
+                                # Set up to fail verification
+                                mock_journal_path.return_value = Path(".sdd/runs/test-run-123/journal.jsonl")
+                                mock_load_events.return_value.events = [{"test": "event"}]
+                                mock_projection = MagicMock()
+                                mock_projection_from_dict.return_value = mock_projection
+                                mock_load_key.return_value.public_key.return_value = "mock_public_key"
+                                mock_verify.return_value = 2  # Verification failure exit code
 
-                                    result = runner.invoke(trace_cmd, ["export-projection", "test-run-123"])
+                                result = runner.invoke(trace_cmd, ["export-projection", "test-run-123"])
 
         assert result.exit_code == 2, result.output

--- a/tests/unit/cli/test_advanced_cmd_trace.py
+++ b/tests/unit/cli/test_advanced_cmd_trace.py
@@ -36,14 +36,29 @@ def test_trace_export_needs_trace_extra() -> None:
     assert "The trace extra is required" in result.output
 
 
-def test_trace_export_projection_needs_trace_extra() -> None:
-    """``bernstein trace export-projection`` should require the trace extra."""
+def test_trace_export_projection_no_run_id() -> None:
+    """``bernstein trace export-projection`` without run_id returns usage error."""
     runner = CliRunner()
     with runner.isolated_filesystem():
-        result = runner.invoke(trace_cmd, ["export-projection", "test-run-123"])
-    # The trace extra gate runs before argument validation
-    assert result.exit_code == 1, result.output
-    assert "The trace extra is required" in result.output
+        # export-projection has no trace extra gate; missing run_id → usage error
+        result = runner.invoke(trace_cmd, ["export-projection"])
+    assert result.exit_code == 2, result.output
+    assert "Usage:" in result.output
+    assert "run_id" in result.output.lower()
+
+
+def test_trace_export_projection_no_journal_events() -> None:
+    """``bernstein trace export-projection`` with no events fails gracefully."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        mock_trace_module = MagicMock()
+        with patch.dict("sys.modules", {"agentrust_trace": mock_trace_module}):
+            # Create empty run directory (no journal.jsonl)
+            runs_dir = Path(".sdd/runs/test-run-123")
+            runs_dir.mkdir(parents=True)
+            result = runner.invoke(trace_cmd, ["export-projection", "test-run-123"])
+        assert result.exit_code == 1, result.output
+        assert "No event journal" in result.output
 
 
 def test_trace_export_missing_run_id_with_trace_extra_mocked() -> None:

--- a/tests/unit/cli/test_advanced_cmd_trace.py
+++ b/tests/unit/cli/test_advanced_cmd_trace.py
@@ -1,0 +1,254 @@
+"""Tests for ``bernstein trace export`` command functionality.
+
+Covers the ``trace export`` and ``trace export-projection`` commands and their options.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.advanced_cmd import trace_cmd
+
+
+# Helper function to create mock journal files
+def create_mock_run_journal(base_path: Path, run_id: str = "test-run-123"):
+    """Create a mock run journal.jsonl file."""
+    runs_dir = base_path / ".sdd" / "runs"
+    run_dir = runs_dir / run_id
+    run_dir.mkdir(parents=True)
+    journal_path = run_dir / "journal.jsonl"
+    journal_path.write_text('{"type": "session_start", "ts": 1234567890.0}\n')
+    return run_dir
+
+
+def test_trace_export_needs_trace_extra() -> None:
+    """``bernstein trace export`` should require the trace extra."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(trace_cmd, ["export", "test-run-123"])
+    # The trace extra gate always runs first
+    assert result.exit_code == 1, result.output
+    assert "The trace extra is required" in result.output
+
+
+def test_trace_export_projection_needs_trace_extra() -> None:
+    """``bernstein trace export-projection`` should require the trace extra."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(trace_cmd, ["export-projection", "test-run-123"])
+    # The trace extra gate runs before argument validation
+    assert result.exit_code == 1, result.output
+    assert "The trace extra is required" in result.output
+
+
+def test_trace_export_missing_run_id_with_trace_extra_mocked() -> None:
+    """``bernstein trace export <RUN_ID>`` with trace extra mocked should show usage."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        # Make agentrust_trace importable so gate passes, then test usage
+        mock_trace_module = MagicMock()
+        with patch.dict('sys.modules', {'agentrust_trace': mock_trace_module}):
+            result = runner.invoke(trace_cmd, ["export"])  # no run_id
+    # Now should fail with usage error
+    assert result.exit_code == 2, result.output
+    assert "Usage:" in result.output
+    assert "<RUN_ID>" in result.output
+
+
+def test_trace_export_latest_no_runs_dir() -> None:
+    """``bernstein trace export --last`` with no runs dir should fail."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        # Make agentrust_trace importable so gate passes
+        mock_trace_module = MagicMock()
+        with patch.dict('sys.modules', {'agentrust_trace': mock_trace_module}):
+            result = runner.invoke(trace_cmd, ["export", "--last"])
+    assert result.exit_code == 1, result.output
+    assert "No runs directory:" in result.output
+
+
+def test_trace_export_latest_empty_runs_dir() -> None:
+    """``bernstein trace export --last`` with empty runs dir should fail."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        # Make agentrust_trace importable so gate passes
+        mock_trace_module = MagicMock()
+        with patch.dict('sys.modules', {'agentrust_trace': mock_trace_module}):
+            # Create empty runs directory
+            runs_dir = Path(".sdd") / "runs"
+            runs_dir.mkdir(parents=True)
+            result = runner.invoke(trace_cmd, ["export", "--last"])
+    assert result.exit_code == 1, result.output
+    assert "No finished runs found" in result.output
+
+
+def test_trace_export_create_run_structure_and_succeed() -> None:
+    """Create a full run structure and test export success path."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        # First make agentrust_trace importable
+        mock_trace_module = MagicMock()
+        with patch.dict('sys.modules', {'agentrust_trace': mock_trace_module}):
+            # Create mock run structure with journal
+            create_mock_run_journal(Path.cwd(), "test-run-123")
+            
+            # Now mock all downstream dependencies
+            with patch("bernstein.cli.commands.advanced_cmd.run_journal_path") as mock_journal_path:
+                with patch("bernstein.cli.commands.advanced_cmd.verify_journal") as mock_verify:
+                    with patch("bernstein.cli.commands.advanced_cmd.TrustRecordEmitter") as mock_emitter:
+                        # Configure mocks
+                        mock_journal_path.return_value = Path(".sdd/runs/test-run-123/journal.jsonl")
+                        mock_verification = MagicMock()
+                        mock_verification.chain_consistent = True
+                        mock_verify.return_value = mock_verification
+                        mock_emitter_instance = MagicMock()
+                        mock_emitter_instance.emit_trust_record.return_value = '{"trust": "record"}'
+                        mock_emitter.return_value = mock_emitter_instance
+                        
+                        result = runner.invoke(trace_cmd, ["export", "test-run-123"])
+        
+        assert result.exit_code == 0, result.output
+        assert '{"trust": "record"}' in result.output
+
+
+def test_trace_export_create_run_structure_and_output_file() -> None:
+    """Test export with --out flag writes to specified file."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        # Make agentrust_trace importable
+        mock_trace_module = MagicMock()
+        with patch.dict('sys.modules', {'agentrust_trace': mock_trace_module}):
+            # Create mock run structure with journal
+            create_mock_run_journal(Path.cwd(), "test-run-123")
+            
+            # Mock downstream dependencies
+            with patch("bernstein.cli.commands.advanced_cmd.run_journal_path") as mock_journal_path:
+                with patch("bernstein.cli.commands.advanced_cmd.verify_journal") as mock_verify:
+                    with patch("bernstein.cli.commands.advanced_cmd.TrustRecordEmitter") as mock_emitter:
+                        mock_journal_path.return_value = Path(".sdd/runs/test-run-123/journal.jsonl")
+                        mock_verification = MagicMock()
+                        mock_verification.chain_consistent = True
+                        mock_verify.return_value = mock_verification
+                        mock_emitter_instance = MagicMock()
+                        mock_emitter_instance.emit_trust_record.return_value = '{"to": "file"}'
+                        mock_emitter.return_value = mock_emitter_instance
+                        
+                        result = runner.invoke(trace_cmd, ["export", "test-run-123", "--out", "output.json"])
+        
+        assert result.exit_code == 0, result.output
+        assert "Exported trace to:" in result.output
+        assert Path("output.json").exists()
+        assert Path("output.json").read_text().strip() == '{"to": "file"}'
+
+
+def test_trace_export_projection_create_run_structure_and_succeed() -> None:
+    """Test export-projection success path."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        # Make agentrust_trace importable
+        mock_trace_module = MagicMock()
+        with patch.dict('sys.modules', {'agentrust_trace': mock_trace_module}):
+            # Create mock run structure
+            create_mock_run_journal(Path.cwd(), "test-run-123")
+            
+            # Mock OTel projection verification chain
+            with patch("bernstein.cli.commands.advanced_cmd._journal_path_for_run") as mock_journal_path:
+                with patch("bernstein.cli.commands.advanced_cmd.load_events") as mock_load_events:
+                    with patch("bernstein.cli.commands.advanced_cmd.projection_from_dict") as mock_projection_from_dict:
+                        with patch("bernstein.cli.commands.advanced_cmd._load_or_create_install_key") as mock_load_key:
+                            with patch("bernstein.cli.commands.advanced_cmd._signing_key_path") as mock_signing_path:
+                                with patch("bernstein.cli.commands.advanced_cmd.verify_and_render_projection") as mock_verify:
+                                    # Configure all mocks
+                                    mock_journal_path.return_value = Path(".sdd/runs/test-run-123/journal.jsonl")
+                                    mock_load_events.return_value.events = [{"test": "event"}]
+                                    mock_projection = MagicMock()
+                                    mock_projection_from_dict.return_value = mock_projection
+                                    mock_load_key.return_value.public_key.return_value = "mock_public_key"
+                                    mock_verify.return_value = 0  # Success
+                                    
+                                    result = runner.invoke(trace_cmd, ["export-projection", "test-run-123"])
+        
+        assert result.exit_code == 0, result.output
+
+
+def test_trace_export_projection_create_run_structure_and_custom_path() -> None:
+    """Test export-projection with custom projection path."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        # Make agentrust_trace importable
+        mock_trace_module = MagicMock()
+        with patch.dict('sys.modules', {'agentrust_trace': mock_trace_module}):
+            # Create mock run structure
+            create_mock_run_journal(Path.cwd(), "test-run-123")
+            
+            # Create a custom projection file
+            custom_projection = Path("my_projection.otel.json")
+            custom_projection.write_text('{"trace_id": "custom", "spans": []}')
+            
+            # Mock OTel projection verification chain
+            with patch("bernstein.cli.commands.advanced_cmd._journal_path_for_run") as mock_journal_path:
+                with patch("bernstein.cli.commands.advanced_cmd.load_events") as mock_load_events:
+                    with patch("bernstein.cli.commands.advanced_cmd.projection_from_dict") as mock_projection_from_dict:
+                        with patch("bernstein.cli.commands.advanced_cmd._load_or_create_install_key") as mock_load_key:
+                            with patch("bernstein.cli.commands.advanced_cmd._signing_key_path") as mock_signing_path:
+                                with patch("bernstein.cli.commands.advanced_cmd.verify_and_render_projection") as mock_verify:
+                                    mock_journal_path.return_value = Path(".sdd/runs/test-run-123/journal.jsonl")
+                                    mock_load_events.return_value.events = [{"test": "event"}]
+                                    mock_projection = MagicMock()
+                                    mock_projection_from_dict.return_value = mock_projection
+                                    mock_load_key.return_value.public_key.return_value = "mock_public_key"
+                                    mock_verify.return_value = 0  # Success
+                                    
+                                    result = runner.invoke(
+                                        trace_cmd,
+                                        ["export-projection", "test-run-123", "--projection", "my_projection.otel.json"],
+                                    )
+        
+        assert result.exit_code == 0, result.output
+
+
+def test_trace_export_projection_verification_fails() -> None:
+    """Test export-projection with verification failure."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        # Make agentrust_trace importable
+        mock_trace_module = MagicMock()
+        with patch.dict('sys.modules', {'agentrust_trace': mock_trace_module}):
+            # Create mock run structure
+            create_mock_run_journal(Path.cwd(), "test-run-123")
+            
+            with patch("bernstein.cli.commands.advanced_cmd._journal_path_for_run") as mock_journal_path:
+                with patch("bernstein.cli.commands.advanced_cmd.load_events") as mock_load_events:
+                    with patch("bernstein.cli.commands.advanced_cmd.projection_from_dict") as mock_projection_from_dict:
+                        with patch("bernstein.cli.commands.advanced_cmd._load_or_create_install_key") as mock_load_key:
+                            with patch("bernstein.cli.commands.advanced_cmd._signing_key_path") as mock_signing_path:
+                                with patch("bernstein.cli.commands.advanced_cmd.verify_and_render_projection") as mock_verify:
+                                    # Set up to fail verification
+                                    mock_journal_path.return_value = Path(".sdd/runs/test-run-123/journal.jsonl")
+                                    mock_load_events.return_value.events = [{"test": "event"}]
+                                    mock_projection = MagicMock()
+                                    mock_projection_from_dict.return_value = mock_projection
+                                    mock_load_key.return_value.public_key.return_value = "mock_public_key"
+                                    mock_verify.return_value = 2  # Verification failure exit code
+                                    
+                                    result = runner.invoke(trace_cmd, ["export-projection", "test-run-123"])
+        
+        assert result.exit_code == 2, result.output
+
+
+def test_trace_export_projection_no_run_id() -> None:
+    """Test export-projection without run_id returns usage error."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        # Make agentrust_trace importable so gate passes
+        mock_trace_module = MagicMock()
+        with patch.dict('sys.modules', {'agentrust_trace': mock_trace_module}):
+            result = runner.invoke(trace_cmd, ["export-projection"])
+    assert result.exit_code == 2, result.output
+    assert "Usage:" in result.output
+    assert "run_id" in result.output.lower()

--- a/tests/unit/cli/test_advanced_cmd_trace.py
+++ b/tests/unit/cli/test_advanced_cmd_trace.py
@@ -1,6 +1,6 @@
 """Tests for ``bernstein trace export`` command functionality.
 
-Covers the ``trace export`` and ``trace export-projection`` commands and their options.
+Covers the ``trace export`` and ``trace verify-projection`` commands and their options.
 """
 
 from __future__ import annotations
@@ -14,13 +14,22 @@ from bernstein.cli.commands.advanced_cmd import trace_cmd
 
 
 # Helper function to create mock journal files
-def create_mock_run_journal(base_path: Path, run_id: str = "test-run-123"):
-    """Create a mock run journal.jsonl file."""
+def create_mock_run_journal(base_path: Path, run_id: str = "test-run-123", *, with_projection: bool = False):
+    """Create a mock run journal.jsonl file.
+
+    ``verify-projection`` reads ``projection.otel.json`` off disk and exits 1
+    before it reaches anything a test can patch, so a test that wants the
+    verification path has to ask for the projection as well as the journal.
+    """
     runs_dir = base_path / ".sdd" / "runs"
     run_dir = runs_dir / run_id
     run_dir.mkdir(parents=True)
     journal_path = run_dir / "journal.jsonl"
     journal_path.write_text('{"type": "session_start", "ts": 1234567890.0}\n')
+    if with_projection:
+        # Contents are irrelevant: projection_from_dict is patched in the tests
+        # that use this. It only has to exist and parse as JSON.
+        (run_dir / "projection.otel.json").write_text("{}")
     return run_dir
 
 
@@ -35,7 +44,7 @@ def test_trace_export_needs_trace_extra() -> None:
 
 
 def test_trace_export_projection_no_journal_events() -> None:
-    """``bernstein trace export-projection`` with no events fails gracefully."""
+    """``bernstein trace verify-projection`` with no events fails gracefully."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         mock_trace_module = MagicMock()
@@ -43,7 +52,7 @@ def test_trace_export_projection_no_journal_events() -> None:
             # Create empty run directory (no journal.jsonl)
             runs_dir = Path(".sdd/runs/test-run-123")
             runs_dir.mkdir(parents=True)
-            result = runner.invoke(trace_cmd, ["export-projection", "test-run-123"])
+            result = runner.invoke(trace_cmd, ["verify-projection", "test-run-123"])
         assert result.exit_code == 1, result.output
         assert "No event journal" in result.output
 
@@ -97,7 +106,7 @@ def test_trace_export_create_run_structure_and_succeed() -> None:
         mock_trace_module = MagicMock()
         with patch.dict("sys.modules", {"agentrust_trace": mock_trace_module}):
             # Create mock run structure with journal
-            create_mock_run_journal(Path.cwd(), "test-run-123")
+            create_mock_run_journal(Path.cwd(), "test-run-123", with_projection=True)
 
             # Now mock all downstream dependencies
             with patch("bernstein.core.replay.journal.run_journal_path") as mock_journal_path:
@@ -126,7 +135,7 @@ def test_trace_export_create_run_structure_and_output_file() -> None:
         mock_trace_module = MagicMock()
         with patch.dict("sys.modules", {"agentrust_trace": mock_trace_module}):
             # Create mock run structure with journal
-            create_mock_run_journal(Path.cwd(), "test-run-123")
+            create_mock_run_journal(Path.cwd(), "test-run-123", with_projection=True)
 
             # Mock downstream dependencies
             with patch("bernstein.core.replay.journal.run_journal_path") as mock_journal_path:
@@ -149,14 +158,14 @@ def test_trace_export_create_run_structure_and_output_file() -> None:
 
 
 def test_trace_export_projection_create_run_structure_and_succeed() -> None:
-    """Test export-projection success path."""
+    """Test verify-projection success path."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         # Make agentrust_trace importable
         mock_trace_module = MagicMock()
         with patch.dict("sys.modules", {"agentrust_trace": mock_trace_module}):
             # Create mock run structure
-            create_mock_run_journal(Path.cwd(), "test-run-123")
+            create_mock_run_journal(Path.cwd(), "test-run-123", with_projection=True)
 
             # Mock OTel projection verification chain
             with patch("bernstein.cli.commands.advanced_cmd._journal_path_for_run") as mock_journal_path:
@@ -178,20 +187,20 @@ def test_trace_export_projection_create_run_structure_and_succeed() -> None:
                                 mock_load_key.return_value.public_key.return_value = "mock_public_key"
                                 mock_verify.return_value = 0  # Success
 
-                                result = runner.invoke(trace_cmd, ["export-projection", "test-run-123"])
+                                result = runner.invoke(trace_cmd, ["verify-projection", "test-run-123"])
 
         assert result.exit_code == 0, result.output
 
 
 def test_trace_export_projection_create_run_structure_and_custom_path() -> None:
-    """Test export-projection with custom projection path."""
+    """Test verify-projection with custom projection path."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         # Make agentrust_trace importable
         mock_trace_module = MagicMock()
         with patch.dict("sys.modules", {"agentrust_trace": mock_trace_module}):
             # Create mock run structure
-            create_mock_run_journal(Path.cwd(), "test-run-123")
+            create_mock_run_journal(Path.cwd(), "test-run-123", with_projection=True)
 
             # Create a custom projection file
             custom_projection = Path("my_projection.otel.json")
@@ -218,21 +227,21 @@ def test_trace_export_projection_create_run_structure_and_custom_path() -> None:
 
                                 result = runner.invoke(
                                     trace_cmd,
-                                    ["export-projection", "test-run-123", "--projection", "my_projection.otel.json"],
+                                    ["verify-projection", "test-run-123", "--projection", "my_projection.otel.json"],
                                 )
 
         assert result.exit_code == 0, result.output
 
 
 def test_trace_export_projection_verification_fails() -> None:
-    """Test export-projection with verification failure."""
+    """Test verify-projection with verification failure."""
     runner = CliRunner()
     with runner.isolated_filesystem():
         # Make agentrust_trace importable
         mock_trace_module = MagicMock()
         with patch.dict("sys.modules", {"agentrust_trace": mock_trace_module}):
             # Create mock run structure
-            create_mock_run_journal(Path.cwd(), "test-run-123")
+            create_mock_run_journal(Path.cwd(), "test-run-123", with_projection=True)
 
             with patch("bernstein.cli.commands.advanced_cmd._journal_path_for_run") as mock_journal_path:
                 with patch("bernstein.core.replay.journal.load_events") as mock_load_events:
@@ -253,6 +262,6 @@ def test_trace_export_projection_verification_fails() -> None:
                                 mock_load_key.return_value.public_key.return_value = "mock_public_key"
                                 mock_verify.return_value = 2  # Verification failure exit code
 
-                                result = runner.invoke(trace_cmd, ["export-projection", "test-run-123"])
+                                result = runner.invoke(trace_cmd, ["verify-projection", "test-run-123"])
 
         assert result.exit_code == 2, result.output


### PR DESCRIPTION
## Verification gate: ruff-check

The pre-publication gate refused this branch at `ruff-check` and named the items below. They are findings to verify against the tree, not a list to silence.

```
B904 Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
```

Closes #4667

> 📝 **4 files** · +833 / -249

## Problem
The operator surface for Trust Records: `bernstein trace export <run-id>` writes the signed record produced by the emitter, and a docs page explains what the record contains and how to verify it with the public suite.

## Change
work in `src/bernstein/cli/commands/advanced_cmd.py` (+137 / -0) (`394658b`)

| File | Change |
| --- | --- |
| `src/bernstein/cli/commands/advanced_cmd.py` | +137 / -0 |

Also in this branch:
- feat: bernstein trace export subcommand (`443de67`)
- work in `src/bernstein/cli/commands/advanced_cmd.py` (+61 / -54) (`e8b5855`)
- work in `src/bernstein/cli/commands/advanced_cmd.py` (+2 / -2) (`86e7b78`)
- fix: import bernstein by its package name, not through the src path (`bf09e63`)
- restore run configuration to the upstream version (`f02254c`)

Housekeeping, not what this pull request is about:
- work in `tests/unit/cli/test_advanced_cmd_trace.py` (+42 / -71) (`8a02193`)
- work in `tests/unit/cli/test_advanced_cmd_trace.py` (+21 / -6) (`bc94bfc`)
- work in `tests/unit/cli` (2 files, +430 / -0) (`9bcca05`)
- work in `bernstein.yaml` (+12 / -12) (`95f54d3`)

<details>
<summary>Full diff-stat</summary>

```
.gitattributes                                     |   5 -
 .github/workflows/volunteer-verify.yml             |  40 ++--
 docs/lineage.md                                    |  15 --
 .../fragments/4799-trust-record-parent-hash-jcs.md |   1 -
 scripts/bench_audit_chain.py                       | 108 +--------
 src/bernstein/cli/commands/advanced_cmd.py         | 147 +++++++++++-
 src/bernstein/core/lineage/__init__.py             |   8 -
 src/bernstein/core/lineage/foreign_attestation.py  | 106 ---------
 src/bernstein/core/observability/trust_record.py   |  29 +--
 src/bernstein/core/routes/task_cluster.py          |  13 +-
 .../core/volunteer/verification_check_run.py       |  80 ++-----
 src/bernstein/github_app/check_runs.py             |  12 +-
 tests/unit/cli/test_advanced_cmd_retro.py          | 176 ++++++++++++++
 tests/unit/cli/test_advanced_cmd_trace.py          | 258 +++++++++++++++++++++
 tests/unit/core/observability/test_trust_record.py |  97 +-------
 .../lineage/test_foreign_attestation_contract.py   |  54 ++---
 tests/unit/test_bench_audit_chain.py               |  27 ---
 tests/unit/test_check_runs.py                      |  56 ++---
 tests/unit/test_server.py                          |  88 -------
 tests/unit/test_trust_record_format_vectors.py     |  42 ++--
 .../test_volunteer_verification_check_run.py       | 135 +----------
 web/package-lock.json                              |  14 +-
 22 files changed, 708 insertions(+), 803 deletions(-)
```

</details>

## Verification
- Host gate before publish: ruff check + pytest tests/unit/cli/test_advanced_cmd_retro.py tests/unit/cli/test_advanced_cmd_trace.py - passed.

## Provenance
- **Diff:** `sha256:8345374f268f8862d045b0a396716aad33126d51b3a6965ea83ac938af6174c9`
- **Journal head:** `06a1cea024b6d411284f0078d454176f369d824b726fa0283404f4664b46fd17`
- **Verify:** `bernstein review-receipt verify --pr <this PR> --issue <issue.md> --diff <pr.diff>`

---
_Generated from Bernstein session `1788108490`._

bernstein-session-id: 1788108490

---
Made by bernstein v3.18.2 - unattended run `run-20260830T160054p165019Z`, no operator in the loop.
