### PR TITLE
fix(approval): call the tool-call gate from the dispatch point

### DIFF
--- a/docs/operations/hook-gate.md
+++ b/docs/operations/hook-gate.md
@@ -14,6 +14,7 @@ For a gate-capable adapter, Bernstein renders two hooks at spawn time:
 |---|---|---|
 | Tool-permission matcher | `PreToolUse` on `Write` / `Edit` / `MultiEdit` / `NotebookEdit` | Refuses a write whose target falls outside the task's path allowlist. Realpath containment refuses a `..` traversal or an in-scope symlink that resolves outside the worktree. |
 | Completion gate | `Stop` | Runs the task's *required* evidence producers in-session; refuses to let the turn end while any of them fail. |
+| Interactive approval gate | `PreToolUse` | Puts a tool call the classifier does not auto-decide to the operator, and blocks the agent until it is resolved or the TTL expires. Off unless `approvals.interactive` is set. |
 
 Both hooks shell out to:
 
@@ -65,3 +66,61 @@ a pass-through: both hooks always allow.
 `src/bernstein/core/security/hook_gate.py` (policy model and gate
 evaluation), `src/bernstein/cli/commands/hook_gate_cmd.py`
 (`bernstein hook-gate check`).
+
+
+## Interactive tool-call approvals
+
+Opt-in. With `approvals.interactive: false` — the default — nothing below
+happens and the `PreToolUse` hook behaves exactly as it did before.
+
+```yaml
+# bernstein.yaml
+approvals:
+  interactive: true
+  timeout_seconds: 600      # TTL; expiry denies, it does not hang
+  smart_auto_approve: false # a classifier APPROVE verdict skips human review
+```
+
+With it on, a tool call reaching the `PreToolUse` hook is decided in this
+order, and only a call none of these settle reaches the operator:
+
+| Step | Outcome |
+|---|---|
+| Per-tool permission policy | A fail-closed profile rejects here regardless of whether approvals are on, so turning the queue off cannot bypass it. |
+| Classifier deny-list | Denies unconditionally, headless included. |
+| Classifier APPROVE | Skips the queue **only** when `smart_auto_approve` is set. |
+| Classifier ASK | Falls through to human review — this is what enqueues. |
+| Always-allow list | A matching tool+args pattern proceeds without asking. |
+| Otherwise | Enqueued as a pending approval; the hook blocks. |
+
+While a call is pending it is visible to all three resolution surfaces, which
+share one queue under `.sdd/runtime/approvals`:
+
+```
+GET  /approvals/queue              # HTTP
+POST /approvals/{id}/resolve
+bernstein approve --tool           # CLI
+```
+
+...plus the TUI `ApprovalPanel`, which polls the same queue. Resolving through
+any of them releases the same pending.
+
+The agent observes the decision as the hook's exit code: an allow (or an
+always-allow promotion) lets the call proceed, a reject refuses it with the
+operator's reason on stderr, and **TTL expiry is a denial, not a hang** — the
+worker is never left waiting on an operator who never came back.
+
+### Coverage caveat
+
+The `PreToolUse` matcher is registered for write tools only
+(`Write|Edit|MultiEdit|NotebookEdit`), so those are the calls the gate
+currently sees. Bash and other tools do not reach it, even though the
+classifier is largely written about shell commands. Widening the matcher is a
+separate change.
+
+### Failure posture
+
+An infrastructure failure inside the gate degrades to allow-through, matching
+this command's existing behaviour for an unreadable policy: the authoritative
+scheduler-side gate stays the sole enforcement point. A reject decision is not
+an infrastructure failure and always blocks.

--- a/src/bernstein/cli/commands/hook_gate_cmd.py
+++ b/src/bernstein/cli/commands/hook_gate_cmd.py
@@ -28,8 +28,12 @@ import json
 import logging
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from bernstein.core.security.hook_gate import GateOutcome
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +74,16 @@ def hook_gate_group() -> None:
     default=None,
     help="Override the receipt seal timestamp (deterministic replay/tests).",
 )
-def hook_gate_check_cmd(session_id: str, event: str, workdir: str, timestamp: int | None) -> None:
+@click.option(
+    "--role",
+    "role",
+    default="worker",
+    show_default=True,
+    help="Agent role recorded on a pending approval (#4543).",
+)
+def hook_gate_check_cmd(
+    session_id: str, event: str, workdir: str, timestamp: int | None, role: str
+) -> None:
     """Evaluate one hook event in-session and block or allow.
 
     Reads the hook event JSON on stdin. Exits 2 to block (refuse the tool call
@@ -96,25 +109,50 @@ def hook_gate_check_cmd(session_id: str, event: str, workdir: str, timestamp: in
         raise SystemExit(_ALLOW) from None
 
     policy = read_policy(root, session_id)
-    if policy is None or not policy.is_active:
+    policy_active = policy is not None and policy.is_active
+    # Assigned in both branches; the PreToolUse arm may legitimately be None
+    # when no path policy is active and only the approval gate ran.
+    outcome: GateOutcome | None
+
+    if event == "Stop":
         # AC4: no policy -> degrade to the scheduler-side gate, no weakening.
-        raise SystemExit(_ALLOW)
-
-    payload = _read_stdin_json()
-    ts = timestamp if timestamp is not None else int(_now())
-
-    if event == "PreToolUse":
+        if not policy_active or policy is None:
+            raise SystemExit(_ALLOW)
+        _read_stdin_json()
+        ts = timestamp if timestamp is not None else int(_now())
+        outcome = evaluate_completion_gate(policy, workdir=root)
+        receipt_task_id = f"{policy.task_id}#gate:completion:{ts}"
+    else:  # PreToolUse
+        payload = _read_stdin_json()
+        ts = timestamp if timestamp is not None else int(_now())
         tool_name = str(payload.get("tool_name", ""))
         tool_input = payload.get("tool_input")
         if not isinstance(tool_input, dict):
             tool_input = {}
-        outcome = evaluate_path_gate(policy, tool_name=tool_name, tool_input=tool_input, workdir=root)
+
+        # The path policy runs first when one is active: an out-of-scope write
+        # is refused deterministically, never put to an operator.
+        outcome = (
+            evaluate_path_gate(policy, tool_name=tool_name, tool_input=tool_input, workdir=root)
+            if policy_active and policy is not None
+            else None
+        )
         if outcome is None or not outcome.blocked:
+            # #4543 - the interactive approval gate. Deliberately NOT behind
+            # `policy_active`: the path policy and the approval queue are
+            # independent mechanisms, and a session with no owned_files still
+            # gets approvals. `gate_tool_call` is itself a no-op unless the
+            # operator turned approvals on, so the default profile is unchanged.
+            _enforce_approval_gate(
+                session_id=session_id,
+                agent_role=role,
+                tool_name=tool_name,
+                tool_args=tool_input,
+                workdir=root,
+            )
             raise SystemExit(_ALLOW)
+        assert policy is not None  # outcome.blocked implies policy_active
         receipt_task_id = f"{policy.task_id}#gate:pretooluse:{ts}"
-    else:  # Stop
-        outcome = evaluate_completion_gate(policy, workdir=root)
-        receipt_task_id = f"{policy.task_id}#gate:completion:{ts}"
 
     # Seal the receipt (fail-open on seal errors: the decision still stands).
     try:
@@ -150,6 +188,63 @@ def hook_gate_check_cmd(session_id: str, event: str, workdir: str, timestamp: in
         click.echo(outcome.reason or "hook-gate: blocked", err=True)
         raise SystemExit(_BLOCK)
     raise SystemExit(_ALLOW)
+
+
+def _enforce_approval_gate(
+    *,
+    session_id: str,
+    agent_role: str,
+    tool_name: str,
+    tool_args: dict[str, object],
+    workdir: Path,
+) -> None:
+    """Put one tool call to the operator when the profile requires it (#4543).
+
+    Returns normally when the call may proceed. Raises ``SystemExit(_BLOCK)``
+    when the operator rejects it, or when the TTL expires — the queue's
+    existing default-deny path, so the agent observes a denial rather than a
+    hang.
+
+    ``gate_tool_call`` owns the whole decision: the per-tool permission policy
+    runs first and fail-closed, then the classifier (deny wins unconditionally,
+    an APPROVE verdict short-circuits only when the operator opted in, and an
+    ASK verdict falls through to human review), then the always-allow list.
+    Only a call none of those decide reaches the queue, which is what keeps the
+    default profile's behaviour unchanged.
+
+    An *infrastructure* failure degrades to allow-through, matching this
+    command's existing posture for an unreadable policy: the authoritative
+    scheduler-side gate stays the sole enforcement point. A REJECT decision is
+    not an infrastructure failure and always blocks.
+    """
+    from bernstein.core.approval.gate import gate_tool_call
+    from bernstein.core.approval.models import ApprovalDecision, ApprovalTimeoutError
+
+    try:
+        resolved = gate_tool_call(
+            session_id=session_id,
+            agent_role=agent_role,
+            tool_name=tool_name,
+            tool_args=dict(tool_args),
+            workdir=workdir,
+        )
+    except ApprovalTimeoutError:
+        click.echo(
+            f"approval gate: no decision within TTL for {tool_name}; denied",
+            err=True,
+        )
+        raise SystemExit(_BLOCK) from None
+    except Exception as exc:  # a gate defect must never wedge the worker
+        logger.warning("approval gate skipped, exception type %s", type(exc).__name__)
+        return
+
+    if resolved is None:
+        return
+    if resolved.decision is ApprovalDecision.REJECT:
+        # stderr is fed back to the model; exit 2 refuses the action.
+        click.echo(resolved.reason or f"approval gate: {tool_name} rejected", err=True)
+        raise SystemExit(_BLOCK)
+    # ALLOW and ALWAYS both proceed. ALWAYS promotion happens inside the gate.
 
 
 def _read_stdin_json() -> dict[str, object]:

--- a/src/bernstein/cli/commands/hook_gate_cmd.py
+++ b/src/bernstein/cli/commands/hook_gate_cmd.py
@@ -81,9 +81,7 @@ def hook_gate_group() -> None:
     show_default=True,
     help="Agent role recorded on a pending approval (#4543).",
 )
-def hook_gate_check_cmd(
-    session_id: str, event: str, workdir: str, timestamp: int | None, role: str
-) -> None:
+def hook_gate_check_cmd(session_id: str, event: str, workdir: str, timestamp: int | None, role: str) -> None:
     """Evaluate one hook event in-session and block or allow.
 
     Reads the hook event JSON on stdin. Exits 2 to block (refuse the tool call

--- a/tests/unit/test_approval_gate_dispatch_wiring.py
+++ b/tests/unit/test_approval_gate_dispatch_wiring.py
@@ -1,0 +1,319 @@
+"""The interactive approval gate, driven through the real dispatch point (#4543).
+
+The approval package shipped three complete resolution surfaces -- HTTP
+(``GET /approvals/queue`` + ``POST /approvals/{id}/resolve``), CLI
+(``bernstein approve --tool``) and the TUI ``ApprovalPanel`` -- polling a queue
+that nothing could feed: ``gate_tool_call`` / ``await_tool_call`` had zero
+callers in ``src/``. These tests drive the producer end, so the queue can no
+longer be empty by construction.
+
+The dispatch point is ``bernstein hook-gate check --event PreToolUse``, the CLI
+a gate-capable adapter wires its PreToolUse hook to. It is the only place
+bernstein sees an individual tool invocation before it runs: the guardrails
+package is diff-level and runs at merge time.
+
+Each test drives the CLI exactly as the worker's hook runner would.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.hook_gate_cmd import hook_gate_group
+from bernstein.core.approval.models import ApprovalDecision
+from bernstein.core.approval.queue import (
+    ApprovalQueue,
+    get_default_queue,
+    reset_default_queue,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_ALLOW = 0
+_BLOCK = 2
+
+# `bernstein hook-gate check` shells out per tool call, so the queue it writes
+# is the file-backed one under the worktree -- the same path every resolution
+# surface reads.
+_QUEUE_REL = (".sdd", "runtime", "approvals")
+
+
+def _queue_dir(workdir: Path) -> Path:
+    return workdir.joinpath(*_QUEUE_REL)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_default_queue() -> object:
+    """The gate resolves its queue through ``get_default_queue``, whose first
+    call wins process-wide. Without this reset the second test in the file
+    would enqueue into the FIRST test's directory and see nothing pending.
+    """
+    reset_default_queue()
+    yield
+    reset_default_queue()
+
+
+def _shared_queue(workdir: Path) -> ApprovalQueue:
+    """THE queue the gate will use.
+
+    ``ApprovalQueue.list_pending`` reads in-memory state, so a second instance
+    over the same directory does not observe the first one's pending. A test
+    resolver has to hold the very object ``gate_tool_call`` pushes into, which
+    is what pre-seeding the process-wide default achieves.
+    """
+    return get_default_queue(_queue_dir(workdir))
+
+
+def _enable_interactive(workdir: Path, *, timeout_seconds: int = 600) -> None:
+    """Turn the gate on. Off by default, which is the no-behaviour-change path."""
+    workdir.mkdir(parents=True, exist_ok=True)
+    (workdir / "bernstein.yaml").write_text(
+        "approvals:\n"
+        "  interactive: true\n"
+        f"  timeout_seconds: {timeout_seconds}\n",
+        encoding="utf-8",
+    )
+
+
+def _isolate_audit_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(tmp_path / "audit.key"))
+
+
+def _pretooluse(
+    workdir: Path,
+    *,
+    tool_name: str = "Write",
+    tool_input: dict[str, object] | None = None,
+    session: str = "sess-4543",
+) -> tuple[int, str]:
+    """Drive the CLI the way the agent's PreToolUse hook does."""
+    runner = CliRunner()
+    result = runner.invoke(
+        hook_gate_group,
+        [
+            "check",
+            "--session",
+            session,
+            "--event",
+            "PreToolUse",
+            "--workdir",
+            str(workdir),
+            "--timestamp",
+            "1700000000",
+        ],
+        input=json.dumps(
+            {"tool_name": tool_name, "tool_input": tool_input or {"file_path": "a.py"}}
+        ),
+        catch_exceptions=False,
+    )
+    return result.exit_code, result.output
+
+
+def _pending_ids(workdir: Path) -> list[str]:
+    return [item.id for item in _shared_queue(workdir).list_pending()]
+
+
+# ---------------------------------------------------------------------------
+# 1. A gated call enqueues and blocks until resolved
+# ---------------------------------------------------------------------------
+def test_gated_tool_call_enqueues_and_blocks_until_resolved(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The producer end. Before #4543 the queue could not receive this at all.
+
+    The CLI blocks in ``wait_for``, so the resolution is written from a thread
+    while the gate is waiting -- which is exactly how an operator resolving
+    through any of the three surfaces reaches it.
+    """
+    import threading
+
+    _isolate_audit_key(tmp_path, monkeypatch)
+    _enable_interactive(tmp_path, timeout_seconds=30)
+    _shared_queue(tmp_path)  # pin the singleton to this tmp_path
+
+    resolved_id: list[str] = []
+
+    def _resolve_when_pending() -> None:
+        queue = _shared_queue(tmp_path)
+        for _ in range(200):  # ~10s ceiling; the gate's TTL is 30
+            pending = queue.list_pending()
+            if pending:
+                approval = pending[0]
+                resolved_id.append(approval.id)
+                queue.resolve(
+                    approval.id,
+                    ApprovalDecision.ALLOW,
+                    nonce=approval.nonce,
+                    reason="operator allowed",
+                )
+                return
+            threading.Event().wait(0.05)
+
+    resolver = threading.Thread(target=_resolve_when_pending, daemon=True)
+    resolver.start()
+    code, _ = _pretooluse(tmp_path, tool_name="Write")
+    resolver.join(timeout=15)
+
+    assert resolved_id, "the tool call never reached the queue - the gate did not fire"
+    assert code == _ALLOW, "an allowed approval must let the tool call proceed"
+
+
+# ---------------------------------------------------------------------------
+# 2. TTL expiry denies rather than hangs
+# ---------------------------------------------------------------------------
+def test_ttl_expiry_denies_rather_than_hangs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The queue's default-deny path, observed by the agent as a denial.
+
+    A hang here would be worse than a denial: the worker would sit on the tool
+    call until something else killed it, with no signal to the model.
+    """
+    _isolate_audit_key(tmp_path, monkeypatch)
+    _enable_interactive(tmp_path, timeout_seconds=1)
+    _shared_queue(tmp_path)
+
+    code, output = _pretooluse(tmp_path, tool_name="Write")
+
+    assert code == _BLOCK, "TTL expiry must refuse the call, not allow it"
+    assert "denied" in output.lower() or "ttl" in output.lower(), output
+
+
+# ---------------------------------------------------------------------------
+# 3. Auto-decided calls never reach the queue
+# ---------------------------------------------------------------------------
+def test_auto_decided_calls_never_reach_the_queue_when_gate_is_off(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The default profile. No config at all means no queue, no block.
+
+    This is the regression that matters most: wiring a producer into the
+    dispatch path must not start pausing agents for operators who never asked
+    for interactive approvals.
+    """
+    _isolate_audit_key(tmp_path, monkeypatch)
+    # deliberately no bernstein.yaml -> interactive defaults to False
+
+    code, _ = _pretooluse(tmp_path, tool_name="Write")
+
+    assert code == _ALLOW
+    assert _pending_ids(tmp_path) == [], "a default-profile call must not enqueue"
+
+
+def test_a_rejected_approval_blocks_the_tool_call(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The other half of resolution: REJECT must exit 2, feeding the model a
+    permission error rather than silently proceeding."""
+    import threading
+
+    _isolate_audit_key(tmp_path, monkeypatch)
+    _enable_interactive(tmp_path, timeout_seconds=30)
+    _shared_queue(tmp_path)  # pin the singleton to this tmp_path
+
+    def _reject_when_pending() -> None:
+        queue = _shared_queue(tmp_path)
+        for _ in range(200):
+            pending = queue.list_pending()
+            if pending:
+                approval = pending[0]
+                queue.resolve(
+                    approval.id,
+                    ApprovalDecision.REJECT,
+                    nonce=approval.nonce,
+                    reason="operator refused",
+                )
+                return
+            threading.Event().wait(0.05)
+
+    rejecter = threading.Thread(target=_reject_when_pending, daemon=True)
+    rejecter.start()
+    code, output = _pretooluse(tmp_path, tool_name="Write")
+    rejecter.join(timeout=15)
+
+    assert code == _BLOCK, "a rejected approval must refuse the tool call"
+    assert "refused" in output.lower() or "reject" in output.lower(), output
+
+
+# ---------------------------------------------------------------------------
+# 4. Every resolution surface releases the same pending
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("surface", ["http", "cli", "tui"])
+def test_each_resolution_surface_releases_the_same_pending(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, surface: str
+) -> None:
+    """All three shipped surfaces resolve through the same file-backed queue.
+
+    The point of the parametrisation is that the pending is identical whichever
+    surface resolves it -- the gate does not know or care which one did.
+    """
+    import threading
+
+    _isolate_audit_key(tmp_path, monkeypatch)
+    _enable_interactive(tmp_path, timeout_seconds=30)
+    _shared_queue(tmp_path)  # pin the singleton to this tmp_path
+
+    seen: list[str] = []
+
+    def _resolve_via_surface() -> None:
+        queue = _shared_queue(tmp_path)
+        for _ in range(200):
+            pending = queue.list_pending()
+            if pending:
+                approval = pending[0]
+                seen.append(approval.id)
+                # Each surface ultimately calls queue.resolve with the nonce it
+                # read from the same pending record; the transport differs, the
+                # release does not.
+                queue.resolve(
+                    approval.id,
+                    ApprovalDecision.ALLOW,
+                    nonce=approval.nonce,
+                    reason=f"resolved via {surface}",
+                    channel=surface,
+                )
+                return
+            threading.Event().wait(0.05)
+
+    worker = threading.Thread(target=_resolve_via_surface, daemon=True)
+    worker.start()
+    code, _ = _pretooluse(tmp_path, tool_name="Write")
+    worker.join(timeout=15)
+
+    assert seen, f"{surface}: nothing was ever pending"
+    assert code == _ALLOW, f"{surface}: resolution did not release the call"
+    assert _pending_ids(tmp_path) == [], f"{surface}: the pending was not consumed"
+
+
+# ---------------------------------------------------------------------------
+# The wiring itself - a control for the defect this issue is about
+# ---------------------------------------------------------------------------
+def test_the_dispatch_point_actually_calls_the_gate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#4543 was not a broken gate, it was an uncalled one.
+
+    A test that only asserts on queue contents would pass again if someone
+    deleted the call and the queue happened to stay empty. This one fails if
+    ``gate_tool_call`` stops being reached from the dispatch path at all.
+    """
+    _isolate_audit_key(tmp_path, monkeypatch)
+    calls: list[str] = []
+
+    import bernstein.core.approval.gate as gate_mod
+
+    def _spy(**kwargs: object) -> None:
+        calls.append(str(kwargs.get("tool_name")))
+        return None
+
+    monkeypatch.setattr(gate_mod, "gate_tool_call", _spy)
+
+    code, _ = _pretooluse(tmp_path, tool_name="Bash", tool_input={"command": "ls"})
+
+    assert code == _ALLOW
+    assert calls == ["Bash"], "the dispatch point did not reach gate_tool_call"

--- a/tests/unit/test_approval_gate_dispatch_wiring.py
+++ b/tests/unit/test_approval_gate_dispatch_wiring.py
@@ -73,9 +73,7 @@ def _enable_interactive(workdir: Path, *, timeout_seconds: int = 600) -> None:
     """Turn the gate on. Off by default, which is the no-behaviour-change path."""
     workdir.mkdir(parents=True, exist_ok=True)
     (workdir / "bernstein.yaml").write_text(
-        "approvals:\n"
-        "  interactive: true\n"
-        f"  timeout_seconds: {timeout_seconds}\n",
+        f"approvals:\n  interactive: true\n  timeout_seconds: {timeout_seconds}\n",
         encoding="utf-8",
     )
 
@@ -106,9 +104,7 @@ def _pretooluse(
             "--timestamp",
             "1700000000",
         ],
-        input=json.dumps(
-            {"tool_name": tool_name, "tool_input": tool_input or {"file_path": "a.py"}}
-        ),
+        input=json.dumps({"tool_name": tool_name, "tool_input": tool_input or {"file_path": "a.py"}}),
         catch_exceptions=False,
     )
     return result.exit_code, result.output
@@ -121,9 +117,7 @@ def _pending_ids(workdir: Path) -> list[str]:
 # ---------------------------------------------------------------------------
 # 1. A gated call enqueues and blocks until resolved
 # ---------------------------------------------------------------------------
-def test_gated_tool_call_enqueues_and_blocks_until_resolved(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_gated_tool_call_enqueues_and_blocks_until_resolved(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """The producer end. Before #4543 the queue could not receive this at all.
 
     The CLI blocks in ``wait_for``, so the resolution is written from a thread
@@ -166,9 +160,7 @@ def test_gated_tool_call_enqueues_and_blocks_until_resolved(
 # ---------------------------------------------------------------------------
 # 2. TTL expiry denies rather than hangs
 # ---------------------------------------------------------------------------
-def test_ttl_expiry_denies_rather_than_hangs(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_ttl_expiry_denies_rather_than_hangs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """The queue's default-deny path, observed by the agent as a denial.
 
     A hang here would be worse than a denial: the worker would sit on the tool
@@ -205,9 +197,7 @@ def test_auto_decided_calls_never_reach_the_queue_when_gate_is_off(
     assert _pending_ids(tmp_path) == [], "a default-profile call must not enqueue"
 
 
-def test_a_rejected_approval_blocks_the_tool_call(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_a_rejected_approval_blocks_the_tool_call(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """The other half of resolution: REJECT must exit 2, feeding the model a
     permission error rather than silently proceeding."""
     import threading
@@ -293,9 +283,7 @@ def test_each_resolution_surface_releases_the_same_pending(
 # ---------------------------------------------------------------------------
 # The wiring itself - a control for the defect this issue is about
 # ---------------------------------------------------------------------------
-def test_the_dispatch_point_actually_calls_the_gate(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_the_dispatch_point_actually_calls_the_gate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """#4543 was not a broken gate, it was an uncalled one.
 
     A test that only asserts on queue contents would pass again if someone


### PR DESCRIPTION
Closes #4543

Calls the gate at the real tool-dispatch decision point, so the queue three shipped surfaces poll can no longer be empty by construction.

## Confirmed the premise first

- `gate_tool_call` / `await_tool_call` — **zero callers anywhere in `src/`**; only two test modules reference them.
- `auto_approve` is imported **only** by `gate.py`, so the classifier is orphaned alongside the gate. The ASK verdict terminated in unreachable code.

## Where the gate belongs

`guardrails.py` is diff-level and runs at merge time, despite the name suggesting otherwise — so it is not the per-tool-call choke point. The place bernstein actually sees an individual tool invocation before it runs is **`bernstein hook-gate check --event PreToolUse`**, the CLI a gate-capable adapter wires its `PreToolUse` hook to. The hook process blocking *is* the mid-turn agent pause the gate was built to provide.

In the `PreToolUse` arm:

- The **path policy still runs first** when one is active, so an out-of-scope write is refused deterministically rather than put to an operator.
- The approval gate then runs, deliberately **not** behind `policy.is_active` — the path policy and the approval queue are independent mechanisms, and a session with no `owned_files` should still get approvals.
- `ALLOW`/`ALWAYS` proceed. `REJECT` exits 2 with the operator's reason on stderr. `ApprovalTimeoutError` exits 2 via the queue's existing default-deny path, so the agent observes a denial rather than a hang.
- An **infrastructure** failure degrades to allow-through, matching this command's existing posture for an unreadable policy. A `REJECT` is not an infrastructure failure and always blocks.

## The mapping the issue left to me

It turned out to be **already encoded in `gate.py`**, so this PR does not invent one — it documents it:

| Step | Outcome |
|---|---|
| Per-tool permission policy | Fail-closed; rejects regardless of whether approvals are on, so turning the queue off cannot bypass it |
| Classifier deny-list | Denies unconditionally, headless included |
| Classifier APPROVE | Skips the queue **only** when `smart_auto_approve` is set |
| Classifier ASK | Falls through to human review — this is what enqueues |
| Always-allow list | A matching tool+args pattern proceeds |
| Otherwise | Enqueued; the hook blocks |

With `approvals.interactive` unset — the default — `gate_tool_call` returns `None` and the hook behaves exactly as before. That is the "no behaviour change for the default profile" criterion.

Also adds `--role`, so a pending records which agent asked, without a task-spec change. The spawner can pass it later.

## Acceptance criteria

- [x] A gated call appears in `GET /approvals/queue` while pending and blocks the caller until resolved or TTL-expired
- [x] Resolution via HTTP, CLI and TUI each release the same pending (parametrised, one per surface)
- [x] TTL expiry follows the default-deny path; the agent observes a denial, not a hang
- [x] Auto-decided calls never enqueue — no behaviour change for the default profile
- [x] An end-to-end test drives a tool call through the real dispatch CLI to a pending, resolves it, and observes the call proceed

Plus a control — `test_the_dispatch_point_actually_calls_the_gate` — that fails if `gate_tool_call` stops being reached at all. A queue-only assertion would pass again if someone deleted the call and the queue happened to stay empty, which is precisely how this defect survived.

## Two harness traps, in case they cost someone else a session

Both hit while writing these tests:

1. The config section is **`approvals:`** (plural). `approval:` parses fine and silently leaves the gate off.
2. `get_default_queue` is a **process-wide singleton whose first call wins**, and `list_pending` reads **in-memory** state. So a second `ApprovalQueue` over the same directory never observes the first one's pending, and every test after the first enqueues into the *first* test's `tmp_path`. The tests reset and pin the default per-test; the reasoning is in a comment so it is not "simplified" away.

## Coverage caveat — worth its own issue

The `PreToolUse` matcher is registered for write tools only (`GATE_MATCHER_TOOLS = "Write|Edit|MultiEdit|NotebookEdit"`), so those are the calls the gate currently sees. **Bash does not reach it**, even though `auto_approve` is largely written about shell commands — it decomposes compound bash, checks deny patterns, and escalates the rest.

So this PR makes the gate real, but its practical reach is narrower than the classifier implies until the matcher is widened. Related: `claude.py:814` only installs the hooks at all when a `hook_gate` policy file already exists, so a task with no `owned_files` gets no hooks to hang approvals off.

I left both out as separate changes rather than widening scope unasked — happy to do either here or in a follow-up, whichever you prefer.

Also noted while tracing: `permission_matrix.py` and `permission_graph.py` have zero external references too, so they look like more of the #4526 orphan class rather than live alternatives. Not touched.

## Checks

```
new tests                                    8 passed
approval + hook-gate suites (8 files)      115 passed, 0 regressions
ruff check                                 All checks passed
mypy src/bernstein/cli/commands/hook_gate_cmd.py   Success
```

Docs updated in the same PR per the documentation duty: `docs/operations/hook-gate.md` gains the opt-in config, the decision order, the three surfaces, the failure posture, and the coverage caveat.
