### PR TITLE
docs(release-notes): edit v3.19.0 down to what it actually says

### DIFF
--- a/docs/release-notes/v3.19.0.md
+++ b/docs/release-notes/v3.19.0.md
@@ -1,5 +1,3 @@
-# v3.19.0
-
 For most of its life the project called itself an orchestrator for CLI coding
 agents. That was the demo, not the product. What it actually ships — an audit
 chain, signed lineage, byte-identical replay, compliance packs — never asked
@@ -17,6 +15,12 @@ find. A conformance lane replays the vectors against a fixture run in CI
 (#3618), and an attestation from outside our own chain is now classified
 fail-closed (#4806).
 
+Reviews resolve which conventions apply to a change before any reviewer runs,
+recording the matched globs and any unscoped paths under a resolution hash
+bound into the review receipt (#3752). The orchestrator anchors a
+content-addressed code-graph digest in the audit chain before it spawns, so a
+parallel schedule can be checked against the tree it was planned on (#3610).
+
 ## Receipts for the runs nobody watched
 
 A completed fan-out produces one signed object binding its spine heads, instead
@@ -26,13 +30,32 @@ verifying a long chain stopped being a reason not to (#3831). Volunteer work
 grew a DSSE-signed consent receipt (#3866) and donor budgets that survive a
 restart (#3867).
 
+The shipped front-page demo receipt now carries a non-empty lineage spine,
+written by the run itself rather than rebuilt afterwards (#3570).
+
 ## Adapters that admit what they cannot do
 
 An adapter declares its authentication basis in its contract (#3875).
 `max_tokens` is part of the enforced sampling surface: an adapter that cannot
-honour it refuses the spawn instead of dropping it quietly (#3586). New this
-release: a HolmesGPT adapter that binds an investigation's data sources to its
-conclusion (#3123), and a deterministic `gitleaks` scanner adapter (#4838).
+honour it refuses the spawn instead of dropping it quietly (#3586). Onboarding
+records a successful smoke invocation as a replayable golden transcript and
+checks three held-out invocations against the same CLI; a failed run stays an
+explicit failure rather than being skipped (#3764). New this release: a
+HolmesGPT adapter that binds an investigation's data sources to its conclusion
+(#3123), and a deterministic `gitleaks` scanner adapter (#4838).
+
+## New commands
+
+- `bernstein gc cas` — mark-and-sweep for the content-addressed store.
+  Referenced digests are collected from the durable roots (write-ahead log,
+  snapshots, audit seals, lineage records, backlog), so a reachable blob
+  survives regardless of age. `--days`, `--dry-run`, `--workdir`; every run
+  writes a prune receipt (#4674).
+- `bernstein volunteer hub` — a standalone app exposing enroll, claim,
+  heartbeat, submit and release over the volunteer lease store (#4037).
+- `bernstein pool` and `bernstein limits pool` are separate on purpose and
+  neither shadows the other: `pool` governs named sandbox environments,
+  `limits pool` governs lease-backed admission slots (#3138).
 
 ## The suite stopped lying
 
@@ -40,7 +63,9 @@ A `test_*.py` module that collects zero items now fails CI (#4834), and so does
 a touched module that loses cases it used to collect (#4873). Both gates exist
 because we shipped green shards that ran nothing, twice. Shards are balanced by
 committed timings rather than by filename (#4840), and 134 pyright excludes
-that matched nothing on disk are gone (#4864).
+that matched nothing on disk are gone (#4864). A task that falls behind the
+rest of its cohort is now reported as one, under `StallReason.COHORT_LAGGARD`
+(#3605).
 
 ## Upgrading
 
@@ -48,9 +73,17 @@ Trust records written before this release whose fields contain non-ASCII
 characters carry parent and member digests an RFC 8785 verifier disagrees with.
 Re-emit them, or pin the reader to the version that wrote them.
 
+`CheckRunClient` no longer accepts `installation_id`. It stored the value and
+never used it — authentication is delegated to the `gh` CLI — and a parameter
+that looks load-bearing but is not had already misled one caller. Drop the
+argument; nothing else changes (#4845).
+
+The root `.env.example` that `docker-compose.yaml` has always told you to copy
+is now actually tracked. `.gitignore` matched it via `.env.*` and dropped it
+silently on `git add` (#4723).
+
 The wheel no longer ships the GUI source map. Packaged GUI assets go from
 5.0 MB to 1.1 MB.
-
 ## Contributors
 
 - **Sarvagya Sharma** — the zero-collection guard (#4858) and its sibling that
@@ -90,248 +123,3 @@ The wheel no longer ships the GUI source map. Packaged GUI assets go from
   (#4845).
 - **Columbus Labs** — the `pymdown-extensions` pin (#4769).
 
-## HolmesGPT adapter
-
-Added HolmesGPT adapter that binds investigation data sources to conclusions with content-addressed observations.
-
-## Sandbox pool and admission limits pool separation
-
-`bernstein pool` and `bernstein limits pool` maintain deliberate domain separation across distinct backing stores (#3138). `bernstein pool` governs named sandbox execution environments (manifests, backend allowlists, capability ceilings, egress classes) projected from the HMAC audit chain and content-addressed store. `bernstein limits pool` governs lease-backed admission slot pools (concurrency ceilings, posture enforcement) recorded in the hash-chained admission work ledger. Neither command group aliases, mutates, or shadows the other.
-
-## 3451 — Mailbox consumption now emits prompt_digest; steer rejection is an audit event
-
-`task.mailbox_consumed` audit records now carry a `prompt_digest` field — the SHA-256 digest of the assembled mailbox section — so the content that drove a prompt can be verified against the chain. In addition, a steering receipt miss is no longer silently dropped: when `consume_steering` encounters a `steer.*` message whose `receipt_hash` has no matching `steering.receipt` event, it appends a `steer.rejected` journal row and records a `steering.rejection` audit event, binding the refusal into the HMAC chain so a steered run is distinguishable from a tampered one.
-
-## The front-page demo receipt carries a non-empty lineage spine
-
-The shipped `docs/assets/demo-run/run-receipt.json` now has `spine.entry_count > 0`. The demo recording script (`scripts/record_demo.sh`) waits for the orchestrator to finalize gracefully, so the spine is written by the run itself rather than rebuilt post-hoc. The README now states the full journal-head + spine-head bind unconditionally (#3570).
-
-### Changed
-
-- Treat `max_tokens` as part of the enforced per-spawn sampling surface: adapters without coarse sampling support or `SUPPORTS_MAX_TOKENS` now refuse the spawn instead of silently dropping the requested limit. The OpenAI Agents adapter declares and continues to honour the override. ([#3586](https://github.com/sipyourdrink-ltd/bernstein/issues/3586))
-
-## Cohort-relative laggard detection
-
-Introduces the new `StallReason.COHORT_LAGGARD` to detect tasks that fall behind the rest of their cohort, enabling the system to identify and handle laggard agents. (#3605)
-
-## Deterministic code graph anchoring for safe parallel execution
-
-Added semantic code graph indexing and anchoring to enable content-addressed code representation for parallel task scheduling.
-
-- Implemented GraphifyCodeGraph protocol using graphifyy CLI for deterministic, content-addressed code graphs
-- Added unparsed_files and edge origin tracking to ast_symbol_graph.py for explicit coverage reporting  
-- Modified orchestrator to build and anchor code graph digest in audit chain before agent spawning
-- Added EVENT_CODE_GRAPH_ANCHORED audit event for verifiable graph state recording
-
-Closes #3610
-
-## Scanner conformance harness replays for real
-
-The golden-transcript harness for scanner adapters could not replay a step: it read a field its step type never defined, dropped the scan scope before calling the adapter, and looked determinism tiers up under a key the registry does not use. Steps now carry an explicit `target` and `scope` that reach `scan()` as given, pinned feed digests and transcripts are actually compared against the recorded run, and the whole replay path is covered by tests, so adapter authors can build against it. (#3618)
-
-## Scope resolution
-
-Reviews now resolve which conventions apply to a change deterministically before any reviewer runs, recording the in-scope receipts, the globs that matched, and any unscoped paths under a stable resolution hash bound into the review receipt (#3752)
-
-## A sealed run-graph receipt can be checked against the tree it sealed
-
-`verify_run_graph_receipt` rebuilds a fan-out's graph from the worktrees and walks every branch's lineage spine, then compares the result with the sealed receipt rather than replaying the receipt's own stored hashes. An edited receipt, a branch whose journal was altered, a missing branch, and a receipt with no spine anchor are each refused by name (#3760).
-
-## A sealed fan-out can be read on the command line, and the tamper sweep now covers one
-
-`bernstein worktrees graph <fanout-id>` renders every branch of a sealed fan-out with its verify status, `--verify` re-derives the whole receipt, and `--json` emits the signed artifact verbatim. `verify_lineage_chains` gained the matching coverage: a tampered branch inside a fan-out now trips the same `lineage_tamper_detected` event and `bernstein_lineage_tamper_total` counter that a tampered single-run spine already did. A fan-out whose worktrees have been reaped, or whose branches have no run id supplied, is reported as not checked rather than as tampered (#3761).
-
-## Onboarded adapters can record and replay a supervised transcript
-
-Adapter onboarding now records a successful smoke invocation as a replayable golden transcript and checks three deterministic held-out invocations against the same CLI. Recorded profiles preserve their exact invocation tokens, while failed smoke or held-out runs remain explicit failures rather than being silently skipped (#3764).
-
-## Incremental `audit verify` reads only the changed tiles
-
-`bernstein audit verify` now trusts previously sealed segments by hash. Each
-segment's hash tile (`<segment>.tile`) records the plain `SHA-256` of the
-sealed byte prefix; the verifier recomputes that hash against the on-disk
-bytes and only re-walks segments whose content no longer matches. A tile
-that does not match (or has no tile, or a non-string `content_sha256`) is
-re-read and reported, never silently skipped because it was seen before.
-The "already verified up to here" marker lives at
-`<audit_dir>/.tiles-read.json`; an operator can force a full re-verify by
-removing it (which costs time, never correctness) or by calling
-`AuditLog.force_full_verify`. The new `verify_incremental` method returns
-an `IncrementalVerifyReport` carrying the tile-read count so the
-measurement is observable, not just a hidden cache. (#3831)
-
-## Volunteer workers add DSSE-signed consent receipt module
-
-Adds DSSE-signed consent receipts for volunteer workers to attest to task consent with offline verifiability (#3866).
-
-## Volunteer workers honor persistent donor budgets
-
-Volunteer donors can cap tasks, wall-clock time, tokens, task size, and adapter selection with restart-safe accounting and auditable receipt line items (#3867).
-
-## Adapter auth basis and volunteer-mode status
-
-Every adapter contract (`tests/contract/contracts/*.yaml`) now declares an explicit `auth.basis` (`api_key`, `local`, `subscription_oauth`, or `unknown`) on `ContractSpec` and `AdapterCapabilityProfile`, making the authentication mechanism readable from the contract rather than inferred from configuration (#3875).
-
-Volunteer donor budgets (`VolunteerBudget.refuses_claim` and `filter_local_profiles`) gate adapter selection by auth basis and `local_models`: `local_only=True` budgets admit only `local_models=True` adapters (`opencode`, `pydantic_ai`); `subscription_oauth` adapters (`agy`, `copilot`) are refused under `local_only`; `api_key` adapters require `local_ok=True`.
-
-The full adapter auth-basis and volunteer-mode table lives in [`docs/adapters/auth-basis-volunteer-mode.md`](auth-basis-volunteer-mode.md).
-
-## Volunteer worker documentation: threat model, donor guide, project guide
-
-Someone donating compute to a volunteer project had no written answer to the
-questions that decide whether they should: what the worker is allowed to run
-on their machine, what a project can and cannot see about them, and who is
-responsible for the work that comes out. The code enforcing those boundaries
-existed; the page explaining them did not.
-
-`docs/volunteer/threat-model.md` states the security surface and what each
-boundary does and does not protect. `docs/volunteer/donor-guide.md` covers
-running a worker, the budget a donor sets and what happens when it is spent.
-`docs/volunteer/project-guide.md` covers the other side: declaring a manifest
-and what a project is committing to. `DISCLAIMER.md` states that volunteers
-act on their own behalf.
-
-## Worker reputation counts are computed from merged pull requests
-
-`bernstein.core.volunteer.reputation` holds the earn-only scoring rules for
-volunteer workers, and `scripts/generate-earn-only-acceptance-rate.py` turns a
-month of merged pull requests into per-worker counts. Attribution reads the
-`worker_keyid` and bundle references carried in the pull request body, so a
-worker is credited by the identity that signed the work rather than by the
-account that opened the pull request. Scores only ever accrue: a reverted pull
-request is recorded alongside the merge instead of subtracting from the total,
-which keeps a count reproducible from the same month of history no matter when
-it is generated (#3879).
-
-## Reclaim CAS storage with `bernstein gc cas`
-
-Mark-and-sweep garbage collection for the content-addressed store. Referenced digests are collected from the durable roots — write-ahead log, snapshots, audit seals, lineage records and the backlog — so a reachable blob is preserved regardless of age. Supports `--days`, `--dry-run` and `--workdir`, and writes a prune receipt for every run (#4674).
-
-Add `bernstein volunteer hub` CLI subcommand that serves a standalone
-FastAPI app (`build_hub_app`) exposing enroll, claim, heartbeat, submit,
-and release endpoints over the volunteer lease store (#4037).
-
-## The volunteer hub refuses to boot with more than one worker
-
-`bernstein volunteer hub` used to print a note asking the operator not to run
-it with `uvicorn --workers N>1`, then start anyway. `LeaseStore` serialises
-writes with an in-process `asyncio.Lock` and appends to JSONL without
-`fcntl.flock`, so a second worker interleaves partial lines and hands one task
-to two claimants — a corruption that only surfaces later, as a duplicate
-submission, with nothing in the log pointing back at `WEB_CONCURRENCY`. The
-note is now a refusal that fires before the port is bound, and the deployment
-README documents the single-process constraint alongside the compose file.
-
-## Root `.env.example` now ships with the repository
-
-`docker-compose.yaml` has always told readers to `cp .env.example .env`, but
-`.gitignore` matched the template via `.env.*` and silently dropped it on
-`git add`. A root `.env.example` is now tracked, listing every variable the
-compose file reads with descriptions of what breaks when a required one is
-missing. A guard test asserts that every "copy `.env.example`" instruction in
-the repo points at a file that exists **and** is tracked by git (#4723).
-
-## Pull-request descriptions no longer carry what the run spent
-
-`build_pr_body` opened every description with the session's spend
-(`> 📝 4 files · +507 / -0 · $38.94`) and closed it with a `## Cost` section
-listing the total, the token count, an effective rate per million tokens and a
-per-role breakdown. All of it landed on a public page.
-
-The module already refuses to source a description from the session's own
-status text, on the grounds that it describes the run while a reader of the
-pull request is asking about the diff. Spend is the same kind of fact and was
-the one place the rule was not applied. Both the headline figure and the
-section are gone; the run's cost accounting is unchanged and still available
-where it belongs, in the run report and the retrospective.
-
-## Adapters declare the authentication mechanism they use
-
-Every shipped adapter contract now carries an explicit `auth_basis`, surfaced on `ContractSpec` and `AdapterCapabilityProfile`, so the mechanism an adapter authenticates with is readable from the contract rather than inferred from its configuration (#3875).
-
-## Trust records conform to the TRACE v0.2 schema
-
-Emitted trust records now carry the v0.2 claim surface — SPIFFE subjects derived from the run journal, `policy.enforcement_mode`, closed `runtime`, build provenance, and an appraisal naming an external verifier. Delegated executions link to their parent by record hash, and a run-level aggregate references its member executions. Four checked-in vectors are validated against the vendored schema, the reference model, and the reference conformance suite at Level 0 on every test run (#4760).
-
-Guard agent-card private keystore mode check to POSIX systems where mode bits apply (#4765).
-
-## 3765 - Route onboarded adapter evidence through admission chain and remove generic from exemption list
-
-This release ensures that evidence gathered during the onboarding process is properly routed through the receipt-gated admission chain, making an onboarded adapter's receipt indistinguishable from a hand-written adapter's. Previously, `generic` adapters were exempt from admission entirely, meaning they could not prove their authority through a sealed receipt.
-
-Key changes:
-- Removed `generic` from `ADMISSION_EXEMPT` in admission.py so onboarded generic adapters must go through the admission gate
-- Updated adapters_verify_cmd.py to route `generic` through the admission gate rather than exempting it
-- Added comprehensive tests in test_adapter_onboard_admit.py to verify the new flow produces sealed receipts
-
-This change affects:
-- Onboarded adapters (evidence now verified through existing chain)
-- The generic adapter path (now requires a contract and sealed receipt)
-- Release notes documentation
-
-No user-facing functional changes except that previously exempt generic adapters now require admission evidence to be verified, which is the correct behavior for production adapters.
-
-## 4776 - Draft capability profile helper
-
-The onboarder now auto-drafts adapter capability profiles from CLI probe evidence, eliminating manual profile specification for new agents.
-
-Key changes:
-- Added ``bernstein.adapters.draft.Draft`` class that auto-drafts ``InvocationSpec`` from probe evidence
-- The drafting helper discovers ``--model`` and ``--prompt`` flags in the help text and records their byte ranges for traceability
-- Missing required fields trigger refusable exceptions that name the exact field missing (e.g., "missing required field(s): --model")
-- The ``draft_from_evidence`` function validates that all profile fields trace back to the evidence, not hardcoded defaults
-- When a CLI's --help output contains ``--model <name>``, the resulting InvocationSpec records the exact byte range of the model flag in the captured help text
-- Profiles built from evidence produce reconstructable argv tokens, with every flag confirmed by the original help text
-- The helper integrates with the onboarder to automatically generate profiles for newly-tracked agents, reducing manual configuration
-
-This change affects:
-- Onboarder for new agents (profiles auto-generated from probe evidence)
-- The draft capability profile helper itself (new functionality)
-- The adapter capability profile test suite (new tests for drafting)
-
-No user-facing functional changes except that onboarders can now specify ``--model`` and ``--prompt`` visibility via evidence, not manual flags.
-
-## bernstein workflow resume command
-
-The ``bernstein workflow resume <run_id>`` command resumes a paused or killed
-workflow run from the last completed node. Spec digest validation prevents
-resuming with a modified manifest. The command re-resolves the manifest from
-the path stored at run start, or from an explicit ``--manifest`` argument.
-
-Digest JCS canonical form for trust record delegation parent hash and aggregate member digests (#4799).
-
-## `CheckRunClient` no longer takes an `installation_id`
-
-The constructor accepted an `installation_id` it stored and never used:
-authentication is delegated to the `gh` CLI, and since #4816 `_configured`
-ignores it too. A parameter that looks load-bearing but isn't had already
-misled a caller once. It is gone from the constructor now; the two
-`volunteer-verify.yml` call sites that passed `None` were updated, and the
-docstring states the real contract — repo slug in, auth from the `gh`
-environment (#4825).
-
-Add UV_NO_SYNC and --no-sync to test subprocess invocations to prevent environment mutation during test runs (#4826).
-
-Reject collect-empty ``test_*.py`` modules in Repo hygiene (#4834).
-
-Duration-balance CI unit-test shards from committed per-file timings (#4840).
-
-Opt-in task-tier classification at dispatch (`role_model_policy.<role>.tier_models`) with a pure, versioned feature vector and audit-chain recording (#4854).
-
-Drop stale `[tool.pyright] exclude` paths that no longer exist on disk (#4864).
-
-## Orchestrator pacing is observed through its own seam
-
-The run loop now paces through `Orchestrator._pace` instead of calling `time.sleep` directly. `time.sleep` is one function object shared by the whole process, so a test that patched it recorded every sleep any code performed while `run()` was on the stack — including CPython's own subprocess reaping busy-wait (1ms, 2ms, 4ms, 8ms). On a machine where a startup subprocess outlived the first tick, those four values were the first four entries and the polling-schedule assertions read them instead of the loop's own, failing the suite on unrelated changes. The seam makes the recorded schedule exactly what the loop chose.
-
-CI fails when a touched test module loses collected cases vs the merge base, with a reviewable per-module PR-body override (#4873).
-
-## An aggregate record's member references carry their digest in `digest`
-
-The `member-execution` entries on a run-level aggregate Trust Record put the member's content digest in `id` and emitted no `digest` field, so a verifier that content-binds references found nothing to bind. `id` now carries the member's `subject` — what names it inside the resolver — and `digest` carries the SHA-256 over the member's own bytes, matching how the sibling `produced-artifact` entry on an execution record already splits the two. The aggregate test vector is re-minted; the other three are unchanged.
-
-Added schema validation in Agent Plugins layout detection (T1/T2 of #3540). The `is_agent_plugins_layout()` function now validates that the `$schema` field in `plugin.json` exactly matches `https://agent-plugins.org/schemas/1.0.0/plugin.schema.json`. Additionally, plugin install provenance anchoring ensures each installed skill and the plugin tree itself receives a content-hash receipt anchored in the lineage spine and audit chain.
-
-Fixed the volunteer receipt verification workflow, whose check-run step built
-its Python source by shell substitution and failed on every pull request. A
-repo-hygiene gate now rejects an unquoted Python heredoc in any workflow.


### PR DESCRIPTION
The published v3.19.0 notes ran 5,507 words. The repo file behind them was 3,395: the curated sections, then every release fragment pasted in verbatim, most of it restating the section above it.

The concatenation had also merged unrelated fragments under a single heading. That is how the `CheckRunClient` note came to cite #4826 — a test-isolation change — when the removal is #4845. Anything a reader followed from that line went somewhere else.

This keeps the narrative sections and folds in the user-visible items that only the fragment dump carried: `bernstein gc cas`, `bernstein volunteer hub`, the deliberate `pool` / `limits pool` split, scope resolution, code-graph anchoring, the recorded onboarding transcript, `StallReason.COHORT_LAGGARD`, the now-tracked root `.env.example`, and the `CheckRunClient` signature change (in Upgrading, where a caller would look for it). Every issue reference in the new text was checked against the issue it names.

3,395 words to 1,035. The published release page is already edited to match.

Worth a separate look: `scripts/rotate_release_notes.py` produces this shape every release — fragments are raw input, and pasting them under the curated notes guarantees the duplication and the heading collisions. Filed separately.