### PR TITLE
fix(cluster): a cordon is operator intent, so it survives a re-registration

### DIFF
--- a/src/bernstein/core/protocols/cluster/cluster.py
+++ b/src/bernstein/core/protocols/cluster/cluster.py
@@ -115,14 +115,18 @@ class NodeRegistry:
         """Register or re-register a node.
 
         If the node ID already exists, update its info (preserving
-        registered_at). Otherwise create a new entry.
+        registered_at, and any status the operator set). Otherwise create a new
+        entry, which starts ``ONLINE``.
         """
         existing = self._nodes.get(node.id)
         if existing is not None:
             existing.name = node.name or existing.name
             existing.url = node.url or existing.url
             existing.capacity = node.capacity
-            existing.status = NodeStatus.ONLINE
+            # Not unconditionally ONLINE: a cordon is an operator's instruction
+            # and a restart is not an answer to it. See
+            # _status_after_reregistration.
+            existing.status = _status_after_reregistration(existing.status, existing)
             existing.last_heartbeat = time.time()
             existing.labels = node.labels or existing.labels
             existing.cell_ids = node.cell_ids or existing.cell_ids
@@ -324,6 +328,49 @@ class NodeRegistry:
             "active_agents": sum(n.capacity.active_agents for n in online),
             "nodes": [_node_to_dict(n) for n in nodes],
         }
+
+
+#: Statuses that record what an *operator* decided, as opposed to what the
+#: server last observed. Only these survive a re-registration.
+#:
+#: ``CORDONED`` and ``DRAINING`` are instructions -- keep work off this node --
+#: and the node restarting is not an answer to either. ``DEGRADED`` and
+#: ``OFFLINE`` are observations about a process, and the process re-registering
+#: is direct evidence they no longer hold, so those are right to reset.
+_OPERATOR_INTENT_STATUSES: frozenset[NodeStatus] = frozenset({NodeStatus.CORDONED, NodeStatus.DRAINING})
+
+
+def _status_after_reregistration(current: NodeStatus, node: NodeInfo) -> NodeStatus:
+    """What a re-registering node's status becomes: intent survives, health resets.
+
+    ``register`` used to set ``ONLINE`` unconditionally on this path, so a node
+    an operator had cordoned returned to ``ONLINE`` the moment it restarted and
+    its slots re-entered ``total_capacity``.
+
+    That inverts the property a cordon exists for. Cordoning is usually a
+    response to a node misbehaving, and a misbehaving node restarts more often
+    than a healthy one -- so the worse a worker behaved, the more reliably it
+    escaped its cordon. The domain convention agrees: a kubelet restart does not
+    clear ``spec.unschedulable``.
+
+    Args:
+        current: The status on the existing registry record.
+        node: The re-registering node, for the log line only.
+
+    Returns:
+        ``current`` when it records operator intent, else ``ONLINE``.
+    """
+    if current not in _OPERATOR_INTENT_STATUSES:
+        return NodeStatus.ONLINE
+    # Nothing said either way before this, so an operator learned a cordon had
+    # been cleared by watching work get scheduled onto the node. Say it plainly.
+    logger.info(
+        "Node %s (%s) re-registered; keeping operator-set status %s",
+        node.id,
+        node.name,
+        current.value,
+    )
+    return current
 
 
 def _node_to_dict(node: NodeInfo) -> dict[str, Any]:

--- a/tests/unit/test_grpc_cluster_auth.py
+++ b/tests/unit/test_grpc_cluster_auth.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 
 import grpc
 import pytest
-from bernstein.core.models import ClusterConfig
+from bernstein.core.models import ClusterConfig, NodeStatus
 
 from bernstein.core.grpc_gen import cluster_pb2
 from bernstein.core.protocols.cluster import NodeRegistry
@@ -401,6 +401,91 @@ class TestReRegistrationIsIdempotent:
 
         assert first.node.id != second.node.id
         assert len(registry.list_nodes()) == 2
+
+
+class TestCordonSurvivesReRegistration:
+    """A cordon is operator intent, and a restart is not an answer to it (#4820).
+
+    ``NodeRegistry.register`` set ``ONLINE`` unconditionally when updating an
+    existing entry, so a cordoned worker became schedulable again by restarting
+    -- on this surface and the REST one alike, since both end in that one call.
+
+    Asserted through ``cluster_summary``'s capacity totals as well as the status
+    field: the total is the number the scheduler actually spends, and a test
+    watching only the status would not notice the slots coming back.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_cordoned_node_is_still_cordoned_after_it_re_registers(self) -> None:
+        registry = _registry()
+        service = ClusterServiceImpl(registry)
+
+        first = await _register_one(service, max_agents=4)
+        registry.cordon(first.node.id)
+        assert registry.cluster_summary()["total_capacity"] == 0
+
+        await _register_one(service, max_agents=4)
+
+        assert registry.get(first.node.id).status is NodeStatus.CORDONED
+        summary = registry.cluster_summary()
+        assert summary["total_nodes"] == 1
+        assert summary["total_capacity"] == 0, "restarting handed the node's slots back"
+
+    @pytest.mark.asyncio
+    async def test_a_draining_node_is_still_draining_after_it_re_registers(self) -> None:
+        registry = _registry()
+        service = ClusterServiceImpl(registry)
+
+        first = await _register_one(service, max_agents=4)
+        registry.start_drain(first.node.id)
+
+        await _register_one(service, max_agents=4)
+
+        assert registry.get(first.node.id).status is NodeStatus.DRAINING
+        assert registry.cluster_summary()["total_capacity"] == 0
+
+    @pytest.mark.asyncio
+    async def test_a_first_registration_still_starts_online(self) -> None:
+        # The over-correction guard: there is no operator decision to preserve
+        # on a node nobody has seen before, so it must be schedulable at once.
+        registry = _registry()
+
+        first = await _register_one(ClusterServiceImpl(registry), max_agents=4)
+
+        assert registry.get(first.node.id).status is NodeStatus.ONLINE
+        assert registry.cluster_summary()["total_capacity"] == 4
+
+    @pytest.mark.asyncio
+    async def test_observed_health_resets_where_operator_intent_does_not(self) -> None:
+        # DEGRADED describes a process the server watched misbehave. That
+        # process re-registering is direct evidence the observation no longer
+        # holds -- unlike a cordon, which is a decision nobody has revisited.
+        registry = _registry()
+        service = ClusterServiceImpl(registry)
+
+        first = await _register_one(service, max_agents=4)
+        registry.get(first.node.id).status = NodeStatus.DEGRADED
+
+        await _register_one(service, max_agents=4)
+
+        assert registry.get(first.node.id).status is NodeStatus.ONLINE
+        assert registry.cluster_summary()["total_capacity"] == 4
+
+    @pytest.mark.asyncio
+    async def test_an_uncordoned_node_returns_to_service(self) -> None:
+        # Preserving a cordon must not make one impossible to lift: once
+        # uncordoned there is no intent left to carry, so the node stays online.
+        registry = _registry()
+        service = ClusterServiceImpl(registry)
+
+        first = await _register_one(service, max_agents=4)
+        registry.cordon(first.node.id)
+        registry.uncordon(first.node.id)
+
+        await _register_one(service, max_agents=4)
+
+        assert registry.get(first.node.id).status is NodeStatus.ONLINE
+        assert registry.cluster_summary()["total_capacity"] == 4
 
 
 class TestNodeRegistryFindByIdentity:

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2183,6 +2183,96 @@ async def test_re_registering_refreshes_the_reported_capacity(cluster_client: As
 
 
 @pytest.mark.anyio
+async def test_a_cordon_survives_the_worker_restarting(cluster_client: AsyncClient) -> None:
+    """Cordoning is an instruction, and a restart is not an answer to it (#4820).
+
+    Both registration handlers rebuild ``NodeInfo`` from the request, and
+    ``status`` defaults to ``ONLINE``, so everything not explicitly carried
+    reset: a cordoned worker returned to ``ONLINE`` the moment it restarted.
+
+    That inverts the property the cordon is for. Cordoning is usually a
+    response to a node misbehaving, and a misbehaving node restarts more often
+    than a healthy one -- so the worse a worker behaved, the more reliably it
+    escaped its cordon.
+
+    Asserted on ``total_capacity`` as well as the status field, because the
+    capacity total is what an operator actually feels: it is the number the
+    scheduler spends.
+    """
+    registered = await cluster_client.post("/cluster/nodes", json=NODE_PAYLOAD)
+    node_id = registered.json()["id"]
+    await cluster_client.post(f"/cluster/nodes/{node_id}/cordon")
+
+    cordoned = await cluster_client.get("/cluster/status")
+    assert cordoned.json()["total_capacity"] == 0, "a cordoned node counted before it even restarted"
+
+    # The worker restarts and re-registers: same name + url, so the same entry.
+    again = await cluster_client.post("/cluster/nodes", json=NODE_PAYLOAD)
+    assert again.status_code == 201
+    assert again.json()["id"] == node_id
+
+    body = (await cluster_client.get("/cluster/status")).json()
+    assert body["total_nodes"] == 1
+    assert body["nodes"][0]["status"] == "cordoned"
+    assert body["total_capacity"] == 0, "restarting released the node's slots back to the scheduler"
+
+
+@pytest.mark.anyio
+async def test_a_draining_node_stays_draining_across_a_restart(cluster_client: AsyncClient) -> None:
+    """Draining is the same kind of fact as cordoning: operator intent.
+
+    Kept as its own case because the two are set by different endpoints, and
+    carrying one without the other would leave a drain that a restart quietly
+    cancels -- the same defect wearing a different label.
+    """
+    registered = await cluster_client.post("/cluster/nodes", json=NODE_PAYLOAD)
+    node_id = registered.json()["id"]
+    await cluster_client.post(f"/cluster/nodes/{node_id}/drain")
+
+    await cluster_client.post("/cluster/nodes", json=NODE_PAYLOAD)
+
+    body = (await cluster_client.get("/cluster/status")).json()
+    assert body["nodes"][0]["status"] == "draining"
+    assert body["total_capacity"] == 0
+
+
+@pytest.mark.anyio
+async def test_a_new_node_registers_online(cluster_client: AsyncClient) -> None:
+    """The over-correction guard: preservation applies only to a node already known.
+
+    A first registration carries no prior operator decision, so it must still
+    start ``ONLINE`` and count toward capacity. Without this, a rule that
+    carried status too eagerly would still pass the cordon cases above.
+    """
+    await cluster_client.post("/cluster/nodes", json=NODE_PAYLOAD)
+
+    body = (await cluster_client.get("/cluster/status")).json()
+    assert body["nodes"][0]["status"] == "online"
+    assert body["total_capacity"] == NODE_PAYLOAD["capacity"]["max_agents"]
+
+
+@pytest.mark.anyio
+async def test_an_uncordoned_node_comes_back_online(cluster_client: AsyncClient) -> None:
+    """Preserving a cordon must not make one impossible to lift.
+
+    ``uncordon`` returns the node to ``ONLINE``, and a later re-registration
+    then has no operator decision left to carry -- so the node stays
+    schedulable. A rule that latched on the first non-online status it saw
+    would strand it out of the cluster.
+    """
+    registered = await cluster_client.post("/cluster/nodes", json=NODE_PAYLOAD)
+    node_id = registered.json()["id"]
+    await cluster_client.post(f"/cluster/nodes/{node_id}/cordon")
+    await cluster_client.post(f"/cluster/nodes/{node_id}/uncordon")
+
+    await cluster_client.post("/cluster/nodes", json=NODE_PAYLOAD)
+
+    body = (await cluster_client.get("/cluster/status")).json()
+    assert body["nodes"][0]["status"] == "online"
+    assert body["total_capacity"] == NODE_PAYLOAD["capacity"]["max_agents"]
+
+
+@pytest.mark.anyio
 async def test_list_nodes_empty(cluster_client: AsyncClient) -> None:
     """GET /cluster/nodes returns [] when no nodes registered."""
     resp = await cluster_client.get("/cluster/nodes")


### PR DESCRIPTION
## What

A node an operator had cordoned returned to `ONLINE` the moment it restarted, and its slots re-entered `total_capacity`. Cordons (and drains) now survive a re-registration; observed health still resets.

Fixes #4820.

## Why

The issue makes the case better than I can restate it, so just the part that decided the implementation: this **inverts** the property a cordon is for. Cordoning is usually a response to a node misbehaving, and a misbehaving node restarts more often than a healthy one — so the worse a worker behaved, the more reliably it escaped its cordon. Nothing logged the transition either, so the operator found out from scheduling.

## How

**One correction to the issue's diagnosis, and it changed the shape of the fix.**

The issue names the two registration handlers, which rebuild `NodeInfo` and carry over only the id. They are the reachable symptom, but they are not where the reset happens: `NodeRegistry.register` sets

```python
existing.status = NodeStatus.ONLINE
```

unconditionally on its update path (`cluster.py:125`). So the clearing happens *underneath* both handlers rather than in either one, and any third caller of `register` would have inherited it too. I confirmed this the hard way — I wrote the two-handler fix first and the tests still failed.

Fixing it in `register` is also the only way to satisfy the acceptance criterion that the two surfaces behave identically **by construction** rather than by two edits somebody has to keep in step.

**Option (2), for the reason the issue gives.** `CORDONED` and `DRAINING` record what an operator decided, and a restart is not an answer to either. `DEGRADED` and `OFFLINE` describe a process the server observed, and that process re-registering is direct evidence the observation no longer holds — so those still reset. The preserved status is logged, which is what option (3) was asking for and costs nothing here.

## Tests

Nine, each named for the property it protects, and four confirmed red without the fix. The other five are guards that pass both ways on purpose — an over-correction would still be caught.

Every assertion is on `cluster_summary`'s **capacity totals** as well as the status field, as the acceptance criteria ask: the total is the number the scheduler actually spends, and a test watching only `status` would not notice the slots coming back.

REST, through the HTTP surface (`test_server.py`):
- a cordoned node re-registers and is still cordoned
- draining survives too — set by a different endpoint, and carrying one without the other leaves a drain that a restart quietly cancels
- a **new** registration still starts `ONLINE` — the over-correction guard the review note asked for
- an uncordoned node comes back online, so preserving a cordon does not make one impossible to lift

gRPC, driving the servicer (`test_grpc_cluster_auth.py`): the same four, plus one pinning that `DEGRADED` resets where a cordon does not — the line between intent and observation this whole change turns on.

## Checklist

- [x] `ruff check src/` passes (also `ruff format --check` — it caught one line of mine)
- [ ] `pyright src/` — **not run clean, and not by this change.** `packages/…/cluster.py` reports ~295 pre-existing strict errors on `main` before I touch it (`reportUnknownMemberType` cascades off untyped `NodeInfo`). Worth flagging separately: 134 of the 172 paths in `[tool.pyright] exclude` no longer exist — they still name pre-reorganisation locations like `src/bernstein/core/grpc_server.py`, which now lives at `src/bernstein/core/protocols/grpc/grpc_server.py`. So the exclusions silently stopped applying to the files they were written for. Happy to open an issue if that is not already known.
- [x] `scripts/run_tests.py` on the touched suites: 190 passed (`test_server.py` 130, `test_grpc_cluster_auth.py` 42, `test_cluster.py` 18)
- [x] New code has type hints

### Documentation duty

- [x] README — N/A, internal scheduling behaviour
- [x] `docs/operations/` — N/A; no operator-facing procedure changes, and the cordon/uncordon commands are unchanged. Say the word if you would rather the new guarantee were written down there.
- [x] `docs/api/` — N/A, no public surface change
- [x] `agents-md sync` — N/A, no new module
- [x] Tests cover the documented behaviour