### PR TITLE
refactor(github-app): drop the unused installation_id from CheckRunClient (#4825)

### DIFF
--- a/.github/workflows/volunteer-verify.yml
+++ b/.github/workflows/volunteer-verify.yml
@@ -145,8 +145,8 @@ jobs:
           )
           pr_body = pr_body_result.stdout
 
-          # Initialize check run client (no installation_id for GITHUB_TOKEN-based auth)
-          check_run_client = CheckRunClient(repo_slug, None)
+          # Initialize check run client (auth is delegated to the gh CLI)
+          check_run_client = CheckRunClient(repo_slug)
 
           # Run verification
           result = run_verification_check(
@@ -229,7 +229,7 @@ jobs:
 
           conclusion = result['conclusion']
 
-          check_run_client = CheckRunClient(os.environ['REPO_SLUG'], None)
+          check_run_client = CheckRunClient(os.environ['REPO_SLUG'])
 
           check_run_result = check_run_client.create_verification_check_run(
               head_sha=os.environ['HEAD_SHA'],

--- a/docs/release-notes/fragments/4825-checkrunclient-installation-id.md
+++ b/docs/release-notes/fragments/4825-checkrunclient-installation-id.md
@@ -1,0 +1,9 @@
+## `CheckRunClient` no longer takes an `installation_id`
+
+The constructor accepted an `installation_id` it stored and never used:
+authentication is delegated to the `gh` CLI, and since #4816 `_configured`
+ignores it too. A parameter that looks load-bearing but isn't had already
+misled a caller once. It is gone from the constructor now; the two
+`volunteer-verify.yml` call sites that passed `None` were updated, and the
+docstring states the real contract — repo slug in, auth from the `gh`
+environment (#4825).

--- a/src/bernstein/github_app/check_runs.py
+++ b/src/bernstein/github_app/check_runs.py
@@ -7,9 +7,10 @@ Check run lifecycle:
   1. ``create`` - called when a fix/QA task is picked up; status=in_progress
   2. ``update`` - called when the task completes; status=completed + conclusion
 
-All operations degrade gracefully when the required environment variables
-(``GITHUB_APP_ID``, ``GITHUB_APP_PRIVATE_KEY``, ``GITHUB_INSTALLATION_ID``)
-are not set - the methods return ``None`` instead of raising.
+Authentication is delegated to the ``gh`` CLI (its token environment), so
+this client needs only the repository slug.  All operations degrade
+gracefully when the slug is missing - the methods return ``None`` instead
+of raising.
 
 GitHub API reference:
   https://docs.github.com/en/rest/checks/runs
@@ -66,13 +67,10 @@ class CheckRunClient:
     Args:
         repo: ``owner/repo`` slug.  Required; if empty all operations are
             no-ops.
-        installation_id: GitHub App installation ID, kept for callers that
-            track one.  Not used for API calls.
     """
 
-    def __init__(self, repo: str, installation_id: str | None = None) -> None:
+    def __init__(self, repo: str) -> None:
         self._repo = repo
-        self._installation_id = installation_id
 
     @property
     def _configured(self) -> bool:

--- a/tests/unit/test_check_runs.py
+++ b/tests/unit/test_check_runs.py
@@ -42,27 +42,12 @@ def test_check_run_result_fields() -> None:
 class TestCheckRunClientCreate:
     def test_create_empty_repo_returns_none(self) -> None:
         """No repo slug → silent no-op."""
-        client = CheckRunClient(repo="", installation_id="42")
+        client = CheckRunClient(repo="")
         result = client.create(head_sha="abc123", task_title="Fix the bug")
         assert result is None
 
-    def test_create_without_installation_id_calls_gh_api(self) -> None:
-        """Auth is delegated to gh; token-authenticated callers pass no installation ID."""
-        client = CheckRunClient(repo="acme/widgets", installation_id=None)
-        response_data = {"id": 999, "html_url": "https://github.com/checks/999"}
-        mock_result = MagicMock()
-        mock_result.returncode = 0
-        mock_result.stdout = json.dumps(response_data).encode()
-        mock_result.stderr = b""
-
-        with patch("subprocess.run", return_value=mock_result):
-            result = client.create(head_sha="abc123", task_title="Fix the bug")
-
-        assert result is not None
-        assert result.check_run_id == 999
-
     def test_create_calls_gh_api(self) -> None:
-        client = CheckRunClient(repo="acme/widgets", installation_id="42")
+        client = CheckRunClient(repo="acme/widgets")
         response_data = {"id": 999, "html_url": "https://github.com/checks/999"}
         mock_result = MagicMock()
         mock_result.returncode = 0
@@ -82,7 +67,7 @@ class TestCheckRunClientCreate:
         assert "POST" in call_args
 
     def test_create_with_details_url(self) -> None:
-        client = CheckRunClient(repo="acme/widgets", installation_id="42")
+        client = CheckRunClient(repo="acme/widgets")
         response_data = {"id": 100, "html_url": "https://github.com/checks/100"}
         mock_result = MagicMock()
         mock_result.returncode = 0
@@ -99,7 +84,7 @@ class TestCheckRunClientCreate:
         assert result is not None
 
     def test_create_gh_failure_returns_none(self) -> None:
-        client = CheckRunClient(repo="acme/widgets", installation_id="42")
+        client = CheckRunClient(repo="acme/widgets")
         mock_result = MagicMock()
         mock_result.returncode = 1
         mock_result.stdout = b""
@@ -111,7 +96,7 @@ class TestCheckRunClientCreate:
         assert result is None
 
     def test_create_file_not_found_returns_none(self) -> None:
-        client = CheckRunClient(repo="acme/widgets", installation_id="42")
+        client = CheckRunClient(repo="acme/widgets")
         with patch("subprocess.run", side_effect=FileNotFoundError("gh not found")):
             result = client.create(head_sha="abc123", task_title="Test")
         assert result is None
@@ -124,12 +109,12 @@ class TestCheckRunClientCreate:
 
 class TestCheckRunClientUpdate:
     def test_update_empty_repo_returns_none(self) -> None:
-        client = CheckRunClient(repo="", installation_id="42")
+        client = CheckRunClient(repo="")
         result = client.update(check_run_id=123, conclusion="success", summary="All good")
         assert result is None
 
     def test_update_success_conclusion(self) -> None:
-        client = CheckRunClient(repo="acme/widgets", installation_id="42")
+        client = CheckRunClient(repo="acme/widgets")
         response_data = {"id": 123, "html_url": "https://github.com/checks/123"}
         mock_result = MagicMock()
         mock_result.returncode = 0
@@ -150,7 +135,7 @@ class TestCheckRunClientUpdate:
         assert "PATCH" in call_args
 
     def test_update_failure_conclusion(self) -> None:
-        client = CheckRunClient(repo="acme/widgets", installation_id="42")
+        client = CheckRunClient(repo="acme/widgets")
         response_data = {"id": 456, "html_url": "https://github.com/checks/456"}
         mock_result = MagicMock()
         mock_result.returncode = 0
@@ -167,7 +152,7 @@ class TestCheckRunClientUpdate:
         assert result is not None
 
     def test_update_request_body_contains_conclusion(self) -> None:
-        client = CheckRunClient(repo="acme/widgets", installation_id="42")
+        client = CheckRunClient(repo="acme/widgets")
         response_data = {"id": 789, "html_url": ""}
         mock_result = MagicMock()
         mock_result.returncode = 0
@@ -196,7 +181,7 @@ class TestCheckRunClientUpdate:
 
 class TestCheckRunClientCreateVerificationCheckRun:
     def test_empty_repo_returns_none(self) -> None:
-        client = CheckRunClient(repo="", installation_id="42")
+        client = CheckRunClient(repo="")
         result = client.create_verification_check_run(
             head_sha="abc123",
             summary="summary",
@@ -205,28 +190,8 @@ class TestCheckRunClientCreateVerificationCheckRun:
         )
         assert result is None
 
-    def test_without_installation_id_posts_check_run(self) -> None:
-        """The receipt verification workflow authenticates via gh and passes no installation ID."""
-        client = CheckRunClient(repo="acme/widgets", installation_id=None)
-        response_data = {"id": 200, "html_url": "https://github.com/checks/200"}
-        mock_result = MagicMock()
-        mock_result.returncode = 0
-        mock_result.stdout = json.dumps(response_data).encode()
-        mock_result.stderr = b""
-
-        with patch("subprocess.run", return_value=mock_result):
-            result = client.create_verification_check_run(
-                head_sha="abc123",
-                summary="summary",
-                details="details",
-                conclusion="neutral",
-            )
-
-        assert result is not None
-        assert result.check_run_id == 200
-
     def test_success_returns_comparison_check_run_result(self) -> None:
-        client = CheckRunClient(repo="acme/widgets", installation_id="42")
+        client = CheckRunClient(repo="acme/widgets")
         response_data = {"id": 200, "html_url": "https://github.com/checks/200"}
         mock_result = MagicMock()
         mock_result.returncode = 0
@@ -250,7 +215,7 @@ class TestCheckRunClientCreateVerificationCheckRun:
         assert any("/check-runs" in str(a) for a in args)
 
     def test_gh_failure_returns_none(self) -> None:
-        client = CheckRunClient(repo="acme/widgets", installation_id="42")
+        client = CheckRunClient(repo="acme/widgets")
         mock_result = MagicMock()
         mock_result.returncode = 1
         mock_result.stdout = b""
@@ -272,7 +237,7 @@ class TestCheckRunClientCreateVerificationCheckRun:
 
 class TestCheckRunClientUpdateVerificationCheckRun:
     def test_empty_repo_returns_none(self) -> None:
-        client = CheckRunClient(repo="", installation_id="42")
+        client = CheckRunClient(repo="")
         result = client.update_verification_check_run(
             check_run_id=123,
             summary="summary",
@@ -282,7 +247,7 @@ class TestCheckRunClientUpdateVerificationCheckRun:
         assert result is None
 
     def test_success_returns_comparison_check_run_result(self) -> None:
-        client = CheckRunClient(repo="acme/widgets", installation_id="42")
+        client = CheckRunClient(repo="acme/widgets")
         response_data = {"id": 456, "html_url": "https://github.com/checks/456"}
         mock_result = MagicMock()
         mock_result.returncode = 0
@@ -305,7 +270,7 @@ class TestCheckRunClientUpdateVerificationCheckRun:
         assert "PATCH" in call_args
 
     def test_gh_failure_returns_none(self) -> None:
-        client = CheckRunClient(repo="acme/widgets", installation_id="42")
+        client = CheckRunClient(repo="acme/widgets")
         mock_result = MagicMock()
         mock_result.returncode = 1
         mock_result.stdout = b""


### PR DESCRIPTION
## Problem

`CheckRunClient(repo, installation_id)` stored `installation_id` and never used it. Authentication is delegated entirely to the `gh` CLI, and since #4816 `_configured` ignores it too — the docstring already admitted "kept for callers that track one; not used for API calls".

A parameter that looks load-bearing but isn't misleads the next caller. It already did once: the receipt-verification workflow assumed it gated auth, and every check-run POST silently no-opped until #4816.

Closes #4825.

## Decision: remove outright, no shim

The issue asks to argue from an actual census. `grep -rn 'CheckRunClient('` across the repo:

- **Production:** two constructions, both in `.github/workflows/volunteer-verify.yml`, both `CheckRunClient(repo_slug, None)`. `src/bernstein/core/volunteer/verification_check_run.py` never constructs one — it takes an already-built instance as a parameter.
- **Tests:** `tests/unit/test_check_runs.py` only.

There is no external caller a one-release accepting-and-ignoring shim would protect — it would exist solely to keep the in-repo tests compiling. So the argument is dropped from the constructor and both call sites updated.

## Changes

- `CheckRunClient.__init__` takes only `repo`; `self._installation_id` removed.
- Class docstring drops the `installation_id` arg; module + class docstrings now state the real contract: repo slug in, auth from the `gh` environment (the module docstring's `GITHUB_APP_ID` / `GITHUB_INSTALLATION_ID` claim was already stale after #4816).
- Both `volunteer-verify.yml` call sites pass just the slug.
- Test constructions updated. Two create-path tests (`test_create_without_installation_id_calls_gh_api`, `test_without_installation_id_posts_check_run`) are removed: each existed only to prove `installation_id` did not gate auth, and with the parameter gone each was a strict subset of the adjacent `test_create_calls_gh_api` / `test_success_returns_comparison_check_run_result`.
- Release-note fragment added.

## Testing

```
uv run python -m pytest tests/unit/test_check_runs.py tests/unit/volunteer/test_volunteer_verification_check_run.py -q   # 53 passed
uv run ruff check .                                                                                                     # clean
uv run ruff format --check src/bernstein/github_app/check_runs.py tests/unit/test_check_runs.py                          # clean
uv run mypy src/bernstein/github_app/check_runs.py                                                                       # clean
uv run python scripts/rotate_release_notes.py check-gate <changed files>                                                 # OK
```