### PR TITLE
fix(scanners): verify trivy database feed pin

### DIFF
--- a/src/bernstein/adapters/trivy.py
+++ b/src/bernstein/adapters/trivy.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 import shutil
 import subprocess
+import sys
+import tempfile
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
@@ -50,7 +53,8 @@ class TrivyInvocation:
     """Stable provenance for one feed-pinned Trivy invocation."""
 
     tool_version: str
-    db_digest: str
+    db_pin: str
+    db_identity: str
     argv_hash: str
 
 
@@ -74,9 +78,9 @@ class TrivyAdapter(ScannerAdapter):
         return self.registry_name
 
     def scan(self, target: Path, scope: ScanScope, workdir: Path) -> ScanResult:
-        """Run Trivy without updating its database and record the caller's DB digest."""
+        """Run Trivy after verifying the caller's pin against the database on disk."""
         self.enforce_network_policy()
-        db_digest = _validate_scope(target, scope)
+        db_pin = _validate_scope(target, scope)
         resolved_target = target.resolve()
         if not resolved_target.exists():
             raise TrivyError(f"Trivy target does not exist: {target}")
@@ -87,15 +91,21 @@ class TrivyAdapter(ScannerAdapter):
                 f"Trivy executable {self._binary!r} was not found on PATH; install trivy or configure its binary"
             )
 
+        cache_dir = _resolve_cache_dir(self._cache_dir)
+        db_identity = _db_identity(cache_dir)
+        if db_identity != db_pin:
+            raise TrivyError(f"Trivy database pin mismatch: expected {db_pin}, observed {db_identity}")
+
         tool_version = _read_version(binary)
         workdir.mkdir(parents=True, exist_ok=True)
         report_path = (workdir / "trivy.sarif").resolve()
         report_path.unlink(missing_ok=True)
-        command = _build_command(binary, resolved_target, report_path, self._cache_dir)
+        command = _build_command(binary, resolved_target, report_path, cache_dir)
         self.last_invocation = TrivyInvocation(
             tool_version=tool_version,
-            db_digest=db_digest,
-            argv_hash=_invocation_argv_hash(tool_version, db_digest),
+            db_pin=db_pin,
+            db_identity=db_identity,
+            argv_hash=_invocation_argv_hash(tool_version, db_identity),
         )
 
         try:
@@ -120,13 +130,13 @@ class TrivyAdapter(ScannerAdapter):
             findings = parse_trivy_sarif(report_path.read_bytes(), target_root=resolved_target)
         finally:
             report_path.unlink(missing_ok=True)
-        return ScanResult(findings=findings, feed_digest=db_digest)
+        return ScanResult(findings=findings, feed_digest=db_identity)
 
 
 def _validate_scope(target: Path, scope: ScanScope) -> str:
     if scope.include or scope.exclude or scope.max_depth is not None:
         raise ValueError("TrivyAdapter does not yet support include, exclude, or max_depth scan scope fields")
-    unsupported = set(scope.config) - {"db_digest"}
+    unsupported = set(scope.config) - {"db_pin"}
     if unsupported:
         raise ValueError(f"Unsupported Trivy scan configuration: {', '.join(sorted(unsupported))}")
     if scope.roots:
@@ -137,10 +147,47 @@ def _validate_scope(target: Path, scope: ScanScope) -> str:
         if not target_is_allowed:
             raise ValueError("Trivy target is outside the allowed ScanScope roots")
 
-    digest = scope.config.get("db_digest")
-    if not isinstance(digest, str) or not _SHA256_DIGEST.fullmatch(digest):
-        raise TrivyError("Feed-pinned Trivy scans require scope.config['db_digest'] as a sha256:<64 hex> digest")
-    return digest.lower()
+    pin = scope.config.get("db_pin")
+    if not isinstance(pin, str) or not _SHA256_DIGEST.fullmatch(pin):
+        raise TrivyError("Feed-pinned Trivy scans require scope.config['db_pin'] as a sha256:<64 hex> digest")
+    return pin.lower()
+
+
+def _resolve_cache_dir(configured: Path | None) -> Path:
+    """Resolve Trivy's platform default and make it explicit on the command line."""
+    if configured is not None:
+        return configured.resolve()
+    if sys.platform == "darwin":
+        home = os.environ.get("HOME")
+        base = Path(home) / "Library" / "Caches" if home else Path(tempfile.gettempdir())
+    elif os.name == "nt":
+        local_app_data = os.environ.get("LOCALAPPDATA")
+        base = Path(local_app_data) if local_app_data else Path(tempfile.gettempdir())
+    else:
+        xdg_cache = os.environ.get("XDG_CACHE_HOME")
+        home = os.environ.get("HOME")
+        if xdg_cache and Path(xdg_cache).is_absolute():
+            base = Path(xdg_cache)
+        elif not xdg_cache and home:
+            base = Path(home) / ".cache"
+        else:
+            base = Path(tempfile.gettempdir())
+    return base / "trivy"
+
+
+def _db_identity(cache_dir: Path) -> str:
+    """Return a content digest of the exact vulnerability database Trivy will load."""
+    database = cache_dir / "db" / "trivy.db"
+    if not database.is_file():
+        raise TrivyError(f"Trivy database does not exist at {database}; download it before running a pinned scan")
+    digest = hashlib.sha256()
+    try:
+        with database.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as exc:
+        raise TrivyError(f"Could not hash Trivy database at {database}: {exc}") from exc
+    return "sha256:" + digest.hexdigest()
 
 
 def _read_version(binary: str) -> str:
@@ -168,7 +215,7 @@ def _read_version(binary: str) -> str:
     return first_line
 
 
-def _build_command(binary: str, target: Path, report_path: Path, cache_dir: Path | None) -> list[str]:
+def _build_command(binary: str, target: Path, report_path: Path, cache_dir: Path) -> list[str]:
     command = [
         binary,
         "filesystem",
@@ -180,16 +227,15 @@ def _build_command(binary: str, target: Path, report_path: Path, cache_dir: Path
         "--output",
         str(report_path),
     ]
-    if cache_dir is not None:
-        command.extend(["--cache-dir", str(cache_dir.resolve())])
+    command.extend(["--cache-dir", str(cache_dir)])
     command.append(str(target))
     return command
 
 
-def _invocation_argv_hash(tool_version: str, db_digest: str) -> str:
+def _invocation_argv_hash(tool_version: str, db_identity: str) -> str:
     semantic_invocation = {
         "command": "filesystem",
-        "db_digest": db_digest,
+        "db_identity": db_identity,
         "report_format": "sarif",
         "scanners": ["vuln"],
         "skip_db_update": True,

--- a/tests/fixtures/scanners/trivy/trivy-conformance.yaml
+++ b/tests/fixtures/scanners/trivy/trivy-conformance.yaml
@@ -6,7 +6,7 @@ steps:
       roots:
         - tests/fixtures/scanners/trivy/target
       config:
-        db_digest: sha256:633b3bacaa4a03f502faef8f94ce2d20d96a8499405d266ed7f67879109ec80d
+        db_pin: sha256:633b3bacaa4a03f502faef8f94ce2d20d96a8499405d266ed7f67879109ec80d
     expect_feed_digest: sha256:633b3bacaa4a03f502faef8f94ce2d20d96a8499405d266ed7f67879109ec80d
     expected_finding_hashes:
       - 6eb0cd0e1d53c3e01693de4cc38f3925f935d5ecebe409eee23313df31986ecf
@@ -19,7 +19,7 @@ steps:
       roots:
         - tests/fixtures/scanners/trivy/target
       config:
-        db_digest: sha256:633b3bacaa4a03f502faef8f94ce2d20d96a8499405d266ed7f67879109ec80d
+        db_pin: sha256:633b3bacaa4a03f502faef8f94ce2d20d96a8499405d266ed7f67879109ec80d
     expect_feed_digest: sha256:633b3bacaa4a03f502faef8f94ce2d20d96a8499405d266ed7f67879109ec80d
     expected_finding_hashes:
       - 6eb0cd0e1d53c3e01693de4cc38f3925f935d5ecebe409eee23313df31986ecf

--- a/tests/unit/adapters/test_trivy_scanner.py
+++ b/tests/unit/adapters/test_trivy_scanner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import hashlib
 import json
 import subprocess
 from pathlib import Path
@@ -19,23 +20,25 @@ from bernstein.adapters.trivy import (
     TrivyAdapter,
     TrivyError,
     TrivyNotInstalledError,
+    _db_identity,
     _invocation_argv_hash,
+    _resolve_cache_dir,
     parse_trivy_sarif,
 )
 
 _FIXTURE = Path("tests/fixtures/scanners/trivy/trivy-0.74.0.sarif")
 _FIXTURE_DIR = _FIXTURE.parent
 _TARGET = _FIXTURE_DIR / "target"
-_DB_DIGEST = "sha256:633b3bacaa4a03f502faef8f94ce2d20d96a8499405d266ed7f67879109ec80d"
-_OTHER_DB_DIGEST = "sha256:" + "a" * 64
+_DB_IDENTITY = "sha256:633b3bacaa4a03f502faef8f94ce2d20d96a8499405d266ed7f67879109ec80d"
+_OTHER_DB_IDENTITY = "sha256:" + "a" * 64
 
 
 def _fixture_text() -> str:
     return _FIXTURE.read_text(encoding="utf-8")
 
 
-def _scope(db_digest: str = _DB_DIGEST) -> ScanScope:
-    return ScanScope(roots=(_TARGET,), config={"db_digest": db_digest})
+def _scope(db_pin: str = _DB_IDENTITY) -> ScanScope:
+    return ScanScope(roots=(_TARGET,), config={"db_pin": db_pin})
 
 
 def _fake_trivy_run(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
@@ -122,18 +125,18 @@ def test_scanner_registry_resolves_trivy() -> None:
     assert isinstance(get_scanner("trivy"), TrivyAdapter)
 
 
-def test_invocation_hash_binds_version_and_db_digest() -> None:
-    baseline = _invocation_argv_hash("0.74.0", _DB_DIGEST)
+def test_invocation_hash_binds_version_and_db_identity() -> None:
+    baseline = _invocation_argv_hash("0.74.0", _DB_IDENTITY)
 
-    assert _invocation_argv_hash("0.74.0", _DB_DIGEST) == baseline
-    assert _invocation_argv_hash("0.74.1", _DB_DIGEST) != baseline
-    assert _invocation_argv_hash("0.74.0", _OTHER_DB_DIGEST) != baseline
+    assert _invocation_argv_hash("0.74.0", _DB_IDENTITY) == baseline
+    assert _invocation_argv_hash("0.74.1", _DB_IDENTITY) != baseline
+    assert _invocation_argv_hash("0.74.0", _OTHER_DB_IDENTITY) != baseline
 
 
-def test_feed_pinned_scan_requires_a_db_digest(tmp_path: Path) -> None:
+def test_feed_pinned_scan_requires_a_db_pin(tmp_path: Path) -> None:
     with (
         patch("bernstein.adapters.trivy.shutil.which") as which,
-        pytest.raises(TrivyError, match=r"require scope.config\['db_digest'\]"),
+        pytest.raises(TrivyError, match=r"require scope.config\['db_pin'\]"),
     ):
         TrivyAdapter().scan(tmp_path, ScanScope(), tmp_path / "work")
     which.assert_not_called()
@@ -144,38 +147,110 @@ def test_scan_runs_trivy_with_database_updates_disabled(tmp_path: Path) -> None:
 
     with (
         patch("bernstein.adapters.trivy.shutil.which", return_value="/usr/local/bin/trivy"),
+        patch("bernstein.adapters.trivy._db_identity", return_value=_DB_IDENTITY),
         patch("bernstein.adapters.trivy.subprocess.run", side_effect=_fake_trivy_run) as run,
     ):
         result = adapter.scan(_TARGET, _scope(), tmp_path / "work")
 
     assert result.finding_hashes() == sorted(f.finding_hash() for f in parse_trivy_sarif(_fixture_text()))
-    assert result.feed_digest == _DB_DIGEST
+    assert result.feed_digest == _DB_IDENTITY
     scan_argv = run.call_args_list[1].args[0]
     assert scan_argv[1:5] == ["filesystem", "--scanners", "vuln", "--skip-db-update"]
     assert scan_argv[-1] == str(_TARGET.resolve())
     assert "--cache-dir" in scan_argv
     assert adapter.last_invocation is not None
     assert adapter.last_invocation.tool_version == "0.74.0"
-    assert adapter.last_invocation.db_digest == _DB_DIGEST
+    assert adapter.last_invocation.db_pin == _DB_IDENTITY
+    assert adapter.last_invocation.db_identity == _DB_IDENTITY
     assert not (tmp_path / "work" / "trivy.sarif").exists()
 
 
-def test_a_changed_db_digest_is_recorded_not_absorbed(tmp_path: Path) -> None:
-    first_adapter = TrivyAdapter()
-    second_adapter = TrivyAdapter()
+def test_a_changed_db_identity_is_recorded_not_absorbed(tmp_path: Path) -> None:
+    first_adapter = TrivyAdapter(cache_dir=tmp_path / "first-cache")
+    second_adapter = TrivyAdapter(cache_dir=tmp_path / "second-cache")
     with (
         patch("bernstein.adapters.trivy.shutil.which", return_value="/usr/local/bin/trivy"),
+        patch("bernstein.adapters.trivy._db_identity", side_effect=[_DB_IDENTITY, _OTHER_DB_IDENTITY]),
         patch("bernstein.adapters.trivy.subprocess.run", side_effect=_fake_trivy_run),
     ):
         first = first_adapter.scan(_TARGET, _scope(), tmp_path / "first")
-        second = second_adapter.scan(_TARGET, _scope(_OTHER_DB_DIGEST), tmp_path / "second")
+        second = second_adapter.scan(_TARGET, _scope(_OTHER_DB_IDENTITY), tmp_path / "second")
 
     assert first.finding_hashes() == second.finding_hashes()
-    assert first.feed_digest == _DB_DIGEST
-    assert second.feed_digest == _OTHER_DB_DIGEST
+    assert first.feed_digest == _DB_IDENTITY
+    assert second.feed_digest == _OTHER_DB_IDENTITY
     assert first_adapter.last_invocation is not None
     assert second_adapter.last_invocation is not None
+    assert first_adapter.last_invocation.db_identity == _DB_IDENTITY
+    assert second_adapter.last_invocation.db_identity == _OTHER_DB_IDENTITY
     assert first_adapter.last_invocation.argv_hash != second_adapter.last_invocation.argv_hash
+
+
+def test_a_db_pin_mismatch_fails_before_trivy_runs(tmp_path: Path) -> None:
+    with (
+        patch("bernstein.adapters.trivy.shutil.which", return_value="/usr/local/bin/trivy"),
+        patch("bernstein.adapters.trivy._db_identity", return_value=_OTHER_DB_IDENTITY),
+        patch("bernstein.adapters.trivy.subprocess.run") as run,
+        pytest.raises(TrivyError, match=f"expected {_DB_IDENTITY}, observed {_OTHER_DB_IDENTITY}"),
+    ):
+        TrivyAdapter(cache_dir=tmp_path / "cache").scan(_TARGET, _scope(), tmp_path / "work")
+    run.assert_not_called()
+
+
+def test_db_identity_hashes_the_database_file_bytes(tmp_path: Path) -> None:
+    database = tmp_path / "db" / "trivy.db"
+    database.parent.mkdir()
+    database.write_bytes(b"recorded trivy database bytes")
+
+    assert _db_identity(tmp_path) == "sha256:" + hashlib.sha256(database.read_bytes()).hexdigest()
+
+
+def test_db_identity_rejects_a_missing_database(tmp_path: Path) -> None:
+    with pytest.raises(TrivyError, match="database does not exist"):
+        _db_identity(tmp_path)
+
+
+def test_a_missing_database_fails_before_trivy_runs(tmp_path: Path) -> None:
+    with (
+        patch("bernstein.adapters.trivy.shutil.which", return_value="/usr/local/bin/trivy"),
+        patch("bernstein.adapters.trivy.subprocess.run") as run,
+        pytest.raises(TrivyError, match="database does not exist"),
+    ):
+        TrivyAdapter(cache_dir=tmp_path / "cache").scan(_TARGET, _scope(), tmp_path / "work")
+    run.assert_not_called()
+
+
+def test_default_cache_directory_matches_trivy_on_macos() -> None:
+    with (
+        patch("bernstein.adapters.trivy.sys.platform", "darwin"),
+        patch.dict("bernstein.adapters.trivy.os.environ", {"HOME": "/Users/example"}, clear=True),
+    ):
+        cache_dir = _resolve_cache_dir(None)
+
+    assert cache_dir == Path("/Users/example/Library/Caches/trivy")
+
+
+def test_default_cache_directory_uses_xdg_cache_home_on_linux() -> None:
+    with (
+        patch("bernstein.adapters.trivy.sys.platform", "linux"),
+        patch("bernstein.adapters.trivy.os.name", "posix"),
+        patch.dict("bernstein.adapters.trivy.os.environ", {"XDG_CACHE_HOME": "/var/cache/example"}, clear=True),
+    ):
+        cache_dir = _resolve_cache_dir(None)
+
+    assert cache_dir == Path("/var/cache/example/trivy")
+
+
+def test_default_cache_directory_matches_trivys_temp_fallback() -> None:
+    with (
+        patch("bernstein.adapters.trivy.sys.platform", "linux"),
+        patch("bernstein.adapters.trivy.os.name", "posix"),
+        patch.dict("bernstein.adapters.trivy.os.environ", {}, clear=True),
+        patch("bernstein.adapters.trivy.tempfile.gettempdir", return_value="/tmp/example"),
+    ):
+        cache_dir = _resolve_cache_dir(None)
+
+    assert cache_dir == Path("/tmp/example/trivy")
 
 
 def test_scan_reports_missing_trivy_without_invoking_a_process(tmp_path: Path) -> None:
@@ -200,6 +275,7 @@ def test_stale_report_cannot_be_reused(tmp_path: Path) -> None:
 
     with (
         patch("bernstein.adapters.trivy.shutil.which", return_value="/usr/local/bin/trivy"),
+        patch("bernstein.adapters.trivy._db_identity", return_value=_DB_IDENTITY),
         patch("bernstein.adapters.trivy.subprocess.run", side_effect=no_report),
         pytest.raises(TrivyError, match="without writing its SARIF report"),
     ):
@@ -214,18 +290,20 @@ def test_scan_rejects_a_real_trivy_execution_error(tmp_path: Path) -> None:
 
     with (
         patch("bernstein.adapters.trivy.shutil.which", return_value="/usr/local/bin/trivy"),
+        patch("bernstein.adapters.trivy._db_identity", return_value=_DB_IDENTITY),
         patch("bernstein.adapters.trivy.subprocess.run", side_effect=fail_scan),
         pytest.raises(TrivyError, match="code 2: database unavailable"),
     ):
         TrivyAdapter().scan(_TARGET, _scope(), tmp_path / "work")
 
 
-def test_conformance_replays_two_runs_with_the_same_db_digest(tmp_path: Path) -> None:
+def test_conformance_replays_two_runs_with_the_same_db_pin(tmp_path: Path) -> None:
     transcripts = load_scanner_golden_transcripts(_FIXTURE_DIR)
     assert len(transcripts) == 1
 
     with (
         patch("bernstein.adapters.trivy.shutil.which", return_value="/usr/local/bin/trivy"),
+        patch("bernstein.adapters.trivy._db_identity", return_value=_DB_IDENTITY),
         patch("bernstein.adapters.trivy.subprocess.run", side_effect=_fake_trivy_run) as run,
     ):
         result = ScannerConformanceHarness().replay_transcript(transcripts[0], workdir=tmp_path)
@@ -233,5 +311,5 @@ def test_conformance_replays_two_runs_with_the_same_db_digest(tmp_path: Path) ->
     assert result.passed
     assert result.adapter_name == "trivy"
     assert result.determinism_tier is DeterminismTier.FEED_PINNED
-    assert [step.feed_digest for step in result.step_results] == [_DB_DIGEST, _DB_DIGEST]
+    assert [step.feed_digest for step in result.step_results] == [_DB_IDENTITY, _DB_IDENTITY]
     assert sum(call.args[0][1] == "filesystem" for call in run.call_args_list) == 2


### PR DESCRIPTION
## What

Adds verification for the Trivy database pin before a feed-pinned scan runs.

Follow-up to #4933 and part of #3618.

## Why

The original Trivy adapter recorded the database digest provided by the caller, but it didn't check that the local Trivy database actually matched it.

This changes that by hashing the actual `trivy.db` file before the scan. If the observed database doesn't match the expected pin, the adapter fails instead of recording an unverified digest.

## How

The caller provides the expected `db_pin` through `ScanScope.config`.

Before running Trivy, the adapter resolves the Trivy cache directory and computes a SHA-256 over `<cache-dir>/db/trivy.db`. That hash is recorded separately as `db_identity` and compared against the caller's pin.

If the database is missing or the hashes don't match, the scan fails before Trivy runs. If they match, the verified `db_identity` is recorded as `feed_digest` and included in the invocation hash.

I also tested two separate downloads of the same Trivy database release. The resulting `trivy.db` files were byte-identical and produced the same SHA-256.

## Checklist

- [x] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` passes
- [ ] `uv run python scripts/run_tests.py -x` passes
- [x] New code has type hints
- [x] Focused Pyright checks pass
- [x] Focused scanner and Trivy tests pass
- [x] Tests pass with Trivy absent from `PATH`
- [x] `uv run bernstein agents-md verify --workdir .` passes
- [x] `git diff --check` passes

The full repository-wide Pyright and test suite were not run locally.

### Documentation duty

- [x] README update N/A — no new user-facing workflow
- [x] Operations documentation N/A
- [x] API schema update N/A — no public surface change
- [x] Module-map sync N/A — no new module; generated docs are in sync
- [x] Tests cover the changed behavior