### PR TITLE
Verify PR acceptance criteria evidence mapping (#4835)

### DIFF
--- a/src/bernstein/core/volunteer/verification_check_run.py
+++ b/src/bernstein/core/volunteer/verification_check_run.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import logging
 import os
 import re
 from dataclasses import dataclass, field
@@ -29,6 +30,8 @@ from bernstein.core.security.result_receipt_bundle import (
     FieldError,
 )
 from bernstein.core.volunteer.manifest import VolunteerManifest, load_manifest_from_repo
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from bernstein.core.github_app.check_runs import CheckRunClient
@@ -92,6 +95,7 @@ class AcceptanceVerificationResult:
     mapping: dict[str, str] = field(default_factory=dict)
     unproven: list[str] = field(default_factory=list)
     invalid_tests: list[str] = field(default_factory=list)
+    reason: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -453,6 +457,15 @@ def _format_comparison_table(comparisons: list[GateComparison]) -> str:
     return "\n".join(lines)
 
 
+def _normalize_criterion(c: str) -> str:
+    import string
+
+    c = c.casefold()
+    c = c.rstrip(string.punctuation)
+    c = re.sub(r"\s+", " ", c).strip()
+    return c
+
+
 def _verify_acceptance_evidence(
     pr_body: str,
     repo_slug: str,
@@ -472,7 +485,15 @@ def _verify_acceptance_evidence(
 
     # 2. Retrieve/parse issue checklist
     client = IssuePRClient()
-    issue = client.get_issue(repo_slug, issue_number)
+    try:
+        issue = client.get_issue(repo_slug, issue_number)
+    except Exception as e:
+        logger.warning(f"Failed to fetch issue #{issue_number}: {e!s}")
+        return AcceptanceVerificationResult(
+            status="neutral",
+            reason=f"Failed to fetch linked issue #{issue_number} from GitHub API.",
+        )
+
     issue_body = issue.get("body") or ""
 
     checklist_match = re.search(
@@ -484,12 +505,14 @@ def _verify_acceptance_evidence(
         return AcceptanceVerificationResult(status="neutral")
 
     issue_criteria = []
+    issue_norm_map = {}
     for line in checklist_match.group(1).splitlines():
         line = line.strip()
         if line.startswith("- [ ]") or line.startswith("- [x]") or line.startswith("- [X]"):
             crit = line[5:].strip()
             if crit:
                 issue_criteria.append(crit)
+                issue_norm_map[_normalize_criterion(crit)] = crit
 
     if not issue_criteria:
         return AcceptanceVerificationResult(status="neutral")
@@ -497,6 +520,7 @@ def _verify_acceptance_evidence(
     # 3. Parse PR evidence block
     marker = "<!-- bernstein:acceptance-evidence -->"
     mapping = {}
+    mapped_norm_map = {}
     if marker in pr_body:
         mapping_section = pr_body.split(marker)[1]
         for line in mapping_section.splitlines():
@@ -520,41 +544,70 @@ def _verify_acceptance_evidence(
                 test_ref = parts[1].strip().strip("`'\"")
                 if crit and test_ref:
                     mapping[crit] = test_ref
+                    mapped_norm_map[_normalize_criterion(crit)] = crit
 
     # 4. Compare issue criteria vs mapped criteria
-    issue_crit_set = set(issue_criteria)
-    mapped_crit_set = set(mapping.keys())
-    missing_criteria = sorted(list(issue_crit_set - mapped_crit_set))
-    extra_criteria = sorted(list(mapped_crit_set - issue_crit_set))
+    issue_crit_set = set(issue_norm_map.keys())
+    mapped_crit_set = set(mapped_norm_map.keys())
+    missing_norms = issue_crit_set - mapped_crit_set
+    extra_norms = mapped_crit_set - issue_crit_set
 
-    unproven = missing_criteria[:]
+    unproven = sorted([issue_norm_map[n] for n in missing_norms])
+    extra_criteria = sorted([mapped_norm_map[n] for n in extra_norms])
     invalid_tests = []
 
     # 5. Call build_report().collected
     script_path = Path(workspace_path) / "scripts" / "check_test_collection.py"
     collected: dict[str, set[str]] = {}
-    if script_path.exists():
-        alias = "_ci_check_test_collection"
-        spec = importlib.util.spec_from_file_location(alias, script_path)
-        if spec and spec.loader:
-            module = importlib.util.module_from_spec(spec)
-            sys.modules[alias] = module
-            try:
-                spec.loader.exec_module(module)
-                collected = module.build_report().collected
-            except Exception:
-                pass
+    if not script_path.exists():
+        return AcceptanceVerificationResult(
+            status="neutral",
+            reason="Test collection script is missing, unable to verify evidence.",
+        )
+
+    alias = "_ci_check_test_collection"
+    spec = importlib.util.spec_from_file_location(alias, script_path)
+    if not spec or not spec.loader:
+        return AcceptanceVerificationResult(
+            status="neutral",
+            reason="Failed to load test collection script spec, unable to verify evidence.",
+        )
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[alias] = module
+    try:
+        spec.loader.exec_module(module)
+        collected = module.build_report().collected
+    except (ImportError, AttributeError, SyntaxError) as e:
+        logger.warning(f"Expected error loading check_test_collection: {e!s}")
+        return AcceptanceVerificationResult(
+            status="neutral",
+            reason="Failed to execute test collection script, unable to verify evidence.",
+        )
+    except Exception as e:
+        logger.warning(f"Unexpected error loading check_test_collection: {e!s}")
+        return AcceptanceVerificationResult(
+            status="neutral",
+            reason="Unexpected error loading test collection script, unable to verify evidence.",
+        )
 
     # 6. Check referenced tests against collected set
     for crit, test_ref in mapping.items():
         if crit in extra_criteria:
             continue
         # Extract file path (e.g. tests/unit/test_foo.py::test_bar -> tests/unit/test_foo.py)
-        file_path = test_ref.split("::")[0].strip()
+        parts = test_ref.split("::")
+        file_path = parts[0].strip()
         if file_path not in collected:
             invalid_tests.append(test_ref)
             if crit not in unproven:
                 unproven.append(crit)
+        elif len(parts) > 1:
+            node_id = parts[1].strip()
+            if node_id not in collected[file_path]:
+                invalid_tests.append(test_ref)
+                if crit not in unproven:
+                    unproven.append(crit)
 
     unproven = sorted(list(set(unproven)))
 
@@ -760,6 +813,9 @@ def run_verification_check(
                 details += "\n**Mapped Evidence:**\n"
                 for crit, test_ref in acceptance_evidence.mapping.items():
                     details += f"- `{crit}` → `{test_ref}`\n"
+    elif acceptance_evidence.reason:
+        details += "\n\n### Acceptance Criteria Verification\n\n"
+        details += f"**NEUTRAL**: {acceptance_evidence.reason}\n"
 
     return VerificationCheckRunResult(
         bundle_verification=bundle_verification,

--- a/src/bernstein/core/volunteer/verification_check_run.py
+++ b/src/bernstein/core/volunteer/verification_check_run.py
@@ -19,7 +19,7 @@ import hashlib
 import json
 import os
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -85,6 +85,16 @@ class GateComparison:
 
 
 @dataclass(frozen=True, slots=True)
+class AcceptanceVerificationResult:
+    """Result of PR acceptance criteria to evidence mapping."""
+
+    status: Literal["pass", "fail", "neutral"]
+    mapping: dict[str, str] = field(default_factory=dict)
+    unproven: list[str] = field(default_factory=list)
+    invalid_tests: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
 class VerificationCheckRunResult:
     """Result of a volunteer receipt verification check run."""
 
@@ -94,6 +104,7 @@ class VerificationCheckRunResult:
     conclusion: Conclusion
     summary: str
     details: str
+    acceptance_evidence: AcceptanceVerificationResult | None = None
 
     @property
     def overall_passed(self) -> bool:
@@ -442,6 +453,125 @@ def _format_comparison_table(comparisons: list[GateComparison]) -> str:
     return "\n".join(lines)
 
 
+def _verify_acceptance_evidence(
+    pr_body: str,
+    repo_slug: str,
+    workspace_path: str,
+) -> AcceptanceVerificationResult:
+    """Verify that every PR acceptance criterion is mapped to an existing test."""
+    import importlib.util
+    import sys
+
+    from bernstein.core.orchestration.issue_to_pr import IssuePRClient
+
+    # 1. Extract linked issue
+    m = re.search(r"(?:[Cc]loses|[Ff]ixes|[Rr]esolves)\s+#(\d+)", pr_body)
+    if not m:
+        return AcceptanceVerificationResult(status="neutral")
+    issue_number = int(m.group(1))
+
+    # 2. Retrieve/parse issue checklist
+    client = IssuePRClient()
+    issue = client.get_issue(repo_slug, issue_number)
+    issue_body = issue.get("body") or ""
+
+    checklist_match = re.search(
+        r"^##\s+Acceptance\s+[Cc]riteria\s*$(.*?)(?=^#|\Z)",
+        issue_body,
+        re.MULTILINE | re.IGNORECASE | re.DOTALL,
+    )
+    if not checklist_match:
+        return AcceptanceVerificationResult(status="neutral")
+
+    issue_criteria = []
+    for line in checklist_match.group(1).splitlines():
+        line = line.strip()
+        if line.startswith("- [ ]") or line.startswith("- [x]") or line.startswith("- [X]"):
+            crit = line[5:].strip()
+            if crit:
+                issue_criteria.append(crit)
+
+    if not issue_criteria:
+        return AcceptanceVerificationResult(status="neutral")
+
+    # 3. Parse PR evidence block
+    marker = "<!-- bernstein:acceptance-evidence -->"
+    mapping = {}
+    if marker in pr_body:
+        mapping_section = pr_body.split(marker)[1]
+        for line in mapping_section.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith("- "):
+                line = line[2:].strip()
+            else:
+                break
+
+            if "→" in line:
+                parts = line.split("→")
+            elif "->" in line:
+                parts = line.split("->")
+            else:
+                continue
+
+            if len(parts) == 2:
+                crit = parts[0].strip().strip("\"'")
+                test_ref = parts[1].strip().strip("`'\"")
+                if crit and test_ref:
+                    mapping[crit] = test_ref
+
+    # 4. Compare issue criteria vs mapped criteria
+    issue_crit_set = set(issue_criteria)
+    mapped_crit_set = set(mapping.keys())
+    missing_criteria = sorted(list(issue_crit_set - mapped_crit_set))
+    extra_criteria = sorted(list(mapped_crit_set - issue_crit_set))
+
+    unproven = missing_criteria[:]
+    invalid_tests = []
+
+    # 5. Call build_report().collected
+    script_path = Path(workspace_path) / "scripts" / "check_test_collection.py"
+    collected: dict[str, set[str]] = {}
+    if script_path.exists():
+        alias = "_ci_check_test_collection"
+        spec = importlib.util.spec_from_file_location(alias, script_path)
+        if spec and spec.loader:
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[alias] = module
+            try:
+                spec.loader.exec_module(module)
+                collected = module.build_report().collected
+            except Exception:
+                pass
+
+    # 6. Check referenced tests against collected set
+    for crit, test_ref in mapping.items():
+        if crit in extra_criteria:
+            continue
+        # Extract file path (e.g. tests/unit/test_foo.py::test_bar -> tests/unit/test_foo.py)
+        file_path = test_ref.split("::")[0].strip()
+        if file_path not in collected:
+            invalid_tests.append(test_ref)
+            if crit not in unproven:
+                unproven.append(crit)
+
+    unproven = sorted(list(set(unproven)))
+
+    if unproven or extra_criteria:
+        # extra criteria can be treated as unproven or we can just fail
+        for ec in extra_criteria:
+            invalid_tests.append(f"Mapped unknown criterion: {ec}")
+        return AcceptanceVerificationResult(
+            status="fail",
+            mapping=mapping,
+            unproven=unproven,
+            invalid_tests=invalid_tests,
+        )
+
+    return AcceptanceVerificationResult(status="pass", mapping=mapping)
+
+
 def run_verification_check(
     *,
     pr_number: int,
@@ -610,6 +740,27 @@ def run_verification_check(
 
     details = "\n".join(details_parts)
 
+    acceptance_evidence = _verify_acceptance_evidence(pr_body, repo_slug, workspace_path)
+
+    if acceptance_evidence.status != "neutral":
+        details += "\n\n### Acceptance Criteria Verification\n\n"
+        if acceptance_evidence.status == "pass":
+            details += f"**PASSED**: {len(acceptance_evidence.mapping)} criteria mapped to collected tests.\n"
+        else:
+            details += "**UNPROVEN / FAILED**\n"
+            if acceptance_evidence.unproven:
+                details += "\n**Unproven Criteria:**\n"
+                for uc in acceptance_evidence.unproven:
+                    details += f"- {uc}\n"
+            if acceptance_evidence.invalid_tests:
+                details += "\n**Invalid Evidence:**\n"
+                for it in acceptance_evidence.invalid_tests:
+                    details += f"- `{it}`\n"
+            if acceptance_evidence.mapping:
+                details += "\n**Mapped Evidence:**\n"
+                for crit, test_ref in acceptance_evidence.mapping.items():
+                    details += f"- `{crit}` → `{test_ref}`\n"
+
     return VerificationCheckRunResult(
         bundle_verification=bundle_verification,
         gate_comparisons=gate_comparisons,
@@ -617,6 +768,7 @@ def run_verification_check(
         conclusion=conclusion,
         summary=summary,
         details=details,
+        acceptance_evidence=acceptance_evidence,
     )
 
 

--- a/tests/unit/test_acceptance_evidence.py
+++ b/tests/unit/test_acceptance_evidence.py
@@ -106,3 +106,72 @@ def test_no_linked_issue_is_neutral(mock_issue_pr_client, mock_workspace):
     pr_body = "Just a normal PR"
     result = _verify_acceptance_evidence(pr_body, "owner/repo", mock_workspace)
     assert result.status == "neutral"
+
+
+def test_missing_collector_script_is_neutral(mock_issue_pr_client, tmp_path):
+    mock_issue_pr_client.get_issue.return_value = {"body": "## Acceptance criteria\n- [ ] Criterion A"}
+    pr_body = "Closes #123\n<!-- bernstein:acceptance-evidence -->\n- Criterion A → tests/unit/test_a.py::test_a"
+
+    result = _verify_acceptance_evidence(pr_body, "owner/repo", str(tmp_path))
+    assert result.status == "neutral"
+    assert "Test collection script is missing" in result.reason
+
+
+def test_failing_collector_script_is_neutral(mock_issue_pr_client, mock_workspace):
+    mock_issue_pr_client.get_issue.return_value = {"body": "## Acceptance criteria\n- [ ] Criterion A"}
+    pr_body = "Closes #123\n<!-- bernstein:acceptance-evidence -->\n- Criterion A → tests/unit/test_a.py::test_a"
+
+    from unittest.mock import patch
+
+    with patch("importlib.util.spec_from_file_location") as mock_spec:
+        mock_spec.return_value.loader.exec_module.side_effect = SyntaxError("bad syntax")
+        result = _verify_acceptance_evidence(pr_body, "owner/repo", mock_workspace)
+
+    assert result.status == "neutral"
+    assert "Failed to execute test collection script" in result.reason
+
+
+def test_node_id_verification_fails_if_wrong_node(mock_issue_pr_client, mock_build_report, mock_workspace):
+    mock_issue_pr_client.get_issue.return_value = {"body": "## Acceptance criteria\n- [ ] Criterion A"}
+
+    pr_body = """
+Closes #123
+<!-- bernstein:acceptance-evidence -->
+- Criterion A → tests/unit/test_a.py::test_does_not_exist
+"""
+    result = _verify_acceptance_evidence(pr_body, "owner/repo", mock_workspace)
+    assert result.status == "fail"
+    assert "Criterion A" in result.unproven
+    assert "tests/unit/test_a.py::test_does_not_exist" in result.invalid_tests
+
+
+def test_criterion_normalization_passes_despite_differences(mock_issue_pr_client, mock_build_report, mock_workspace):
+    mock_issue_pr_client.get_issue.return_value = {
+        "body": "## Acceptance criteria\n- [ ]   Handle user login   .\n- [ ] Show   error  MESSAGE!"
+    }
+
+    pr_body = """
+Closes #123
+<!-- bernstein:acceptance-evidence -->
+- Handle User Login → tests/unit/test_a.py::test_a
+- show error message → tests/unit/test_b.py::test_b
+"""
+
+    result = _verify_acceptance_evidence(pr_body, "owner/repo", mock_workspace)
+    assert result.status == "pass"
+    # mapping contains the original strings from the PR mapping block
+    assert result.mapping == {
+        "Handle User Login": "tests/unit/test_a.py::test_a",
+        "show error message": "tests/unit/test_b.py::test_b",
+    }
+    assert result.unproven == []
+
+
+def test_github_api_failure_is_neutral(mock_issue_pr_client, mock_workspace):
+    mock_issue_pr_client.get_issue.side_effect = Exception("API rate limit exceeded")
+
+    pr_body = "Closes #123\n<!-- bernstein:acceptance-evidence -->\n- Criterion A → tests/unit/test_a.py::test_a"
+
+    result = _verify_acceptance_evidence(pr_body, "owner/repo", mock_workspace)
+    assert result.status == "neutral"
+    assert "Failed to fetch linked issue #123" in result.reason

--- a/tests/unit/test_acceptance_evidence.py
+++ b/tests/unit/test_acceptance_evidence.py
@@ -1,0 +1,108 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bernstein.core.volunteer.verification_check_run import _verify_acceptance_evidence
+
+
+@pytest.fixture
+def mock_issue_pr_client():
+    with patch("bernstein.core.orchestration.issue_to_pr.IssuePRClient") as mock_client_class:
+        mock_instance = MagicMock()
+        mock_client_class.return_value = mock_instance
+        yield mock_instance
+
+
+@pytest.fixture
+def mock_build_report():
+    with patch("importlib.util.spec_from_file_location") as mock_spec:
+        mock_module = MagicMock()
+        mock_spec.return_value.loader.exec_module = MagicMock()
+        mock_spec.return_value.loader = MagicMock()
+
+        with patch("importlib.util.module_from_spec", return_value=mock_module):
+            mock_report = MagicMock()
+            mock_report.collected = {
+                "tests/unit/test_a.py": set(["test_a"]),
+                "tests/unit/test_b.py": set(["test_b"]),
+            }
+            mock_module.build_report = MagicMock(return_value=mock_report)
+            yield mock_module
+
+
+@pytest.fixture
+def mock_workspace(tmp_path):
+    # Create dummy script so that exists() is True
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "check_test_collection.py").touch()
+    return str(tmp_path)
+
+
+def test_complete_mapping_passes(mock_issue_pr_client, mock_build_report, mock_workspace):
+    mock_issue_pr_client.get_issue.return_value = {
+        "body": "## Acceptance criteria\n- [ ] Criterion A\n- [ ] Criterion B"
+    }
+
+    pr_body = """
+Closes #123
+<!-- bernstein:acceptance-evidence -->
+- Criterion A → tests/unit/test_a.py::test_a
+- Criterion B → tests/unit/test_b.py::test_b
+"""
+
+    result = _verify_acceptance_evidence(pr_body, "owner/repo", mock_workspace)
+    assert result.status == "pass"
+    assert result.mapping == {
+        "Criterion A": "tests/unit/test_a.py::test_a",
+        "Criterion B": "tests/unit/test_b.py::test_b",
+    }
+    assert result.unproven == []
+    assert result.invalid_tests == []
+
+
+def test_mapping_skips_criterion_fails(mock_issue_pr_client, mock_build_report, mock_workspace):
+    mock_issue_pr_client.get_issue.return_value = {
+        "body": "## Acceptance criteria\n- [ ] Criterion A\n- [ ] Criterion B"
+    }
+
+    pr_body = """
+Closes #123
+<!-- bernstein:acceptance-evidence -->
+- Criterion A → tests/unit/test_a.py::test_a
+"""
+
+    result = _verify_acceptance_evidence(pr_body, "owner/repo", mock_workspace)
+    assert result.status == "fail"
+    assert "Criterion B" in result.unproven
+    assert "Criterion B" not in result.mapping
+
+
+def test_mapping_names_nonexistent_test_fails(mock_issue_pr_client, mock_build_report, mock_workspace):
+    mock_issue_pr_client.get_issue.return_value = {"body": "## Acceptance criteria\n- [ ] Criterion A"}
+
+    pr_body = """
+Closes #123
+<!-- bernstein:acceptance-evidence -->
+- Criterion A → tests/unit/definitely_not_a_real_test.py::test_fake
+"""
+
+    result = _verify_acceptance_evidence(pr_body, "owner/repo", mock_workspace)
+    assert result.status == "fail"
+    assert "Criterion A" in result.unproven
+    assert "tests/unit/definitely_not_a_real_test.py::test_fake" in result.invalid_tests
+
+
+def test_issue_without_acceptance_checklist_is_neutral(mock_issue_pr_client, mock_build_report, mock_workspace):
+    mock_issue_pr_client.get_issue.return_value = {"body": "## Description\nFix a typo."}
+
+    pr_body = "Closes #123"
+
+    result = _verify_acceptance_evidence(pr_body, "owner/repo", mock_workspace)
+    assert result.status == "neutral"
+
+
+def test_no_linked_issue_is_neutral(mock_issue_pr_client, mock_workspace):
+    pr_body = "Just a normal PR"
+    result = _verify_acceptance_evidence(pr_body, "owner/repo", mock_workspace)
+    assert result.status == "neutral"


### PR DESCRIPTION
Closes #4835

Adds advisory verification for PR acceptance-criteria evidence mappings.

### What changed

* Parse the linked issue's acceptance checklist.
* Parse the PR's acceptance-evidence mapping block.
* Verify every acceptance criterion is represented in the mapping.
* Verify every referenced test exists in Bernstein's canonical collected test set.
* Record the mapping and verification result in the existing verification artefacts.
* Keep the check advisory so missing evidence does not block unrelated verification.

### Behavior

* Complete mapping → passes
* Missing criterion → fails verification and identifies the missing criterion
* Non-existent test → fails verification and identifies the invalid test reference
* No linked issue → neutral
* Linked issue without an acceptance checklist → neutral

### Design decision

An issue without an acceptance checklist is treated as neutral rather than as a failure. Without a checklist there is no deterministic acceptance contract to verify, and treating the absence of optional acceptance metadata as a failure could unnecessarily affect unrelated PRs.

### Test discovery

The implementation reuses the existing test-collection derivation from `scripts/check_test_collection.py` rather than introducing a separate test-discovery mechanism.

### Out of scope

This check verifies that acceptance criteria are completely mapped to existing tests. It does not determine whether a particular test actually proves the criterion; that remains a human review decision.
