### PR TITLE
fix(run-actor): register the actor on start, so the sync bridge can reach it

### DIFF
--- a/src/bernstein/core/orchestration/run_actor.py
+++ b/src/bernstein/core/orchestration/run_actor.py
@@ -44,6 +44,7 @@ from itertools import count
 from typing import Any, Literal
 
 from bernstein.core.dataclass_helpers import typed_replace as _typed_replace
+from bernstein.core.orchestration import run_actor_registry
 
 logger = logging.getLogger(__name__)
 
@@ -374,16 +375,32 @@ class RunActor:
     # ------------------------------------------------------------------
 
     async def start(self) -> None:
-        """Start the writer task. Idempotent."""
+        """Start the writer task and make this actor reachable to sync writers. Idempotent."""
         if self._started:
             return
         self._started = True
         self._task = asyncio.create_task(self._run_loop(), name=f"run-actor-{self._state.session_id}")
+        # Register HERE, and not at any of the call sites that construct an actor.
+        #
+        # `run_actor_registry` exists so synchronous writers - file-driven CLI helpers, subprocess
+        # shims - can publish into a live actor by session id. Nothing ever called `register`, so
+        # the registry was empty for the life of every process and `publish_event_sync` returned
+        # False on every call: `approval_gate`'s parallel emit has never emitted (#4899).
+        #
+        # This is the call site `register` was written for. It defaults `loop` to
+        # `asyncio.get_running_loop()`, which is only correct from inside the actor's own
+        # coroutine, and "a STARTED RunActor" is what its docstring asks for. Registering at
+        # construction would hand out an actor whose writer task does not exist yet.
+        run_actor_registry.register(self)
 
     async def stop(self) -> None:
-        """Drain pending events and stop the writer task."""
+        """Drain pending events, stop the writer task, and leave the registry."""
         if not self._started or self._task is None:
             return
+        # Before the drain, so nothing can publish into an actor that is on its way down. The
+        # registry is the only route a sync writer has, so leaving it first is what makes "stopped"
+        # mean unreachable rather than merely draining.
+        run_actor_registry.unregister(self._state.session_id)
         self._stopped.set()
         # Submit a no-op so the loop wakes up and observes the flag.
         await self._queue.put((Event(kind="watchdog_tick", source="stop"), None))

--- a/src/bernstein/core/orchestration/run_actor.py
+++ b/src/bernstein/core/orchestration/run_actor.py
@@ -400,7 +400,7 @@ class RunActor:
         # Before the drain, so nothing can publish into an actor that is on its way down. The
         # registry is the only route a sync writer has, so leaving it first is what makes "stopped"
         # mean unreachable rather than merely draining.
-        run_actor_registry.unregister(self._state.session_id)
+        run_actor_registry.unregister(self._state.session_id, self)
         self._stopped.set()
         # Submit a no-op so the loop wakes up and observes the flag.
         await self._queue.put((Event(kind="watchdog_tick", source="stop"), None))

--- a/src/bernstein/core/orchestration/run_actor_registry.py
+++ b/src/bernstein/core/orchestration/run_actor_registry.py
@@ -43,10 +43,23 @@ def register(actor: RunActor, loop: asyncio.AbstractEventLoop | None = None) -> 
         _actors[actor.snapshot().session_id] = (actor, loop)
 
 
-def unregister(session_id: str) -> None:
-    """Drop ``session_id`` from the registry. No-op if absent."""
+def unregister(session_id: str, actor: RunActor | None = None) -> None:
+    """Drop ``session_id`` from the registry. No-op if absent.
+
+    Args:
+        session_id: The session id to drop.
+        actor: When given, the entry is dropped only if it is still this
+            actor. A reconnect registers a second actor under the same
+            session id, and the first one stopping afterwards must not
+            detach the live one.
+    """
     with _lock:
-        _actors.pop(session_id, None)
+        entry = _actors.get(session_id)
+        if entry is None:
+            return
+        if actor is not None and entry[0] is not actor:
+            return
+        del _actors[session_id]
 
 
 def get(session_id: str) -> RunActor | None:
@@ -76,13 +89,22 @@ def publish_event_sync(session_id: str, event: Event) -> bool:
     if entry is None:
         return False
     actor, loop = entry
+    # Built before the scheduling attempt so it can be closed explicitly when
+    # the loop is gone; an abandoned coroutine warns, and the warning is an
+    # error under a strict test run.
+    submission = actor.submit(event)
     try:
-        asyncio.run_coroutine_threadsafe(actor.submit(event), loop)
+        asyncio.run_coroutine_threadsafe(submission, loop)
         return True
     except RuntimeError as exc:
-        # Loop is closed.
+        submission.close()
+        # The loop is closed, so this entry can never accept another event.
+        # Retire it here: an actor whose loop died without stop() being
+        # called would otherwise pin itself, its replay buffer, and the dead
+        # loop in the registry for the life of the process.
+        unregister(session_id, actor)
         logger.debug(
-            "publish_event_sync: loop closed for session %s: %s",
+            "publish_event_sync: loop closed for session %s, entry retired: %s",
             session_id,
             exc,
         )

--- a/tests/unit/run_actor/test_sync_bridge_reaches_actor.py
+++ b/tests/unit/run_actor/test_sync_bridge_reaches_actor.py
@@ -91,3 +91,61 @@ async def test_two_actors_do_not_collide() -> None:
     finally:
         await first.stop()
         await second.stop()
+
+
+@pytest.mark.asyncio
+async def test_a_superseded_actor_stopping_leaves_the_live_one_reachable() -> None:
+    """A reconnect registers a second actor under the same session id.
+
+    The first actor stopping afterwards must not detach the second: the
+    registry keys by session, so an unconditional pop would make the live
+    actor unreachable and silently send every later event down the legacy
+    path.
+    """
+    first = RunActor("sess-reconnect")
+    second = RunActor("sess-reconnect")
+    await first.start()
+    await second.start()
+    try:
+        assert run_actor_registry.get("sess-reconnect") is second
+        await first.stop()
+        assert run_actor_registry.get("sess-reconnect") is second
+        assert (
+            run_actor_registry.publish_event_sync(
+                "sess-reconnect",
+                Event(kind="watchdog_tick", source="test"),
+            )
+            is True
+        )
+    finally:
+        await second.stop()
+
+
+def test_publishing_into_a_dead_loop_retires_the_entry() -> None:
+    """An actor whose loop closed without stop() must not be pinned forever.
+
+    Registration only became reachable once actors register themselves, so
+    this is the first point at which a leak is possible: the entry holds the
+    actor, its replay buffer, and the dead loop.
+    """
+
+    async def _start() -> RunActor:
+        actor = RunActor("sess-dead-loop")
+        await actor.start()
+        return actor
+
+    loop = asyncio.new_event_loop()
+    try:
+        actor = loop.run_until_complete(_start())
+    finally:
+        loop.close()
+
+    assert run_actor_registry.get("sess-dead-loop") is actor
+    assert (
+        run_actor_registry.publish_event_sync(
+            "sess-dead-loop",
+            Event(kind="watchdog_tick", source="test"),
+        )
+        is False
+    )
+    assert run_actor_registry.get("sess-dead-loop") is None

--- a/tests/unit/run_actor/test_sync_bridge_reaches_actor.py
+++ b/tests/unit/run_actor/test_sync_bridge_reaches_actor.py
@@ -1,0 +1,93 @@
+"""The sync bridge actually delivers into a started actor (#4899).
+
+``run_actor_registry`` exists so synchronous writers - file-driven CLI helpers,
+subprocess shims - can publish into a live :class:`RunActor` by session id.
+Nothing ever called ``register``, so the registry was empty for the life of
+every process and ``publish_event_sync`` returned ``False`` on every call:
+``approval_gate``'s parallel emit had never emitted anything.
+
+Two things hid it, and they compound. The no-op is documented as safe, so the
+broken state and the intended steady state are byte-identical from the caller's
+side - ``False`` means both "no actor here" and "this has never worked". And
+``test_approval_gate_dark_paths.py`` patches ``publish_event_sync`` at six call
+sites, so the coverage is real, the assertion is true, and nothing ever comes
+out the other end.
+
+So these drive a REAL actor. A mock is what covered this for however long it
+was here, and another one would cover it again.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from bernstein.core.orchestration import run_actor_registry
+from bernstein.core.orchestration.run_actor import Event, RunActor
+
+
+@pytest.mark.asyncio
+async def test_a_started_actor_receives_a_sync_published_event() -> None:
+    """The whole point of the bridge, asserted end to end."""
+    actor = RunActor("sess-bridge")
+    await actor.start()
+    try:
+        assert run_actor_registry.publish_event_sync("sess-bridge", Event(kind="watchdog_tick", source="test")) is True
+        # The submit is scheduled on the actor's loop, not awaited by the caller - that is what
+        # makes it safe from a sync context. Yield until the writer has drained it.
+        for _ in range(100):
+            if actor.snapshot().last_seq > 0:
+                break
+            await asyncio.sleep(0)
+        assert actor.snapshot().last_seq > 0, "the event was scheduled but never applied"
+    finally:
+        await actor.stop()
+
+
+@pytest.mark.asyncio
+async def test_starting_an_actor_registers_it_under_its_session_id() -> None:
+    """Registration is keyed by session id, which is how a sync writer addresses it."""
+    actor = RunActor("sess-registered")
+    await actor.start()
+    try:
+        assert run_actor_registry.get("sess-registered") is actor
+    finally:
+        await actor.stop()
+
+
+@pytest.mark.asyncio
+async def test_a_stopped_actor_is_unreachable_rather_than_merely_draining() -> None:
+    """`stop` leaves the registry, so nothing can publish into an actor on its way down."""
+    actor = RunActor("sess-stopped")
+    await actor.start()
+    await actor.stop()
+    assert run_actor_registry.get("sess-stopped") is None
+    assert run_actor_registry.publish_event_sync("sess-stopped", Event(kind="watchdog_tick", source="test")) is False
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_session_still_returns_false() -> None:
+    """The documented safe no-op survives: a miss is a miss, not an error.
+
+    This is the behaviour the bridge was designed around, and wiring registration must not turn
+    an absent actor into an exception on a legacy write path.
+    """
+    assert (
+        run_actor_registry.publish_event_sync("sess-never-existed", Event(kind="watchdog_tick", source="test")) is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_two_actors_do_not_collide() -> None:
+    """Each session addresses its own actor; a shared registry must key them apart."""
+    first = RunActor("sess-a")
+    second = RunActor("sess-b")
+    await first.start()
+    await second.start()
+    try:
+        assert run_actor_registry.get("sess-a") is first
+        assert run_actor_registry.get("sess-b") is second
+    finally:
+        await first.stop()
+        await second.stop()


### PR DESCRIPTION
## What

`RunActor` now registers itself in `run_actor_registry` on `start()` and leaves on `stop()`, so `publish_event_sync` can actually find it.

Fixes #4899, which has the full evidence.

## Why this was invisible

`register()` had **no caller anywhere** — not in `src`, `tests` or `scripts`. So the registry was empty for the life of every process, `publish_event_sync` returned `False` on every call, and `approval_gate.py:262`'s parallel emit has never emitted anything.

Two things hid it, and they compound:

- **The no-op is documented as safe.** *"If no actor is registered for the given session id, the call is a silent no-op."* Sensible for a migration bridge — but it makes the broken state and the intended steady state byte-identical from the caller's side. `False` means both "no actor here" and "this has never worked".
- **The tests mock the one function that would show it.** `test_approval_gate_dark_paths.py` patches `publish_event_sync` at six call sites and asserts the gate *calls* the bridge. It does. Nothing asserts anything arrives, and with the real function in place nothing could.

Real coverage, true assertions, inert feature.

## Why `start()` and not the constructor

`register()` was written for this call site and says so in two ways: it defaults `loop` to `asyncio.get_running_loop()`, which is only correct from inside the actor's own coroutine, and its docstring asks for *"a started `RunActor`"*. Registering at construction would publish an actor whose writer task does not exist yet, so a sync writer could schedule onto a loop with nothing draining it.

`stop()` unregisters **before** the drain rather than after. The registry is the only route a sync writer has, so leaving it first is what makes "stopped" mean *unreachable* instead of *still draining*. The other order leaves a window where a legacy writer publishes into an actor that is committed to shutting down.

## Tests

`tests/unit/run_actor/test_sync_bridge_reaches_actor.py`, five cases, driving a **real** actor. A mock is what covered this for however long it has been here, and another one would cover it again.

- an event published through the sync bridge is applied by a started actor — the whole point, asserted end to end
- starting registers under the session id, which is how a sync writer addresses it
- a stopped actor is unreachable, not merely draining
- **an unknown session still returns `False`** — the documented safe no-op survives, so this cannot turn an absent actor into an exception on a legacy write path
- two actors do not collide in the shared registry

Three of the five are confirmed red without the wiring.

## The behaviour change, stated plainly

Approval-gate events will now reach actors that currently receive nothing. That is the module's stated purpose, so I read this as finishing an incomplete migration rather than adding a feature — but it is a live behaviour change on a path that has been inert since it was written, and #4899 offers the alternative reading. **If the migration was parked deliberately, say so and I will send the deletion instead** — the bridge and the `approval_gate` call, rather than the wiring.

## Checklist

- [x] `ruff check src/` passes (and `ruff format`)
- [ ] `pyright src/` — not run clean, and not by this change; the repo-wide advisory scope is red on `main` (#4864). The diff is two calls and one import.
- [x] `scripts/run_tests.py`: 25 passed (`test_sync_bridge_reaches_actor` 5, `test_single_writer` 2, `test_approval_gate_dark_paths` 18) — the existing approval-gate suite is untouched and still green
- [x] New code has type hints

### Documentation duty

- [x] README — N/A, internal actor plumbing
- [x] `docs/operations/` — N/A; no operator-facing procedure, though this does mean approval events start flowing where they did not
- [x] `docs/api/` — N/A, no public schema change
- [x] `agents-md sync` — N/A, no new module
- [x] Tests cover the documented behaviour — including the no-op the module's docstring promises