### PR TITLE
docs: regenerate adapter last-green table from canary receipts

### DIFF
--- a/docs/adapters/conformance-canary.md
+++ b/docs/adapters/conformance-canary.md
@@ -214,15 +214,15 @@ covered under *Chronic-skip handling*.
 | Adapter | Binary | Last-green version | Verified | Receipt |
 |---|---|---|---|---|
 | agy | `agy` | 1.0.0 | 2026-07-11T05:57:23Z (not probed) | `006fb946868d` |
-| aider | `aider` | 0.86.2 | 2026-08-30T10:14:52Z | `21be1c27a63e` |
-| claude | `claude` | 2.1.251 | 2026-08-30T10:14:52Z | `e998c00b1e08` |
-| codex | `codex` | 0.151.0 | 2026-08-30T10:14:52Z | `538298a2b76d` |
-| copilot | `copilot` | 1.0.82 | 2026-08-30T10:14:52Z | `31eb755450b1` |
-| gemini | `gemini` | 0.57.0 | 2026-08-30T10:14:52Z | `db278cc19270` |
-| kimi | `kimi` | 1.49.0 | 2026-08-30T10:14:52Z | `515fc853a0b6` |
-| opencode | `opencode` | 1.18.25 | 2026-08-30T10:14:52Z | `aa3b51f200f0` |
-| pydantic_ai | `clai` | 2.36.0 | 2026-08-30T10:14:52Z | `79712e98e1bf` |
-| qwen | `qwen` | 0.22.3 | 2026-08-30T10:14:52Z | `42b1d0bf333a` |
+| aider | `aider` | 0.86.2 | 2026-08-31T11:13:48Z | `fe246ae66846` |
+| claude | `claude` | 2.1.251 | 2026-08-31T11:13:48Z | `fca6c8f6b208` |
+| codex | `codex` | 0.151.0 | 2026-08-31T11:13:48Z | `1e4a75f1ef50` |
+| copilot | `copilot` | 1.0.82 | 2026-08-31T11:13:48Z | `735bb734fb94` |
+| gemini | `gemini` | 0.57.0 | 2026-08-31T11:13:48Z | `8b6c9dcfef35` |
+| kimi | `kimi` | 1.49.0 | 2026-08-31T11:13:48Z | `211490da1bb4` |
+| opencode | `opencode` | 1.18.25 | 2026-08-31T11:13:48Z | `1f679c647279` |
+| pydantic_ai | `clai` | 2.36.0 | 2026-08-31T11:13:48Z | `0a75e3d8d61d` |
+| qwen | `qwen` | 0.22.3 | 2026-08-31T11:13:48Z | `ce7400a5114c` |
 <!-- last-green:end -->
 
 ## Operator knobs

--- a/scripts/gen_distribution_manifests.py
+++ b/scripts/gen_distribution_manifests.py
@@ -108,8 +108,6 @@ def _load_vendored_schema(filename: str) -> dict[str, object]:
     return schema
 
 
-
-
 def _require_schema_valid(document: object, schema_file: str, manifest_name: str) -> None:
     """Raise :class:`ManifestValidationError` if *document* violates the vendored schema."""
     schema = _load_vendored_schema(schema_file)

--- a/src/bernstein/adapters/last_green.json
+++ b/src/bernstein/adapters/last_green.json
@@ -8,59 +8,59 @@
     },
     "aider": {
       "binary": "aider",
-      "receipt_sha256": "21be1c27a63e990882002d0fa368594874ab023dba331834c1437ca423397bc0",
-      "recorded_at": "2026-08-30T10:14:52Z",
+      "receipt_sha256": "fe246ae66846bfe72f900c9daf4664b15218bc82005847608452c79c31db0d15",
+      "recorded_at": "2026-08-31T11:13:48Z",
       "version": "0.86.2"
     },
     "claude": {
       "binary": "claude",
-      "receipt_sha256": "e998c00b1e08aa96b20b6da01f669fb9184ab9ecda0b1fb72f1f9f00132804a5",
-      "recorded_at": "2026-08-30T10:14:52Z",
+      "receipt_sha256": "fca6c8f6b2082894e592fa462c3ec3941b8752da7040455d66d300418bd7ac69",
+      "recorded_at": "2026-08-31T11:13:48Z",
       "version": "2.1.251"
     },
     "codex": {
       "binary": "codex",
-      "receipt_sha256": "538298a2b76df8a43d7e6ec2f696a2f14f3fde1dfb57e1c662da946b625a0844",
-      "recorded_at": "2026-08-30T10:14:52Z",
+      "receipt_sha256": "1e4a75f1ef50efa88e8b4ee66b880c61baee1fd3d19f74c4a91d428c91a69ccc",
+      "recorded_at": "2026-08-31T11:13:48Z",
       "version": "0.151.0"
     },
     "copilot": {
       "binary": "copilot",
-      "receipt_sha256": "31eb755450b1094b3fa45699b6366a6d0e7ce81509528337886b2c7352de99b1",
-      "recorded_at": "2026-08-30T10:14:52Z",
+      "receipt_sha256": "735bb734fb94f259311a2d4ab3fa6c9c4bedd96d2b2b71fc6fa0684254729685",
+      "recorded_at": "2026-08-31T11:13:48Z",
       "version": "1.0.82"
     },
     "gemini": {
       "binary": "gemini",
-      "receipt_sha256": "db278cc1927059cbb333bf07d725408f5d633ef6fdc8d2137af1f0d1e1a740c1",
-      "recorded_at": "2026-08-30T10:14:52Z",
+      "receipt_sha256": "8b6c9dcfef359004cbf0db4447a665a1740fcafefc08736c02e2c4bf1c673a6b",
+      "recorded_at": "2026-08-31T11:13:48Z",
       "version": "0.57.0"
     },
     "kimi": {
       "binary": "kimi",
-      "receipt_sha256": "515fc853a0b61bebe762b0c845edb1abdab16769428b81f10e3e00b10bca435a",
-      "recorded_at": "2026-08-30T10:14:52Z",
+      "receipt_sha256": "211490da1bb46b70875648e2ad532f970a46d908af748d520e8a5876289b58bd",
+      "recorded_at": "2026-08-31T11:13:48Z",
       "version": "1.49.0"
     },
     "opencode": {
       "binary": "opencode",
-      "receipt_sha256": "aa3b51f200f099847694b2fc38a9a8fe6d6d9d2b82fa1eba29bb9b76a5e1a6da",
-      "recorded_at": "2026-08-30T10:14:52Z",
+      "receipt_sha256": "1f679c647279d3b077ea03776df38a75f1183d5152a2ed307534eaf1a27ed99f",
+      "recorded_at": "2026-08-31T11:13:48Z",
       "version": "1.18.25"
     },
     "pydantic_ai": {
       "binary": "clai",
-      "receipt_sha256": "79712e98e1bf822ce24209748821e205e6247690fe986a967ce796883957155c",
-      "recorded_at": "2026-08-30T10:14:52Z",
+      "receipt_sha256": "0a75e3d8d61d0e5550ea93c013feffbff6500cb38ac891ea9b5cfb03e2ce5379",
+      "recorded_at": "2026-08-31T11:13:48Z",
       "version": "2.36.0"
     },
     "qwen": {
       "binary": "qwen",
-      "receipt_sha256": "42b1d0bf333ad9a21d382df4a1b9471129410e724d3b219aeeee7aa18ac143ce",
-      "recorded_at": "2026-08-30T10:14:52Z",
+      "receipt_sha256": "ce7400a5114c5936f970ecad20a6ccaef5a2736360c09ae167ca370bf26009aa",
+      "recorded_at": "2026-08-31T11:13:48Z",
       "version": "0.22.3"
     }
   },
-  "projection_sha256": "27dab1d48c5ed056f1395f1842f8efd2454758a71a220f1553bb3f3d27f2dfa2",
+  "projection_sha256": "dd4f6b85b5ebfccd8d586485642335d641d92dd782eb9bdf9ee35f5c298f855d",
   "schema_version": 2
 }


### PR DESCRIPTION
Nightly adapter conformance canary regeneration of the per-adapter last-green projection (packaged last_green.json + the docs table). Every row is anchored to the receipt that attested it; receipts for this run are attached to the workflow run as artifacts.

Workflow run: https://github.com/sipyourdrink-ltd/bernstein/actions/runs/33385697211