### PR TITLE
feat(scanners): add deterministic gitleaks adapter

### DIFF
--- a/docs/sdd/module-map.md
+++ b/docs/sdd/module-map.md
@@ -133,6 +133,7 @@ Full per-file module map. `AGENTS.md`'s own "Module map" section links here inst
 | `forge.py`                  | Forge CLI adapter |
 | `gemini.py`                 | Google Gemini / Antigravity CLI adapter |
 | `generic.py`                | Generic CLI adapter for arbitrary coding agent CLIs |
+| `gitleaks.py`               | Deterministic Gitleaks scanner adapter and SARIF normalization |
 | `goose.py`                  | Goose CLI adapter for Bernstein |
 | `goose_stream_parser.py`    | Parse Goose ``--output-format stream-json`` events |
 | `gptme.py`                  | gptme CLI adapter |

--- a/src/bernstein/adapters/gitleaks.py
+++ b/src/bernstein/adapters/gitleaks.py
@@ -1,0 +1,334 @@
+"""Deterministic Gitleaks scanner adapter and SARIF normalization."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+from bernstein.adapters._contract import (
+    ScannerCategory as ContractScannerCategory,
+)
+from bernstein.adapters._contract import (
+    ScannerDeterminism,
+    ScannerOutputFormat,
+    register_scanner_capabilities,
+)
+from bernstein.adapters.env_isolation import build_filtered_env  # pyright: ignore[reportUnknownVariableType]
+from bernstein.adapters.scanner import (
+    DeterminismTier,
+    OutputFormat,
+    ScannerAdapter,
+    ScannerCategory,
+    ScanResult,
+    ScanScope,
+)
+from bernstein.adapters.scanner_finding import Finding
+
+GITLEAKS_REGISTRY_NAME = "gitleaks"
+_SCAN_TIMEOUT_SECONDS = 300
+
+
+class GitleaksError(RuntimeError):
+    """Base error raised when Gitleaks cannot complete a scan."""
+
+
+class GitleaksNotInstalledError(GitleaksError):
+    """Raised when the Gitleaks executable cannot be found on ``PATH``."""
+
+
+@dataclass(frozen=True)
+class GitleaksInvocation:
+    """Stable provenance for one Gitleaks invocation."""
+
+    tool_version: str
+    ruleset_digest: str
+    argv_hash: str
+
+
+class GitleaksAdapter(ScannerAdapter):
+    """Run Gitleaks directory scans and normalize their SARIF findings."""
+
+    registry_name = GITLEAKS_REGISTRY_NAME
+    output_format = OutputFormat.SARIF
+    determinism = DeterminismTier.DETERMINISTIC
+    pinned_inputs: tuple[str, ...] = ()
+    category = ScannerCategory.SECRET
+
+    def __init__(self, *, binary: str = "gitleaks", config_path: str | Path | None = None) -> None:
+        super().__init__()
+        self._binary = binary
+        self._config_path = Path(config_path) if config_path is not None else None
+        self.last_invocation: GitleaksInvocation | None = None
+
+    def name(self) -> str:
+        """Return the registry key used by the conformance capability lookup."""
+        return self.registry_name
+
+    def scan(self, target: Path, scope: ScanScope, workdir: Path) -> ScanResult:
+        """Run a deterministic Gitleaks directory scan.
+
+        Gitleaks exit code 1 means findings were detected, not that execution
+        failed. Both exit codes 0 and 1 therefore produce a ``ScanResult``.
+        """
+        self.enforce_network_policy()
+        _validate_scope(target, scope)
+        resolved_target = target.resolve()
+        if not resolved_target.exists():
+            raise GitleaksError(f"Gitleaks target does not exist: {target}")
+        binary = shutil.which(self._binary)
+        if binary is None:
+            raise GitleaksNotInstalledError(
+                f"Gitleaks executable {self._binary!r} was not found on PATH; install gitleaks or configure its binary"
+            )
+
+        config_path = self._resolve_config_path(scope, resolved_target)
+        ignore_root = resolved_target if resolved_target.is_dir() else resolved_target.parent
+        ignore_file = ignore_root / ".gitleaksignore"
+        tool_version = _read_version(binary)
+        ruleset_digest = _ruleset_digest(binary, config_path, ignore_file if ignore_file.is_file() else None)
+
+        workdir.mkdir(parents=True, exist_ok=True)
+        report_path = (workdir / "gitleaks.sarif").resolve()
+        report_path.unlink(missing_ok=True)
+        command = _build_command(binary, resolved_target, report_path, config_path, ignore_root)
+        self.last_invocation = GitleaksInvocation(
+            tool_version=tool_version,
+            ruleset_digest=ruleset_digest,
+            argv_hash=_invocation_argv_hash(tool_version, ruleset_digest),
+        )
+
+        try:
+            completed = subprocess.run(
+                command,
+                check=False,
+                capture_output=True,
+                text=True,
+                env=build_filtered_env([]),
+                timeout=_SCAN_TIMEOUT_SECONDS,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise GitleaksError(f"Gitleaks execution failed: {exc}") from exc
+
+        if completed.returncode not in (0, 1):
+            detail = completed.stderr.strip() or completed.stdout.strip() or "no diagnostic output"
+            raise GitleaksError(f"Gitleaks exited with code {completed.returncode}: {detail}")
+        if not report_path.is_file():
+            raise GitleaksError("Gitleaks completed without writing its SARIF report")
+
+        try:
+            findings = parse_gitleaks_sarif(report_path.read_bytes(), target_root=resolved_target)
+        finally:
+            # SARIF snippets may contain secrets. Findings retain only a digest,
+            # so the raw report should not outlive parsing.
+            report_path.unlink(missing_ok=True)
+        return ScanResult(findings=findings)
+
+    def _resolve_config_path(self, scope: ScanScope, target: Path) -> Path | None:
+        configured = scope.config.get("config_path")
+        config_path = Path(str(configured)) if configured is not None else self._config_path
+        if config_path is None:
+            config_root = target if target.is_dir() else target.parent
+            target_config = config_root / ".gitleaks.toml"
+            config_path = target_config if target_config.is_file() else None
+        if config_path is not None and not config_path.is_file():
+            raise GitleaksError(f"Gitleaks config does not exist: {config_path}")
+        return config_path.resolve() if config_path is not None else None
+
+
+def _validate_scope(target: Path, scope: ScanScope) -> None:
+    if scope.include or scope.exclude or scope.max_depth is not None:
+        raise ValueError("GitleaksAdapter does not yet support include, exclude, or max_depth scan scope fields")
+    unsupported = set(scope.config) - {"config_path"}
+    if unsupported:
+        raise ValueError(f"Unsupported Gitleaks scan configuration: {', '.join(sorted(unsupported))}")
+    if scope.roots:
+        resolved_target = target.resolve()
+        target_is_allowed = any(
+            resolved_target == root.resolve() or resolved_target.is_relative_to(root.resolve()) for root in scope.roots
+        )
+        if not target_is_allowed:
+            raise ValueError("Gitleaks target is outside the allowed ScanScope roots")
+
+
+def _read_version(binary: str) -> str:
+    try:
+        completed = subprocess.run(
+            [binary, "version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=build_filtered_env([]),
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise GitleaksError(f"Could not read Gitleaks version: {exc}") from exc
+    if completed.returncode != 0:
+        raise GitleaksError(f"Could not read Gitleaks version: {completed.stderr.strip()}")
+    version = completed.stdout.strip()
+    if not version:
+        raise GitleaksError("Gitleaks returned an empty version")
+    return version
+
+
+def _build_command(
+    binary: str,
+    target: Path,
+    report_path: Path,
+    config_path: Path | None,
+    ignore_root: Path,
+) -> list[str]:
+    command = [
+        binary,
+        "dir",
+        "--no-banner",
+        "--report-format",
+        "sarif",
+        "--report-path",
+        str(report_path),
+        "--gitleaks-ignore-path",
+        str(ignore_root),
+    ]
+    if config_path is not None:
+        command.extend(["--config", str(config_path)])
+    command.append(str(target))
+    return command
+
+
+def _ruleset_digest(binary: str, config_path: Path | None, ignore_path: Path | None = None) -> str:
+    source = config_path if config_path is not None else Path(binary)
+    source_bytes = source.read_bytes()
+    if ignore_path is None:
+        digest_bytes = source_bytes
+    else:
+        digest_bytes = b"gitleaks-policy-v1\0" + source_bytes + b"\0ignore\0" + ignore_path.read_bytes()
+    return "sha256:" + hashlib.sha256(digest_bytes).hexdigest()
+
+
+def _invocation_argv_hash(tool_version: str, ruleset_digest: str) -> str:
+    semantic_invocation = {
+        "command": "dir",
+        "report_format": "sarif",
+        "ruleset_digest": ruleset_digest,
+        "tool": GITLEAKS_REGISTRY_NAME,
+        "tool_version": tool_version,
+    }
+    canonical = json.dumps(semantic_invocation, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(canonical).hexdigest()
+
+
+def parse_gitleaks_sarif(report: str | bytes, *, target_root: Path | None = None) -> list[Finding]:
+    """Parse a Gitleaks SARIF report into stable Bernstein findings.
+
+    Source coordinates and Gitleaks fingerprints are deliberately excluded
+    from the finding. Gitleaks fingerprints contain the start line, so using
+    them would make a cosmetic line shift change the finding hash.
+
+    Args:
+        report: UTF-8 SARIF JSON emitted by Gitleaks.
+        target_root: Scan root used to make absolute Gitleaks paths portable.
+
+    Returns:
+        Findings in report order.
+
+    Raises:
+        ValueError: If the report is not valid Gitleaks SARIF.
+    """
+    try:
+        raw = json.loads(report)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ValueError(f"Invalid Gitleaks SARIF JSON: {exc}") from exc
+
+    root = _mapping(raw, "SARIF root")
+    if root.get("version") != "2.1.0":
+        raise ValueError("Gitleaks report must use SARIF 2.1.0")
+
+    findings: list[Finding] = []
+    for run_index, run_raw in enumerate(_sequence(root.get("runs"), "runs")):
+        run = _mapping(run_raw, f"runs[{run_index}]")
+        driver = _mapping(_mapping(run.get("tool"), "tool").get("driver"), "tool.driver")
+        if driver.get("name") != "gitleaks":
+            raise ValueError("SARIF tool.driver.name must be 'gitleaks'")
+
+        descriptions = _rule_descriptions(driver)
+        for result_index, result_raw in enumerate(_sequence(run.get("results", []), "results")):
+            result = _mapping(result_raw, f"results[{result_index}]")
+            rule = str(result.get("ruleId") or "")
+            if not rule:
+                raise ValueError(f"results[{result_index}] is missing ruleId")
+
+            physical = _physical_location(result, result_index)
+            artifact = _mapping(physical.get("artifactLocation"), "artifactLocation")
+            path = str(artifact.get("uri") or "").replace("\\", "/")
+            if not path:
+                raise ValueError(f"results[{result_index}] is missing artifactLocation.uri")
+            normalized_path = _normalize_path(path, target_root)
+
+            region = _mapping(physical.get("region"), "region")
+            snippet = str(_mapping(region.get("snippet"), "region.snippet").get("text") or "")
+            snippet_hash = "sha256:" + hashlib.sha256(snippet.encode("utf-8")).hexdigest()
+
+            findings.append(
+                Finding(
+                    rule=rule,
+                    path=normalized_path,
+                    severity="informational",
+                    summary=descriptions.get(rule, rule),
+                    extra={"snippet_hash": snippet_hash},
+                )
+            )
+
+    return findings
+
+
+def _normalize_path(path: str, target_root: Path | None) -> str:
+    candidate = Path(path)
+    if target_root is not None and candidate.is_absolute():
+        with suppress(ValueError):
+            candidate = candidate.relative_to(target_root.resolve())
+    return candidate.as_posix()
+
+
+def _rule_descriptions(driver: dict[str, Any]) -> dict[str, str]:
+    descriptions: dict[str, str] = {}
+    for rule_raw in _sequence(driver.get("rules", []), "tool.driver.rules"):
+        rule = _mapping(rule_raw, "tool.driver.rules entry")
+        rule_id = str(rule.get("id") or "")
+        short = _mapping(rule.get("shortDescription", {}), "rule.shortDescription")
+        if rule_id:
+            descriptions[rule_id] = str(short.get("text") or rule_id)
+    return descriptions
+
+
+def _physical_location(result: dict[str, Any], result_index: int) -> dict[str, Any]:
+    locations = _sequence(result.get("locations"), f"results[{result_index}].locations")
+    if not locations:
+        raise ValueError(f"results[{result_index}] has no location")
+    location = _mapping(locations[0], "location")
+    return _mapping(location.get("physicalLocation"), "physicalLocation")
+
+
+def _mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    return cast("dict[str, Any]", value)
+
+
+def _sequence(value: Any, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValueError(f"{label} must be an array")
+    return cast("list[Any]", value)
+
+
+register_scanner_capabilities(
+    GITLEAKS_REGISTRY_NAME,
+    output_format=ScannerOutputFormat.SARIF,
+    determinism=ScannerDeterminism.DETERMINISTIC,
+    pinned_inputs=(),
+    category=ContractScannerCategory.SECRET,
+)

--- a/src/bernstein/adapters/scanner_registry.py
+++ b/src/bernstein/adapters/scanner_registry.py
@@ -11,6 +11,7 @@ import logging
 from importlib.metadata import entry_points
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
+from bernstein.adapters.gitleaks import GitleaksAdapter
 from bernstein.adapters.scanner import ScannerAdapter
 
 if TYPE_CHECKING:
@@ -148,3 +149,6 @@ def scanner_name_for_provider(provider_name: str | None, model: str) -> str | No
     """
     # Not implemented in slice 2 - external tools are looked up by name directly
     return None
+
+
+register_scanner(GitleaksAdapter.registry_name, GitleaksAdapter)

--- a/tests/fixtures/scanners/gitleaks/gitleaks-8.30.1.sarif
+++ b/tests/fixtures/scanners/gitleaks/gitleaks-8.30.1.sarif
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "gitleaks",
+          "semanticVersion": "v8.0.0",
+          "informationUri": "https://github.com/gitleaks/gitleaks",
+          "rules": [
+            {
+              "id": "bernstein-test-token",
+              "shortDescription": {
+                "text": "Bernstein synthetic test token"
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "message": {
+            "text": "bernstein-test-token has detected secret for file app.env."
+          },
+          "ruleId": "bernstein-test-token",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app.env"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 12,
+                  "endLine": 1,
+                  "endColumn": 53,
+                  "snippet": {
+                    "text": "bernstein_test_secret_abcdefghijklmnopqrst"
+                  }
+                }
+              }
+            }
+          ],
+          "partialFingerprints": {
+            "commitSha": "",
+            "email": "",
+            "author": "",
+            "date": "",
+            "commitMessage": ""
+          },
+          "properties": {
+            "tags": []
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/scanners/gitleaks/gitleaks-conformance.yaml
+++ b/tests/fixtures/scanners/gitleaks/gitleaks-conformance.yaml
@@ -1,0 +1,17 @@
+name: gitleaks-recorded-sarif
+adapter_class: bernstein.adapters.gitleaks.GitleaksAdapter
+ctor_kwargs:
+  config_path: tests/fixtures/scanners/gitleaks/gitleaks.toml
+steps:
+  - target: tests/fixtures/scanners/gitleaks/target
+    scope:
+      roots:
+        - tests/fixtures/scanners/gitleaks/target
+    expected_finding_hashes:
+      - 3330329f898a6c6cac9e3dabdfc3b845dc2025a08cceb8cb6a37562b4e8167af
+  - target: tests/fixtures/scanners/gitleaks/target
+    scope:
+      roots:
+        - tests/fixtures/scanners/gitleaks/target
+    expected_finding_hashes:
+      - 3330329f898a6c6cac9e3dabdfc3b845dc2025a08cceb8cb6a37562b4e8167af

--- a/tests/fixtures/scanners/gitleaks/gitleaks.toml
+++ b/tests/fixtures/scanners/gitleaks/gitleaks.toml
@@ -1,0 +1,7 @@
+title = "Bernstein Gitleaks adapter fixture"
+
+[[rules]]
+id = "bernstein-test-token"
+description = "Bernstein synthetic test token"
+regex = '''bernstein_test_secret_[a-z0-9]{20}'''
+keywords = ["bernstein_test_secret_"]

--- a/tests/fixtures/scanners/gitleaks/target/app.env
+++ b/tests/fixtures/scanners/gitleaks/target/app.env
@@ -1,0 +1,1 @@
+TEST_TOKEN=bernstein_test_secret_abcdefghijklmnopqrst

--- a/tests/unit/adapters/test_gitleaks_scanner.py
+++ b/tests/unit/adapters/test_gitleaks_scanner.py
@@ -1,0 +1,236 @@
+"""Tests for deterministic normalization of recorded Gitleaks SARIF."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from bernstein.adapters._contract import ScannerDeterminism, scanner_determinism
+from bernstein.adapters.gitleaks import (
+    GitleaksAdapter,
+    GitleaksError,
+    GitleaksNotInstalledError,
+    _invocation_argv_hash,
+    _ruleset_digest,
+    parse_gitleaks_sarif,
+)
+from bernstein.adapters.scanner import DeterminismTier, OutputFormat, ScannerCategory, ScanScope
+from bernstein.adapters.scanner_conformance import (
+    ScannerConformanceHarness,
+    load_scanner_golden_transcripts,
+)
+from bernstein.adapters.scanner_registry import get_scanner
+
+_FIXTURE = Path("tests/fixtures/scanners/gitleaks/gitleaks-8.30.1.sarif")
+_CONFIG = Path("tests/fixtures/scanners/gitleaks/gitleaks.toml")
+_FIXTURE_DIR = _FIXTURE.parent
+_SYNTHETIC_SECRET = "bernstein_test_secret_abcdefghijklmnopqrst"
+
+
+def _fixture_text() -> str:
+    return _FIXTURE.read_text(encoding="utf-8")
+
+
+def _fake_gitleaks_run(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+    if argv[1:] == ["version"]:
+        return subprocess.CompletedProcess(argv, 0, stdout="8.30.1\n", stderr="")
+    report_path = Path(argv[argv.index("--report-path") + 1])
+    report_path.write_text(_fixture_text(), encoding="utf-8")
+    return subprocess.CompletedProcess(argv, 1, stdout="", stderr="leaks found")
+
+
+def test_real_gitleaks_sarif_is_normalized_to_a_finding() -> None:
+    finding = parse_gitleaks_sarif(_fixture_text())[0]
+
+    assert finding.rule == "bernstein-test-token"
+    assert finding.path == "app.env"
+    assert finding.severity == "informational"
+    assert finding.summary == "Bernstein synthetic test token"
+    assert finding.extra["snippet_hash"].startswith("sha256:")
+    assert _SYNTHETIC_SECRET not in json.dumps(finding.to_dict())
+
+
+def test_two_parses_of_the_same_recorded_run_have_identical_hashes() -> None:
+    first = [finding.finding_hash() for finding in parse_gitleaks_sarif(_fixture_text())]
+    second = [finding.finding_hash() for finding in parse_gitleaks_sarif(_fixture_text())]
+
+    assert first == second
+
+
+def test_cosmetic_line_shift_does_not_change_the_finding_hash() -> None:
+    original = json.loads(_fixture_text())
+    shifted = copy.deepcopy(original)
+    region = shifted["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"]
+    region["startLine"] += 7
+    region["endLine"] += 7
+
+    original_hashes = [finding.finding_hash() for finding in parse_gitleaks_sarif(json.dumps(original))]
+    shifted_hashes = [finding.finding_hash() for finding in parse_gitleaks_sarif(json.dumps(shifted))]
+
+    assert shifted_hashes == original_hashes
+
+
+def test_absolute_report_path_is_normalized_to_the_scan_target() -> None:
+    report = json.loads(_fixture_text())
+    artifact = report["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["artifactLocation"]
+    artifact["uri"] = "/checkout/project/app.env"
+
+    finding = parse_gitleaks_sarif(json.dumps(report), target_root=Path("/checkout/project"))[0]
+
+    assert finding.path == "app.env"
+
+
+def test_non_gitleaks_sarif_is_rejected() -> None:
+    report = json.loads(_fixture_text())
+    report["runs"][0]["tool"]["driver"]["name"] = "another-scanner"
+
+    with pytest.raises(ValueError, match="must be 'gitleaks'"):
+        parse_gitleaks_sarif(json.dumps(report))
+
+
+def test_invalid_json_is_rejected() -> None:
+    with pytest.raises(ValueError, match="Invalid Gitleaks SARIF JSON"):
+        parse_gitleaks_sarif("not-json")
+
+
+def test_adapter_declares_the_deterministic_secret_scanner_contract() -> None:
+    adapter = GitleaksAdapter(config_path=_CONFIG)
+
+    assert adapter.name() == "gitleaks"
+    assert adapter.output_format is OutputFormat.SARIF
+    assert adapter.determinism is DeterminismTier.DETERMINISTIC
+    assert adapter.category is ScannerCategory.SECRET
+    assert scanner_determinism(adapter.name()) is ScannerDeterminism.DETERMINISTIC
+
+
+def test_scanner_registry_resolves_gitleaks() -> None:
+    assert isinstance(get_scanner("gitleaks"), GitleaksAdapter)
+
+
+def test_invocation_hash_binds_version_and_ruleset() -> None:
+    baseline = _invocation_argv_hash("8.30.1", "sha256:rules-a")
+
+    assert _invocation_argv_hash("8.30.1", "sha256:rules-a") == baseline
+    assert _invocation_argv_hash("8.30.2", "sha256:rules-a") != baseline
+    assert _invocation_argv_hash("8.30.1", "sha256:rules-b") != baseline
+
+
+def test_ignore_file_is_bound_into_the_ruleset_digest(tmp_path: Path) -> None:
+    ignore = tmp_path / ".gitleaksignore"
+    ignore.write_text("app.env:bernstein-test-token:1\n", encoding="utf-8")
+
+    without_ignore = _ruleset_digest("unused-binary", _CONFIG)
+    with_ignore = _ruleset_digest("unused-binary", _CONFIG, ignore)
+
+    assert with_ignore != without_ignore
+
+
+def test_scan_runs_gitleaks_and_accepts_findings_exit_code(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    adapter = GitleaksAdapter(config_path=_CONFIG)
+
+    with (
+        patch("bernstein.adapters.gitleaks.shutil.which", return_value="/usr/local/bin/gitleaks"),
+        patch("bernstein.adapters.gitleaks.subprocess.run", side_effect=_fake_gitleaks_run) as run,
+    ):
+        result = adapter.scan(target, ScanScope(roots=(target,)), tmp_path / "work")
+
+    expected_hash = parse_gitleaks_sarif(_fixture_text())[0].finding_hash()
+    assert result.finding_hashes() == [expected_hash]
+    scan_argv = run.call_args_list[1].args[0]
+    assert scan_argv[1:5] == ["dir", "--no-banner", "--report-format", "sarif"]
+    assert "--config" in scan_argv
+    assert scan_argv[-1] == str(target.resolve())
+    assert adapter.last_invocation is not None
+    assert adapter.last_invocation.tool_version == "8.30.1"
+    assert adapter.last_invocation.ruleset_digest == "sha256:" + hashlib.sha256(_CONFIG.read_bytes()).hexdigest()
+    assert not (tmp_path / "work" / "gitleaks.sarif").exists()
+
+
+def test_target_local_config_is_explicitly_pinned(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    local_config = target / ".gitleaks.toml"
+    local_config.write_bytes(_CONFIG.read_bytes())
+    adapter = GitleaksAdapter()
+
+    with (
+        patch("bernstein.adapters.gitleaks.shutil.which", return_value="/usr/local/bin/gitleaks"),
+        patch("bernstein.adapters.gitleaks.subprocess.run", side_effect=_fake_gitleaks_run) as run,
+    ):
+        adapter.scan(target, ScanScope(roots=(target,)), tmp_path / "work")
+
+    scan_argv = run.call_args_list[1].args[0]
+    assert scan_argv[scan_argv.index("--config") + 1] == str(local_config.resolve())
+    assert scan_argv[scan_argv.index("--gitleaks-ignore-path") + 1] == str(target.resolve())
+    assert adapter.last_invocation is not None
+    assert adapter.last_invocation.ruleset_digest == "sha256:" + hashlib.sha256(local_config.read_bytes()).hexdigest()
+
+
+def test_stale_report_cannot_be_reused(tmp_path: Path) -> None:
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    (workdir / "gitleaks.sarif").write_text(_fixture_text(), encoding="utf-8")
+
+    def no_report(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if argv[1:] == ["version"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="8.30.1\n", stderr="")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    adapter = GitleaksAdapter(config_path=_CONFIG)
+    with (
+        patch("bernstein.adapters.gitleaks.shutil.which", return_value="/usr/local/bin/gitleaks"),
+        patch("bernstein.adapters.gitleaks.subprocess.run", side_effect=no_report),
+        pytest.raises(GitleaksError, match="without writing its SARIF report"),
+    ):
+        adapter.scan(tmp_path, ScanScope(), workdir)
+
+
+def test_scan_reports_missing_gitleaks_without_invoking_a_process(tmp_path: Path) -> None:
+    adapter = GitleaksAdapter(config_path=_CONFIG)
+    with (
+        patch("bernstein.adapters.gitleaks.shutil.which", return_value=None),
+        patch("bernstein.adapters.gitleaks.subprocess.run") as run,
+        pytest.raises(GitleaksNotInstalledError, match="not found on PATH"),
+    ):
+        adapter.scan(tmp_path, ScanScope(), tmp_path / "work")
+    run.assert_not_called()
+
+
+def test_scan_rejects_a_real_gitleaks_execution_error(tmp_path: Path) -> None:
+    def fail_scan(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if argv[1:] == ["version"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="8.30.1\n", stderr="")
+        return subprocess.CompletedProcess(argv, 2, stdout="", stderr="bad config")
+
+    adapter = GitleaksAdapter(config_path=_CONFIG)
+    with (
+        patch("bernstein.adapters.gitleaks.shutil.which", return_value="/usr/local/bin/gitleaks"),
+        patch("bernstein.adapters.gitleaks.subprocess.run", side_effect=fail_scan),
+        pytest.raises(GitleaksError, match="code 2: bad config"),
+    ):
+        adapter.scan(tmp_path, ScanScope(), tmp_path / "work")
+
+
+def test_conformance_replays_two_identical_gitleaks_runs(tmp_path: Path) -> None:
+    transcripts = load_scanner_golden_transcripts(_FIXTURE_DIR)
+    assert len(transcripts) == 1
+
+    with (
+        patch("bernstein.adapters.gitleaks.shutil.which", return_value="/usr/local/bin/gitleaks"),
+        patch("bernstein.adapters.gitleaks.subprocess.run", side_effect=_fake_gitleaks_run) as run,
+    ):
+        result = ScannerConformanceHarness().replay_transcript(transcripts[0], workdir=tmp_path)
+
+    assert result.passed
+    assert result.adapter_name == "gitleaks"
+    assert result.determinism_tier is DeterminismTier.DETERMINISTIC
+    assert sum(call.args[0][1] == "dir" for call in run.call_args_list) == 2


### PR DESCRIPTION
```markdown
## What

Adds the gitleaks adapter for the deterministic scanner tier in #3618.

This PR only covers gitleaks, as discussed. trivy and nmap will come in separate PRs.

## Why

This gives the deterministic tier a real scanner to test against. The same finding should keep the same hash across equivalent scans. For example, adding a blank line above a secret should not make it a new finding.

## How

The adapter runs `gitleaks dir` with SARIF output and converts the results into Bernstein `Finding` objects.

Line and column numbers are excluded from finding identity. Matched secrets are hashed instead of stored in normalized findings. Absolute paths are made relative to the scan target. Exit code `1` is treated as a successful scan with findings, and temporary SARIF output is deleted after parsing.

Tests use a recorded Gitleaks 8.30.1 SARIF fixture, so CI does not need Gitleaks installed.

## Invocation hash

The invocation hash includes the Gitleaks version, scan mode, output format, and effective ruleset digest. The ruleset digest also accounts for `.gitleaksignore`.

Temporary paths, absolute paths, `--no-banner`, and timeout values are excluded because they do not change the logical scan.

## Verification

Ruff passed. Pyright passed for the new module. Import contracts passed. All 16 gitleaks tests passed without Gitleaks in `PATH`, and 39 existing scanner tests passed. A live Gitleaks 8.30.1 scan also produced the same finding hash as the recorded fixture.

Full-repository Pyright still reports baseline errors outside this change.
```