### PR TITLE
docs(release): refresh release milestones table from live GitHub data

### DIFF
--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -28,11 +28,13 @@ Update this table whenever a release workflow is added, renamed, or moved.
 
 Bernstein uses GitHub milestones to plan minor and major releases. Patch releases do not get milestones; they ship from `main` as the `auto-release.yml` workflow determines they have meaningful changes.
 
+Only open, version-numbered milestones are listed below -- a shipped version drops off this table rather than being marked done, and non-version tracking milestones (e.g. epics like "Volunteer workers") are out of scope since they don't follow this release cadence. Re-derive the rows from `gh api repos/sipyourdrink-ltd/bernstein/milestones` when this goes stale; don't hand-edit target dates.
+
 | Milestone | Target Date | Status |
 |---|---|---|
-| `v3.18.0` | 2026-09-05 | Planned |
-| `v3.19.0` | 2026-09-19 | Planned |
-| `v4.0.0` | TBD | Planned |
+| `v3.19.0` | 2026-09-05 | Planned |
+| `v3.20.0` | 2026-09-19 | Planned |
+| `v4.0.0` | 2026-12-19 | Planned |
 
 ### Triage guidance
 


### PR DESCRIPTION
## Summary

- `docs/operations/release.md`'s Release Milestones table still showed `v3.18.0` as "Planned" after it shipped (v3.18.1 and v3.18.2 followed), and listed `v3.19.0`'s target date as 2026-09-19 when the open milestone's actual `due_on` is 2026-09-05 -- so the Triage guidance section right below it pointed at the wrong milestone.
- Replaced the rows with the currently open, version-numbered milestones and their real `due_on` values, read via `gh api repos/sipyourdrink-ltd/bernstein/milestones`.
- Scoped the table to open release milestones only (added a line above it saying so) so shipped versions don't get re-added, and so a non-version tracking milestone like "Volunteer workers - MVP" -- which is deliberately not tied to a release version -- doesn't get added to it either.
- No other content in the file was touched.

## Test plan

- [x] Confirmed current milestone state against the API: `gh api repos/sipyourdrink-ltd/bernstein/milestones --jq '.[] | "\(.title) \(.due_on) \(.state)"'`
- [x] `git diff` scoped to exactly the table + one explanatory line in `docs/operations/release.md`