### PR TITLE
chore(ci): raise diff-coverage floor to 89%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,8 +1,8 @@
 {
-  "diff_coverage_floor_percent": 88,
+  "diff_coverage_floor_percent": 89,
   "head_sha": "f3a65b8c3ce345e149f250e39aa6bcf4a6d530d9",
   "line_rate": 0.8422,
   "run_id": "32972568476",
   "total_coverage_percent": 84.22,
-  "updated_at": "2026-08-26T16:15:13+00:00"
+  "updated_at": "2026-08-31T15:12:02+00:00"
 }


### PR DESCRIPTION
Weekly nudge of the LEVEL 1 diff-coverage floor.

The diff-coverage gate in `.github/workflows/ci.yml` reads
`diff_coverage_floor_percent` from `.coverage-baseline.json`.
This PR raises that floor so every subsequent PR must cover a
slightly higher share of its changed lines.

New floor: **89%**.

The gate stays advisory (`continue-on-error`) until an operator
promotes it; see `docs/operations/coverage-ratchet.md` for the
promotion and override procedure. If the increment is too steep
for the current trunk, close this PR - the floor only moves when
the PR merges.

Generated by `.github/workflows/coverage-ratchet-weekly.yml`.