### PR TITLE
feat(ci): fail when a touched test module loses collected cases (#4873)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -520,6 +520,25 @@ jobs:
         run: |
           uv run python scripts/render_tui_snapshot.py
           uv run python scripts/bind_webui_renders.py
+      - name: Test-count drop vs merge base (#4873)
+        # Catches a touched test module that still collects but lost cases
+        # relative to the merge base. Parametrized consolidation stays green
+        # (collect-only counts). Override via PR body:
+        #   test-count-drop: tests/unit/foo.py -N
+        # Without a base (non-PR / missing ref) the script skips — never fake-green.
+        env:
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
+          BASE_REF: ${{ github.base_ref || 'main' }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          BASE=""
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            git fetch --no-tags origin "refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}" || true
+            BASE="$(git merge-base "origin/${BASE_REF}" HEAD 2>/dev/null || true)"
+          elif [ "$EVENT_NAME" = "merge_group" ]; then
+            BASE="${{ github.event.merge_group.base_sha }}"
+          fi
+          uv run python scripts/check_test_count_drop.py --base "${BASE}"
 
   lint:
     name: Lint

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -50,10 +50,14 @@ storage, unavailable or throwing browser APIs, inaccessible document roots,
 and the matching `ThemeProvider` storage fallback. They do not start a web
 server or make network requests.
 
-## Test-count drop vs merge base (#4873)
+Test-count drop vs merge base (#4873)
 
 Repo hygiene compares `pytest --collect-only` counts for every touched
-`test_*.py` / `*_test.py` against the merge base. A drop fails the job.
+`test_*.py` / `*_test.py` against the merge base. A drop fails the job
+outright (no committed ratchet baseline — overrides are the escape hatch).
+
+Outcome words are distinct: `OK` means compared and clean; `NOT_RUN` means
+no merge base so the guard never compared (not a clean bill of health).
 
 Parametrized consolidation (N cases → one `@pytest.mark.parametrize` with N
 values) keeps the collected count stable and stays green. Intentional drops
@@ -64,7 +68,9 @@ test-count-drop: tests/unit/foo/test_bar.py -3
 ```
 
 Unused overrides fail (stale). A deleted test whose matching `src/**/<stem>.py`
-was also deleted is carved out. Locally:
+was also deleted is carved out. An import failure under collect-only is named
+`cause=import_error` in the message so it is not mistaken for a silent count
+drop. Locally:
 
 ```bash
 uv run python scripts/check_test_count_drop.py --base origin/main

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -29,6 +29,7 @@ locally without waiting for the cloud runner.
 | **diff-cover** (LEVEL 1)    | Changed lines below the committed diff-coverage floor             | PR (advisory)       |
 | **coverage ratchet** (LEVEL 2) | Total coverage dropped below the committed high-water mark      | push to main (advisory) |
 | **import-linter**           | Architecture-contract violations (cross-package imports)          | PR                  |
+| **test-count drop** (#4873) | Touched test module lost collected cases vs merge base            | PR (Repo hygiene)   |
 | **No-network guard**        | Unit tests that open a real outbound connection (flaky by design) | PR (every unit run) |
 | **Spawned-process identity race** | Duplicate run identities hidden by thread-only locking      | PR (identity anchor unit suite) |
 | **ruff** + **typos**        | Lint, format drift, common typos                                  | PR                  |
@@ -48,6 +49,27 @@ isolated VM contexts. They cover stored and system theme resolution, blocked
 storage, unavailable or throwing browser APIs, inaccessible document roots,
 and the matching `ThemeProvider` storage fallback. They do not start a web
 server or make network requests.
+
+## Test-count drop vs merge base (#4873)
+
+Repo hygiene compares `pytest --collect-only` counts for every touched
+`test_*.py` / `*_test.py` against the merge base. A drop fails the job.
+
+Parametrized consolidation (N cases → one `@pytest.mark.parametrize` with N
+values) keeps the collected count stable and stays green. Intentional drops
+need a PR-body override a reviewer can see:
+
+```text
+test-count-drop: tests/unit/foo/test_bar.py -3
+```
+
+Unused overrides fail (stale). A deleted test whose matching `src/**/<stem>.py`
+was also deleted is carved out. Locally:
+
+```bash
+uv run python scripts/check_test_count_drop.py --base origin/main
+uv run python scripts/check_test_count_drop.py --base origin/main --pr-body "$(gh pr view --json body -q .body)"
+```
 
 ## Run any of the above locally
 

--- a/docs/release-notes/fragments/4873-test-count-drop.md
+++ b/docs/release-notes/fragments/4873-test-count-drop.md
@@ -1,0 +1,1 @@
+CI fails when a touched test module loses collected cases vs the merge base, with a reviewable per-module PR-body override (#4873).

--- a/scripts/check_test_count_drop.py
+++ b/scripts/check_test_count_drop.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Fail when a touched test module loses collected cases vs the merge base (#4873).
+
+The zero-collection guard (#4834) catches a module emptied to nothing. This
+check catches the residual shape: a module that still collects, but fewer
+items than at the merge base.
+
+Counts come from ``pytest --collect-only``, not AST ``def test_*`` counts, so
+folding N one-off cases into one ``@pytest.mark.parametrize`` with N values
+keeps the collected count stable and stays green without an override.
+
+Override (PR body, reviewable)::
+
+    test-count-drop: tests/unit/foo/test_bar.py -3
+
+Allow that path's collected count to fall by **at most** 3. Overrides that
+name a module with no drop are stale and fail the check. There is no
+path-less global budget.
+
+A deleted test module whose matching subject under ``src/`` was also deleted
+in the same diff is carved out. Needs ``--base`` (CI merge base); without a
+base the check skips with a clear message rather than a fake green.
+
+Usage::
+
+    python scripts/check_test_count_drop.py --base origin/main
+    python scripts/check_test_count_drop.py --base "$BASE" --pr-body "$PR_BODY"
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+OVERRIDE_RE = re.compile(
+    r"(?m)^[ \t]*test-count-drop:[ \t]+(\S+)[ \t]+-(\d+)[ \t]*$",
+)
+_TEST_NAME_RE = re.compile(r"^(?:test_(.+)|(.+)_test)$")
+
+
+@dataclass
+class DropReport:
+    """Result of comparing collected counts for touched test modules."""
+
+    drops: list[tuple[str, int, int]] = field(default_factory=list)  # path, base, head
+    excused: list[tuple[str, int, int, int]] = field(default_factory=list)  # path, base, head, allowed
+    carved: list[str] = field(default_factory=list)
+    stale_overrides: list[str] = field(default_factory=list)
+    skipped: str | None = None
+    checked: int = 0
+
+
+def is_test_module(path: str) -> bool:
+    """Return True when *path* matches pytest's default ``python_files`` under tests/."""
+    posix = path.replace("\\", "/")
+    if not posix.startswith("tests/"):
+        return False
+    name = Path(posix).name
+    if name in {"conftest.py", "__init__.py"}:
+        return False
+    if name.startswith("test_") and name.endswith(".py"):
+        return True
+    return name.endswith("_test.py")
+
+
+def parse_overrides(pr_body: str) -> dict[str, int]:
+    """Parse per-module ``test-count-drop: <path> -<N>`` lines from a PR body."""
+    found: dict[str, int] = {}
+    for match in OVERRIDE_RE.finditer(pr_body or ""):
+        rel = match.group(1).replace("\\", "/")
+        found[rel] = int(match.group(2))
+    return found
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def changed_paths(repo: Path, base: str, head: str = "HEAD") -> tuple[set[str], set[str], set[str]]:
+    """Return (modified, deleted, added) repo-relative paths for ``base...head``."""
+    out = _git(repo, "diff", "--name-status", f"{base}...{head}")
+    modified: set[str] = set()
+    deleted: set[str] = set()
+    added: set[str] = set()
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        status = parts[0]
+        if status.startswith("R") and len(parts) >= 3:
+            deleted.add(parts[1].replace("\\", "/"))
+            added.add(parts[2].replace("\\", "/"))
+            continue
+        if status.startswith("C") and len(parts) >= 3:
+            added.add(parts[2].replace("\\", "/"))
+            continue
+        path = parts[-1].replace("\\", "/")
+        if status.startswith("D"):
+            deleted.add(path)
+        elif status.startswith("A"):
+            added.add(path)
+        else:
+            modified.add(path)
+    return modified, deleted, added
+
+
+def subject_stem(test_path: str) -> str | None:
+    """Return the production-module stem implied by a test path, if any."""
+    match = _TEST_NAME_RE.match(Path(test_path).stem)
+    if match is None:
+        return None
+    return match.group(1) or match.group(2)
+
+
+def subject_deleted(test_path: str, deleted_paths: set[str]) -> bool:
+    """True when a matching ``src/**/<stem>.py`` was deleted in the same diff."""
+    stem = subject_stem(test_path)
+    if not stem:
+        return False
+    needle = f"/{stem}.py"
+    return any(
+        path.startswith("src/") and (path.endswith(needle) or path == f"src/{stem}.py") for path in deleted_paths
+    )
+
+
+def pytest_collect_count(path: Path, *, python: str = sys.executable, cwd: Path | None = None) -> int:
+    """Return how many items pytest collects from *path*."""
+    result = subprocess.run(
+        [
+            python,
+            "-m",
+            "pytest",
+            str(path),
+            "--collect-only",
+            "-q",
+            "--no-header",
+            "--no-cov",
+        ],
+        cwd=cwd or path.parent,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    blob = f"{result.stdout}\n{result.stderr}"
+    if re.search(r"\bno tests collected\b", blob, re.IGNORECASE):
+        return 0
+    match = re.search(r"(\d+)\s+tests?\s+collected", blob, re.IGNORECASE)
+    if match:
+        return int(match.group(1))
+    # pytest -q lists one node id per line when collection succeeds without a
+    # summary line (or with an older summary format).
+    lines = [
+        line
+        for line in result.stdout.splitlines()
+        if line.strip() and not line.startswith("=") and "collected" not in line.lower()
+    ]
+    return len(lines)
+
+
+def collect_count_at_revision(
+    repo: Path,
+    rev: str,
+    rel_path: str,
+    *,
+    python: str = sys.executable,
+) -> int | None:
+    """Collect-count for ``rel_path`` as it existed at *rev*, or ``None`` if absent."""
+    show = subprocess.run(
+        ["git", "show", f"{rev}:{rel_path}"],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+    )
+    if show.returncode != 0:
+        return None
+    with tempfile.TemporaryDirectory(prefix="bernstein-test-count-") as tmp:
+        target = Path(tmp) / Path(rel_path).name
+        target.write_bytes(show.stdout)
+        # Isolate from the live tree's conftest by collecting in the temp dir.
+        return pytest_collect_count(target, python=python, cwd=Path(tmp))
+
+
+def collect_count_at_head(repo: Path, rel_path: str, *, python: str = sys.executable) -> int | None:
+    """Collect-count for ``rel_path`` in the working tree, or ``None`` if missing."""
+    path = repo / rel_path
+    if not path.is_file():
+        return None
+    return pytest_collect_count(path, python=python, cwd=repo)
+
+
+def build_report(
+    repo: Path,
+    *,
+    base: str | None,
+    head: str = "HEAD",
+    pr_body: str = "",
+    python: str = sys.executable,
+) -> DropReport:
+    """Compare collected counts for test modules touched between *base* and *head*."""
+    report = DropReport()
+    if not base:
+        report.skipped = "no merge base (--base); skip rather than fake-green"
+        return report
+
+    overrides = parse_overrides(pr_body)
+    modified, deleted, added = changed_paths(repo, base, head)
+    touched = {p for p in (modified | deleted | added) if is_test_module(p)}
+    report.checked = len(touched)
+
+    consumed: set[str] = set()
+    for rel in sorted(touched):
+        base_count = collect_count_at_revision(repo, base, rel, python=python)
+        head_count = collect_count_at_head(repo, rel, python=python)
+        if base_count is None:
+            continue  # new test module at head — not a drop
+        head_n = 0 if head_count is None else head_count
+        if head_n >= base_count:
+            continue
+        drop = base_count - head_n
+        if head_count is None and subject_deleted(rel, deleted):
+            report.carved.append(rel)
+            continue
+        allowed = overrides.get(rel)
+        if allowed is not None:
+            consumed.add(rel)
+            if drop <= allowed:
+                report.excused.append((rel, base_count, head_n, allowed))
+                continue
+            # Override too small for the actual drop — still a failure.
+            report.drops.append((rel, base_count, head_n))
+            continue
+        report.drops.append((rel, base_count, head_n))
+
+    for rel, allowed in sorted(overrides.items()):
+        if rel not in consumed:
+            # Stale: named a module with no drop (or not in the touched set).
+            report.stale_overrides.append(f"{rel} -{allowed}")
+
+    return report
+
+
+def format_report(report: DropReport) -> str:
+    """Human-readable report for CI logs."""
+    lines: list[str] = []
+    if report.skipped:
+        lines.append(f"SKIP: {report.skipped}")
+        return "\n".join(lines)
+    if report.drops:
+        lines.append("Test modules lost collected cases vs merge base (issue #4873):")
+        for rel, base_n, head_n in report.drops:
+            lines.append(f"  {rel}: {base_n} -> {head_n} (drop {base_n - head_n})")
+        lines.append(
+            "Restore the cases, consolidate via parametrize (collected count must stay "
+            "stable), carve out a deleted subject, or add a PR-body override: "
+            "`test-count-drop: <path> -<N>`."
+        )
+    if report.stale_overrides:
+        lines.append("Stale test-count-drop overrides (no drop for that path):")
+        for entry in report.stale_overrides:
+            lines.append(f"  {entry}")
+    if report.excused:
+        lines.append("Overrides consumed:")
+        for rel, base_n, head_n, allowed in report.excused:
+            lines.append(f"  {rel}: {base_n} -> {head_n} (allowed -{allowed})")
+    if report.carved:
+        lines.append("Deleted test modules carved out (subject also deleted):")
+        for rel in report.carved:
+            lines.append(f"  {rel}")
+    if not report.drops and not report.stale_overrides:
+        lines.append(f"OK: {report.checked} touched test modules; no unexplained collection drops.")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default=os.environ.get("TEST_COUNT_DROP_BASE", ""), help="Merge-base SHA or ref")
+    parser.add_argument("--head", default="HEAD", help="Head ref (default HEAD)")
+    parser.add_argument(
+        "--pr-body",
+        default=os.environ.get("PR_BODY", ""),
+        help="PR body text (or set PR_BODY); used for test-count-drop overrides",
+    )
+    parser.add_argument("--root", type=Path, default=REPO_ROOT, help="Repository root")
+    args = parser.parse_args(argv)
+
+    base = args.base.strip() or None
+    report = build_report(args.root, base=base, head=args.head, pr_body=args.pr_body)
+    print(format_report(report))
+    if report.skipped:
+        return 0
+    return 1 if report.drops or report.stale_overrides else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_test_count_drop.py
+++ b/scripts/check_test_count_drop.py
@@ -9,6 +9,19 @@ Counts come from ``pytest --collect-only``, not AST ``def test_*`` counts, so
 folding N one-off cases into one ``@pytest.mark.parametrize`` with N values
 keeps the collected count stable and stays green without an override.
 
+Base and head are collected under the **same** isolated temp environment
+(``git show`` bytes into sibling files, one pytest invocation style) so the
+delta measures the diff, not the ambient tree.
+
+Outcome words (never collapse these)::
+
+    OK       compared touched modules; no unexplained drop
+    NOT_RUN  no merge base — guard did not compare (not a clean bill of health)
+    FAIL     unexplained drop and/or stale override
+
+A module that fails to import collects zero; the message names
+``import_error`` so it is not read as a silent false-positive count drop.
+
 Override (PR body, reviewable)::
 
     test-count-drop: tests/unit/foo/test_bar.py -3
@@ -18,8 +31,10 @@ name a module with no drop are stale and fail the check. There is no
 path-less global budget.
 
 A deleted test module whose matching subject under ``src/`` was also deleted
-in the same diff is carved out. Needs ``--base`` (CI merge base); without a
-base the check skips with a clear message rather than a fake green.
+in the same diff is carved out.
+
+Policy choice: drops fail outright against the merge base (no committed
+ratchet baseline). Stricter on refactors; override is the escape hatch.
 
 Usage::
 
@@ -37,6 +52,7 @@ import sys
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Literal
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -44,17 +60,33 @@ OVERRIDE_RE = re.compile(
     r"(?m)^[ \t]*test-count-drop:[ \t]+(\S+)[ \t]+-(\d+)[ \t]*$",
 )
 _TEST_NAME_RE = re.compile(r"^(?:test_(.+)|(.+)_test)$")
+_IMPORT_ERROR_RE = re.compile(
+    r"(ImportError|ModuleNotFoundError|ERROR collecting|Interrupted:)",
+    re.IGNORECASE,
+)
+
+CollectStatus = Literal["ok", "missing", "import_error"]
+
+
+@dataclass(frozen=True)
+class CollectResult:
+    """One collect-only attempt under the shared isolation environment."""
+
+    status: CollectStatus
+    count: int = 0
+    detail: str = ""
 
 
 @dataclass
 class DropReport:
     """Result of comparing collected counts for touched test modules."""
 
-    drops: list[tuple[str, int, int]] = field(default_factory=list)  # path, base, head
-    excused: list[tuple[str, int, int, int]] = field(default_factory=list)  # path, base, head, allowed
+    # path, base_count, head_count, head_status
+    drops: list[tuple[str, int, int, str]] = field(default_factory=list)
+    excused: list[tuple[str, int, int, int]] = field(default_factory=list)
     carved: list[str] = field(default_factory=list)
     stale_overrides: list[str] = field(default_factory=list)
-    skipped: str | None = None
+    not_run: str | None = None
     checked: int = 0
 
 
@@ -138,8 +170,36 @@ def subject_deleted(test_path: str, deleted_paths: set[str]) -> bool:
     )
 
 
-def pytest_collect_count(path: Path, *, python: str = sys.executable, cwd: Path | None = None) -> int:
-    """Return how many items pytest collects from *path*."""
+def _parse_collect_output(result: subprocess.CompletedProcess[str]) -> CollectResult:
+    """Interpret pytest --collect-only stdout/stderr into a :class:`CollectResult`."""
+    blob = f"{result.stdout}\n{result.stderr}"
+    if result.returncode != 0 and _IMPORT_ERROR_RE.search(blob):
+        snippet = next(
+            (line.strip() for line in blob.splitlines() if line.strip()),
+            "collection failed",
+        )
+        return CollectResult(status="import_error", count=0, detail=snippet[:200])
+    if re.search(r"\bno tests collected\b", blob, re.IGNORECASE):
+        return CollectResult(status="ok", count=0)
+    match = re.search(r"(\d+)\s+tests?\s+collected", blob, re.IGNORECASE)
+    if match:
+        return CollectResult(status="ok", count=int(match.group(1)))
+    if result.returncode != 0:
+        snippet = next(
+            (line.strip() for line in blob.splitlines() if line.strip()),
+            "collection failed",
+        )
+        return CollectResult(status="import_error", count=0, detail=snippet[:200])
+    lines = [
+        line
+        for line in result.stdout.splitlines()
+        if line.strip() and not line.startswith("=") and "collected" not in line.lower()
+    ]
+    return CollectResult(status="ok", count=len(lines))
+
+
+def pytest_collect_file(path: Path, *, python: str, cwd: Path) -> CollectResult:
+    """Run collect-only on *path* with cwd=*cwd* (shared isolation root)."""
     result = subprocess.run(
         [
             python,
@@ -151,35 +211,15 @@ def pytest_collect_count(path: Path, *, python: str = sys.executable, cwd: Path 
             "--no-header",
             "--no-cov",
         ],
-        cwd=cwd or path.parent,
+        cwd=cwd,
         capture_output=True,
         text=True,
         check=False,
     )
-    blob = f"{result.stdout}\n{result.stderr}"
-    if re.search(r"\bno tests collected\b", blob, re.IGNORECASE):
-        return 0
-    match = re.search(r"(\d+)\s+tests?\s+collected", blob, re.IGNORECASE)
-    if match:
-        return int(match.group(1))
-    # pytest -q lists one node id per line when collection succeeds without a
-    # summary line (or with an older summary format).
-    lines = [
-        line
-        for line in result.stdout.splitlines()
-        if line.strip() and not line.startswith("=") and "collected" not in line.lower()
-    ]
-    return len(lines)
+    return _parse_collect_output(result)
 
 
-def collect_count_at_revision(
-    repo: Path,
-    rev: str,
-    rel_path: str,
-    *,
-    python: str = sys.executable,
-) -> int | None:
-    """Collect-count for ``rel_path`` as it existed at *rev*, or ``None`` if absent."""
+def _git_show_bytes(repo: Path, rev: str, rel_path: str) -> bytes | None:
     show = subprocess.run(
         ["git", "show", f"{rev}:{rel_path}"],
         cwd=repo,
@@ -188,19 +228,40 @@ def collect_count_at_revision(
     )
     if show.returncode != 0:
         return None
+    return show.stdout
+
+
+def collect_pair(
+    repo: Path,
+    *,
+    base: str,
+    head: str,
+    rel_path: str,
+    python: str = sys.executable,
+) -> tuple[CollectResult, CollectResult]:
+    """Collect base and head under one shared temp environment.
+
+    Both revisions are materialised as sibling files and collected with the
+    same interpreter and cwd, so the delta is the file content, not ambient
+    conftest / import-path drift between worktree and isolation.
+    """
+    base_bytes = _git_show_bytes(repo, base, rel_path)
+    head_bytes = _git_show_bytes(repo, head, rel_path)
     with tempfile.TemporaryDirectory(prefix="bernstein-test-count-") as tmp:
-        target = Path(tmp) / Path(rel_path).name
-        target.write_bytes(show.stdout)
-        # Isolate from the live tree's conftest by collecting in the temp dir.
-        return pytest_collect_count(target, python=python, cwd=Path(tmp))
-
-
-def collect_count_at_head(repo: Path, rel_path: str, *, python: str = sys.executable) -> int | None:
-    """Collect-count for ``rel_path`` in the working tree, or ``None`` if missing."""
-    path = repo / rel_path
-    if not path.is_file():
-        return None
-    return pytest_collect_count(path, python=python, cwd=repo)
+        root = Path(tmp)
+        base_path = root / f"base_{Path(rel_path).name}"
+        head_path = root / f"head_{Path(rel_path).name}"
+        if base_bytes is None:
+            base_result = CollectResult(status="missing")
+        else:
+            base_path.write_bytes(base_bytes)
+            base_result = pytest_collect_file(base_path, python=python, cwd=root)
+        if head_bytes is None:
+            head_result = CollectResult(status="missing")
+        else:
+            head_path.write_bytes(head_bytes)
+            head_result = pytest_collect_file(head_path, python=python, cwd=root)
+        return base_result, head_result
 
 
 def build_report(
@@ -214,7 +275,7 @@ def build_report(
     """Compare collected counts for test modules touched between *base* and *head*."""
     report = DropReport()
     if not base:
-        report.skipped = "no merge base (--base); skip rather than fake-green"
+        report.not_run = "no merge base (--base); guard did not compare"
         return report
 
     overrides = parse_overrides(pr_body)
@@ -224,31 +285,37 @@ def build_report(
 
     consumed: set[str] = set()
     for rel in sorted(touched):
-        base_count = collect_count_at_revision(repo, base, rel, python=python)
-        head_count = collect_count_at_head(repo, rel, python=python)
-        if base_count is None:
-            continue  # new test module at head — not a drop
-        head_n = 0 if head_count is None else head_count
-        if head_n >= base_count:
+        base_result, head_result = collect_pair(repo, base=base, head=head, rel_path=rel, python=python)
+        if base_result.status == "missing":
+            continue  # new at head — not a drop
+        base_n = base_result.count
+        if head_result.status == "missing":
+            head_n = 0
+            head_status = "missing"
+        else:
+            head_n = head_result.count
+            head_status = head_result.status
+        if head_n >= base_n and head_status == "ok":
             continue
-        drop = base_count - head_n
-        if head_count is None and subject_deleted(rel, deleted):
+        if head_n >= base_n:
+            continue
+        drop = base_n - head_n
+        if head_result.status == "missing" and subject_deleted(rel, deleted):
             report.carved.append(rel)
             continue
+        cause = head_status if head_status != "ok" else "count_drop"
         allowed = overrides.get(rel)
         if allowed is not None:
             consumed.add(rel)
             if drop <= allowed:
-                report.excused.append((rel, base_count, head_n, allowed))
+                report.excused.append((rel, base_n, head_n, allowed))
                 continue
-            # Override too small for the actual drop — still a failure.
-            report.drops.append((rel, base_count, head_n))
+            report.drops.append((rel, base_n, head_n, cause))
             continue
-        report.drops.append((rel, base_count, head_n))
+        report.drops.append((rel, base_n, head_n, cause))
 
     for rel, allowed in sorted(overrides.items()):
         if rel not in consumed:
-            # Stale: named a module with no drop (or not in the touched set).
             report.stale_overrides.append(f"{rel} -{allowed}")
 
     return report
@@ -257,20 +324,30 @@ def build_report(
 def format_report(report: DropReport) -> str:
     """Human-readable report for CI logs."""
     lines: list[str] = []
-    if report.skipped:
-        lines.append(f"SKIP: {report.skipped}")
+    if report.not_run is not None:
+        # Distinct from OK: an unrun guard must not read as a clean bill of health.
+        lines.append(f"NOT_RUN: {report.not_run}")
         return "\n".join(lines)
     if report.drops:
-        lines.append("Test modules lost collected cases vs merge base (issue #4873):")
-        for rel, base_n, head_n in report.drops:
-            lines.append(f"  {rel}: {base_n} -> {head_n} (drop {base_n - head_n})")
+        lines.append("FAIL: test modules lost collected cases vs merge base (issue #4873):")
+        for rel, base_n, head_n, cause in report.drops:
+            if cause == "import_error":
+                lines.append(
+                    f"  {rel}: {base_n} -> {head_n} (drop {base_n - head_n}; "
+                    "cause=import_error — module failed to import under collect-only, "
+                    "not necessarily deleted tests)"
+                )
+            elif cause == "missing":
+                lines.append(f"  {rel}: {base_n} -> 0 (file deleted at head)")
+            else:
+                lines.append(f"  {rel}: {base_n} -> {head_n} (drop {base_n - head_n}; cause=count_drop)")
         lines.append(
             "Restore the cases, consolidate via parametrize (collected count must stay "
             "stable), carve out a deleted subject, or add a PR-body override: "
             "`test-count-drop: <path> -<N>`."
         )
     if report.stale_overrides:
-        lines.append("Stale test-count-drop overrides (no drop for that path):")
+        lines.append("FAIL: stale test-count-drop overrides (no drop for that path):")
         for entry in report.stale_overrides:
             lines.append(f"  {entry}")
     if report.excused:
@@ -301,7 +378,7 @@ def main(argv: list[str] | None = None) -> int:
     base = args.base.strip() or None
     report = build_report(args.root, base=base, head=args.head, pr_body=args.pr_body)
     print(format_report(report))
-    if report.skipped:
+    if report.not_run is not None:
         return 0
     return 1 if report.drops or report.stale_overrides else 0
 

--- a/tests/unit/scripts/test_check_test_count_drop.py
+++ b/tests/unit/scripts/test_check_test_count_drop.py
@@ -32,7 +32,6 @@ def _init_repo(root: Path) -> None:
     _git(root, "init")
     _git(root, "config", "user.email", "test@example.com")
     _git(root, "config", "user.name", "test")
-    # Default branch name varies; pin it.
     _git(root, "checkout", "-b", "main")
 
 
@@ -54,9 +53,13 @@ test-count-drop: tests/unit/test_bar.py -1
     }
 
 
-def test_skip_without_base(check_module: ModuleType, tmp_path: Path) -> None:
+def test_not_run_without_base_is_not_ok(check_module: ModuleType, tmp_path: Path) -> None:
+    """An unrun guard must not share the OK outcome word."""
     report = check_module.build_report(tmp_path, base=None)
-    assert report.skipped is not None
+    assert report.not_run is not None
+    text = check_module.format_report(report)
+    assert text.startswith("NOT_RUN:")
+    assert not text.startswith("OK:")
     assert check_module.main(["--root", str(tmp_path)]) == 0
 
 
@@ -80,8 +83,9 @@ def test_drop_turns_red(check_module: ModuleType, tmp_path: Path) -> None:
     _commit_all(repo, "drop one test")
 
     report = check_module.build_report(repo, base=base, python=sys.executable)
-    assert report.drops == [("tests/unit/test_sample.py", 3, 2)]
+    assert report.drops == [("tests/unit/test_sample.py", 3, 2, "count_drop")]
     assert check_module.main(["--root", str(repo), "--base", base]) == 1
+    assert "cause=count_drop" in check_module.format_report(report)
 
 
 def test_parametrize_consolidation_stays_green(check_module: ModuleType, tmp_path: Path) -> None:
@@ -106,7 +110,37 @@ def test_parametrize_consolidation_stays_green(check_module: ModuleType, tmp_pat
     report = check_module.build_report(repo, base=base, python=sys.executable)
     assert report.drops == []
     assert report.stale_overrides == []
+    assert check_module.format_report(report).startswith("OK:")
     assert check_module.main(["--root", str(repo), "--base", base]) == 0
+
+
+def test_import_error_named_in_drop_message(check_module: ModuleType, tmp_path: Path) -> None:
+    """A module that stops importing is a drop with cause=import_error, not silent zero."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    test_dir = repo / "tests" / "unit"
+    test_dir.mkdir(parents=True)
+    (test_dir / "test_sample.py").write_text(
+        "def test_a():\n    assert True\n\ndef test_b():\n    assert True\n",
+        encoding="utf-8",
+    )
+    base = _commit_all(repo, "two tests")
+
+    (test_dir / "test_sample.py").write_text(
+        "import definitely_not_a_real_module_4873  # noqa: F401\n\ndef test_a():\n    assert True\n",
+        encoding="utf-8",
+    )
+    _commit_all(repo, "break import")
+
+    report = check_module.build_report(repo, base=base, python=sys.executable)
+    assert len(report.drops) == 1
+    rel, base_n, head_n, cause = report.drops[0]
+    assert rel == "tests/unit/test_sample.py"
+    assert base_n == 2
+    assert head_n == 0
+    assert cause == "import_error"
+    assert "cause=import_error" in check_module.format_report(report)
 
 
 def test_override_excuses_drop_and_stale_fails(check_module: ModuleType, tmp_path: Path) -> None:
@@ -172,4 +206,22 @@ def test_deleted_test_without_subject_fails(check_module: ModuleType, tmp_path: 
     _commit_all(repo, "delete test only")
 
     report = check_module.build_report(repo, base=base, python=sys.executable)
-    assert report.drops == [("tests/unit/test_widget.py", 1, 0)]
+    assert report.drops == [("tests/unit/test_widget.py", 1, 0, "missing")]
+
+
+def test_guard_discriminates_when_a_drop_exists(check_module: ModuleType, tmp_path: Path) -> None:
+    """Counterfactual: with a real drop the report is non-empty (not vacuously OK)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    test_dir = repo / "tests" / "unit"
+    test_dir.mkdir(parents=True)
+    (test_dir / "test_sample.py").write_text(
+        "def test_a():\n    assert True\n\ndef test_b():\n    assert True\n",
+        encoding="utf-8",
+    )
+    base = _commit_all(repo, "two")
+    (test_dir / "test_sample.py").write_text("def test_a():\n    assert True\n", encoding="utf-8")
+    _commit_all(repo, "one")
+    report = check_module.build_report(repo, base=base, python=sys.executable)
+    assert report.drops, "a real drop must surface; otherwise the guard is vacuous"

--- a/tests/unit/scripts/test_check_test_count_drop.py
+++ b/tests/unit/scripts/test_check_test_count_drop.py
@@ -1,0 +1,175 @@
+"""Tests for ``scripts/check_test_count_drop.py`` (#4873)."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_test_count_drop.py"
+
+
+@pytest.fixture(scope="module")
+def check_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_test_count_drop_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.check_output(["git", *args], cwd=cwd, text=True)
+
+
+def _init_repo(root: Path) -> None:
+    _git(root, "init")
+    _git(root, "config", "user.email", "test@example.com")
+    _git(root, "config", "user.name", "test")
+    # Default branch name varies; pin it.
+    _git(root, "checkout", "-b", "main")
+
+
+def _commit_all(root: Path, message: str) -> str:
+    _git(root, "add", "-A")
+    _git(root, "commit", "-m", message)
+    return _git(root, "rev-parse", "HEAD").strip()
+
+
+def test_parse_overrides(check_module: ModuleType) -> None:
+    body = """
+## Summary
+test-count-drop: tests/unit/test_foo.py -3
+test-count-drop: tests/unit/test_bar.py -1
+"""
+    assert check_module.parse_overrides(body) == {
+        "tests/unit/test_foo.py": 3,
+        "tests/unit/test_bar.py": 1,
+    }
+
+
+def test_skip_without_base(check_module: ModuleType, tmp_path: Path) -> None:
+    report = check_module.build_report(tmp_path, base=None)
+    assert report.skipped is not None
+    assert check_module.main(["--root", str(tmp_path)]) == 0
+
+
+def test_drop_turns_red(check_module: ModuleType, tmp_path: Path) -> None:
+    """Fixture module that loses cases turns the check red (failure path)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    test_dir = repo / "tests" / "unit"
+    test_dir.mkdir(parents=True)
+    (test_dir / "test_sample.py").write_text(
+        "def test_a():\n    assert True\n\ndef test_b():\n    assert True\n\ndef test_c():\n    assert True\n",
+        encoding="utf-8",
+    )
+    base = _commit_all(repo, "base with three tests")
+
+    (test_dir / "test_sample.py").write_text(
+        "def test_a():\n    assert True\n\ndef test_b():\n    assert True\n",
+        encoding="utf-8",
+    )
+    _commit_all(repo, "drop one test")
+
+    report = check_module.build_report(repo, base=base, python=sys.executable)
+    assert report.drops == [("tests/unit/test_sample.py", 3, 2)]
+    assert check_module.main(["--root", str(repo), "--base", base]) == 1
+
+
+def test_parametrize_consolidation_stays_green(check_module: ModuleType, tmp_path: Path) -> None:
+    """N cases folded into one parametrize table keep collected count stable."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    test_dir = repo / "tests" / "unit"
+    test_dir.mkdir(parents=True)
+    (test_dir / "test_sample.py").write_text(
+        "def test_a():\n    assert 1 == 1\n\ndef test_b():\n    assert 2 == 2\n\ndef test_c():\n    assert 3 == 3\n",
+        encoding="utf-8",
+    )
+    base = _commit_all(repo, "three separate tests")
+
+    (test_dir / "test_sample.py").write_text(
+        "import pytest\n\n@pytest.mark.parametrize('n', [1, 2, 3])\ndef test_n(n):\n    assert n == n\n",
+        encoding="utf-8",
+    )
+    _commit_all(repo, "consolidate to parametrize")
+
+    report = check_module.build_report(repo, base=base, python=sys.executable)
+    assert report.drops == []
+    assert report.stale_overrides == []
+    assert check_module.main(["--root", str(repo), "--base", base]) == 0
+
+
+def test_override_excuses_drop_and_stale_fails(check_module: ModuleType, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    test_dir = repo / "tests" / "unit"
+    test_dir.mkdir(parents=True)
+    (test_dir / "test_sample.py").write_text(
+        "def test_a():\n    assert True\n\ndef test_b():\n    assert True\n",
+        encoding="utf-8",
+    )
+    base = _commit_all(repo, "two tests")
+
+    (test_dir / "test_sample.py").write_text("def test_a():\n    assert True\n", encoding="utf-8")
+    _commit_all(repo, "drop one")
+
+    body = "test-count-drop: tests/unit/test_sample.py -1\n"
+    report = check_module.build_report(repo, base=base, pr_body=body, python=sys.executable)
+    assert report.drops == []
+    assert report.excused == [("tests/unit/test_sample.py", 2, 1, 1)]
+
+    stale_body = body + "test-count-drop: tests/unit/test_other.py -2\n"
+    stale = check_module.build_report(repo, base=base, pr_body=stale_body, python=sys.executable)
+    assert stale.stale_overrides
+    assert check_module.main(["--root", str(repo), "--base", base, "--pr-body", stale_body]) == 1
+
+
+def test_deleted_test_with_subject_is_carved_out(check_module: ModuleType, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    src = repo / "src" / "pkg"
+    src.mkdir(parents=True)
+    (src / "widget.py").write_text("X = 1\n", encoding="utf-8")
+    test_dir = repo / "tests" / "unit"
+    test_dir.mkdir(parents=True)
+    (test_dir / "test_widget.py").write_text("def test_x():\n    assert True\n", encoding="utf-8")
+    base = _commit_all(repo, "widget + test")
+
+    (src / "widget.py").unlink()
+    (test_dir / "test_widget.py").unlink()
+    _commit_all(repo, "delete widget and its test")
+
+    report = check_module.build_report(repo, base=base, python=sys.executable)
+    assert report.carved == ["tests/unit/test_widget.py"]
+    assert report.drops == []
+
+
+def test_deleted_test_without_subject_fails(check_module: ModuleType, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    src = repo / "src" / "pkg"
+    src.mkdir(parents=True)
+    (src / "widget.py").write_text("X = 1\n", encoding="utf-8")
+    test_dir = repo / "tests" / "unit"
+    test_dir.mkdir(parents=True)
+    (test_dir / "test_widget.py").write_text("def test_x():\n    assert True\n", encoding="utf-8")
+    base = _commit_all(repo, "widget + test")
+
+    (test_dir / "test_widget.py").unlink()
+    _commit_all(repo, "delete test only")
+
+    report = check_module.build_report(repo, base=base, python=sys.executable)
+    assert report.drops == [("tests/unit/test_widget.py", 1, 0)]


### PR DESCRIPTION
## Summary

- New `scripts/check_test_count_drop.py`: for every touched `test_*.py` / `*_test.py`, compare `pytest --collect-only` counts at merge base vs head.
- A drop fails with module + both counts; parametrize consolidation stays green (collect-only, not AST).
- Override: `test-count-drop: <path> -<N>` in the PR body (at most N); unused overrides fail stale.
- Deleted test + matching deleted `src/**/<stem>.py` carved out.
- Outcome words are distinct: `OK` vs `NOT_RUN` (no base — guard did not compare) vs `FAIL`.
- Base and head collected under the same isolated temp env; `cause=import_error` when collect fails to import.

Closes #4873.

## Policy choice (open decision from the issue)

**Fail outright against the merge base** — not a committed ratchet baseline. Stricter/noisier on refactors; the per-module PR-body override is the escape hatch, and stale overrides fail so it cannot quietly rot. A ratchet file would need its own honesty guard; that is a larger design for little gain here.

## Test plan

- [x] `uv run pytest tests/unit/scripts/test_check_test_count_drop.py -q --no-cov` (9 passed: drop red, parametrize green, carve-out, stale override, NOT_RUN ≠ OK, import_error named, counterfactual)
- [ ] Repo hygiene green on the PR (ignore unrelated AdaptivePollingBackoff — #4872)