### PR TITLE
fix(orchestrator): pace the run loop through its own seam

### DIFF
--- a/docs/release-notes/fragments/4869-orchestrator-pacing-seam.md
+++ b/docs/release-notes/fragments/4869-orchestrator-pacing-seam.md
@@ -1,0 +1,3 @@
+## Orchestrator pacing is observed through its own seam
+
+The run loop now paces through `Orchestrator._pace` instead of calling `time.sleep` directly. `time.sleep` is one function object shared by the whole process, so a test that patched it recorded every sleep any code performed while `run()` was on the stack — including CPython's own subprocess reaping busy-wait (1ms, 2ms, 4ms, 8ms). On a machine where a startup subprocess outlived the first tick, those four values were the first four entries and the polling-schedule assertions read them instead of the loop's own, failing the suite on unrelated changes. The seam makes the recorded schedule exactly what the loop chose.

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -3060,6 +3060,19 @@ class Orchestrator:
         except OSError as exc:
             logger.warning("failed to write .finalized marker: %s", exc)
 
+    def _pace(self, seconds: float) -> None:
+        """Sleep between ticks. The run loop's only pacing seam.
+
+        ``time.sleep`` is one function object shared by the whole process,
+        so a test that patches it observes every sleep anything performs
+        while ``run()`` is on the stack - including CPython's own
+        ``subprocess.Popen`` reaping loop, whose 1ms/2ms/4ms/8ms busy-wait
+        lands in the record before the loop's first tick has paced at all.
+        Routing the loop's pacing through one method lets a test watch the
+        schedule this loop chooses and nothing else.
+        """
+        time.sleep(seconds)
+
     def run(self) -> None:
         """Run the orchestrator loop until stopped.
 
@@ -3234,15 +3247,15 @@ class Orchestrator:
             server_failures = getattr(self, "_consecutive_server_failures", 0)
             if server_failures > 0:
                 # Backoff: 5s, 10s, 15s, 20s, 30s (capped)
-                time.sleep(min(5.0 * server_failures, 30.0))
+                self._pace(min(5.0 * server_failures, 30.0))
             elif tick_result is not None and (
                 tick_result.spawned or tick_result.verified or tick_result.retried or tick_result.open_tasks > 0
             ):
                 self._idle_multiplier = 1
-                time.sleep(self._config.poll_interval_s)
+                self._pace(self._config.poll_interval_s)
             else:
                 self._idle_multiplier = min(self._idle_multiplier * 2, 8)
-                time.sleep(min(self._config.poll_interval_s * self._idle_multiplier, 30.0))
+                self._pace(min(self._config.poll_interval_s * self._idle_multiplier, 30.0))
 
             # Hot-reload bernstein.yaml config (mutable fields only)
             self._maybe_reload_config()

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -5905,9 +5905,8 @@ class TestAdaptivePollingBackoff:
     def test_idle_ticks_double_sleep_up_to_30s(self, tmp_path: Path, monkeypatch: object) -> None:
         orch = self._make_orch(tmp_path, poll_interval_s=3)
         sleep_calls: list[float] = []
-        import bernstein.core.orchestrator as _orch_mod
 
-        monkeypatch.setattr(_orch_mod.time, "sleep", lambda s: sleep_calls.append(float(s)))
+        monkeypatch.setattr(orch, "_pace", lambda s: sleep_calls.append(float(s)))
 
         call_count = 0
 
@@ -5924,20 +5923,23 @@ class TestAdaptivePollingBackoff:
         monkeypatch.setattr(orch, "_cleanup", lambda: None)
         orch.run()
 
-        # After each idle tick, sleep doubles: 6, 12, 24, 24 (cap at 8x), 24
-        assert len(sleep_calls) > 0
-        assert sleep_calls[0] == pytest.approx(6.0)
-        assert sleep_calls[1] == pytest.approx(12.0)
-        assert sleep_calls[2] == pytest.approx(24.0)
-        assert sleep_calls[3] == pytest.approx(24.0)
-        assert sleep_calls[4] == pytest.approx(24.0)
+        # After each idle tick, sleep doubles: 6, 12, 24, 24 (cap at 8x), 24.
+        # ``_pace`` is the loop's own seam, so this list is the schedule and
+        # nothing else - no sleep performed elsewhere in the process can
+        # enter it.
+        assert sleep_calls == [
+            pytest.approx(6.0),
+            pytest.approx(12.0),
+            pytest.approx(24.0),
+            pytest.approx(24.0),
+            pytest.approx(24.0),
+        ]
 
     def test_active_tick_resets_sleep_to_poll_interval(self, tmp_path: Path, monkeypatch: object) -> None:
         orch = self._make_orch(tmp_path, poll_interval_s=3)
         sleep_calls: list[float] = []
-        import bernstein.core.orchestrator as _orch_mod
 
-        monkeypatch.setattr(_orch_mod.time, "sleep", lambda s: sleep_calls.append(float(s)))
+        monkeypatch.setattr(orch, "_pace", lambda s: sleep_calls.append(float(s)))
 
         call_count = 0
 
@@ -5962,16 +5964,43 @@ class TestAdaptivePollingBackoff:
 
         # tick 1 (idle) → sleep 6, tick 2 (idle) → sleep 12,
         # tick 3 (active, resets) → sleep 3, tick 4 (idle, stops loop) → sleep 6
-        #
-        # By index rather than by equality on the whole list, the way the
-        # sibling test above already does it. `time.sleep` is one object
-        # shared by the whole process, so patching it here records every
-        # sleep anything performs while `run()` is on the stack - including
-        # a lock-acquire loop in the post-loop path, which under a
-        # no-op sleep spins its full real-time deadline and appended six
-        # thousand entries. The subject of this test is the polling
-        # schedule the loop chooses, and that is the first four.
-        assert sleep_calls[:4] == [6.0, 12.0, 3.0, 6.0]
+        assert sleep_calls == [6.0, 12.0, 3.0, 6.0]
+
+    def test_pacing_record_excludes_sleeps_the_loop_did_not_perform(self, tmp_path: Path, monkeypatch: object) -> None:
+        """A sleep performed by anything else must not read as a pacing decision.
+
+        ``time.sleep`` is one function object for the whole process. Before the
+        loop had its own seam, a test that patched it recorded every sleep any
+        code performed while ``run()`` was on the stack - CPython reaps a
+        finished subprocess with a 1ms/2ms/4ms/8ms busy-wait, so on a machine
+        where a startup subprocess outlived the first tick those four values
+        were the first four entries and the schedule assertions read them
+        instead of the loop's own. Here a tick sleeps like that on purpose: the
+        record must still hold only what the loop paced.
+        """
+        orch = self._make_orch(tmp_path, poll_interval_s=3)
+        paced: list[float] = []
+        monkeypatch.setattr(orch, "_pace", lambda s: paced.append(float(s)))
+
+        call_count = 0
+
+        def fake_tick() -> TickResult:
+            nonlocal call_count
+            call_count += 1
+            # Stands in for CPython's subprocess reaping busy-wait.
+            for delay in (0.001, 0.002, 0.004, 0.008):
+                time.sleep(delay)
+            if call_count >= 2:
+                orch._running = False
+            return TickResult()
+
+        monkeypatch.setattr(orch, "tick", fake_tick)
+        monkeypatch.setattr(orch, "_has_active_agents", lambda: False)
+        monkeypatch.setattr(orch, "_drain_before_cleanup", lambda: None)
+        monkeypatch.setattr(orch, "_cleanup", lambda: None)
+        orch.run()
+
+        assert paced == [pytest.approx(6.0), pytest.approx(12.0)]
 
     def test_idle_multiplier_field_exists(self, tmp_path: Path) -> None:
         orch = self._make_orch(tmp_path)


### PR DESCRIPTION
## The failure

`main` is red, and so is every open PR that lands `tests/unit/test_orchestrator.py` in its shard:

```
FAILED tests/unit/test_orchestrator.py::TestAdaptivePollingBackoff::test_active_tick_resets_sleep_to_poll_interval
E   assert [0.001, 0.002, 0.004, 0.008] == [6.0, 12.0, 3.0, 6.0]
```

Those values are not a broken schedule. `time.sleep` is one function object shared by the whole process, so patching it records every sleep **anything** performs while `run()` is on the stack. CPython reaps a finished subprocess with a busy-wait that starts at 500µs and doubles before each sleep — 1ms, 2ms, 4ms, 8ms. The run loop's startup path shells out, and on a machine where one of those subprocesses outlives the first tick, its reaping sleeps occupy the first four slots of the record. The assertion then compares the polling schedule against the reaper's backoff.

The `[:4]` prefix the test uses today does not help: the foreign sleeps arrive *before* the loop's first pacing sleep, so the prefix is exactly the wrong four values.

Reproduced deterministically by making a tick perform sleeps in that shape — the failure text comes out identical to CI's, character for character.

## The change

The run loop's three sleeps go through `Orchestrator._pace`. A test patches that seam, so the record holds the schedule the loop chose and nothing else. No behaviour change: `_pace` calls `time.sleep`.

## Tests

- Both pacing tests assert on the full recorded list again (`== [6.0, 12.0, 3.0, 6.0]`, and the five idle values) instead of a prefix.
- New `test_pacing_record_excludes_sleeps_the_loop_did_not_perform` performs subprocess-shaped sleeps inside a tick and asserts they never enter the record — the failure path executes rather than being described.
- `tests/unit/test_orchestrator.py`: 228 passed. `tests/unit/orchestration/`: 645 passed.
