### PR TITLE
fix(ci): read the test-count-drop override where the merge is gated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,8 +530,13 @@ jobs:
       - name: Test-count drop vs merge base (#4873)
         # Catches a touched test module that still collects but lost cases
         # relative to the merge base. Parametrized consolidation stays green
-        # (collect-only counts). Override via PR body:
+        # (collect-only counts). Override, in the PR body or in a commit
+        # message in the compared range:
         #   test-count-drop: tests/unit/foo.py -N
+        # A merge_group event carries no pull_request payload, so PR_BODY is
+        # empty in this lane and a body-only override is invisible exactly
+        # where the merge is gated; the script reads the range's commit
+        # messages so one declaration holds in both lanes.
         # Without a base (non-PR / missing ref) the script skips — never fake-green.
         env:
           PR_BODY: ${{ github.event.pull_request.body || '' }}

--- a/scripts/check_test_count_drop.py
+++ b/scripts/check_test_count_drop.py
@@ -22,13 +22,22 @@ Outcome words (never collapse these)::
 A module that fails to import collects zero; the message names
 ``import_error`` so it is not read as a silent false-positive count drop.
 
-Override (PR body, reviewable)::
+Override (reviewable), in the PR body **or** in any commit message in the
+compared range::
 
     test-count-drop: tests/unit/foo/test_bar.py -3
 
 Allow that path's collected count to fall by **at most** 3. Overrides that
 name a module with no drop are stale and fail the check. There is no
 path-less global budget.
+
+Declare it in a commit message when the drop must survive the merge queue.
+A ``merge_group`` build carries no ``pull_request`` payload, so the PR body
+is empty in the one lane that gates the merge; a body-only override goes
+green on the PR lane and then fails the queue, taking every entry stacked
+behind it down with it. Commits are present in both lanes and cannot be
+edited after the merge, so the reason the cases went away stays on the
+record.
 
 A deleted test module whose matching subject under ``src/`` was also deleted
 in the same diff is carved out.
@@ -149,6 +158,21 @@ def changed_paths(repo: Path, base: str, head: str = "HEAD") -> tuple[set[str], 
         else:
             modified.add(path)
     return modified, deleted, added
+
+
+def commit_message_text(repo: Path, base: str, head: str = "HEAD") -> str:
+    """Return the concatenated commit messages of ``base..head``.
+
+    Second override channel, and the only one that survives the merge queue:
+    a ``merge_group`` build has no ``pull_request`` payload, so ``PR_BODY``
+    is empty there. Reading the commits keeps one declaration readable in
+    both lanes without a token or an API call, and keeps it immutable — a PR
+    body edited after the merge erases the reason the cases went away.
+    """
+    try:
+        return _git(repo, "log", "--format=%B", f"{base}..{head}")
+    except subprocess.CalledProcessError:
+        return ""
 
 
 def subject_stem(test_path: str) -> str | None:
@@ -278,7 +302,7 @@ def build_report(
         report.not_run = "no merge base (--base); guard did not compare"
         return report
 
-    overrides = parse_overrides(pr_body)
+    overrides = parse_overrides(f"{pr_body}\n{commit_message_text(repo, base, head)}")
     modified, deleted, added = changed_paths(repo, base, head)
     touched = {p for p in (modified | deleted | added) if is_test_module(p)}
     report.checked = len(touched)
@@ -343,8 +367,10 @@ def format_report(report: DropReport) -> str:
                 lines.append(f"  {rel}: {base_n} -> {head_n} (drop {base_n - head_n}; cause=count_drop)")
         lines.append(
             "Restore the cases, consolidate via parametrize (collected count must stay "
-            "stable), carve out a deleted subject, or add a PR-body override: "
-            "`test-count-drop: <path> -<N>`."
+            "stable), carve out a deleted subject, or declare an override: "
+            "`test-count-drop: <path> -<N>`. Put it in a commit message, not only in "
+            "the PR body: the merge-queue build has no PR body to read, so a body-only "
+            "override passes the PR lane and then fails here."
         )
     if report.stale_overrides:
         lines.append("FAIL: stale test-count-drop overrides (no drop for that path):")

--- a/tests/unit/scripts/test_check_test_count_drop.py
+++ b/tests/unit/scripts/test_check_test_count_drop.py
@@ -225,3 +225,96 @@ def test_guard_discriminates_when_a_drop_exists(check_module: ModuleType, tmp_pa
     _commit_all(repo, "one")
     report = check_module.build_report(repo, base=base, python=sys.executable)
     assert report.drops, "a real drop must surface; otherwise the guard is vacuous"
+
+
+def test_override_in_a_commit_message_is_read_when_the_pr_body_is_empty(
+    check_module: ModuleType, tmp_path: Path
+) -> None:
+    """The merge-queue shape: no PR body exists, so the commits must carry the override.
+
+    A ``merge_group`` build has no ``pull_request`` payload; ``PR_BODY`` is
+    empty. Before the commit-message channel existed, a body-only override
+    passed the PR lane and then failed the queue build, taking every entry
+    stacked behind it with it. The counterfactual at the end of this test is
+    that pre-fix behaviour.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    test_dir = repo / "tests" / "unit"
+    test_dir.mkdir(parents=True)
+    (test_dir / "test_sample.py").write_text(
+        "def test_a():\n    assert True\n\ndef test_b():\n    assert True\n",
+        encoding="utf-8",
+    )
+    base = _commit_all(repo, "two tests")
+
+    (test_dir / "test_sample.py").write_text("def test_a():\n    assert True\n", encoding="utf-8")
+    _commit_all(
+        repo,
+        "drop one case\n\ntest-count-drop: tests/unit/test_sample.py -1\n",
+    )
+
+    report = check_module.build_report(repo, base=base, pr_body="", python=sys.executable)
+    assert report.drops == []
+    assert report.excused == [("tests/unit/test_sample.py", 2, 1, 1)]
+    assert check_module.main(["--root", str(repo), "--base", base]) == 0
+
+    # Counterfactual: with the commit-message channel removed — the pre-fix
+    # script, which read the PR body alone — the same commit turns the guard red.
+    original = check_module.commit_message_text
+    check_module.commit_message_text = lambda *a, **k: ""  # type: ignore[assignment]
+    try:
+        pre_fix = check_module.build_report(repo, base=base, pr_body="", python=sys.executable)
+    finally:
+        check_module.commit_message_text = original  # type: ignore[assignment]
+    assert pre_fix.drops == [("tests/unit/test_sample.py", 2, 1, "count_drop")], (
+        "the counterfactual must fail; otherwise this test proves nothing about the new channel"
+    )
+
+
+def test_a_stale_override_in_a_commit_message_still_fails(check_module: ModuleType, tmp_path: Path) -> None:
+    """The new channel is a second door to the same room, not a free pass."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    test_dir = repo / "tests" / "unit"
+    test_dir.mkdir(parents=True)
+    (test_dir / "test_sample.py").write_text("def test_a():\n    assert True\n", encoding="utf-8")
+    base = _commit_all(repo, "one test")
+
+    (test_dir / "test_sample.py").write_text(
+        "def test_a():\n    assert True\n\ndef test_b():\n    assert True\n",
+        encoding="utf-8",
+    )
+    _commit_all(repo, "add a case\n\ntest-count-drop: tests/unit/test_sample.py -2\n")
+
+    report = check_module.build_report(repo, base=base, pr_body="", python=sys.executable)
+    assert report.stale_overrides == ["tests/unit/test_sample.py -2"]
+    assert check_module.main(["--root", str(repo), "--base", base]) == 1
+
+
+def test_commit_messages_outside_the_compared_range_are_not_read(check_module: ModuleType, tmp_path: Path) -> None:
+    """An override spent on an earlier merge must not excuse a later drop.
+
+    ``base..head`` is the range the guard compares; reading the whole history
+    would let one declaration, written once, silently cover every future drop
+    in that module.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    test_dir = repo / "tests" / "unit"
+    test_dir.mkdir(parents=True)
+    (test_dir / "test_sample.py").write_text(
+        "def test_a():\n    assert True\n\ndef test_b():\n    assert True\n",
+        encoding="utf-8",
+    )
+    _commit_all(repo, "two tests\n\ntest-count-drop: tests/unit/test_sample.py -1\n")
+    base = _git(repo, "rev-parse", "HEAD").strip()
+
+    (test_dir / "test_sample.py").write_text("def test_a():\n    assert True\n", encoding="utf-8")
+    _commit_all(repo, "drop one, declaring nothing")
+
+    report = check_module.build_report(repo, base=base, pr_body="", python=sys.executable)
+    assert report.drops == [("tests/unit/test_sample.py", 2, 1, "count_drop")]


### PR DESCRIPTION
The `Test-count drop vs merge base (#4873)` step documents an override — `test-count-drop: <path> -<N>` — and reads it from `github.event.pull_request.body`.

A `merge_group` event carries no `pull_request` payload, so `PR_BODY` is empty in the merge-queue lane. The override is readable in the lane that only reports, and unreadable in the lane that gates the merge. A pull request that records one passes its own checks and then fails the queue build; queue entries are stacked, so every entry behind it is rebuilt with it.

That is not hypothetical — a queue batch failed tonight on

```
FAIL: test modules lost collected cases vs merge base (issue #4873):
  tests/unit/test_adapter_contract.py: 599 -> 586 (drop 13; cause=count_drop)
```

with the matching override sitting in the pull request body the build could not see.

## Change

`build_report` now parses the override from the commit messages of `base..head` as well as from the PR body.

- Commits are present in **both** lanes, so one declaration holds in both.
- No token and no API call — the range is already checked out.
- A commit message cannot be edited after the merge, so the reason the cases went away stays on the record. A PR body can.
- The range is `base..head`, not the whole history: an override spent on an earlier merge must not excuse a later drop in the same module.

The failure message now says where to put the declaration so it survives the queue. The step comment in `ci.yml` says the same. The PR-body channel is unchanged.

## Tests

`tests/unit/scripts/test_check_test_count_drop.py`, three added:

| Test | Property |
|---|---|
| `test_override_in_a_commit_message_is_read_when_the_pr_body_is_empty` | the merge-queue shape (`pr_body=""`) is excused, **and** the counterfactual — the same fixture with the commit-message channel removed — turns the guard red |
| `test_a_stale_override_in_a_commit_message_still_fails` | the second channel is another door to the same room, not a free pass |
| `test_commit_messages_outside_the_compared_range_are_not_read` | an override spent on an earlier merge does not excuse a later drop |

`12 passed` locally (9 before).