### PR TITLE
docs: scope the replay claim to what the code actually guarantees

### DIFF
--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bernstein",
   "version": "3.19.0",
-  "description": "The open-source governance layer for AI agents. Spawn parallel agents in per-task git worktrees, verify their work, and merge results; no model in the coordination loop, so runs replay byte-identically.",
+  "description": "The open-source governance layer for AI agents. Spawn parallel agents in per-task git worktrees, verify their work, and merge results; no model in the coordination loop, so replaying a plan reproduces its task graph byte-identically.",
   "author": {
     "name": "chernistry",
     "url": "https://github.com/chernistry"

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN pip install --no-cache-dir hatchling==1.29.0 && \
 FROM python:3.13-slim@sha256:ffb752e139c0a19692a43af8d8523b274222dd68eebad5d583b45c2201c6e30a
 
 LABEL org.opencontainers.image.title="bernstein" \
-      org.opencontainers.image.description="The open-source governance layer for AI agents (runs Claude Code, Codex, Gemini CLI, and 40+ more). No model in the coordination loop, so parallel runs in per-task git worktrees replay byte-identically." \
+      org.opencontainers.image.description="The open-source governance layer for AI agents (runs Claude Code, Codex, Gemini CLI, and 40+ more). No model in the coordination loop, so replaying a plan reproduces its task graph byte-identically." \
       org.opencontainers.image.source="https://github.com/sipyourdrink-ltd/bernstein" \
       io.modelcontextprotocol.server.name="io.github.sipyourdrink-ltd/bernstein"
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "Bernstein - agent orchestration"
-description: "The open-source governance layer for AI agents, run from GitHub Actions. No model in the coordination loop, so parallel runs in per-task git worktrees replay byte-identically. Supports ad-hoc tasks and automatic CI-fix mode."
+description: "The open-source governance layer for AI agents, run from GitHub Actions. No model in the coordination loop, so replaying a plan reproduces its task graph byte-identically. Supports ad-hoc tasks and automatic CI-fix mode."
 author: "Bernstein contributors"
 
 branding:

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -144,7 +144,7 @@ build_comment() {
 
 <details>
 <summary>What is Bernstein?</summary>
-Bernstein is a deterministic orchestrator that hires short-lived CLI coding agents, one git worktree per task. No model sits in its coordination loop, so runs replay byte-identically.
+Bernstein is a deterministic orchestrator that hires short-lived CLI coding agents, one git worktree per task. No model sits in its coordination loop, so replaying a plan reproduces its task graph byte-identically.
 Learn more at https://github.com/sipyourdrink-ltd/bernstein
 </details>
 MARKDOWN

--- a/commands/run.md
+++ b/commands/run.md
@@ -2,7 +2,7 @@
 description: Start a Bernstein orchestration run with a goal
 ---
 
-Start an orchestration run. Bernstein decomposes the goal into tasks, spawns CLI coding agents in parallel git worktrees, verifies their output, and merges results. No model sits in the coordination loop, so the run replays byte-identically.
+Start an orchestration run. Bernstein decomposes the goal into tasks, spawns CLI coding agents in parallel git worktrees, verifies their output, and merges results. No model sits in the coordination loop, so replaying a plan reproduces its task graph byte-identically.
 
 Usage: /bernstein:run $ARGUMENTS
 

--- a/deploy/helm/bernstein/Chart.yaml
+++ b/deploy/helm/bernstein/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bernstein
-description: The open-source governance layer for AI agents - no model in the coordination loop, so parallel runs in per-task git worktrees replay byte-identically
+description: The open-source governance layer for AI agents - no model in the coordination loop, so replaying a plan reproduces its task graph byte-identically
 type: application
 version: 0.2.0
 appVersion: "3.9.0"

--- a/docs/ENTERPRISE.md
+++ b/docs/ENTERPRISE.md
@@ -6,7 +6,7 @@ This page is the short path through Bernstein's enterprise surface. It does not 
 
 ## Executive summary
 
-Bernstein is a local-first, open-source governance layer for AI agents. No model sits in its coordination loop, so parallel runs in per-task git worktrees replay byte-identically. In the default deployment model:
+Bernstein is a local-first, open-source governance layer for AI agents. No model sits in its coordination loop, so replaying a plan reproduces its task graph byte-identically. In the default deployment model:
 
 - orchestration state lives on disk under `.sdd/`
 - agents run as separate local processes, usually in per-task git worktrees

--- a/docs/agents.txt
+++ b/docs/agents.txt
@@ -1,6 +1,6 @@
 User-agent: *
 Name: Bernstein
-Description: The open-source governance layer for AI agents - no model in the coordination loop, so parallel runs in per-task git worktrees replay byte-identically; signed lineage and an opt-in HMAC audit chain, air-gap friendly
+Description: The open-source governance layer for AI agents - no model in the coordination loop, so replaying a plan reproduces its task graph byte-identically; signed lineage and an opt-in HMAC audit chain, air-gap friendly
 Homepage: https://bernstein.readthedocs.io/
 Repository: https://github.com/sipyourdrink-ltd/bernstein
 Package: https://pypi.org/project/bernstein/

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 title: Bernstein - The Open-Source Governance Layer for AI Agents
 description: >-
   The open-source governance layer for AI agents. No model in the coordination
-  loop, so parallel runs in per-task git worktrees replay byte-identically.
+  loop, so replaying a plan reproduces its task graph byte-identically.
   Signed lineage plus an opt-in HMAC audit chain a reviewer checks offline,
   without rerunning it. Run Claude Code, Codex, Gemini CLI, and 40+ more behind
   one governance surface, for any deliverable, with zero vendor lock-in.

--- a/docs/release-notes/v3.19.0.md
+++ b/docs/release-notes/v3.19.0.md
@@ -2,7 +2,7 @@
 
 For most of its life the project called itself an orchestrator for CLI coding
 agents. That was the demo, not the product. What it actually ships — an audit
-chain, signed lineage, byte-identical replay, compliance packs — never asked
+chain, signed lineage, byte-identical run receipts, compliance packs — never asked
 whether the agent was writing code, reading logs or assembling evidence.
 Bernstein is the open-source governance layer for AI agents. Nothing in the
 code had to change for that sentence. Only the sentence did.

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -2,7 +2,7 @@
   "//": "The version field below is stamped from the release tag at publish time (publish.yml's npm job runs `npm version $VERSION`); the committed value is not the released value.",
   "name": "bernstein-orchestrator",
   "version": "1.9.0",
-  "description": "The open-source governance layer for AI agents. Spawn parallel agents in per-task git worktrees, verify with tests, commit clean code; no model in the coordination loop, so runs replay byte-identically.",
+  "description": "The open-source governance layer for AI agents. Spawn parallel agents in per-task git worktrees, verify with tests, commit clean code; no model in the coordination loop, so replaying a plan reproduces its task graph byte-identically.",
   "keywords": [
     "ai",
     "agents",

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
     "name": "chernistry",
     "url": "https://github.com/chernistry"
   },
-  "description": "The open-source governance layer for AI agents. Spawn parallel agents in per-task git worktrees, verify their work, and merge results; no model in the coordination loop, so runs replay byte-identically.",
+  "description": "The open-source governance layer for AI agents. Spawn parallel agents in per-task git worktrees, verify their work, and merge results; no model in the coordination loop, so replaying a plan reproduces its task graph byte-identically.",
   "homepage": "https://github.com/sipyourdrink-ltd/bernstein",
   "keywords": [
     "orchestration",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "bernstein"
 version = "3.19.0"
-description = "The open-source governance layer for AI agents. No model in the coordination loop, so parallel runs in per-task git worktrees replay byte-identically. Signed lineage plus an opt-in HMAC audit chain a reviewer checks offline, without rerunning it. Runs Claude Code, Codex, Gemini CLI, and 40+ CLI agents; governs any deliverable from code to research to audit evidence packs. Cluster mode, air-gap deploy."
+description = "The open-source governance layer for AI agents. No model in the coordination loop, so replaying a plan reproduces its task graph byte-identically, and run receipts are byte-identical across independent builds. Signed lineage plus an opt-in HMAC audit chain a reviewer checks offline, without rerunning it. Runs Claude Code, Codex, Gemini CLI, and 40+ CLI agents; governs any deliverable from code to research to audit evidence packs. Cluster mode, air-gap deploy."
 readme = "README.md"
 requires-python = ">=3.12"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.sipyourdrink-ltd/bernstein",
-  "description": "The open-source governance layer for AI agents. Byte-identical replay, 40+ adapters, air-gap.",
+  "description": "The open-source governance layer for AI agents. Byte-identical run receipts, 40+ adapters, air-gap.",
   "websiteUrl": "https://bernstein.run",
   "repository": {
     "url": "https://github.com/sipyourdrink-ltd/bernstein",

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -411,7 +411,7 @@ def print_rich_help() -> None:
     c.print(
         Panel(
             "[bold]bernstein[/bold]  the open-source governance layer for AI agents.\n"
-            "  No model in the coordination loop, so runs replay byte-identically.\n"
+            "  No model in the coordination loop, so a plan replays to the same task graph.\n"
             "  40+ adapters, per-task git worktrees, opt-in HMAC-SHA256 audit chain (RFC 2104).",
             border_style="blue",
             padding=(0, 2),
@@ -763,7 +763,7 @@ def cli(
 ) -> None:
     """The open-source governance layer for AI agents.
 
-    Parallel runs in per-task git worktrees, byte-identical replay, signed
+    Parallel runs in per-task git worktrees, byte-identical run receipts, signed
     lineage that checks offline from the artefacts. Replaying the HMAC audit
     chain additionally needs the install audit key.
     """

--- a/src/bernstein/mcp/server.py
+++ b/src/bernstein/mcp/server.py
@@ -133,7 +133,7 @@ _package_repo_url = package_repo_url
 # Budget and tool-name accuracy are asserted in tests/unit/test_mcp_server.py.
 _SERVER_INSTRUCTIONS = (
     "Bernstein is the open-source governance layer for AI agents, one git "
-    "worktree per task, so runs replay byte-identically. Verifying the audit "
+    "worktree per task; a plan replays to the same task graph. Verifying the audit "
     "chain offline needs the install audit key.\n"
     "Driving a run:\n"
     "1. bernstein_run starts a run and returns immediately with a task_id, "


### PR DESCRIPTION
Sixteen public surfaces stated that runs "replay byte-identically" with no qualification. The code does not offer that, and the docs that describe it never claimed it did.

## What the code actually does

| | |
|---|---|
| `internal_llm_provider` default | `none` (`core/config/seed_config.py:450`) |
| What recording covers | the internal `call_llm` path only |
| CLI agent subprocesses | not on that path |
| Default config, recording run | no `llm_calls.jsonl` is written at all |

`DeterministicReplayError` states it in its own message (`core/orchestration/deterministic.py`):

> This run recorded no LLM calls - the CLI-adapter path (`internal_llm_provider` 'none' + a CLI agent) does not record, so it cannot be replayed hermetically.

## What *is* byte-identical

`docs/operations/deterministic-replay.md`:

> Receipt bytes are byte-identical across independent builds of the same run.

And the task graph, which the deterministic scheduler does reproduce — `CITATION.cff` and the README have both said exactly this for a while:

> replay of yesterday's plan reproduces yesterday's task graph byte-identically

The guarantee for a live re-run is that divergence is **localised to the step**, not prevented. An unqualified "replay byte-identically" promises prevention.

## Changed

PyPI description (`pyproject.toml`), Actions Marketplace (`action.yml`, `action/entrypoint.sh`), MCP registry (`server.json`, `mcp/server.py`), Helm chart, npm package, plugin manifests, OCI image label (`Dockerfile`), CLI `--help` (`cli/main.py`), `docs/index.md`, `docs/agents.txt`, `docs/ENTERPRISE.md`, `commands/run.md`, and `docs/release-notes/v3.19.0.md`.

Generated manifests were regenerated with `scripts/gen_distribution_manifests.py` rather than hand-edited.

## Deliberately unchanged

- `docs/interop/acp.md` — already scoped: "Two faithful replays of a **recorded** ACP session".
- The narrow uses elsewhere in `docs/` (template restore, schedule graph hashes, cursor resumption, clearance recompute). Each names one deterministic operation and is accurate.
- `README.md`, `CITATION.cff` — already correct.
- The `deterministic-replay` repo topic — a discovery keyword, and the feature is real within its scope.

Also needs doing outside this repo: the GitHub About text carries the same sentence.