### PR TITLE
docs(release-notes): restore the v3.19.0 heading

### DIFF
--- a/docs/release-notes/v3.19.0.md
+++ b/docs/release-notes/v3.19.0.md
@@ -1,3 +1,5 @@
+# v3.19.0
+
 For most of its life the project called itself an orchestrator for CLI coding
 agents. That was the demo, not the product. What it actually ships — an audit
 chain, signed lineage, byte-identical replay, compliance packs — never asked


### PR DESCRIPTION
`main` is red and the merge queue is ejecting queued PRs.

**What broke.** #4946 edited `docs/release-notes/v3.19.0.md` down and dropped its `# v3.19.0` heading. That was the only place the version string appeared in the body, and `test_served_notes_mention_the_current_version` reads the expected version from package metadata and asserts it appears in the page the CLI serves offline:

```
AssertionError: no release-notes page mentions version 3.19.0;
newest page is v3.19.0.md. Add docs/release-notes/v3.19.0.md with the version bump.
```

Shard 1 went red on the merge-queue batch at 04:54, which ejected #4821 and #4887 and disarmed their auto-merge.

**Fix.** Put the heading back. Every other page under `docs/release-notes/` opens with the same one.

Verified in a clean worktree off `main`: `tests/unit/test_release_notes.py` fails on that test without the heading and all 19 pass with it.