### PR TITLE
fix(tests): isolate uv run subprocess invocations with UV_NO_SYNC (#4826)

### DIFF
--- a/docs/release-notes/fragments/4826-uv-no-sync-in-test-subprocesses.md
+++ b/docs/release-notes/fragments/4826-uv-no-sync-in-test-subprocesses.md
@@ -1,0 +1,1 @@
+Add UV_NO_SYNC and --no-sync to test subprocess invocations to prevent environment mutation during test runs (#4826).

--- a/tests/unit/test_trust_record_conformance.py
+++ b/tests/unit/test_trust_record_conformance.py
@@ -25,6 +25,7 @@ it cannot run in a given environment.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -289,11 +290,13 @@ def _resolve_trace_tests() -> str | None:
     if shutil.which("uv") is None:
         return None
     try:
+        env = {**os.environ, "UV_NO_SYNC": "1"}
         probe = subprocess.run(
-            ["uv", "run", "--with", "agentrust-trace-tests==0.5.1", "trace-tests", "--version"],
+            ["uv", "run", "--no-sync", "--with", "agentrust-trace-tests==0.5.1", "trace-tests", "--version"],
             capture_output=True,
             text=True,
             timeout=60,
+            env=env,
         )
     except (subprocess.TimeoutExpired, OSError):
         return None
@@ -326,10 +329,12 @@ class TestReferenceConformanceSuite:
 
     @pytest.mark.parametrize("name", _VECTOR_NAMES)
     def test_vector_passes_level_0(self, name: str) -> None:
+        env = {**os.environ, "UV_NO_SYNC": "1"}
         result = subprocess.run(
             [
                 "uv",
                 "run",
+                "--no-sync",
                 "--with",
                 "agentrust-trace-tests==0.5.1",
                 "trace-tests",
@@ -344,6 +349,7 @@ class TestReferenceConformanceSuite:
             capture_output=True,
             text=True,
             timeout=120,
+            env=env,
         )
         assert "Result: PASS" in result.stdout, result.stdout + result.stderr
         assert "TR-SIG" in result.stdout

--- a/tests/unit/test_uv_no_sync_isolation.py
+++ b/tests/unit/test_uv_no_sync_isolation.py
@@ -1,0 +1,65 @@
+"""Tests verifying UV_NO_SYNC and --no-sync isolation for test subprocesses (issue #4826).
+
+When tests invoke `uv run` in a subprocess, `uv` defaults to reconciling the project
+environment (.venv). In a parallel test runner (e.g. pytest or run_tests.py), this
+can rewrite the active virtual environment that other tests are running from.
+Setting `UV_NO_SYNC=1` and/or `--no-sync` ensures `uv run` acts solely as a launcher
+without mutating or syncing the project .venv.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("uv") is None,
+    reason="uv binary not found on PATH",
+)
+
+
+def test_uv_run_with_no_sync_does_not_create_or_sync_project_venv(tmp_path: Path) -> None:
+    """Invoking ``uv run --no-sync`` or with ``UV_NO_SYNC=1`` avoids project sync.
+
+    Against a scratch directory declaring a non-installed dependency, ``uv run``
+    without ``--no-sync`` would attempt to sync and fail or alter the environment,
+    whereas ``--no-sync`` and ``UV_NO_SYNC=1`` executes cleanly without syncing.
+    """
+    proj = tmp_path / "project"
+    proj.mkdir()
+    (proj / "pyproject.toml").write_text(
+        '[project]\nname = "scratch-pkg"\nversion = "0.1.0"\ndependencies = ["nonexistent-package-xyz==99.99.99"]\n',
+        encoding="utf-8",
+    )
+
+    # Without --no-sync or UV_NO_SYNC, uv run attempts to sync and fails resolving nonexistent package
+    env_sync = {k: v for k, v in os.environ.items() if k != "UV_NO_SYNC"}
+    env_sync["UV_PROJECT"] = str(proj)
+    proc_sync = subprocess.run(
+        ["uv", "run", "--python", sys.executable, "python", "-c", "print('should-not-run')"],
+        cwd=proj,
+        env=env_sync,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc_sync.returncode != 0
+    assert "nonexistent-package-xyz" in proc_sync.stderr or "error" in proc_sync.stderr
+
+    # With --no-sync and UV_NO_SYNC=1, uv run executes directly without syncing
+    env_nosync = {**os.environ, "UV_NO_SYNC": "1", "UV_PROJECT": str(proj)}
+    proc_nosync = subprocess.run(
+        ["uv", "run", "--no-sync", "--python", sys.executable, "python", "-c", "import sys; print('isolated-ok')"],
+        cwd=proj,
+        env=env_nosync,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc_nosync.returncode == 0
+    assert "isolated-ok" in proc_nosync.stdout


### PR DESCRIPTION
Fixes #4826

### Problem
`uv run` defaults to reconciling the project environment (`.venv`) before executing commands. When a test invokes `uv run` in a subprocess, this reconciliation can rewrite the active virtual environment that other concurrent test files in the test session are actively executing from, leading to deleted executables or corrupted shared libraries.

### Solution
1. **Isolate Launcher Subprocesses**:
   - In `tests/unit/test_trust_record_conformance.py`, passed `env={**os.environ, "UV_NO_SYNC": "1"}` and `--no-sync` flag to `uv run` invocations for `agentrust-trace-tests`, ensuring it runs purely as an ephemeral launcher without synchronizing the project `.venv`.
   - Reviewed other mentioned sites (such as snapshot tests and unit string matches) and verified they only mention `uv run` in docstrings/string constants and do not spawn subprocesses.
2. **Proof & Test**:
   - Added `tests/unit/test_uv_no_sync_isolation.py` which demonstrates that against a scratch project with a nonexistent dependency, `uv run` without `--no-sync` fails on environment sync, while `uv run --no-sync` with `UV_NO_SYNC=1` executes cleanly without attempting to sync.
3. **Release Note**:
   - Added BOM-free fragment `docs/release-notes/fragments/4826-uv-no-sync-in-test-subprocesses.md`.
