### PR TITLE
fix(adapters): wire GPTME_MAX_TOKENS from mcp_config for gptme

### DIFF
--- a/docs/release-notes/fragments/4955-gptme-max-tokens.md
+++ b/docs/release-notes/fragments/4955-gptme-max-tokens.md
@@ -1,0 +1,10 @@
+## gptme honouring `max_tokens`
+
+The gptme adapter now wires `mcp_config["max_tokens"]` through to the
+per-process `GPTME_MAX_TOKENS` environment override instead of leaving it
+unused. The adapter declares the narrow `SUPPORTS_MAX_TOKENS` capability, so
+the sampling gate admits a spawn carrying `max_tokens` for gptme rather than
+refusing it (the value was previously refused and honoured nowhere).
+`GPTME_MAX_TOKENS` is set on the filtered environment after
+`build_filtered_env`, not passed through `extra_keys`, so an ambient shell
+variable cannot leak through. #4955

--- a/src/bernstein/adapters/gptme.py
+++ b/src/bernstein/adapters/gptme.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
 from bernstein.adapters.env_isolation import build_filtered_env
+from bernstein.adapters.plugin_sdk import AdapterCapability, AdapterPluginInfo
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -97,6 +98,15 @@ class GptmeAdapter(CLIAdapter):
         )
 
         env = build_filtered_env(["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY"])
+        # ``GPTME_MAX_TOKENS`` is gptme's per-process completion-length
+        # override. The value originates in ``mcp_config``, not the operator's
+        # shell, so it is set here after ``build_filtered_env`` rather than
+        # passed through ``extra_keys``: adding it there would let an ambient
+        # shell variable reach the agent, which is the opposite of what the
+        # environment filter is for.
+        max_tokens = (mcp_config or {}).get("max_tokens")
+        if max_tokens is not None:
+            env["GPTME_MAX_TOKENS"] = str(max_tokens)
         with log_path.open("w") as log_file:
             try:
                 proc = subprocess.Popen(
@@ -117,6 +127,24 @@ class GptmeAdapter(CLIAdapter):
         if timeout_seconds > 0:
             result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
         return result
+
+    def plugin_info(self) -> AdapterPluginInfo:
+        """Declare the sampling surface GptmeAdapter genuinely wires.
+
+        gptme honours a completion-length limit per process via the
+        ``GPTME_MAX_TOKENS`` environment variable (see :meth:`spawn`), so
+        :func:`bernstein.adapters.plugin_sdk.ensure_sampling_params_supported`
+        admits a spawn carrying ``max_tokens``. No ``--temperature`` /
+        ``--top-p`` / ``--top-k`` flags are wired - upstream exposes none -
+        so only :attr:`AdapterCapability.SUPPORTS_MAX_TOKENS` is declared.
+        """
+        return AdapterPluginInfo(
+            name="gptme",
+            version="0.1.0",
+            author="bernstein",
+            description="gptme CLI adapter",
+            capabilities=(AdapterCapability.SUPPORTS_MAX_TOKENS,),
+        )
 
     def name(self) -> str:
         """Return the human-readable adapter name."""

--- a/tests/unit/test_adapter_gptme.py
+++ b/tests/unit/test_adapter_gptme.py
@@ -53,5 +53,52 @@ def test_spawn_translates_missing_cli(tmp_path: Path) -> None:
         )
 
 
+def test_spawn_forwards_max_tokens_env(tmp_path: Path) -> None:
+    adapter = GptmeAdapter()
+    proc_mock = make_popen_mock(900)
+
+    with patch("bernstein.adapters.gptme.subprocess.Popen", return_value=proc_mock) as popen:
+        adapter.spawn(
+            prompt="fix the bug",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="sonnet", effort="high"),
+            session_id="gptme-s1",
+            mcp_config={"max_tokens": 4096},
+        )
+
+    env = popen.call_args.kwargs["env"]
+    assert env["GPTME_MAX_TOKENS"] == "4096"
+
+
+def test_spawn_omits_max_tokens_env_when_unset(tmp_path: Path) -> None:
+    adapter = GptmeAdapter()
+    proc_mock = make_popen_mock(900)
+
+    with patch("bernstein.adapters.gptme.subprocess.Popen", return_value=proc_mock) as popen:
+        adapter.spawn(
+            prompt="fix the bug",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="sonnet", effort="high"),
+            session_id="gptme-s1",
+        )
+
+    env = popen.call_args.kwargs["env"]
+    assert "GPTME_MAX_TOKENS" not in env
+
+
 def test_name() -> None:
     assert GptmeAdapter().name() == "gptme"
+
+
+def test_sampling_gate_admits_max_tokens_but_refuses_unwired_keys() -> None:
+    from bernstein.adapters.plugin_sdk import (
+        SamplingParamsRefusal,
+        ensure_sampling_params_supported,
+    )
+
+    adapter = GptmeAdapter()
+
+    ensure_sampling_params_supported(adapter, {"max_tokens": 4096})
+
+    with pytest.raises(SamplingParamsRefusal):
+        ensure_sampling_params_supported(adapter, {"temperature": 0.5})


### PR DESCRIPTION
Follow-up for the gptme adapter's "could honour it but does not today" bucket in #3586; closes the wiring half of #4955.

## Problem

`GptmeAdapter.spawn()` builds its subprocess environment with `build_filtered_env(["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY"])` and nothing anywhere sets `GPTME_MAX_TOKENS`. gptme honours a completion-length limit per process via that variable, so the capability exists upstream but is unused here — and because #3586 unified the sampling surface, a spawn carrying `max_tokens` is refused at the gate, so the value is honoured nowhere.

## Change

- **Wire the value where it belongs.** `GPTME_MAX_TOKENS` originates in `mcp_config`, not the operator's shell, so it is set on the returned dict **after** `build_filtered_env(...)` rather than passed through `extra_keys`. **Considered and rejected:** adding it to `extra_keys` would let an ambient shell variable reach the agent, which is the opposite of what the environment filter is for.
- **Declare the capability.** `plugin_info()` now returns `SUPPORTS_MAX_TOKENS`. Wiring the variable without declaring it would leave the gate still refusing the spawn, so the value stays unused and the change is unobservable. Declaring it turns the refusal into a working path. Only the narrow capability is declared; `--temperature`/`--top-p`/`--top-k` remain unwired (upstream exposes none) and the gate still refuses them.

## Tests

- Positive: spawn with `mcp_config={"max_tokens": N}` → `env["GPTME_MAX_TOKENS"] == str(N)`.
- Negative: spawn without `max_tokens` → the key is **absent**, not empty-string (guards against an unconditional setter).
- Gate: `ensure_sampling_params_supported(gptme, {"max_tokens": N})` admits; `{"temperature": ...}` still rejects.

## Out of scope

- `SAMPLING_PARAM_KEYS` and the gate surface are untouched — settled by #3586.
- Other adapters in the #3586 "could honour it but does not" bucket — one adapter per PR.