### PR TITLE
test: compare pinned trust-record pubkey without CRLF normalization

### DIFF
--- a/tests/unit/test_trust_record_format_vectors.py
+++ b/tests/unit/test_trust_record_format_vectors.py
@@ -204,7 +204,7 @@ def test_committed_public_key_matches_the_key_recovered_from_cnf_jwk() -> None:
     """
     doc = _load(_SOLO)
     from_cnf = _public_key_pem_from_cnf_jwk(doc)
-    pinned = _PUBKEY.read_bytes().replace(b"\r\n", b"\n")
+    pinned = _PUBKEY.read_bytes()
     assert from_cnf == pinned
 
 


### PR DESCRIPTION
## Summary
- Removes the leftover `.replace(b\r\n, b\n)` in `test_committed_public_key_matches_the_key_recovered_from_cnf_jwk` so the pinned PEM is compared as raw committed bytes.
- After #4817 marked `tests/fixtures/trust-record-vectors/*` as `-text`, checkout can no longer rewrite those endings; the strip no longer compensates for anything and would hide a corrupted fixture.

Fixes #4824

## Decision: neighbouring `.rstrip(\n)` (issue ask)

Those neighbours are **gone**, and they were a **different convention** — not the same class of masking.

Before #4814, parent/member digest tests hashed the emitted JSON string bytes. Committed record files carry a trailing POSIX newline the in-memory emit string did not, so `.rstrip(\n)` recovered the real hash preimage. That was intentional framing for a known on-disk convention, not checkout EOL translation.

#4814 moved those digests to JCS over the parsed document, so the rstrips were removed. What remains nearby is either:
- `_load()` / `json.loads(read_text(...))` — semantic field checks after parse, not byte identity; or
- `test_regenerating_the_vectors_is_byte_identical_to_the_committed_files` — already uses raw `read_bytes()` with no normalization, same class as this pubkey check.

So nothing else in the file needs the same treatment; only the PEM CRLF replace was leftover checkout compensation.

## Test plan
- [x] `uv run python scripts/run_tests.py tests/unit/test_trust_record_format_vectors.py::test_committed_public_key_matches_the_key_recovered_from_cnf_jwk` — pass
- [x] Local sanity: inject `\r\n` into a copy of the pinned key and confirm `from_cnf == pinned` fails (corruption not committed)
- [ ] CI green on Linux fresh clone