### PR TITLE
ci(trivy): stop the filesystem gate scanning the scanner fixtures

### DIFF
--- a/.github/workflows/static-analysis-extended.yml
+++ b/.github/workflows/static-analysis-extended.yml
@@ -186,6 +186,14 @@ jobs:
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           exit-code: "0"
+          # The scanner adapters under test need real, deliberately
+          # vulnerable inputs to scan: tests/fixtures/scanners/*/target
+          # holds a lockfile pinning a known-bad lodash and an env file
+          # with a planted secret. Our own supply-chain gate scanned them
+          # too and failed main on a finding that is the fixture's whole
+          # point. Only the target trees are skipped; the conformance
+          # fixtures beside them are still scanned.
+          skip-dirs: "tests/fixtures/scanners/trivy/target,tests/fixtures/scanners/gitleaks/target"
       - name: Drop suppressed SARIF results
         if: always()
         run: |
@@ -215,6 +223,14 @@ jobs:
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           exit-code: "1"
+          # The scanner adapters under test need real, deliberately
+          # vulnerable inputs to scan: tests/fixtures/scanners/*/target
+          # holds a lockfile pinning a known-bad lodash and an env file
+          # with a planted secret. Our own supply-chain gate scanned them
+          # too and failed main on a finding that is the fixture's whole
+          # point. Only the target trees are skipped; the conformance
+          # fixtures beside them are still scanned.
+          skip-dirs: "tests/fixtures/scanners/trivy/target,tests/fixtures/scanners/gitleaks/target"
       - name: Upload SARIF as workflow artifact
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/tests/unit/test_adapter_contract.py
+++ b/tests/unit/test_adapter_contract.py
@@ -84,9 +84,7 @@ def _discover_registered_names() -> list[str]:
       Covered by ``test_adapter_muse.py``, which exercises spawn with the
       vendor model plus every refusal path.
     """
-    return sorted(
-        n for n in _ADAPTERS if n not in {"mock", "generic", "iac", "clm", "q_dev", "python_runtime", "muse"}
-    )
+    return sorted(n for n in _ADAPTERS if n not in {"mock", "generic", "iac", "clm", "q_dev", "python_runtime", "muse"})
 
 
 #: Adapters whose ``prompt`` argument is a structured descriptor rather than


### PR DESCRIPTION
`main` is red: the Trivy filesystem gate failed on `tests/fixtures/scanners/trivy/target/package-lock.json`, which pins lodash 4.17.20 — CVE-2021-23337 and CVE-2026-4800, both HIGH.

That lockfile is the input the trivy scanner adapter is tested against. It is vulnerable on purpose; a fixture the scanner finds nothing in proves nothing. The same is true of `tests/fixtures/scanners/gitleaks/target/app.env`, which carries a planted secret.

Adds `skip-dirs` for those two target trees to both Trivy filesystem steps — the SARIF upload and the failing gate — matching how `trivy-iac` already skips `.clusterfuzzlite` in this file. The conformance fixtures sitting beside the targets stay in scope, so a real finding anywhere else under `tests/` still fails the gate.

Verification: the failing gate is `if: github.event_name != 'pull_request'`, so it does not run on this pull request. Proven by a `workflow_dispatch` run of this branch instead — link in a comment below.