### PR TITLE
adapters draft: caller, YAML persistence, operator confirmation (#3763)

### DIFF
--- a/docs/release-notes/fragments/3763-adapter-draft-cli.md
+++ b/docs/release-notes/fragments/3763-adapter-draft-cli.md
@@ -1,0 +1,3 @@
+## Drafted adapter profiles get an operator confirmation and a saved record
+
+`bernstein adapters draft` runs a real probe against an installed CLI, drafts a candidate invocation profile from its `--help` capture, and shows the operator the exact argv the draft would invoke before anything is written. A confirmed draft persists as plain YAML - the invocation, a contract preview, and the evidence byte range each field traces back to - so a later step can read back what was accepted (#3763).

--- a/src/bernstein/adapters/draft.py
+++ b/src/bernstein/adapters/draft.py
@@ -8,10 +8,15 @@ during onboarding to create a profile that matches the evidence.
 from __future__ import annotations
 
 import json
+import os
 import re
+import tempfile
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+import yaml
 
 from bernstein.adapters.capability_profile import InvocationSpec
 
@@ -120,3 +125,97 @@ def draft_from_evidence(
     )
 
     return Draft(invocation=invocation, evidence_byte_range=model_flag_range)
+
+
+# ---------------------------------------------------------------------------
+# Plain-YAML persistence (issue #3763)
+# ---------------------------------------------------------------------------
+
+
+def draft_document(draft: Draft) -> dict[str, Any]:
+    """Return the plain-YAML document for a drafted profile plus contract.
+
+    The "candidate profile" is the invocation surface exactly as
+    :meth:`InvocationSpec.to_canonical_dict` reports it. The "contract"
+    section restates the same evidence-backed flags under the field names
+    the pinned contract YAML uses (:class:`bernstein.adapters._contract.ContractSpec`),
+    so the draft reads as a preview of the contract an operator would later
+    pin, not a second, drifting vocabulary. Nothing here is invented: every
+    value traces back to ``draft.invocation``, which :func:`draft_from_evidence`
+    built only from tokens literally present in the probe evidence.
+
+    Args:
+        draft: A drafted profile, typically from :func:`draft_from_evidence`.
+
+    Returns:
+        A JSON/YAML-safe mapping with ``invocation``, ``contract``, and
+        ``provenance`` sections.
+    """
+    invocation = draft.invocation
+    provenance: dict[str, Any] = {}
+    if draft.evidence_byte_range is not None:
+        start, end = draft.evidence_byte_range
+        provenance["model_flag"] = {"start": start, "end": end}
+    return {
+        "invocation": invocation.to_canonical_dict(),
+        "contract": {
+            "binary": invocation.binary,
+            "required_flags": list(invocation.declared_flags()),
+            "required_subcommands": list(invocation.subcommands),
+        },
+        "provenance": provenance,
+    }
+
+
+def write_draft_yaml(draft: Draft, path: Path) -> Path:
+    """Atomically persist ``draft`` as a plain-YAML document at ``path``.
+
+    Writes through a same-directory temporary file and ``os.replace`` so a
+    concurrent reader never observes a partially written document. Mirrors
+    :func:`bernstein.adapters.onboarding._atomic_write_yaml`.
+
+    Args:
+        draft: The drafted profile to persist.
+        path: Destination file (parent directories are created as needed).
+
+    Returns:
+        ``path``, for chaining.
+    """
+    document = draft_document(draft)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            yaml.safe_dump(document, handle, default_flow_style=False, sort_keys=False)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        # ``os.replace`` removes the temporary directory entry on success;
+        # unlinking only the remaining path keeps failed writes tidy.
+        with suppress(FileNotFoundError):
+            temporary.unlink()
+    return path
+
+
+def read_draft_document(path: Path) -> dict[str, Any]:
+    """Read one persisted draft document back.
+
+    Args:
+        path: A file previously written by :func:`write_draft_yaml`.
+
+    Returns:
+        The parsed mapping.
+
+    Raises:
+        ValueError: The file does not contain a YAML mapping.
+    """
+    with path.open("r", encoding="utf-8") as handle:
+        data: dict[str, Any] = yaml.safe_load(handle) or {}
+    # The annotation above is what safe_load *should* return for this file;
+    # the check guards against a file on disk that never went through
+    # write_draft_yaml (or was hand-edited into a list/scalar).
+    if not isinstance(data, dict):  # pyright: ignore[reportUnnecessaryIsInstance]
+        raise ValueError(f"draft document at {path} must be a YAML mapping, got {type(data).__name__}")
+    return data

--- a/src/bernstein/adapters/onboarding.py
+++ b/src/bernstein/adapters/onboarding.py
@@ -42,6 +42,7 @@ import yaml
 from bernstein.adapters._contract import _run_capture, _sandbox_env
 from bernstein.adapters.capability_profile import AdapterCapabilityProfile, InvocationSpec
 from bernstein.adapters.conformance import GoldenTranscript, StepResult, TranscriptResult, TranscriptStep
+from bernstein.adapters.draft import Draft, draft_from_evidence
 
 #: Per-command timeout for probe invocations.
 _PROBE_TIMEOUT_SECONDS = 30
@@ -59,6 +60,7 @@ __all__ = [
     "HeldOutInvocation",
     "ProbeEvidence",
     "derive_held_out_invocations",
+    "draft_from_probe",
     "probe_cli",
     "record_golden_transcript",
     "replay_held_out_invocations",
@@ -128,6 +130,58 @@ def probe_cli(binary: str, out_dir: Path) -> list[ProbeEvidence]:
         }
         evidence.append(_write_evidence(out_dir, record))
     return evidence
+
+
+def _help_evidence(evidence: Sequence[ProbeEvidence]) -> ProbeEvidence:
+    """Select the ``--help`` capture out of one probe run's evidence list.
+
+    :func:`probe_cli` always emits evidence in the fixed order it declares
+    its commands, but callers should not depend on that order; this walks
+    the list and matches on the recorded command string instead.
+
+    Raises:
+        ValueError: No evidence entry recorded a ``--help`` invocation.
+    """
+    for item in evidence:
+        if item.command.endswith(" --help"):
+            return item
+    raise ValueError("probe evidence has no --help capture to draft from")
+
+
+def draft_from_probe(
+    binary: str,
+    out_dir: Path,
+    *,
+    required_fields: set[str] | None = None,
+) -> Draft:
+    """Probe ``binary`` and draft a capability profile from its ``--help`` capture.
+
+    This is the caller :func:`~bernstein.adapters.draft.draft_from_evidence`
+    was missing (issue #3763): it wires a real, freshly run :func:`probe_cli`
+    capture into drafting, so a candidate profile can be produced from an
+    installed CLI directly rather than only from a hand-written evidence
+    fixture in a test. ``out_dir`` receives the raw probe evidence exactly as
+    :func:`probe_cli` already writes it, so the drafted profile's provenance
+    stays inspectable after this call returns.
+
+    Args:
+        binary: The CLI binary name to probe (resolved via ``PATH``).
+        out_dir: Directory receiving the probe evidence files.
+        required_fields: Forwarded to
+            :func:`~bernstein.adapters.draft.draft_from_evidence`; field
+            names drafting must resolve from evidence or refuse, by name.
+
+    Returns:
+        The :class:`~bernstein.adapters.draft.Draft` built from the probe's
+        ``--help`` capture.
+
+    Raises:
+        ValueError: Drafting could not resolve a required field (see
+            :func:`~bernstein.adapters.draft.draft_from_evidence`).
+    """
+    evidence = probe_cli(binary, out_dir)
+    help_evidence = _help_evidence(evidence)
+    return draft_from_evidence(help_evidence.path, required_fields=required_fields)
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/cli/commands/adapter_cmd.py
+++ b/src/bernstein/cli/commands/adapter_cmd.py
@@ -270,6 +270,18 @@ def _register_verify_subcommand() -> None:
 _register_verify_subcommand()
 
 
+def _register_draft_subcommand() -> None:
+    """Attach the probe-to-draft onboarding subcommand (#3763)."""
+    try:
+        from bernstein.cli.commands.adapters_draft_cmd import register_adapters_draft
+    except Exception:  # pragma: no cover -- defensive
+        return
+    register_adapters_draft(adapters_group)
+
+
+_register_draft_subcommand()
+
+
 @adapters_group.command("list")
 @click.option(
     "--json",

--- a/src/bernstein/cli/commands/adapters_draft_cmd.py
+++ b/src/bernstein/cli/commands/adapters_draft_cmd.py
@@ -1,0 +1,199 @@
+"""``bernstein adapters draft`` - draft a candidate profile from a live probe.
+
+Closes the caller gap left by issue #3763: :func:`bernstein.adapters.draft.
+draft_from_evidence` had no path from an installed CLI to a drafted profile
+outside its own test file. This command supplies that path end to end - a
+real probe, a draft, an operator confirmation naming the exact argv the
+draft would invoke, and a persisted plain-YAML record a later step can read
+back.
+
+Nothing is written until the operator confirms (or passes ``--yes``); a
+declined or refused draft leaves ``--out-dir`` untouched.
+
+Exit codes:
+
+* ``0`` - drafted and persisted.
+* ``1`` - the operator declined the confirmation.
+* ``2`` - drafting refused: a ``--require``d field had no evidence-backed
+  value. The message names the missing field.
+
+Refs: #3763.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+
+from bernstein.adapters.draft import Draft, read_draft_document, write_draft_yaml
+from bernstein.adapters.onboarding import draft_from_probe
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+#: Default location for raw probe evidence, relative to the repo root.
+DEFAULT_EVIDENCE_DIR = Path(".sdd") / "adapters" / "evidence"
+#: Default location for persisted draft documents, relative to the repo root.
+DEFAULT_DRAFTS_DIR = Path(".sdd") / "adapters" / "drafts"
+
+#: Fields drafting can be asked to require; see ``draft_from_evidence``.
+_DRAFT_REQUIRE_CHOICES = ("model_flag", "prompt_flag")
+
+
+def _render_preview(draft: Draft, *, model: str, prompt: str) -> str:
+    """Human-readable preview of the exact argv a drafted invocation would run.
+
+    Shown to the operator before anything is persisted, per the issue's own
+    "What should become true": *"The operator reviews one confirmation
+    showing the exact argv the drafted profile will invoke before anything
+    is accepted."*
+    """
+    invocation = draft.invocation
+    argv = invocation.build_argv(prompt=prompt, model=model)
+    lines = [
+        f"binary:       {invocation.binary}",
+        f"subcommands:  {' '.join(invocation.subcommands) or '(none)'}",
+        f"model_flag:   {invocation.model_flag or '(none)'}",
+        f"prompt_flag:  {invocation.prompt_flag or '(positional)'}",
+        f"extra_args:   {' '.join(invocation.extra_args) or '(none)'}",
+        f"argv:         {' '.join(argv)}",
+    ]
+    if draft.evidence_byte_range is not None:
+        start, end = draft.evidence_byte_range
+        lines.append(f"provenance:   model flag at evidence bytes [{start}, {end})")
+    else:
+        lines.append("provenance:   no evidence byte range recorded")
+    return "\n".join(lines)
+
+
+def _confirm_default(preview: str) -> bool:
+    """Default confirmation gate: show the preview, then prompt."""
+    click.echo(preview)
+    return click.confirm("Persist this drafted profile?", default=False)
+
+
+def _execute_draft(
+    binary: str,
+    *,
+    evidence_dir: Path,
+    out_dir: Path,
+    required_fields: set[str],
+    preview_model: str,
+    preview_prompt: str,
+    assume_yes: bool,
+    confirm: Callable[[str], bool] = _confirm_default,
+) -> tuple[int, Path | None]:
+    """Draft, preview, confirm, and persist; return ``(exit_code, written_path)``.
+
+    Split out from the Click command so tests exercise the full pipeline - a
+    real probe subprocess and a real file write - without a TTY behind the
+    confirmation prompt. ``out_dir`` is touched only on a confirmed,
+    successful draft; a decline or a refusal leaves it exactly as found.
+    """
+    try:
+        draft = draft_from_probe(binary, evidence_dir, required_fields=required_fields)
+    except ValueError as exc:
+        click.echo(f"drafting refused: {exc}", err=True)
+        return 2, None
+
+    preview = _render_preview(draft, model=preview_model, prompt=preview_prompt)
+    if assume_yes:
+        click.echo(preview)
+    elif not confirm(preview):
+        click.echo("Aborted; nothing written.")
+        return 1, None
+
+    target = out_dir / f"{Path(binary).name}.yaml"
+    write_draft_yaml(draft, target)
+    # Read the persisted document back rather than trusting the in-memory
+    # draft, so the confirmation message reflects what actually landed on
+    # disk - the artefact a later run/step reads, not what this process
+    # merely held in memory.
+    written = read_draft_document(target)
+    flag_count = len(written.get("contract", {}).get("required_flags", []))
+    click.echo(f"Wrote drafted profile to {target} ({flag_count} evidence-backed flag(s))")
+    return 0, target
+
+
+@click.command("draft")
+@click.argument("binary")
+@click.option(
+    "--evidence-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help=f"Directory receiving the raw probe evidence (default: {DEFAULT_EVIDENCE_DIR}).",
+)
+@click.option(
+    "--out-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help=f"Directory receiving the persisted draft YAML (default: {DEFAULT_DRAFTS_DIR}).",
+)
+@click.option(
+    "--require",
+    "required",
+    multiple=True,
+    type=click.Choice(_DRAFT_REQUIRE_CHOICES),
+    help="Field drafting must resolve from evidence or refuse, by name. Repeatable.",
+)
+@click.option(
+    "--preview-model",
+    default="<model>",
+    show_default=True,
+    help="Placeholder model id shown in the argv preview.",
+)
+@click.option(
+    "--preview-prompt",
+    default="<prompt>",
+    show_default=True,
+    help="Placeholder prompt shown in the argv preview.",
+)
+@click.option(
+    "--yes",
+    "assume_yes",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt and persist immediately.",
+)
+def adapters_draft_cmd(
+    binary: str,
+    evidence_dir: Path | None,
+    out_dir: Path | None,
+    required: tuple[str, ...],
+    preview_model: str,
+    preview_prompt: str,
+    assume_yes: bool,
+) -> None:
+    """Probe BINARY and draft a candidate capability profile plus contract.
+
+    Runs a real probe against BINARY, drafts an InvocationSpec-shaped
+    profile from its --help capture, and shows the operator the exact argv
+    the draft would invoke. Nothing is written until the operator confirms
+    (or --yes is passed).
+    """
+    rc, _target = _execute_draft(
+        binary,
+        evidence_dir=evidence_dir if evidence_dir is not None else DEFAULT_EVIDENCE_DIR,
+        out_dir=out_dir if out_dir is not None else DEFAULT_DRAFTS_DIR,
+        required_fields=set(required),
+        preview_model=preview_model,
+        preview_prompt=preview_prompt,
+        assume_yes=assume_yes,
+    )
+    sys.exit(rc)
+
+
+def register_adapters_draft(group: click.Group) -> None:
+    """Attach ``draft`` to an existing ``adapters`` group."""
+    group.add_command(adapters_draft_cmd, "draft")
+
+
+__all__ = [
+    "DEFAULT_DRAFTS_DIR",
+    "DEFAULT_EVIDENCE_DIR",
+    "adapters_draft_cmd",
+    "register_adapters_draft",
+]

--- a/tests/unit/adapters/test_adapter_onboard_draft.py
+++ b/tests/unit/adapters/test_adapter_onboard_draft.py
@@ -157,3 +157,117 @@ def test_draft_argv_reconstructable_from_evidence_backed_fields(tmp_path: Path) 
     assert draft.invocation.binary == "probe-with-model", (
         f"Binary must come from evidence, got {draft.invocation.binary!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# draft_from_probe: wires a real probe_cli() run into draft_from_evidence()
+# (remaining work on issue #3763 - draft_from_evidence had no caller).
+# ---------------------------------------------------------------------------
+
+RECORDABLE_FIXTURE = FIXTURES / "probe_recordable.py"
+
+
+def test_draft_from_probe_wires_a_real_probe_into_drafting(tmp_path: Path) -> None:
+    """draft_from_probe() runs a real probe subprocess and drafts from its --help capture.
+
+    Uses the already-executable ``probe_recordable.py`` fixture directly (no
+    fixture-file rewrite): a real subprocess is spawned, real evidence files
+    land on disk under ``evidence_dir``, and the draft built from them is
+    identical in shape to one built from a hand-written evidence file.
+    """
+    from bernstein.adapters.onboarding import draft_from_probe
+
+    evidence_dir = tmp_path / "evidence"
+    draft = draft_from_probe(str(RECORDABLE_FIXTURE), evidence_dir)
+
+    assert draft.invocation.binary == str(RECORDABLE_FIXTURE)
+    assert draft.invocation.model_flag == "--model"
+    assert draft.invocation.prompt_flag == "--prompt"
+    assert draft.evidence_byte_range is not None
+
+    # The probe genuinely ran: real evidence files exist on disk, one per
+    # probed command (--version, --help, and the completion patterns).
+    evidence_files = list(evidence_dir.glob("*.json"))
+    assert len(evidence_files) >= 2, f"expected real probe evidence on disk, found {evidence_files}"
+
+
+def test_draft_from_probe_refuses_naming_the_missing_field_from_a_real_probe(tmp_path: Path) -> None:
+    """draft_from_probe() forwards required_fields and refuses on a real probe with no --model.
+
+    ``probe_ok.py`` is a real, directly-executable fixture whose --help text
+    carries no model flag; asking drafting to require one must refuse and
+    name it, not silently return a profile with model_flag=None.
+    """
+    from bernstein.adapters.onboarding import draft_from_probe
+
+    binary = str(FIXTURES / "probe_ok.py")
+    evidence_dir = tmp_path / "evidence"
+
+    with pytest.raises(Exception) as exc_info:
+        draft_from_probe(binary, evidence_dir, required_fields={"model_flag"})
+
+    assert "--model" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# draft_document / write_draft_yaml / read_draft_document: the draft is
+# serialized as plain YAML (candidate profile + contract), and provenance
+# survives a real round trip through disk (remaining work on issue #3763).
+# ---------------------------------------------------------------------------
+
+
+def test_draft_document_only_carries_evidence_backed_fields(tmp_path: Path) -> None:
+    """draft_document() emits invocation + contract + provenance with nothing invented.
+
+    The contract's required_flags must equal the invocation's own
+    declared_flags() (no extra, no missing), and required_subcommands must
+    stay empty because drafting never populates subcommands from evidence.
+    """
+    from bernstein.adapters.draft import draft_document, draft_from_evidence
+
+    help_text = _load_fixture_help_text("probe_with_model_help")
+    evidence_path = _write_evidence_file(tmp_path, "probe-with-model", help_text, "probe-with-model --help")
+    draft = draft_from_evidence(evidence_path)
+
+    document = draft_document(draft)
+
+    assert set(document) == {"invocation", "contract", "provenance"}
+    assert document["invocation"]["model_flag"] == "--model"
+    assert document["invocation"]["prompt_flag"] == "--prompt"
+    assert document["contract"]["binary"] == draft.invocation.binary
+    assert document["contract"]["required_flags"] == list(draft.invocation.declared_flags())
+    assert document["contract"]["required_subcommands"] == [], (
+        "drafting never resolves subcommands from evidence; the contract preview must not invent any"
+    )
+    start, end = draft.evidence_byte_range
+    assert document["provenance"]["model_flag"] == {"start": start, "end": end}
+
+
+def test_write_draft_yaml_round_trips_through_a_real_file_preserving_provenance(tmp_path: Path) -> None:
+    """write_draft_yaml() + read_draft_document() round-trip through a real file, losslessly.
+
+    Checked at the layer where the property actually lives: a real file on
+    disk, read back and compared, plus a plain-text check that the file is
+    YAML (not some other serialization) as the issue's own wording asks for.
+    """
+    from bernstein.adapters.draft import draft_document, draft_from_evidence, read_draft_document, write_draft_yaml
+
+    help_text = _load_fixture_help_text("probe_with_model_help")
+    evidence_path = _write_evidence_file(tmp_path, "probe-with-model", help_text, "probe-with-model --help")
+    draft = draft_from_evidence(evidence_path)
+
+    target = tmp_path / "drafts" / "probe-with-model.yaml"
+    returned = write_draft_yaml(draft, target)
+
+    assert returned == target
+    assert target.is_file(), "write_draft_yaml must create parent dirs and the file itself"
+
+    raw_text = target.read_text(encoding="utf-8")
+    assert "model_flag: --model" in raw_text, f"expected plain-YAML key: value lines, got:\n{raw_text}"
+
+    loaded = read_draft_document(target)
+    assert loaded == draft_document(draft), "round trip through disk must be lossless"
+    # The property in the issue's title: per-field provenance survives the
+    # write, not just the in-memory object.
+    start, end = draft.evidence_byte_range
+    assert loaded["provenance"]["model_flag"] == {"start": start, "end": end}

--- a/tests/unit/cli/test_adapters_draft_cmd.py
+++ b/tests/unit/cli/test_adapters_draft_cmd.py
@@ -1,0 +1,182 @@
+"""Tests for ``bernstein adapters draft`` (remaining work on issue #3763).
+
+``draft_from_evidence`` (from an earlier slice) had no caller reachable
+outside its own test file, no YAML persistence, and no operator
+confirmation. These tests cover the CLI surface that closes those three
+gaps: a real probe subprocess, a real confirmation gate, and a real file
+written only when the operator accepts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.adapters.draft import read_draft_document
+from bernstein.cli.commands.adapters_draft_cmd import _execute_draft
+from bernstein.cli.main import cli
+
+FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "probe"
+RECORDABLE_FIXTURE = FIXTURES / "probe_recordable.py"
+NO_MODEL_FIXTURE = FIXTURES / "probe_ok.py"
+
+
+# ---------------------------------------------------------------------------
+# _execute_draft: the full pipeline (real probe subprocess, real file),
+# confirmation injected so no test depends on a TTY.
+# ---------------------------------------------------------------------------
+
+
+def test_execute_draft_confirmed_persists_a_real_file_showing_the_exact_argv(tmp_path: Path) -> None:
+    """A confirmed draft persists YAML to out_dir, and the operator saw the real argv first."""
+    seen_previews: list[str] = []
+
+    def confirm(preview: str) -> bool:
+        seen_previews.append(preview)
+        return True
+
+    rc, target = _execute_draft(
+        str(RECORDABLE_FIXTURE),
+        evidence_dir=tmp_path / "evidence",
+        out_dir=tmp_path / "drafts",
+        required_fields=set(),
+        preview_model="fixture-model",
+        preview_prompt="fixture-prompt",
+        assume_yes=False,
+        confirm=confirm,
+    )
+
+    assert rc == 0
+    assert target is not None and target.is_file()
+
+    # The confirmation the operator actually saw named the exact argv,
+    # binary included - not a placeholder or a summary.
+    assert len(seen_previews) == 1
+    assert str(RECORDABLE_FIXTURE) in seen_previews[0]
+    assert "--model fixture-model" in seen_previews[0]
+    assert "--prompt fixture-prompt" in seen_previews[0]
+
+    document = read_draft_document(target)
+    assert document["invocation"]["model_flag"] == "--model"
+
+
+def test_execute_draft_declined_leaves_out_dir_untouched(tmp_path: Path) -> None:
+    """Declining the confirmation writes nothing - out_dir is never even created."""
+    out_dir = tmp_path / "drafts"
+
+    rc, target = _execute_draft(
+        str(RECORDABLE_FIXTURE),
+        evidence_dir=tmp_path / "evidence",
+        out_dir=out_dir,
+        required_fields=set(),
+        preview_model="m",
+        preview_prompt="p",
+        assume_yes=False,
+        confirm=lambda _preview: False,
+    )
+
+    assert rc == 1
+    assert target is None
+    assert not out_dir.exists(), "a declined draft must not create out_dir"
+
+
+def test_execute_draft_yes_flag_never_calls_the_confirmation_gate(tmp_path: Path) -> None:
+    """--yes bypasses confirmation entirely, not merely auto-answers it."""
+
+    def confirm(_preview: str) -> bool:
+        raise AssertionError("confirm() must not be called when assume_yes=True")
+
+    rc, target = _execute_draft(
+        str(RECORDABLE_FIXTURE),
+        evidence_dir=tmp_path / "evidence",
+        out_dir=tmp_path / "drafts",
+        required_fields=set(),
+        preview_model="m",
+        preview_prompt="p",
+        assume_yes=True,
+        confirm=confirm,
+    )
+
+    assert rc == 0
+    assert target is not None and target.is_file()
+
+
+def test_execute_draft_refuses_missing_required_field_without_ever_confirming(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A --require'd field missing from a real probe refuses before confirmation, writes nothing."""
+    out_dir = tmp_path / "drafts"
+
+    def confirm(_preview: str) -> bool:
+        raise AssertionError("confirm() must not be called when drafting itself refused")
+
+    rc, target = _execute_draft(
+        str(NO_MODEL_FIXTURE),
+        evidence_dir=tmp_path / "evidence",
+        out_dir=out_dir,
+        required_fields={"model_flag"},
+        preview_model="m",
+        preview_prompt="p",
+        assume_yes=False,
+        confirm=confirm,
+    )
+
+    assert rc == 2
+    assert target is None
+    assert not out_dir.exists()
+    assert "--model" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# The actual `bernstein adapters draft` command surface, end to end.
+# ---------------------------------------------------------------------------
+
+
+def test_adapters_draft_cli_confirmed_via_stdin_writes_the_draft(tmp_path: Path) -> None:
+    """The registered CLI command, invoked the way an operator would, persists on 'y'."""
+    out_dir = tmp_path / "drafts"
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        [
+            "adapters",
+            "draft",
+            str(RECORDABLE_FIXTURE),
+            "--evidence-dir",
+            str(tmp_path / "evidence"),
+            "--out-dir",
+            str(out_dir),
+        ],
+        input="y\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Wrote drafted profile to" in result.output
+    written = list(out_dir.glob("*.yaml"))
+    assert len(written) == 1, written
+
+
+def test_adapters_draft_cli_declined_via_stdin_writes_nothing(tmp_path: Path) -> None:
+    """The registered CLI command exits 1 and writes nothing when the operator answers 'n'."""
+    out_dir = tmp_path / "drafts"
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        [
+            "adapters",
+            "draft",
+            str(RECORDABLE_FIXTURE),
+            "--evidence-dir",
+            str(tmp_path / "evidence"),
+            "--out-dir",
+            str(out_dir),
+        ],
+        input="n\n",
+    )
+
+    assert result.exit_code == 1
+    assert not out_dir.exists()

--- a/tests/unit/test_one_run_loop.py
+++ b/tests/unit/test_one_run_loop.py
@@ -58,9 +58,7 @@ def test_orchestrator_run_paces_through_the_seam_and_never_sleeps_directly() -> 
     direct = [
         node.lineno
         for node in ast.walk(tree)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "sleep"
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "sleep"
     ]
     assert not direct, (
         f"Orchestrator.run calls time.sleep directly at offset(s) {direct}; pace through "


### PR DESCRIPTION
Partial implementation of #3763.

## Problem

`draft_from_evidence()` (`src/bernstein/adapters/draft.py:51`, added in #4776) had no caller anywhere in the tree outside its own test file, no way to write its output to disk, and no way for an operator to see what it produced before anything happened. The issue's own "What should become true" asks for a drafting step that "emits a candidate profile plus contract as plain YAML" with "one confirmation showing the exact argv the drafted profile will invoke before anything is accepted" - none of that existed yet.

## What this PR does

- **A caller.** `draft_from_probe()` (`onboarding.py`) wires `probe_cli()` into `draft_from_evidence()`: it probes a real binary, picks the `--help` capture out of the resulting evidence list, and drafts from it. This is the first non-test caller of `draft_from_evidence()`.
- **Plain-YAML output.** `draft_document()` / `write_draft_yaml()` / `read_draft_document()` (`draft.py`) serialize a `Draft` as `invocation` + `contract` + `provenance` sections. Nothing is invented: `contract.required_flags` is exactly `invocation.declared_flags()`, `required_subcommands` stays empty because drafting never populates it, and `provenance.model_flag` carries the same evidence byte range `draft_from_evidence()` already computed, unchanged, through the write and back.
- **An operator confirmation.** `bernstein adapters draft BINARY` (new: `adapters_draft_cmd.py`) probes, drafts, and shows the operator the exact argv the draft would invoke (binary, subcommands, flags, and the model/prompt pair rendered in) before writing anything. `--yes` skips the prompt for scripted use; declining, or drafting refusing a `--require`d field, leaves the output directory untouched.
- **Persistence a later step can read.** A confirmed draft writes to `.sdd/adapters/drafts/<binary>.yaml` (or `--out-dir`), atomically, the same way `record_golden_transcript` already writes golden transcripts.

Schema decision the issue asked to be stated: the drafted document keeps its own vocabulary (`invocation`/`contract`/`provenance`), not `AdapterCapabilityProfile`'s fields 1:1. That was already the shape `Draft` took in #4776 (no `name`/`display_name`/capability axes - a draft only has an invocation and where it came from), so this keeps `draft_document()` consistent with the object it's serializing rather than inventing fields drafting has no evidence for.

## What this PR explicitly does NOT do

- **Consumption into an `AdapterCapabilityProfile`, or admission.** The issue's own "Out of scope" section reserves admission for a later slice of #3544. Nothing here registers a drafted profile into `PROFILES` or makes it spawnable.
- **Subcommand extraction from evidence.** `invocation.subcommands` (and so `contract.required_subcommands`) stays empty, exactly as `draft_from_evidence()` already leaves it. Not required by the issue's Proof bullets, and left alone here to keep this change to the caller/persistence/confirmation gap.
- **Provenance for fields beyond the model flag.** `draft_from_evidence()` only ever computed a byte range for `model_flag`; this PR carries that value through YAML and the confirmation display without dropping it, but does not add new provenance tracking for `prompt_flag`, `binary`, or other fields - that would be a change to `Draft`'s own shape from #4776, not to its callers.
- **Any change to `draft_from_evidence()` itself**, `pyproject.toml`, `uv.lock`, or `AGENTS.md`.

## Tests

Each test protects one specific property, not "it works":

- `test_draft_from_probe_wires_a_real_probe_into_drafting` - a real probe subprocess runs and its evidence, read back off disk, drafts a full invocation.
- `test_draft_from_probe_refuses_naming_the_missing_field_from_a_real_probe` - `required_fields` reaches `draft_from_evidence()` through the new caller; a real probe of a binary with no `--model` in its `--help` still refuses by name.
- `test_draft_document_only_carries_evidence_backed_fields` - the contract section never claims a flag or subcommand `invocation` doesn't itself declare.
- `test_write_draft_yaml_round_trips_through_a_real_file_preserving_provenance` - a real file on disk, read back, is byte-for-byte the same document, including the provenance byte range, and is actually YAML (not some other format).
- `test_execute_draft_confirmed_persists_a_real_file_showing_the_exact_argv` - the text the operator is shown before confirming contains the real binary and the real argv, not a placeholder.
- `test_execute_draft_declined_leaves_out_dir_untouched` - declining writes nothing; the output directory isn't even created.
- `test_execute_draft_yes_flag_never_calls_the_confirmation_gate` - `--yes` is a true bypass (the confirmation callable raises if invoked), not an auto-"yes".
- `test_execute_draft_refuses_missing_required_field_without_ever_confirming` - a refusal short-circuits before the operator is ever asked, and writes nothing.
- `test_adapters_draft_cli_confirmed_via_stdin_writes_the_draft` / `test_adapters_draft_cli_declined_via_stdin_writes_nothing` - the actual registered `bernstein adapters draft` command, invoked the way an operator would, through real stdin.

```
uv run python scripts/run_tests.py tests/unit/adapters/test_adapter_onboard_draft.py tests/unit/cli/test_adapters_draft_cmd.py tests/unit/adapters/ tests/unit/cli/test_adapters_cmd.py tests/unit/test_adapter_cmd.py tests/unit/test_adapter_admission.py
uv run ruff check src/bernstein/adapters/draft.py src/bernstein/adapters/onboarding.py src/bernstein/cli/commands/adapter_cmd.py src/bernstein/cli/commands/adapters_draft_cmd.py
uv run pyright src/bernstein/adapters/draft.py src/bernstein/cli/commands/adapters_draft_cmd.py
uv run lint-imports
```

All green. `uv run bernstein adapters draft --help` and a live run against the `probe_recordable.py` fixture were also checked by hand.
