### PR TITLE
fix(adapters): enforce max_tokens capability gate

### DIFF
--- a/docs/adapters/capability_contract.md
+++ b/docs/adapters/capability_contract.md
@@ -187,6 +187,7 @@ capabilities. The overrides travel in the per-spawn `mcp_config` and, for
 | `temperature` | float | Sampling temperature. Absent = provider default. |
 | `top_p` | float | Nucleus sampling. Absent = provider default. |
 | `top_k` | int | Top-k sampling, forwarded for OpenAI-compatible endpoints that accept it. Absent = provider default. |
+| `max_tokens` | int | Per-spawn completion-token cap. Absent = adapter or provider default. |
 | `base_url` | str | OpenAI-compatible endpoint URL. Absent = default endpoint. |
 | `api_key_env` | str | NAME of the environment variable holding the API key for `base_url`. Never a literal key. |
 
@@ -210,8 +211,10 @@ value in its `start` event; only the env var name is ever logged, never
 the key itself.
 
 The spawn path enforces the capability: requesting any of these keys for an
-adapter that does not declare `SUPPORTS_SAMPLING_PARAMS` raises
-`SamplingParamsRefusal` instead of silently dropping the parameters. See
+adapter that declares neither the coarse `SUPPORTS_SAMPLING_PARAMS` capability
+nor the matching narrow per-field capability raises `SamplingParamsRefusal`
+instead of silently dropping the parameters. `max_tokens` maps to
+`SUPPORTS_MAX_TOKENS`; endpoint fields have no narrow capability. See
 `ensure_sampling_params_supported` in
 [`src/bernstein/adapters/plugin_sdk.py`](https://github.com/sipyourdrink-ltd/bernstein/blob/main/src/bernstein/adapters/plugin_sdk.py).
 

--- a/docs/release-notes/fragments/3586-max-tokens-gate.md
+++ b/docs/release-notes/fragments/3586-max-tokens-gate.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Treat `max_tokens` as part of the enforced per-spawn sampling surface: adapters without coarse sampling support or `SUPPORTS_MAX_TOKENS` now refuse the spawn instead of silently dropping the requested limit. The OpenAI Agents adapter declares and continues to honour the override. ([#3586](https://github.com/sipyourdrink-ltd/bernstein/issues/3586))

--- a/src/bernstein/adapters/openai_agents.py
+++ b/src/bernstein/adapters/openai_agents.py
@@ -144,6 +144,7 @@ class OpenAIAgentsAdapter(PluginAdapter):
                 AdapterCapability.RATE_LIMIT_DETECTION,
                 AdapterCapability.STRUCTURED_OUTPUT,
                 AdapterCapability.SUPPORTS_SAMPLING_PARAMS,
+                AdapterCapability.SUPPORTS_MAX_TOKENS,
             ),
         )
 

--- a/src/bernstein/adapters/plugin_sdk.py
+++ b/src/bernstein/adapters/plugin_sdk.py
@@ -77,10 +77,7 @@ class AdapterCapability(Enum):
     #: SDK parameter (PR3).
     SUPPORTS_TOP_K = "supports_top_k"
     #: Adapter wires an incoming ``max_tokens`` override to a real CLI flag
-    #: or SDK parameter (PR3). Note ``max_tokens`` is NOT a member of
-    #: :data:`SAMPLING_PARAM_KEYS` (that tuple predates this capability and
-    #: is gated separately) - this capability exists for adapters/callers
-    #: that want to probe max_tokens support specifically.
+    #: or SDK parameter (PR3).
     SUPPORTS_MAX_TOKENS = "supports_max_tokens"
 
 
@@ -94,6 +91,7 @@ SAMPLING_PARAM_KEYS: tuple[str, ...] = (
     "temperature",
     "top_p",
     "top_k",
+    "max_tokens",
     "base_url",
     "api_key_env",
 )
@@ -110,6 +108,7 @@ _SAMPLING_KEY_CAPABILITY: dict[str, AdapterCapability] = {
     "temperature": AdapterCapability.SUPPORTS_TEMPERATURE,
     "top_p": AdapterCapability.SUPPORTS_TOP_P,
     "top_k": AdapterCapability.SUPPORTS_TOP_K,
+    "max_tokens": AdapterCapability.SUPPORTS_MAX_TOKENS,
 }
 
 

--- a/src/bernstein/adapters/qwen.py
+++ b/src/bernstein/adapters/qwen.py
@@ -160,15 +160,13 @@ class QwenAdapter(CLIAdapter):
             # sampling flag that is not in its surface aborts the run instead
             # of being ignored. None are wired; plugin_info() declares no
             # sampling capability, so a spawn carrying one of the enforced keys
-            # is refused before reaching here. ``max_tokens`` is the exception:
-            # it is absent from SAMPLING_PARAM_KEYS, so nothing refuses it and
-            # this warning is the only signal the value was dropped (#3586).
+            # is refused before reaching here. Direct adapter.spawn() callers can
+            # bypass the composition gate, so retain a warning for those calls.
             for dropped_key in ("temperature", "top_p", "top_k", "max_tokens"):
                 if mcp_config.get(dropped_key) is not None:
                     logger.warning(
                         "qwen adapter: %s=%r requested but not wired (qwen CLI has no matching "
-                        "flag) - ensure_sampling_params_supported should have refused this spawn "
-                        "before reaching here",
+                        "flag); call ensure_sampling_params_supported before spawning",
                         dropped_key,
                         mcp_config.get(dropped_key),
                     )

--- a/tests/unit/adapters/test_openai_agents.py
+++ b/tests/unit/adapters/test_openai_agents.py
@@ -89,11 +89,16 @@ class TestPluginInfo:
         assert AdapterCapability.RATE_LIMIT_DETECTION in info.capabilities
         assert AdapterCapability.STRUCTURED_OUTPUT in info.capabilities
         assert AdapterCapability.SUPPORTS_SAMPLING_PARAMS in info.capabilities
+        assert AdapterCapability.SUPPORTS_MAX_TOKENS in info.capabilities
 
     def test_sampling_gate_passes_for_openai_agents(self) -> None:
         ensure_sampling_params_supported(
             OpenAIAgentsAdapter(),
-            {"temperature": 0.5, "base_url": "http://localhost:8000/v1"},
+            {
+                "temperature": 0.5,
+                "max_tokens": 4096,
+                "base_url": "http://localhost:8000/v1",
+            },
         )
 
     def test_display_name(self) -> None:

--- a/tests/unit/test_adapter_plugin_sdk.py
+++ b/tests/unit/test_adapter_plugin_sdk.py
@@ -428,6 +428,11 @@ class TestEnsureSamplingParamsSupported:
         with pytest.raises(SamplingParamsRefusal, match="temperature"):
             ensure_sampling_params_supported(_StubPluginAdapter(), {"temperature": 0.2})
 
+    def test_raises_for_max_tokens_without_capability(self) -> None:
+        with pytest.raises(SamplingParamsRefusal) as excinfo:
+            ensure_sampling_params_supported(_StubPluginAdapter(), {"max_tokens": 4096})
+        assert excinfo.value.requested_keys == ("max_tokens",)
+
     def test_error_names_adapter_and_keys(self) -> None:
         with pytest.raises(SamplingParamsRefusal) as excinfo:
             ensure_sampling_params_supported(

--- a/tests/unit/test_adapter_qwen.py
+++ b/tests/unit/test_adapter_qwen.py
@@ -12,7 +12,11 @@ import pytest
 from bernstein.core.llm import LLMSettings
 from bernstein.core.models import ApiTier, ModelConfig, ProviderType
 
-from bernstein.adapters.plugin_sdk import AdapterCapability
+from bernstein.adapters.plugin_sdk import (
+    AdapterCapability,
+    SamplingParamsRefusal,
+    ensure_sampling_params_supported,
+)
 from bernstein.adapters.qwen import QwenAdapter
 from bernstein.core.defaults import QWEN_INSTALL_HINT
 from bernstein.core.orchestration.preflight import _CLI_INSTALL_HINT
@@ -390,6 +394,11 @@ class TestQwenAdapterPluginInfo:
         assert AdapterCapability.SUPPORTS_TOP_P not in info.capabilities
         assert AdapterCapability.SUPPORTS_TOP_K not in info.capabilities
         assert AdapterCapability.SUPPORTS_MAX_TOKENS not in info.capabilities
+
+    def test_max_tokens_is_refused_before_spawn(self) -> None:
+        with pytest.raises(SamplingParamsRefusal) as excinfo:
+            ensure_sampling_params_supported(QwenAdapter(), {"max_tokens": 4096})
+        assert excinfo.value.requested_keys == ("max_tokens",)
 
 
 class TestQwenAdapterSamplingParams:


### PR DESCRIPTION
## Summary

- add `max_tokens` to the enforced per-spawn sampling surface
- map it to the narrow `SUPPORTS_MAX_TOKENS` capability
- declare verified support for the OpenAI Agents adapter
- make incapable adapters such as Qwen fail closed before spawning
- update the capability contract and release notes

## Testing

- Related adapter tests: 252 passed
- `ruff check .`: passed
- `ruff format --check .`: passed
- `lint-imports`: passed
- `git diff --check`: passed
- Full unit suite was attempted through the isolated runner. The affected adapter tests passed, but the repository baseline contains unrelated environment failures involving home-directory sandbox permissions, paths containing spaces, narrow-TTY rendering, and unavailable networking.
- Pyright is not clean on the current baseline because of existing dependency-resolution and repository-wide typing errors.

Closes #3586