### PR TITLE
chore: ignore run-local web-research notes at the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,8 @@ REVIEW-*.md
 
 # Qwen Code internal files (never part of the repo)
 *.qwen*.json
+
+# Web-research notes an orchestrated run writes beside the checkout while it
+# works. They are inputs to one run, not part of the tree; one of them was
+# committed by an agent pass and would have shipped in the pull request.
+/web-research/

--- a/scripts/gen_distribution_manifests.py
+++ b/scripts/gen_distribution_manifests.py
@@ -108,8 +108,6 @@ def _load_vendored_schema(filename: str) -> dict[str, object]:
     return schema
 
 
-
-
 def _require_schema_valid(document: object, schema_file: str, manifest_name: str) -> None:
     """Raise :class:`ManifestValidationError` if *document* violates the vendored schema."""
     schema = _load_vendored_schema(schema_file)


### PR DESCRIPTION
An orchestrated run writes web-research notes beside the checkout while it works. The directory is not ignored, so an agent pass committed one of those notes onto its branch (`web-research/20260831T082206-...RES.md`) — it would have shipped in the pull request as if it were part of the change.

Same shape as the `/task*.json` and `/verdicts.json` entries already at the bottom of the file, and the same fix: ignore it at the repo root only, so a real file with that name elsewhere in the tree is unaffected.
