### PR TITLE
feat(scanners): add feed-pinned trivy adapter

### DIFF
--- a/docs/sdd/module-map.md
+++ b/docs/sdd/module-map.md
@@ -180,6 +180,7 @@ Full per-file module map. `AGENTS.md`'s own "Module map" section links here inst
 | `session_id.py`             | Deterministic session-id binding for adapter replay isolation |
 | `skills_injector.py`        | Inject per-task Claude Code skills into the worktree before spawn |
 | `strict_schema.py`          | Strict structured-output validation and user-owned-field protection |
+| `trivy.py`                  | Feed-pinned Trivy scanner adapter and SARIF normalization |
 | `use_cases.py`              | Per-adapter metadata for the ``bernstein integrations list`` command |
 | `ci/`                       | CI system adapters for log parsing and failure extraction |
 | `digest/`                   | Tool output digesters registry and ruleset models |

--- a/src/bernstein/adapters/scanner_registry.py
+++ b/src/bernstein/adapters/scanner_registry.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from bernstein.adapters.gitleaks import GitleaksAdapter
 from bernstein.adapters.scanner import ScannerAdapter
+from bernstein.adapters.trivy import TrivyAdapter
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -152,3 +153,4 @@ def scanner_name_for_provider(provider_name: str | None, model: str) -> str | No
 
 
 register_scanner(GitleaksAdapter.registry_name, GitleaksAdapter)
+register_scanner(TrivyAdapter.registry_name, TrivyAdapter)

--- a/src/bernstein/adapters/trivy.py
+++ b/src/bernstein/adapters/trivy.py
@@ -1,0 +1,323 @@
+"""Feed-pinned Trivy scanner adapter and SARIF normalization."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+from urllib.parse import unquote, urlparse
+
+from bernstein.adapters._contract import (
+    ScannerCategory as ContractScannerCategory,
+)
+from bernstein.adapters._contract import (
+    ScannerDeterminism,
+    ScannerOutputFormat,
+    register_scanner_capabilities,
+)
+from bernstein.adapters.env_isolation import build_filtered_env  # pyright: ignore[reportUnknownVariableType]
+from bernstein.adapters.scanner import (
+    DeterminismTier,
+    OutputFormat,
+    ScannerAdapter,
+    ScannerCategory,
+    ScanResult,
+    ScanScope,
+)
+from bernstein.adapters.scanner_finding import Finding
+
+TRIVY_REGISTRY_NAME = "trivy"
+_SCAN_TIMEOUT_SECONDS = 300
+_SHA256_DIGEST = re.compile(r"sha256:[0-9a-fA-F]{64}\Z")
+
+
+class TrivyError(RuntimeError):
+    """Base error raised when Trivy cannot complete a scan."""
+
+
+class TrivyNotInstalledError(TrivyError):
+    """Raised when the Trivy executable cannot be found on ``PATH``."""
+
+
+@dataclass(frozen=True)
+class TrivyInvocation:
+    """Stable provenance for one feed-pinned Trivy invocation."""
+
+    tool_version: str
+    db_digest: str
+    argv_hash: str
+
+
+class TrivyAdapter(ScannerAdapter):
+    """Run feed-pinned Trivy filesystem scans and normalize SARIF findings."""
+
+    registry_name = TRIVY_REGISTRY_NAME
+    output_format = OutputFormat.SARIF
+    determinism = DeterminismTier.FEED_PINNED
+    pinned_inputs = ("trivy_db",)
+    category = ScannerCategory.SCA
+
+    def __init__(self, *, binary: str = "trivy", cache_dir: str | Path | None = None) -> None:
+        super().__init__()
+        self._binary = binary
+        self._cache_dir = Path(cache_dir) if cache_dir is not None else None
+        self.last_invocation: TrivyInvocation | None = None
+
+    def name(self) -> str:
+        """Return the registry key used by the conformance capability lookup."""
+        return self.registry_name
+
+    def scan(self, target: Path, scope: ScanScope, workdir: Path) -> ScanResult:
+        """Run Trivy without updating its database and record the caller's DB digest."""
+        self.enforce_network_policy()
+        db_digest = _validate_scope(target, scope)
+        resolved_target = target.resolve()
+        if not resolved_target.exists():
+            raise TrivyError(f"Trivy target does not exist: {target}")
+
+        binary = shutil.which(self._binary)
+        if binary is None:
+            raise TrivyNotInstalledError(
+                f"Trivy executable {self._binary!r} was not found on PATH; install trivy or configure its binary"
+            )
+
+        tool_version = _read_version(binary)
+        workdir.mkdir(parents=True, exist_ok=True)
+        report_path = (workdir / "trivy.sarif").resolve()
+        report_path.unlink(missing_ok=True)
+        command = _build_command(binary, resolved_target, report_path, self._cache_dir)
+        self.last_invocation = TrivyInvocation(
+            tool_version=tool_version,
+            db_digest=db_digest,
+            argv_hash=_invocation_argv_hash(tool_version, db_digest),
+        )
+
+        try:
+            completed = subprocess.run(
+                command,
+                check=False,
+                capture_output=True,
+                text=True,
+                env=build_filtered_env([]),
+                timeout=_SCAN_TIMEOUT_SECONDS,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise TrivyError(f"Trivy execution failed: {exc}") from exc
+
+        if completed.returncode != 0:
+            detail = completed.stderr.strip() or completed.stdout.strip() or "no diagnostic output"
+            raise TrivyError(f"Trivy exited with code {completed.returncode}: {detail}")
+        if not report_path.is_file():
+            raise TrivyError("Trivy completed without writing its SARIF report")
+
+        try:
+            findings = parse_trivy_sarif(report_path.read_bytes(), target_root=resolved_target)
+        finally:
+            report_path.unlink(missing_ok=True)
+        return ScanResult(findings=findings, feed_digest=db_digest)
+
+
+def _validate_scope(target: Path, scope: ScanScope) -> str:
+    if scope.include or scope.exclude or scope.max_depth is not None:
+        raise ValueError("TrivyAdapter does not yet support include, exclude, or max_depth scan scope fields")
+    unsupported = set(scope.config) - {"db_digest"}
+    if unsupported:
+        raise ValueError(f"Unsupported Trivy scan configuration: {', '.join(sorted(unsupported))}")
+    if scope.roots:
+        resolved_target = target.resolve()
+        target_is_allowed = any(
+            resolved_target == root.resolve() or resolved_target.is_relative_to(root.resolve()) for root in scope.roots
+        )
+        if not target_is_allowed:
+            raise ValueError("Trivy target is outside the allowed ScanScope roots")
+
+    digest = scope.config.get("db_digest")
+    if not isinstance(digest, str) or not _SHA256_DIGEST.fullmatch(digest):
+        raise TrivyError("Feed-pinned Trivy scans require scope.config['db_digest'] as a sha256:<64 hex> digest")
+    return digest.lower()
+
+
+def _read_version(binary: str) -> str:
+    try:
+        completed = subprocess.run(
+            [binary, "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=build_filtered_env([]),
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise TrivyError(f"Could not read Trivy version: {exc}") from exc
+    if completed.returncode != 0:
+        raise TrivyError(f"Could not read Trivy version: {completed.stderr.strip()}")
+    output = completed.stdout.strip()
+    if not output:
+        raise TrivyError("Trivy returned an empty version")
+    first_line = output.splitlines()[0].strip()
+    if first_line.lower().startswith("version:"):
+        first_line = first_line.partition(":")[2].strip()
+    if not first_line:
+        raise TrivyError("Trivy returned an empty version")
+    return first_line
+
+
+def _build_command(binary: str, target: Path, report_path: Path, cache_dir: Path | None) -> list[str]:
+    command = [
+        binary,
+        "filesystem",
+        "--scanners",
+        "vuln",
+        "--skip-db-update",
+        "--format",
+        "sarif",
+        "--output",
+        str(report_path),
+    ]
+    if cache_dir is not None:
+        command.extend(["--cache-dir", str(cache_dir.resolve())])
+    command.append(str(target))
+    return command
+
+
+def _invocation_argv_hash(tool_version: str, db_digest: str) -> str:
+    semantic_invocation = {
+        "command": "filesystem",
+        "db_digest": db_digest,
+        "report_format": "sarif",
+        "scanners": ["vuln"],
+        "skip_db_update": True,
+        "tool": TRIVY_REGISTRY_NAME,
+        "tool_version": tool_version,
+    }
+    canonical = json.dumps(semantic_invocation, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(canonical).hexdigest()
+
+
+def parse_trivy_sarif(report: str | bytes, *, target_root: Path | None = None) -> list[Finding]:
+    """Parse Trivy SARIF into findings whose identity excludes source coordinates."""
+    try:
+        raw = json.loads(report)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ValueError(f"Invalid Trivy SARIF JSON: {exc}") from exc
+
+    root = _mapping(raw, "SARIF root")
+    if root.get("version") != "2.1.0":
+        raise ValueError("Trivy report must use SARIF 2.1.0")
+
+    findings: list[Finding] = []
+    for run_index, run_raw in enumerate(_sequence(root.get("runs"), "runs")):
+        run = _mapping(run_raw, f"runs[{run_index}]")
+        driver = _mapping(_mapping(run.get("tool"), "tool").get("driver"), "tool.driver")
+        if str(driver.get("name") or "").lower() != "trivy":
+            raise ValueError("SARIF tool.driver.name must be 'Trivy'")
+        rules = _rules_by_id(driver)
+
+        for result_index, result_raw in enumerate(_sequence(run.get("results", []), "results")):
+            result = _mapping(result_raw, f"results[{result_index}]")
+            rule_id = str(result.get("ruleId") or "")
+            if not rule_id:
+                raise ValueError(f"results[{result_index}] is missing ruleId")
+            path = _result_path(result, result_index, target_root)
+            message = str(_mapping(result.get("message"), "message").get("text") or "").strip()
+            rule = rules.get(rule_id, {})
+            summary = message or _rule_summary(rule, rule_id)
+            findings.append(
+                Finding(
+                    rule=rule_id,
+                    path=path,
+                    severity=_severity(result, rule),
+                    summary=summary,
+                )
+            )
+    return findings
+
+
+def _rules_by_id(driver: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    rules: dict[str, dict[str, Any]] = {}
+    for raw_rule in _sequence(driver.get("rules", []), "tool.driver.rules"):
+        rule = _mapping(raw_rule, "tool.driver.rules entry")
+        rule_id = str(rule.get("id") or "")
+        if rule_id:
+            rules[rule_id] = rule
+    return rules
+
+
+def _result_path(result: dict[str, Any], result_index: int, target_root: Path | None) -> str:
+    locations = _sequence(result.get("locations"), f"results[{result_index}].locations")
+    if not locations:
+        raise ValueError(f"results[{result_index}] has no location")
+    location = _mapping(locations[0], "location")
+    physical = _mapping(location.get("physicalLocation"), "physicalLocation")
+    artifact = _mapping(physical.get("artifactLocation"), "artifactLocation")
+    uri = str(artifact.get("uri") or "")
+    if not uri:
+        raise ValueError(f"results[{result_index}] is missing artifactLocation.uri")
+    return _normalize_path(uri, target_root)
+
+
+def _normalize_path(uri: str, target_root: Path | None) -> str:
+    parsed = urlparse(uri)
+    path = unquote(parsed.path) if parsed.scheme == "file" else unquote(uri)
+    candidate = Path(path.replace("\\", "/"))
+    if target_root is not None and candidate.is_absolute():
+        root = target_root if target_root.is_dir() or not target_root.exists() else target_root.parent
+        with suppress(ValueError):
+            candidate = candidate.relative_to(root.resolve())
+    return candidate.as_posix()
+
+
+def _rule_summary(rule: dict[str, Any], fallback: str) -> str:
+    short = _mapping(rule.get("shortDescription", {}), "rule.shortDescription")
+    return str(short.get("text") or fallback)
+
+
+def _severity(result: dict[str, Any], rule: dict[str, Any]) -> str:
+    properties = _mapping(rule.get("properties", {}), "rule.properties")
+    tags = [str(tag).lower() for tag in _sequence(properties.get("tags", []), "rule.properties.tags")]
+    for value in ("critical", "high", "medium", "low", "informational"):
+        if value in tags:
+            return value
+
+    score = properties.get("security-severity")
+    with suppress(ValueError):
+        numeric = float(str(score))
+        if numeric >= 9:
+            return "critical"
+        if numeric >= 7:
+            return "high"
+        if numeric >= 4:
+            return "medium"
+        if numeric > 0:
+            return "low"
+
+    return {"error": "high", "warning": "medium", "note": "low", "none": "informational"}.get(
+        str(result.get("level") or "none").lower(), "informational"
+    )
+
+
+def _mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    return cast("dict[str, Any]", value)
+
+
+def _sequence(value: Any, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValueError(f"{label} must be an array")
+    return cast("list[Any]", value)
+
+
+register_scanner_capabilities(
+    TRIVY_REGISTRY_NAME,
+    output_format=ScannerOutputFormat.SARIF,
+    determinism=ScannerDeterminism.FEED_PINNED,
+    pinned_inputs=("trivy_db",),
+    category=ContractScannerCategory.SCA,
+)

--- a/tests/fixtures/scanners/trivy/target/package-lock.json
+++ b/tests/fixtures/scanners/trivy/target/package-lock.json
@@ -1,0 +1,18 @@
+{
+  "name": "bernstein-trivy-fixture",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bernstein-trivy-fixture",
+      "version": "1.0.0",
+      "dependencies": {
+        "lodash": "4.17.20"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.20"
+    }
+  }
+}

--- a/tests/fixtures/scanners/trivy/trivy-0.74.0.sarif
+++ b/tests/fixtures/scanners/trivy/trivy-0.74.0.sarif
@@ -1,0 +1,308 @@
+{
+  "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "fullName": "Trivy Vulnerability Scanner",
+          "informationUri": "https://github.com/aquasecurity/trivy",
+          "name": "Trivy",
+          "rules": [
+            {
+              "id": "CVE-2021-23337",
+              "name": "LanguageSpecificPackageVulnerability",
+              "shortDescription": {
+                "text": "nodejs-lodash: command injection via template"
+              },
+              "fullDescription": {
+                "text": "Lodash versions prior to 4.17.21 are vulnerable to Command Injection via the template function."
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "helpUri": "https://avd.aquasec.com/nvd/cve-2021-23337",
+              "help": {
+                "text": "Vulnerability CVE-2021-23337\nSeverity: HIGH\nPackage: lodash\nFixed Version: 4.17.21\nLink: [CVE-2021-23337](https://avd.aquasec.com/nvd/cve-2021-23337)\nLodash versions prior to 4.17.21 are vulnerable to Command Injection via the template function.",
+                "markdown": "**Vulnerability CVE-2021-23337**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|HIGH|lodash|4.17.21|[CVE-2021-23337](https://avd.aquasec.com/nvd/cve-2021-23337)|\n\nLodash versions prior to 4.17.21 are vulnerable to Command Injection via the template function."
+              },
+              "properties": {
+                "cvssv3_baseScore": 7.2,
+                "cvssv3_vector": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H",
+                "precision": "very-high",
+                "security-severity": "7.2",
+                "tags": [
+                  "vulnerability",
+                  "security",
+                  "HIGH"
+                ]
+              }
+            },
+            {
+              "id": "CVE-2026-4800",
+              "name": "LanguageSpecificPackageVulnerability",
+              "shortDescription": {
+                "text": "lodash: lodash: Arbitrary code execution via untrusted input in template imports"
+              },
+              "fullDescription": {
+                "text": "Impact:\n\nThe fix for CVE-2021-23337 (https://github.com/advisories/GHSA-35jh-r3h4-6jhm) added validation for the variable option in _.template but did not apply the same validation to options.imports key names. Both paths flow into the same Function() constructor sink.\n\nWhen an application passes untrusted input as options.imports key names, an attacker can inject default-parameter expressions that execute arbitrary code at template compilation time.\n\nAdditionally, _.template uses assignInWith to merge imports, which enumerates inherited properties via for..in. If Object.prototype has been polluted by any other vector, the polluted keys are copied into the imports object and passed to Function().\n\nPatches:\n\nUsers should upgrade to version 4.18.0.\n\nWorkarounds:\n\nDo not pass untrusted input as key names in options.imports. Only use developer-controlled, static key names."
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "helpUri": "https://avd.aquasec.com/nvd/cve-2026-4800",
+              "help": {
+                "text": "Vulnerability CVE-2026-4800\nSeverity: HIGH\nPackage: lodash\nFixed Version: 4.18.0\nLink: [CVE-2026-4800](https://avd.aquasec.com/nvd/cve-2026-4800)\nImpact:\n\nThe fix for CVE-2021-23337 (https://github.com/advisories/GHSA-35jh-r3h4-6jhm) added validation for the variable option in _.template but did not apply the same validation to options.imports key names. Both paths flow into the same Function() constructor sink.\n\nWhen an application passes untrusted input as options.imports key names, an attacker can inject default-parameter expressions that execute arbitrary code at template compilation time.\n\nAdditionally, _.template uses assignInWith to merge imports, which enumerates inherited properties via for..in. If Object.prototype has been polluted by any other vector, the polluted keys are copied into the imports object and passed to Function().\n\nPatches:\n\nUsers should upgrade to version 4.18.0.\n\nWorkarounds:\n\nDo not pass untrusted input as key names in options.imports. Only use developer-controlled, static key names.",
+                "markdown": "**Vulnerability CVE-2026-4800**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|HIGH|lodash|4.18.0|[CVE-2026-4800](https://avd.aquasec.com/nvd/cve-2026-4800)|\n\nImpact:\n\nThe fix for CVE-2021-23337 (https://github.com/advisories/GHSA-35jh-r3h4-6jhm) added validation for the variable option in _.template but did not apply the same validation to options.imports key names. Both paths flow into the same Function() constructor sink.\n\nWhen an application passes untrusted input as options.imports key names, an attacker can inject default-parameter expressions that execute arbitrary code at template compilation time.\n\nAdditionally, _.template uses assignInWith to merge imports, which enumerates inherited properties via for..in. If Object.prototype has been polluted by any other vector, the polluted keys are copied into the imports object and passed to Function().\n\nPatches:\n\nUsers should upgrade to version 4.18.0.\n\nWorkarounds:\n\nDo not pass untrusted input as key names in options.imports. Only use developer-controlled, static key names."
+              },
+              "properties": {
+                "cvssv3_baseScore": 8.1,
+                "cvssv3_vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "precision": "very-high",
+                "security-severity": "8.1",
+                "tags": [
+                  "vulnerability",
+                  "security",
+                  "HIGH"
+                ]
+              }
+            },
+            {
+              "id": "CVE-2020-28500",
+              "name": "LanguageSpecificPackageVulnerability",
+              "shortDescription": {
+                "text": "nodejs-lodash: ReDoS via the toNumber, trim and trimEnd functions"
+              },
+              "fullDescription": {
+                "text": "Lodash versions prior to 4.17.21 are vulnerable to Regular Expression Denial of Service (ReDoS) via the toNumber, trim and trimEnd functions."
+              },
+              "defaultConfiguration": {
+                "level": "warning"
+              },
+              "helpUri": "https://avd.aquasec.com/nvd/cve-2020-28500",
+              "help": {
+                "text": "Vulnerability CVE-2020-28500\nSeverity: MEDIUM\nPackage: lodash\nFixed Version: 4.17.21\nLink: [CVE-2020-28500](https://avd.aquasec.com/nvd/cve-2020-28500)\nLodash versions prior to 4.17.21 are vulnerable to Regular Expression Denial of Service (ReDoS) via the toNumber, trim and trimEnd functions.",
+                "markdown": "**Vulnerability CVE-2020-28500**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|MEDIUM|lodash|4.17.21|[CVE-2020-28500](https://avd.aquasec.com/nvd/cve-2020-28500)|\n\nLodash versions prior to 4.17.21 are vulnerable to Regular Expression Denial of Service (ReDoS) via the toNumber, trim and trimEnd functions."
+              },
+              "properties": {
+                "cvssv3_baseScore": 5.3,
+                "cvssv3_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+                "precision": "very-high",
+                "security-severity": "5.3",
+                "tags": [
+                  "vulnerability",
+                  "security",
+                  "MEDIUM"
+                ]
+              }
+            },
+            {
+              "id": "CVE-2025-13465",
+              "name": "LanguageSpecificPackageVulnerability",
+              "shortDescription": {
+                "text": "lodash: prototype pollution in _.unset and _.omit functions"
+              },
+              "fullDescription": {
+                "text": "Lodash versions 4.0.0 through 4.17.22 are vulnerable to prototype pollution in the _.unset and _.omit functions. An attacker can pass crafted paths which cause Lodash to delete methods from global prototypes.\n\nThe issue permits deletion of properties but does not allow overwriting their original behavior.\n\nThis issue is patched on 4.17.23"
+              },
+              "defaultConfiguration": {
+                "level": "warning"
+              },
+              "helpUri": "https://avd.aquasec.com/nvd/cve-2025-13465",
+              "help": {
+                "text": "Vulnerability CVE-2025-13465\nSeverity: MEDIUM\nPackage: lodash\nFixed Version: 4.17.23\nLink: [CVE-2025-13465](https://avd.aquasec.com/nvd/cve-2025-13465)\nLodash versions 4.0.0 through 4.17.22 are vulnerable to prototype pollution in the _.unset and _.omit functions. An attacker can pass crafted paths which cause Lodash to delete methods from global prototypes.\n\nThe issue permits deletion of properties but does not allow overwriting their original behavior.\n\nThis issue is patched on 4.17.23",
+                "markdown": "**Vulnerability CVE-2025-13465**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|MEDIUM|lodash|4.17.23|[CVE-2025-13465](https://avd.aquasec.com/nvd/cve-2025-13465)|\n\nLodash versions 4.0.0 through 4.17.22 are vulnerable to prototype pollution in the _.unset and _.omit functions. An attacker can pass crafted paths which cause Lodash to delete methods from global prototypes.\n\nThe issue permits deletion of properties but does not allow overwriting their original behavior.\n\nThis issue is patched on 4.17.23"
+              },
+              "properties": {
+                "cvssv3_baseScore": 6.5,
+                "cvssv3_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:L",
+                "cvssv40_baseScore": 6.9,
+                "cvssv40_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:L/VA:L/SC:H/SI:H/SA:H/E:P",
+                "precision": "very-high",
+                "security-severity": "6.5",
+                "tags": [
+                  "vulnerability",
+                  "security",
+                  "MEDIUM"
+                ]
+              }
+            },
+            {
+              "id": "CVE-2026-2950",
+              "name": "LanguageSpecificPackageVulnerability",
+              "shortDescription": {
+                "text": "lodash: Lodash: Prototype pollution allows deletion of built-in prototype properties via array path bypass"
+              },
+              "fullDescription": {
+                "text": "Impact:\n\nLodash versions 4.17.23 and earlier are vulnerable to prototype pollution in the _.unset and _.omit functions. The fix for (CVE-2025-13465: https://github.com/lodash/lodash/security/advisories/GHSA-xxjr-mmjv-4gpg) only guards against string key members, so an attacker can bypass the check by passing array-wrapped path segments. This allows deletion of properties from built-in prototypes such as Object.prototype, Number.prototype, and String.prototype.\n\nThe issue permits deletion of prototype properties but does not allow overwriting their original behavior.\n\nPatches:\n\nThis issue is patched in 4.18.0.\n\nWorkarounds:\n\nNone. Upgrade to the patched version."
+              },
+              "defaultConfiguration": {
+                "level": "warning"
+              },
+              "helpUri": "https://avd.aquasec.com/nvd/cve-2026-2950",
+              "help": {
+                "text": "Vulnerability CVE-2026-2950\nSeverity: MEDIUM\nPackage: lodash\nFixed Version: 4.18.0\nLink: [CVE-2026-2950](https://avd.aquasec.com/nvd/cve-2026-2950)\nImpact:\n\nLodash versions 4.17.23 and earlier are vulnerable to prototype pollution in the _.unset and _.omit functions. The fix for (CVE-2025-13465: https://github.com/lodash/lodash/security/advisories/GHSA-xxjr-mmjv-4gpg) only guards against string key members, so an attacker can bypass the check by passing array-wrapped path segments. This allows deletion of properties from built-in prototypes such as Object.prototype, Number.prototype, and String.prototype.\n\nThe issue permits deletion of prototype properties but does not allow overwriting their original behavior.\n\nPatches:\n\nThis issue is patched in 4.18.0.\n\nWorkarounds:\n\nNone. Upgrade to the patched version.",
+                "markdown": "**Vulnerability CVE-2026-2950**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|MEDIUM|lodash|4.18.0|[CVE-2026-2950](https://avd.aquasec.com/nvd/cve-2026-2950)|\n\nImpact:\n\nLodash versions 4.17.23 and earlier are vulnerable to prototype pollution in the _.unset and _.omit functions. The fix for (CVE-2025-13465: https://github.com/lodash/lodash/security/advisories/GHSA-xxjr-mmjv-4gpg) only guards against string key members, so an attacker can bypass the check by passing array-wrapped path segments. This allows deletion of properties from built-in prototypes such as Object.prototype, Number.prototype, and String.prototype.\n\nThe issue permits deletion of prototype properties but does not allow overwriting their original behavior.\n\nPatches:\n\nThis issue is patched in 4.18.0.\n\nWorkarounds:\n\nNone. Upgrade to the patched version."
+              },
+              "properties": {
+                "cvssv3_baseScore": 6.5,
+                "cvssv3_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:L",
+                "precision": "very-high",
+                "security-severity": "6.5",
+                "tags": [
+                  "vulnerability",
+                  "security",
+                  "MEDIUM"
+                ]
+              }
+            }
+          ],
+          "version": "0.74.0"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "CVE-2021-23337",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "text": "Package: lodash\nInstalled Version: 4.17.20\nVulnerability CVE-2021-23337\nSeverity: HIGH\nFixed Version: 4.17.21\nLink: [CVE-2021-23337](https://avd.aquasec.com/nvd/cve-2021-23337)"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "package-lock.json",
+                  "uriBaseId": "ROOTPATH"
+                },
+                "region": {
+                  "startLine": 14,
+                  "startColumn": 1,
+                  "endLine": 16,
+                  "endColumn": 1
+                }
+              },
+              "message": {
+                "text": "package-lock.json: lodash@4.17.20"
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "CVE-2026-4800",
+          "ruleIndex": 1,
+          "level": "error",
+          "message": {
+            "text": "Package: lodash\nInstalled Version: 4.17.20\nVulnerability CVE-2026-4800\nSeverity: HIGH\nFixed Version: 4.18.0\nLink: [CVE-2026-4800](https://avd.aquasec.com/nvd/cve-2026-4800)"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "package-lock.json",
+                  "uriBaseId": "ROOTPATH"
+                },
+                "region": {
+                  "startLine": 14,
+                  "startColumn": 1,
+                  "endLine": 16,
+                  "endColumn": 1
+                }
+              },
+              "message": {
+                "text": "package-lock.json: lodash@4.17.20"
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "CVE-2020-28500",
+          "ruleIndex": 2,
+          "level": "warning",
+          "message": {
+            "text": "Package: lodash\nInstalled Version: 4.17.20\nVulnerability CVE-2020-28500\nSeverity: MEDIUM\nFixed Version: 4.17.21\nLink: [CVE-2020-28500](https://avd.aquasec.com/nvd/cve-2020-28500)"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "package-lock.json",
+                  "uriBaseId": "ROOTPATH"
+                },
+                "region": {
+                  "startLine": 14,
+                  "startColumn": 1,
+                  "endLine": 16,
+                  "endColumn": 1
+                }
+              },
+              "message": {
+                "text": "package-lock.json: lodash@4.17.20"
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "CVE-2025-13465",
+          "ruleIndex": 3,
+          "level": "warning",
+          "message": {
+            "text": "Package: lodash\nInstalled Version: 4.17.20\nVulnerability CVE-2025-13465\nSeverity: MEDIUM\nFixed Version: 4.17.23\nLink: [CVE-2025-13465](https://avd.aquasec.com/nvd/cve-2025-13465)"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "package-lock.json",
+                  "uriBaseId": "ROOTPATH"
+                },
+                "region": {
+                  "startLine": 14,
+                  "startColumn": 1,
+                  "endLine": 16,
+                  "endColumn": 1
+                }
+              },
+              "message": {
+                "text": "package-lock.json: lodash@4.17.20"
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "CVE-2026-2950",
+          "ruleIndex": 4,
+          "level": "warning",
+          "message": {
+            "text": "Package: lodash\nInstalled Version: 4.17.20\nVulnerability CVE-2026-2950\nSeverity: MEDIUM\nFixed Version: 4.18.0\nLink: [CVE-2026-2950](https://avd.aquasec.com/nvd/cve-2026-2950)"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "package-lock.json",
+                  "uriBaseId": "ROOTPATH"
+                },
+                "region": {
+                  "startLine": 14,
+                  "startColumn": 1,
+                  "endLine": 16,
+                  "endColumn": 1
+                }
+              },
+              "message": {
+                "text": "package-lock.json: lodash@4.17.20"
+              }
+            }
+          ]
+        }
+      ],
+      "columnKind": "utf16CodeUnits",
+      "originalUriBaseIds": {
+        "ROOTPATH": {
+          "uri": "file:///Users/sakethbandi/Projects/bernstein/tests/fixtures/scanners/trivy/target/"
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/scanners/trivy/trivy-conformance.yaml
+++ b/tests/fixtures/scanners/trivy/trivy-conformance.yaml
@@ -1,0 +1,29 @@
+name: trivy-recorded-sarif
+adapter_class: bernstein.adapters.trivy.TrivyAdapter
+steps:
+  - target: tests/fixtures/scanners/trivy/target
+    scope:
+      roots:
+        - tests/fixtures/scanners/trivy/target
+      config:
+        db_digest: sha256:633b3bacaa4a03f502faef8f94ce2d20d96a8499405d266ed7f67879109ec80d
+    expect_feed_digest: sha256:633b3bacaa4a03f502faef8f94ce2d20d96a8499405d266ed7f67879109ec80d
+    expected_finding_hashes:
+      - 6eb0cd0e1d53c3e01693de4cc38f3925f935d5ecebe409eee23313df31986ecf
+      - 57311d085280497d6cb74ea98954da760448c9711c1b3906f41a81a87bce8658
+      - 7caf3acd8c9f5432a787b1d12ca2385435f749232d06a06f9c5ef03d3e24b191
+      - 6751c3e0c6938584f1347a5e97bfd1a775aef5cad88d16e1487182f98ae8342c
+      - cf9290276c693a60d88d265a39592b0cab42aab2853f0ef6751def25eca84643
+  - target: tests/fixtures/scanners/trivy/target
+    scope:
+      roots:
+        - tests/fixtures/scanners/trivy/target
+      config:
+        db_digest: sha256:633b3bacaa4a03f502faef8f94ce2d20d96a8499405d266ed7f67879109ec80d
+    expect_feed_digest: sha256:633b3bacaa4a03f502faef8f94ce2d20d96a8499405d266ed7f67879109ec80d
+    expected_finding_hashes:
+      - 6eb0cd0e1d53c3e01693de4cc38f3925f935d5ecebe409eee23313df31986ecf
+      - 57311d085280497d6cb74ea98954da760448c9711c1b3906f41a81a87bce8658
+      - 7caf3acd8c9f5432a787b1d12ca2385435f749232d06a06f9c5ef03d3e24b191
+      - 6751c3e0c6938584f1347a5e97bfd1a775aef5cad88d16e1487182f98ae8342c
+      - cf9290276c693a60d88d265a39592b0cab42aab2853f0ef6751def25eca84643

--- a/tests/unit/adapters/test_trivy_scanner.py
+++ b/tests/unit/adapters/test_trivy_scanner.py
@@ -1,0 +1,237 @@
+"""Tests for feed-pinned normalization of recorded Trivy SARIF."""
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from bernstein.adapters._contract import ScannerDeterminism, scanner_determinism, scanner_pinned_inputs
+from bernstein.adapters.scanner import DeterminismTier, OutputFormat, ScannerCategory, ScanScope
+from bernstein.adapters.scanner_conformance import ScannerConformanceHarness, load_scanner_golden_transcripts
+from bernstein.adapters.scanner_registry import get_scanner
+from bernstein.adapters.trivy import (
+    TrivyAdapter,
+    TrivyError,
+    TrivyNotInstalledError,
+    _invocation_argv_hash,
+    parse_trivy_sarif,
+)
+
+_FIXTURE = Path("tests/fixtures/scanners/trivy/trivy-0.74.0.sarif")
+_FIXTURE_DIR = _FIXTURE.parent
+_TARGET = _FIXTURE_DIR / "target"
+_DB_DIGEST = "sha256:633b3bacaa4a03f502faef8f94ce2d20d96a8499405d266ed7f67879109ec80d"
+_OTHER_DB_DIGEST = "sha256:" + "a" * 64
+
+
+def _fixture_text() -> str:
+    return _FIXTURE.read_text(encoding="utf-8")
+
+
+def _scope(db_digest: str = _DB_DIGEST) -> ScanScope:
+    return ScanScope(roots=(_TARGET,), config={"db_digest": db_digest})
+
+
+def _fake_trivy_run(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+    if argv[1:] == ["--version"]:
+        return subprocess.CompletedProcess(
+            argv,
+            0,
+            stdout="Version: 0.74.0\nVulnerability DB:\n  Version: 2\n",
+            stderr="",
+        )
+    report_path = Path(argv[argv.index("--output") + 1])
+    report_path.write_text(_fixture_text(), encoding="utf-8")
+    return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+
+def test_real_trivy_sarif_is_normalized_to_findings() -> None:
+    findings = parse_trivy_sarif(_fixture_text())
+
+    assert len(findings) == 5
+    assert findings[0].rule == "CVE-2021-23337"
+    assert findings[0].path == "package-lock.json"
+    assert findings[0].severity == "high"
+    assert "lodash" in findings[0].summary
+
+
+def test_two_parses_of_the_same_recorded_run_have_identical_hashes() -> None:
+    first = [finding.finding_hash() for finding in parse_trivy_sarif(_fixture_text())]
+    second = [finding.finding_hash() for finding in parse_trivy_sarif(_fixture_text())]
+
+    assert first == second
+
+
+def test_cosmetic_line_shift_does_not_change_the_finding_hash() -> None:
+    original = json.loads(_fixture_text())
+    shifted = copy.deepcopy(original)
+    for result in shifted["runs"][0]["results"]:
+        region = result["locations"][0]["physicalLocation"]["region"]
+        region["startLine"] += 7
+        region["endLine"] += 7
+
+    original_hashes = [finding.finding_hash() for finding in parse_trivy_sarif(json.dumps(original))]
+    shifted_hashes = [finding.finding_hash() for finding in parse_trivy_sarif(json.dumps(shifted))]
+
+    assert shifted_hashes == original_hashes
+
+
+def test_absolute_report_path_is_normalized_to_the_scan_target() -> None:
+    report = json.loads(_fixture_text())
+    for result in report["runs"][0]["results"]:
+        artifact = result["locations"][0]["physicalLocation"]["artifactLocation"]
+        artifact["uri"] = "/checkout/project/package-lock.json"
+
+    finding = parse_trivy_sarif(json.dumps(report), target_root=Path("/checkout/project"))[0]
+
+    assert finding.path == "package-lock.json"
+
+
+def test_non_trivy_sarif_is_rejected() -> None:
+    report = json.loads(_fixture_text())
+    report["runs"][0]["tool"]["driver"]["name"] = "another-scanner"
+
+    with pytest.raises(ValueError, match="must be 'Trivy'"):
+        parse_trivy_sarif(json.dumps(report))
+
+
+def test_invalid_json_is_rejected() -> None:
+    with pytest.raises(ValueError, match="Invalid Trivy SARIF JSON"):
+        parse_trivy_sarif("not-json")
+
+
+def test_adapter_declares_the_feed_pinned_sca_contract() -> None:
+    adapter = TrivyAdapter()
+
+    assert adapter.name() == "trivy"
+    assert adapter.output_format is OutputFormat.SARIF
+    assert adapter.determinism is DeterminismTier.FEED_PINNED
+    assert adapter.pinned_inputs == ("trivy_db",)
+    assert adapter.category is ScannerCategory.SCA
+    assert scanner_determinism(adapter.name()) is ScannerDeterminism.FEED_PINNED
+    assert scanner_pinned_inputs(adapter.name()) == ("trivy_db",)
+
+
+def test_scanner_registry_resolves_trivy() -> None:
+    assert isinstance(get_scanner("trivy"), TrivyAdapter)
+
+
+def test_invocation_hash_binds_version_and_db_digest() -> None:
+    baseline = _invocation_argv_hash("0.74.0", _DB_DIGEST)
+
+    assert _invocation_argv_hash("0.74.0", _DB_DIGEST) == baseline
+    assert _invocation_argv_hash("0.74.1", _DB_DIGEST) != baseline
+    assert _invocation_argv_hash("0.74.0", _OTHER_DB_DIGEST) != baseline
+
+
+def test_feed_pinned_scan_requires_a_db_digest(tmp_path: Path) -> None:
+    with (
+        patch("bernstein.adapters.trivy.shutil.which") as which,
+        pytest.raises(TrivyError, match=r"require scope.config\['db_digest'\]"),
+    ):
+        TrivyAdapter().scan(tmp_path, ScanScope(), tmp_path / "work")
+    which.assert_not_called()
+
+
+def test_scan_runs_trivy_with_database_updates_disabled(tmp_path: Path) -> None:
+    adapter = TrivyAdapter(cache_dir=tmp_path / "cache")
+
+    with (
+        patch("bernstein.adapters.trivy.shutil.which", return_value="/usr/local/bin/trivy"),
+        patch("bernstein.adapters.trivy.subprocess.run", side_effect=_fake_trivy_run) as run,
+    ):
+        result = adapter.scan(_TARGET, _scope(), tmp_path / "work")
+
+    assert result.finding_hashes() == sorted(f.finding_hash() for f in parse_trivy_sarif(_fixture_text()))
+    assert result.feed_digest == _DB_DIGEST
+    scan_argv = run.call_args_list[1].args[0]
+    assert scan_argv[1:5] == ["filesystem", "--scanners", "vuln", "--skip-db-update"]
+    assert scan_argv[-1] == str(_TARGET.resolve())
+    assert "--cache-dir" in scan_argv
+    assert adapter.last_invocation is not None
+    assert adapter.last_invocation.tool_version == "0.74.0"
+    assert adapter.last_invocation.db_digest == _DB_DIGEST
+    assert not (tmp_path / "work" / "trivy.sarif").exists()
+
+
+def test_a_changed_db_digest_is_recorded_not_absorbed(tmp_path: Path) -> None:
+    first_adapter = TrivyAdapter()
+    second_adapter = TrivyAdapter()
+    with (
+        patch("bernstein.adapters.trivy.shutil.which", return_value="/usr/local/bin/trivy"),
+        patch("bernstein.adapters.trivy.subprocess.run", side_effect=_fake_trivy_run),
+    ):
+        first = first_adapter.scan(_TARGET, _scope(), tmp_path / "first")
+        second = second_adapter.scan(_TARGET, _scope(_OTHER_DB_DIGEST), tmp_path / "second")
+
+    assert first.finding_hashes() == second.finding_hashes()
+    assert first.feed_digest == _DB_DIGEST
+    assert second.feed_digest == _OTHER_DB_DIGEST
+    assert first_adapter.last_invocation is not None
+    assert second_adapter.last_invocation is not None
+    assert first_adapter.last_invocation.argv_hash != second_adapter.last_invocation.argv_hash
+
+
+def test_scan_reports_missing_trivy_without_invoking_a_process(tmp_path: Path) -> None:
+    with (
+        patch("bernstein.adapters.trivy.shutil.which", return_value=None),
+        patch("bernstein.adapters.trivy.subprocess.run") as run,
+        pytest.raises(TrivyNotInstalledError, match="not found on PATH"),
+    ):
+        TrivyAdapter().scan(_TARGET, _scope(), tmp_path / "work")
+    run.assert_not_called()
+
+
+def test_stale_report_cannot_be_reused(tmp_path: Path) -> None:
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    (workdir / "trivy.sarif").write_text(_fixture_text(), encoding="utf-8")
+
+    def no_report(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if argv[1:] == ["--version"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="Version: 0.74.0\n", stderr="")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    with (
+        patch("bernstein.adapters.trivy.shutil.which", return_value="/usr/local/bin/trivy"),
+        patch("bernstein.adapters.trivy.subprocess.run", side_effect=no_report),
+        pytest.raises(TrivyError, match="without writing its SARIF report"),
+    ):
+        TrivyAdapter().scan(_TARGET, _scope(), workdir)
+
+
+def test_scan_rejects_a_real_trivy_execution_error(tmp_path: Path) -> None:
+    def fail_scan(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if argv[1:] == ["--version"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="Version: 0.74.0\n", stderr="")
+        return subprocess.CompletedProcess(argv, 2, stdout="", stderr="database unavailable")
+
+    with (
+        patch("bernstein.adapters.trivy.shutil.which", return_value="/usr/local/bin/trivy"),
+        patch("bernstein.adapters.trivy.subprocess.run", side_effect=fail_scan),
+        pytest.raises(TrivyError, match="code 2: database unavailable"),
+    ):
+        TrivyAdapter().scan(_TARGET, _scope(), tmp_path / "work")
+
+
+def test_conformance_replays_two_runs_with_the_same_db_digest(tmp_path: Path) -> None:
+    transcripts = load_scanner_golden_transcripts(_FIXTURE_DIR)
+    assert len(transcripts) == 1
+
+    with (
+        patch("bernstein.adapters.trivy.shutil.which", return_value="/usr/local/bin/trivy"),
+        patch("bernstein.adapters.trivy.subprocess.run", side_effect=_fake_trivy_run) as run,
+    ):
+        result = ScannerConformanceHarness().replay_transcript(transcripts[0], workdir=tmp_path)
+
+    assert result.passed
+    assert result.adapter_name == "trivy"
+    assert result.determinism_tier is DeterminismTier.FEED_PINNED
+    assert [step.feed_digest for step in result.step_results] == [_DB_DIGEST, _DB_DIGEST]
+    assert sum(call.args[0][1] == "filesystem" for call in run.call_args_list) == 2


### PR DESCRIPTION
## What

Adds the Trivy reference scanner adapter for the feed-pinned tier in #3618.

## Why

This brings Trivy in as the SCA example for feed-pinned scans. Results are anchored to a specific vulnerability database instead of changing silently because of a background database update.

This PR only covers Trivy. Nmap will follow separately.

## How

The adapter runs `trivy filesystem` with SARIF output and `--skip-db-update`. It normalizes results into Bernstein findings and leaves source coordinates out of finding identity, so simple line shifts do not change finding hashes.

For the database digest, I chose to require the caller to pass a SHA-256 digest through `ScanScope.config` instead of reading it automatically from Trivy metadata. This adds a small setup step, but prevents accidentally running an unpinned scan. The adapter refuses to run without a valid digest.

The digest is returned as `feed_digest` and included in the invocation hash. This keeps a database change visible in the scan record even when the findings stay the same.

Tests also verify that changing the supplied database digest is surfaced in the scan record rather than silently absorbed.

Tests use real SARIF output recorded with Trivy 0.74.0, so Trivy does not need to be installed in CI.

## Checklist

- [x] `uv run ruff check src/`
- [x] Pyright passes for the new Trivy adapter
- [x] Focused Trivy, scanner, registry, and conformance tests pass
- [x] Trivy tests pass without Trivy in `PATH`
- [x] Import contracts pass
- [x] New code has type hints
- [x] Tests cover the feed-pinned behavior
- [x] `uv run bernstein agents-md verify --workdir .`

## Documentation

- [x] Generated module map updated
- [x] README update not applicable because this adapter is not currently a user-facing workflow
- [x] Operations documentation not applicable
- [x] Public API schema update not applicable