### PR TITLE
refactor(orchestrator): delete the dead second run loop left by ORCH-009

### DIFF
--- a/src/bernstein/core/orchestration/orchestrator_run.py
+++ b/src/bernstein/core/orchestration/orchestrator_run.py
@@ -1,262 +1,28 @@
-"""Orchestrator run loop: startup, main loop, and shutdown coordination.
+"""Scheduled dependency-scan helpers for the orchestrator.
 
-Extracted from orchestrator.py as part of ORCH-009 decomposition.
-Functions here operate on an Orchestrator instance passed as the first
-argument, keeping the Orchestrator class as the public facade.
+This module was opened by the ORCH-009 decomposition to hold the run loop,
+with ``Orchestrator`` kept as the public facade. The extraction landed; the
+delegation never did, so ``Orchestrator.run()`` kept its own copy and nothing
+ever called the one here.
+
+A dead duplicate would have been harmless if it had stayed identical. It did
+not: the copy here hardcoded the failure ceiling the live loop reads from
+config, never recorded ``RunClosureOutcome.FAILED``, and - after #4872 gave the
+live loop a ``_pace`` seam - still paced with a bare ``time.sleep``. The
+repository held both a bug and its fix, with only one of them reachable.
+Removed in #4882; the run loop lives in ``Orchestrator.run()``, and there is
+one of it.
+
+What remains here is the scheduled dependency-scan path, which is live and is
+reached through these module-level helpers.
 """
 
 from __future__ import annotations
 
 import logging
-import time
-from typing import TYPE_CHECKING, Any
-
-from bernstein.core.task_lifecycle import (
-    collect_completion_data,
-)
-
-if TYPE_CHECKING:
-    from bernstein.core.models import (
-        AgentSession,
-    )
-    from bernstein.core.orchestration.tick_pipeline import (
-        CompletionData,
-    )
+from typing import Any
 
 logger = logging.getLogger(__name__)
-
-
-def run(orch: Any) -> None:
-    """Run the orchestrator loop until stopped.
-
-    Blocks the calling thread. Call ``stop()`` from another thread or
-    a signal handler to break the loop. Individual tick failures are
-    caught and logged so a single bad tick cannot kill the loop.
-
-    Args:
-        orch: The orchestrator instance.
-
-    Raises:
-        SystemExit(2): If the stalled-manager detector (#1261) tripped during
-            the run. The orchestrator drains and persists state first; the
-            non-zero exit makes the failure visible to the parent CLI without
-            having to grep the orchestrator log.
-    """
-    _run_startup(orch)
-    _run_loop(orch)
-    _run_shutdown(orch)
-    diagnostic = getattr(orch, "_stalled_manager_diagnostic", None)
-    if diagnostic is not None:
-        raise SystemExit(2)
-
-
-def _run_startup(orch: Any) -> None:
-    """Initialise the orchestrator before the first tick."""
-    orch._running = True
-    logger.info(
-        "Orchestrator started (poll=%ds, max_agents=%d, server=%s)",
-        orch._config.poll_interval_s,
-        orch._config.max_agents,
-        orch._config.server_url,
-    )
-    if orch._heartbeat_client is not None:
-        orch._heartbeat_client.start()
-        logger.info("Cluster heartbeat client started")
-    orch._post_bulletin("status", "run started")
-    orch._notify("run.started", "Bernstein run started", "Agents are being spawned.")
-    orch._reconcile_claimed_tasks()
-    _record_run_started(orch)
-    _recover_wal(orch)
-    _verify_audit_integrity(orch)
-    _cleanup_zombies(orch)
-
-
-def _record_run_started(orch: Any) -> None:
-    """Record the run_started event."""
-    extra: dict[str, object] = {}
-    if orch._workflow_executor is not None:
-        extra["workflow_name"] = orch._workflow_executor.definition.name
-        extra["workflow_hash"] = orch._workflow_executor.definition_hash
-    orch._recorder.record(
-        "run_started",
-        run_id=orch._run_id,
-        max_agents=orch._config.max_agents,
-        budget_usd=orch._config.budget_usd,
-        git_sha=orch._replay_metadata.git_sha,
-        git_branch=orch._replay_metadata.git_branch,
-        config_hash=orch._replay_metadata.config_hash,
-        **extra,
-    )
-    try:
-        from bernstein.core.orchestration.run_closure_owner import write_spawner_run_owner
-
-        write_spawner_run_owner(
-            sdd_dir=orch._workdir / ".sdd",
-            run_id=orch._run_id,
-            journal_head=orch._recorder.fingerprint(),
-            journal_event_count=orch._recorder.event_count(),
-        )
-    except OSError as exc:
-        logger.warning("Run owner record not written for %s: %s", orch._run_id, exc)
-
-
-def _recover_wal(orch: Any) -> None:
-    """WAL recovery: detect uncommitted entries from crashed previous runs."""
-    try:
-        orch._recover_from_wal()
-    except Exception:
-        logger.exception("WAL recovery failed (non-fatal) - continuing startup")
-
-
-def _verify_audit_integrity(orch: Any) -> None:
-    """Audit log integrity check: verify the last N HMAC-chained entries."""
-    try:
-        from bernstein.core.audit_integrity import verify_on_startup
-
-        _integrity = verify_on_startup(orch._workdir / ".sdd")
-        if not _integrity.valid:
-            logger.warning(
-                "Audit integrity check found %d error(s) - review with 'bernstein audit verify'",
-                len(_integrity.errors),
-            )
-        elif _integrity.entries_checked > 0:
-            logger.info(
-                "Audit integrity OK (%d entries verified in %.1fms)",
-                _integrity.entries_checked,
-                _integrity.duration_ms,
-            )
-    except Exception:
-        logger.exception("Audit integrity check failed (non-fatal) - continuing startup")
-
-
-def _cleanup_zombies(orch: Any) -> None:
-    """Terminate orphaned agent processes from prior crashed runs."""
-    try:
-        from bernstein.core.zombie_cleanup import scan_and_cleanup_zombies
-
-        _zr = scan_and_cleanup_zombies(orch._workdir)
-        if _zr.orphans_found:
-            logger.info(
-                "Zombie cleanup: found=%d killed=%d stale=%d errors=%d",
-                _zr.orphans_found,
-                _zr.orphans_killed,
-                _zr.stale_removed,
-                len(_zr.errors),
-            )
-    except Exception:
-        logger.exception("Zombie cleanup failed (non-fatal) - continuing startup")
-
-
-def _run_loop(orch: Any) -> None:
-    """Execute the main tick loop."""
-    consecutive_failures = 0
-    max_consecutive_failures = 10
-
-    from bernstein.core.orchestration.orchestrator import TickResult  # noqa: TC001
-
-    while orch._running or _has_active_agents(orch):
-        tick_result: TickResult | None = None
-        try:
-            tick_result = orch.tick()
-            consecutive_failures = 0
-        except Exception:
-            consecutive_failures += 1
-            logger.exception(
-                "Tick %d failed (%d consecutive failures)",
-                orch._tick_count,
-                consecutive_failures,
-            )
-            if consecutive_failures >= max_consecutive_failures:
-                logger.error("Stopping after %d consecutive tick failures", consecutive_failures)
-                break
-        if orch._config.dry_run:
-            break
-        _adaptive_sleep(orch, tick_result)
-        orch._maybe_reload_config()
-        if _check_restart_needed(orch):
-            return
-
-
-def _adaptive_sleep(orch: Any, tick_result: Any) -> None:
-    """Sleep with adaptive backoff based on tick activity."""
-    server_failures = getattr(orch, "_consecutive_server_failures", 0)
-    if server_failures > 0:
-        time.sleep(min(5.0 * server_failures, 30.0))
-    elif tick_result is not None and (
-        tick_result.spawned or tick_result.verified or tick_result.retried or tick_result.open_tasks > 0
-    ):
-        orch._idle_multiplier = 1
-        time.sleep(orch._config.poll_interval_s)
-    else:
-        orch._idle_multiplier = min(orch._idle_multiplier * 2, 8)
-        time.sleep(min(orch._config.poll_interval_s * orch._idle_multiplier, 30.0))
-
-
-def _check_restart_needed(orch: Any) -> bool:
-    """Check if the orchestrator should restart (code change or flag file)."""
-    restart_flag = orch._workdir / ".sdd" / "runtime" / "restart_requested"
-    needs_restart = False
-    if restart_flag.exists():
-        restart_flag.unlink(missing_ok=True)
-        needs_restart = True
-    elif orch._config.evolve_mode and orch._check_source_changed():
-        needs_restart = True
-
-    if needs_restart:
-        logger.info("Restarting orchestrator (own code updated)")
-        orch._save_session_state()
-        orch._restart()
-        return True
-    return False
-
-
-def _run_shutdown(orch: Any) -> None:
-    """Drain active agents and clean up."""
-    orch._drain_before_cleanup()
-    orch._cleanup()
-    orch._post_bulletin("status", "run stopped")
-    orch._recorder.record(
-        "run_completed",
-        run_id=orch._run_id,
-        ticks=orch._tick_count,
-        fingerprint=orch._recorder.fingerprint(),
-        outcome=getattr(orch, "_closure_outcome", "completed"),
-    )
-    orch._seal_journal_into_lineage_spine()
-    orch._write_run_closure()
-    logger.info(
-        "Orchestrator stopped (replay: %s, fingerprint: %s)",
-        orch._recorder.path,
-        orch._recorder.fingerprint()[:16] + "...",
-    )
-
-
-def _has_active_agents(orch: Any) -> bool:
-    """Return True if any agents are still alive (not dead).
-
-    Args:
-        orch: The orchestrator instance.
-
-    Returns:
-        True if at least one agent is alive.
-    """
-    alive = sum(1 for s in orch._agents.values() if s.status != "dead")
-    if alive > 0 and not orch._running:
-        logger.info("Orchestrator draining: %d agent(s) still active", alive)
-    return alive > 0
-
-
-def _collect_completion_data(orch: Any, session: AgentSession) -> CompletionData:
-    """Delegate to task_lifecycle.collect_completion_data.
-
-    Args:
-        orch: The orchestrator instance.
-        session: The agent session whose completion data to collect.
-
-    Returns:
-        CompletionData for the session.
-    """
-    return collect_completion_data(orch._workdir, session)
 
 
 def _run_scheduled_dependency_scan(orch: Any) -> None:

--- a/src/bernstein/core/orchestration/stalled_manager.py
+++ b/src/bernstein/core/orchestration/stalled_manager.py
@@ -488,7 +488,7 @@ def handle_stalled_manager(orch: Any) -> StalledManagerDiagnostic | None:
     Returns the diagnostic on detection (also written to logs + failures dir);
     returns ``None`` when no stall is present. Setting ``_running = False`` on
     the orchestrator triggers the existing clean-drain path in
-    ``orchestrator_run._run_loop`` - no generic-watchdog kill is required.
+    ``Orchestrator.run`` - no generic-watchdog kill is required.
     """
     # Avoid emitting the same diagnostic on every tick.
     if getattr(orch, "_stalled_manager_emitted", False):

--- a/tests/unit/test_one_run_loop.py
+++ b/tests/unit/test_one_run_loop.py
@@ -1,0 +1,83 @@
+"""There is exactly one orchestrator run loop, and it paces through one seam.
+
+ORCH-009 opened ``orchestrator_run.py`` to hold the run loop, with
+``Orchestrator`` as the public facade. The extraction landed and the delegation
+did not, so two loops existed and only one ran. The dead one then drifted: it
+hardcoded the failure ceiling the live loop reads from config, never recorded
+``RunClosureOutcome.FAILED``, and kept a bare ``time.sleep`` after #4872 gave
+the live loop its ``_pace`` seam - so the repository held both a bug and its
+fix, with only the bug's fix unreachable.
+
+Deleting the duplicate is not self-enforcing: the next decomposition can
+recreate it, and nothing would notice for as long as nothing called it. These
+tests pin the two properties that made the drift expensive - one loop, and one
+pacing seam on it.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from pathlib import Path
+
+from bernstein.core.orchestration import orchestrator_run
+from bernstein.core.orchestration.orchestrator import Orchestrator
+
+ORCHESTRATION_DIR = Path(orchestrator_run.__file__).resolve().parent
+
+
+def test_the_run_loop_module_holds_no_second_loop() -> None:
+    """``orchestrator_run`` must not reacquire a run loop or its parts.
+
+    Named individually rather than as "no public functions" because the module
+    legitimately keeps the dependency-scan helpers; the loop is the part that
+    must not come back.
+    """
+    resurrected = [
+        name
+        for name in ("run", "_run_loop", "_adaptive_sleep", "_run_startup", "_run_shutdown")
+        if hasattr(orchestrator_run, name)
+    ]
+    assert not resurrected, (
+        f"orchestrator_run has regrown run-loop functions {resurrected}. The loop lives in "
+        "Orchestrator.run(); a second copy drifts silently because nothing calls it."
+    )
+
+
+def test_orchestrator_run_paces_through_the_seam_and_never_sleeps_directly() -> None:
+    """``Orchestrator.run`` must reach ``time.sleep`` only via ``_pace``.
+
+    ``time.sleep`` is one object shared by the whole process, so a test that
+    patches it sees every sleep taken while ``run()`` is on the stack. #4872
+    routed the loop's own pacing through ``_pace`` so the schedule could be
+    observed on its own; a direct call added later silently reopens that.
+    """
+    # dedent: getsource on a method returns it at class indentation, which ast rejects
+    tree = ast.parse(textwrap.dedent(inspect.getsource(Orchestrator.run)))
+    direct = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "sleep"
+    ]
+    assert not direct, (
+        f"Orchestrator.run calls time.sleep directly at offset(s) {direct}; pace through "
+        "self._pace() so a test can observe the loop's own schedule and nothing else."
+    )
+
+
+def test_no_module_in_orchestration_defines_a_rival_adaptive_sleep() -> None:
+    """The adaptive-backoff schedule must have one definition.
+
+    Two copies is how the ceiling and the closure outcome drifted apart in the
+    first place: each fix landed in whichever copy its author was reading.
+    """
+    definitions: list[str] = []
+    for path in sorted(ORCHESTRATION_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "_adaptive_sleep":
+                definitions.append(f"{path.name}:{node.lineno}")
+    assert not definitions, f"rival adaptive-sleep definition(s): {definitions}"


### PR DESCRIPTION
## What

Removes the unreachable run loop in `orchestrator_run.py` — 209 of its 306 lines — leaving exactly one orchestrator run loop.

Fixes #4882, which has the full evidence. The decision it asks you for is **delete vs. complete ORCH-009**; this PR is the delete option, and I am happy to throw it away and write the other one if you prefer.

## Why this is not tidiness

The duplicate had drifted, and in three ways that matter:

| | `Orchestrator.run()` (live) | the copy this deletes |
|---|---|---|
| failure ceiling | `ORCHESTRATOR.max_consecutive_failures` | hardcoded `10` |
| on giving up | sets `_closure_outcome = RunClosureOutcome.FAILED` | never set |
| pacing | `self._pace(...)` | bare `time.sleep(...)` |

The last row is the one that made me look. #4872 added `_pace()` so a test could watch the loop's own schedule rather than every sleep taken while `run()` is on the stack. That fix landed in the live copy; the dead copy still calls `time.sleep`. So the repository contained both the bug and its fix, and only one of them was reachable.

The first two are worse in kind — a run-closure outcome that is never recorded and a config knob silently ignored. Anyone who completed the delegation the docstring promised would have shipped all three at once, and the config one would have looked like a bug in the config system.

## How

Deleted the twelve unreachable functions. Kept the three dependency-scan helpers, which are live, reached through this module, and covered by `test_dependency_scan_tasks.py`.

Two of the deleted names look referenced and are not: every external reference to `_has_active_agents` and `_collect_completion_data` resolves to the identically-named **`Orchestrator` methods** (`orchestrator.py:3482`, `:4833`). I checked each of the twelve individually rather than trusting a name grep, which is exactly what would have gone wrong here.

`stalled_manager.py:491` explained real drain behaviour by pointing at `orchestrator_run._run_loop` — a reader following that reference was reading code that could not execute. It now names `Orchestrator.run`.

The module docstring no longer claims a decomposition that did not happen; it records what the module is now and why the loop is not in it.

## Tests

`tests/unit/test_one_run_loop.py`, three guards — because deleting this is not self-enforcing. The next decomposition can recreate it, and nothing would notice for as long as nothing called it, which is precisely how it survived this long.

- `orchestrator_run` has not regrown `run` / `_run_loop` / `_adaptive_sleep` / `_run_startup` / `_run_shutdown`. Named individually rather than "no public functions", since the module legitimately keeps the scan helpers.
- `Orchestrator.run` reaches `time.sleep` only through `_pace` — parsed from its AST, so a direct call added later fails here instead of silently reopening #4872.
- No module under `core/orchestration/` defines a second `_adaptive_sleep`. Two copies is how the ceiling and the closure outcome drifted apart: each fix landed in whichever copy its author happened to be reading.

Two of the three are confirmed red before the deletion.

## Checklist

- [x] `ruff check src/` passes (and `ruff format`)
- [ ] `pyright src/` — not run clean, and not by this change; the repo-wide advisory scope is red on `main` (see #4864). This PR only deletes from `src/`, and the file it leaves behind is `ruff`-clean with no unused imports.
- [x] `scripts/run_tests.py`: **276 passed** across `test_one_run_loop` (3), `test_dependency_scan_tasks` (15), `test_stalled_manager` (30), `test_orchestrator` (228)
- [x] New code has type hints

### Documentation duty

- [x] README — N/A, internal structure
- [x] `docs/operations/` — N/A, no operator-facing behaviour changes; the live loop is untouched
- [x] `docs/api/` — N/A, nothing public; every deleted name was module-private or unreferenced
- [x] `agents-md sync` — N/A, no new module (one shrinks)
- [x] Tests cover the documented behaviour

One note on blast radius: this PR does not touch `Orchestrator.run()` at all. Every deleted line was proven unreachable first, so the running system is bit-for-bit what it was — which is also why the guards, rather than the deletion, are the durable part of this change.