### PR TITLE
chore(tick): delete check_nudges_during_tick, which is neither called nor implemented

### DIFF
--- a/src/bernstein/core/orchestration/tick_pipeline.py
+++ b/src/bernstein/core/orchestration/tick_pipeline.py
@@ -782,36 +782,6 @@ def compute_total_spent(workdir: Path) -> float:
 # ---------------------------------------------------------------------------
 
 
-def check_nudges_during_tick() -> None:
-    """Check and process orchestrator nudges during tick (T567)."""
-    from bernstein.core.orchestration.orchestrator import get_orchestrator_nudges
-
-    nudges = get_orchestrator_nudges(priority_threshold=2)  # Medium+ priority
-
-    for nudge in nudges:
-        logger.info(f"Processing orchestrator nudge: {nudge.nudge_type} - {nudge.message}")
-
-        # Process different nudge types
-        match nudge.nudge_type:
-            case "increase_parallelism":
-                logger.info("Nudge: Increasing parallelism for better throughput")
-                # Implementation would adjust parallelism settings
-            case "reduce_cost":
-                logger.info("Nudge: Reducing cost by using cheaper models")
-                # Implementation would adjust model selection
-            case "improve_quality":
-                logger.info("Nudge: Improving quality with more thorough verification")
-                # Implementation would adjust quality gates
-            case "speed_up":
-                logger.info("Nudge: Speeding up with faster models")
-                # Implementation would adjust speed/quality tradeoff
-
-        # Acknowledge the nudge
-        from bernstein.core.orchestration.orchestrator import nudge_manager
-
-        nudge_manager.acknowledge_nudge(nudge)
-
-
 # ---------------------------------------------------------------------------
 # Context collapse integration (T418)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Removes `tick_pipeline.check_nudges_during_tick` — 28 lines, uncalled, and stubbed.

Refs #4901, which has the full picture. Resolves one `KNOWN_UNREACHABLE` entry from #4896.

## Why

The **producing** half of the nudge system is live and tested. `nudge_orchestrator` records a nudge, `get_orchestrator_nudges` reads them back, both are re-exported from `orchestrator.py:7342-7344`, and `test_nudge_manager.py` covers them.

This function was the only reader in `src/`, and it fails on both counts:

- **never called** — nothing invokes it, from the tick loop or anywhere else
- **not implemented** — every branch logs and returns:

```python
case "increase_parallelism":
    logger.info("Nudge: Increasing parallelism for better throughput")
    # Implementation would adjust parallelism settings
```

Those four `Implementation would` comments are the only occurrences of that phrase in `src/`, so this is one placeholder rather than a house pattern.

## Why delete rather than wire

Wiring it into the tick loop is a two-line change that delivers **four log statements**. I think that is worse than leaving it out: a line reading *"Nudge: Increasing parallelism for better throughput"* while adjusting nothing reads as a working feature in exactly the logs someone would check to find out whether it worked. Silence is honest; a confident log line is not.

Deleting makes the gap visible for whoever builds the real consumer, and leaves the producing half completely untouched — `nudge_orchestrator`, `get_orchestrator_nudges` and their tests are unchanged, so nothing is lost if that work starts tomorrow.

If the nudge system is parked deliberately, #4901 suggests a line in the module docstring saying nothing downstream reads it, which I am happy to add here instead.

## Verification

- `scripts/run_tests.py`: 239 passed (`test_nudge_manager` 11, `test_orchestrator` 228)
- `tick_pipeline` imports cleanly with the function gone
- `ruff check` / `ruff format` clean

## Checklist

- [x] `ruff check src/` passes
- [x] `pyright` — N/A in effect; this only removes code
- [x] `scripts/run_tests.py` on the touched areas: 239 passed
- [x] New code has type hints — N/A

### Documentation duty

- [x] README / `docs/operations/` / `docs/api/` — N/A; the function was unreachable, so it backed no documented behaviour
- [x] `agents-md sync` — N/A, no new module
- [x] Tests cover the documented behaviour — the nudge tests that exist cover the half that is real, and still pass unchanged