### PR TITLE
fix(security): an unreachable policy engine denies, instead of reading as no-match

### DIFF
--- a/src/bernstein/core/security/external_policy_hook.py
+++ b/src/bernstein/core/security/external_policy_hook.py
@@ -40,6 +40,12 @@ class HookVerdict(StrEnum):
     ALLOW = "allow"
     DENY = "deny"
     ABSTAIN = "abstain"  # Hook has no opinion
+    #: The engine did not produce an answer: binary missing, non-zero exit, timeout,
+    #: unparseable output, or an exception. Distinct from ABSTAIN on purpose - "no rule
+    #: matched" is a decision the policy made, and this is the absence of one. Collapsing
+    #: them makes an unreachable policy engine indistinguishable from a permissive one,
+    #: which is the wrong default for a decision boundary (#4912).
+    UNAVAILABLE = "unavailable"
 
 
 @dataclass(frozen=True)
@@ -186,7 +192,7 @@ class OPAHook(ExternalPolicyHook):
             if result.returncode != 0:
                 return HookResponse(
                     hook_name=self.name,
-                    verdict=HookVerdict.ABSTAIN,
+                    verdict=HookVerdict.UNAVAILABLE,
                     reason=f"OPA evaluation failed: {result.stderr.strip()}",
                     latency_ms=latency,
                     error=result.stderr.strip(),
@@ -211,6 +217,9 @@ class OPAHook(ExternalPolicyHook):
                     latency_ms=latency,
                 )
 
+            # Deliberately ABSTAIN, not UNAVAILABLE: OPA ran, exited zero and answered
+            # with nothing, which is a genuine no-match rather than an engine that could
+            # not be reached. The distinction this verdict draws is about availability.
             return HookResponse(
                 hook_name=self.name,
                 verdict=HookVerdict.ABSTAIN,
@@ -222,7 +231,7 @@ class OPAHook(ExternalPolicyHook):
             latency = (time.monotonic() - start) * 1000
             return HookResponse(
                 hook_name=self.name,
-                verdict=HookVerdict.ABSTAIN,
+                verdict=HookVerdict.UNAVAILABLE,
                 reason="OPA binary not found",
                 latency_ms=latency,
                 error="opa not found on PATH",
@@ -231,16 +240,18 @@ class OPAHook(ExternalPolicyHook):
             latency = (time.monotonic() - start) * 1000
             return HookResponse(
                 hook_name=self.name,
-                verdict=HookVerdict.ABSTAIN,
+                verdict=HookVerdict.UNAVAILABLE,
                 reason="OPA evaluation timed out",
                 latency_ms=latency,
                 error="timeout",
             )
         except Exception as exc:
+            # json.JSONDecodeError lands here too: output we cannot parse is output the
+            # engine did not give us, whatever its exit code said.
             latency = (time.monotonic() - start) * 1000
             return HookResponse(
                 hook_name=self.name,
-                verdict=HookVerdict.ABSTAIN,
+                verdict=HookVerdict.UNAVAILABLE,
                 reason=f"OPA hook error: {exc}",
                 latency_ms=latency,
                 error=str(exc),
@@ -436,9 +447,18 @@ class PolicyHookRegistry:
     Hooks are evaluated in registration order.  The first non-ABSTAIN
     verdict wins.  If all hooks abstain, the default verdict applies.
 
+    An engine that could not answer is decisive and DENIES. UNAVAILABLE is never
+    collapsed into the all-abstained default: "the policy engine is unreachable" and
+    "no rule matched" have opposite safety properties, and reporting the first as the
+    second makes a broken decision boundary look like a permissive one (#4912).
+
     Args:
         default_verdict: Verdict when all hooks abstain.
-        fail_open: If True, hook errors result in ALLOW; if False, DENY.
+        fail_open: If True, an engine that cannot answer is treated as having no
+            opinion and evaluation continues; if False (the default), it denies.
+            This used to be consulted only for exceptions escaping ``hook.evaluate``,
+            which cannot happen because that method catches everything - so the flag
+            was unreachable. It is now the per-deployment switch it was written to be.
     """
 
     def __init__(
@@ -479,11 +499,15 @@ class PolicyHookRegistry:
                 response = hook.evaluate(request)
                 responses.append(response)
             except Exception as exc:
-                verdict = HookVerdict.ALLOW if self._fail_open else HookVerdict.DENY
+                # An escaping exception is an engine that did not answer, like any other
+                # unavailability. Reported as UNAVAILABLE rather than resolved to
+                # ALLOW/DENY here so that ONE place decides what unavailability means -
+                # `first_decisive`, which honours `fail_open`. Deciding it twice is how
+                # the flag came to be consulted on a path that could never run.
                 responses.append(
                     HookResponse(
                         hook_name=hook.name,
-                        verdict=verdict,
+                        verdict=HookVerdict.UNAVAILABLE,
                         reason=f"Hook error: {exc}",
                         error=str(exc),
                     ),
@@ -491,7 +515,12 @@ class PolicyHookRegistry:
         return responses
 
     def first_decisive(self, request: HookRequest) -> HookResponse:
-        """Evaluate hooks and return the first non-ABSTAIN response.
+        """Evaluate hooks and return the first decisive response.
+
+        An UNAVAILABLE engine is decisive and denies, unless ``fail_open`` is set, in
+        which case it is treated as having no opinion and evaluation continues. Either
+        way the verdict says which happened: the caller is never handed "all hooks
+        abstained" about an engine that was never reached.
 
         Args:
             request: The permission request.
@@ -501,6 +530,17 @@ class PolicyHookRegistry:
         """
         responses = self.evaluate(request)
         for resp in responses:
+            if resp.verdict == HookVerdict.UNAVAILABLE:
+                if self._fail_open:
+                    continue
+                return HookResponse(
+                    hook_name=resp.hook_name,
+                    verdict=HookVerdict.DENY,
+                    reason=f"Policy engine unavailable, denying: {resp.reason}",
+                    latency_ms=resp.latency_ms,
+                    error=resp.error,
+                    policy_digest=resp.policy_digest,
+                )
             if resp.verdict != HookVerdict.ABSTAIN:
                 return resp
         return HookResponse(

--- a/tests/unit/test_external_policy_hook.py
+++ b/tests/unit/test_external_policy_hook.py
@@ -117,10 +117,15 @@ class TestCedarHook:
 
 
 class TestOPAHook:
-    def test_opa_binary_not_found_abstains(self) -> None:
+    def test_opa_binary_not_found_is_unavailable_not_abstain(self) -> None:
+        """A missing engine did not decide anything, so it must not read as a no-match.
+
+        This asserted ABSTAIN, which is what made an unreachable policy engine
+        indistinguishable from a policy that simply had no rule for the request (#4912).
+        """
         opa = OPAHook(policy_path="/nonexistent/policy.rego", opa_binary="/nonexistent/opa")
         resp = opa.evaluate(_req())
-        assert resp.verdict == HookVerdict.ABSTAIN
+        assert resp.verdict == HookVerdict.UNAVAILABLE
         assert resp.error
 
     def test_hook_name(self) -> None:
@@ -164,10 +169,17 @@ class TestPolicyHookRegistry:
             def evaluate(self, request: HookRequest) -> HookResponse:
                 raise RuntimeError("hook error")
 
+        # `evaluate` now reports what happened - the engine did not answer - and
+        # `first_decisive` is the single place that decides what unavailability MEANS.
+        # Resolving it in both is how `fail_open` came to be consulted on a path that
+        # could never run.
         registry = PolicyHookRegistry(fail_open=True)
         registry.register(FailingHook())
         responses = registry.evaluate(_req())
-        assert responses[0].verdict == HookVerdict.ALLOW
+        assert responses[0].verdict == HookVerdict.UNAVAILABLE
+        # fail_open: the unavailable engine is treated as having no opinion, so the
+        # registry falls through to its default rather than denying.
+        assert registry.first_decisive(_req()).verdict == HookVerdict.ABSTAIN
 
     def test_fail_closed_on_error(self) -> None:
         class FailingHook(ExternalPolicyHook):
@@ -181,7 +193,12 @@ class TestPolicyHookRegistry:
         registry = PolicyHookRegistry(fail_open=False)
         registry.register(FailingHook())
         responses = registry.evaluate(_req())
-        assert responses[0].verdict == HookVerdict.DENY
+        assert responses[0].verdict == HookVerdict.UNAVAILABLE
+        # The verdict a caller acts on: fail-closed turns unavailability into a DENY that
+        # says why, rather than into the all-abstained default.
+        decisive = registry.first_decisive(_req())
+        assert decisive.verdict == HookVerdict.DENY
+        assert "unavailable" in decisive.reason.lower()
 
     def test_first_decisive_skips_abstain(self) -> None:
         registry = PolicyHookRegistry()

--- a/tests/unit/test_policy_engine_unavailable.py
+++ b/tests/unit/test_policy_engine_unavailable.py
@@ -1,0 +1,133 @@
+"""An unreachable policy engine must not read as "no rule matched" (#4912).
+
+`external_policy_hook` resolved every failure inside `OPAHook.evaluate` to
+`ABSTAIN`: missing binary, non-zero exit, timeout, unparseable output, any
+exception. `PolicyHookRegistry.first_decisive` then fell through to its
+all-abstained default, which is also `ABSTAIN`. So "the engine could not be
+reached" and "the policy had no rule for this" produced the same verdict, and
+the two have opposite safety properties.
+
+`fail_open` existed for exactly this and could never fire: it was consulted only
+for exceptions escaping `hook.evaluate`, and that method catches everything.
+
+Nothing consults the registry yet (scope item 1 of #4912), so this changes no
+live decision. It makes the boundary fail closed before it is given traffic.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.security.external_policy_hook import (
+    ExternalPolicyHook,
+    HookRequest,
+    HookResponse,
+    HookVerdict,
+    OPAHook,
+    PolicyHookRegistry,
+)
+
+
+def _req() -> HookRequest:
+    return HookRequest(action="deploy", resource="prod", agent_id="agent-1")
+
+
+class _Unreachable(ExternalPolicyHook):
+    """An engine that raises rather than answering."""
+
+    @property
+    def name(self) -> str:
+        return "unreachable"
+
+    def evaluate(self, request: HookRequest) -> HookResponse:
+        raise RuntimeError("engine down")
+
+
+class _Abstains(ExternalPolicyHook):
+    """An engine that answers, with no opinion."""
+
+    @property
+    def name(self) -> str:
+        return "quiet"
+
+    def evaluate(self, request: HookRequest) -> HookResponse:
+        return HookResponse(hook_name=self.name, verdict=HookVerdict.ABSTAIN, reason="no rule")
+
+
+class _Allows(ExternalPolicyHook):
+    @property
+    def name(self) -> str:
+        return "permissive"
+
+    def evaluate(self, request: HookRequest) -> HookResponse:
+        return HookResponse(hook_name=self.name, verdict=HookVerdict.ALLOW, reason="ok")
+
+
+def test_a_missing_binary_denies_by_default() -> None:
+    """The headline: an engine that cannot run refuses, rather than waving it through."""
+    registry = PolicyHookRegistry()
+    registry.register(OPAHook(policy_path="/nonexistent.rego", opa_binary="/nonexistent/opa"))
+    decisive = registry.first_decisive(_req())
+    assert decisive.verdict == HookVerdict.DENY
+
+
+def test_the_denial_says_the_engine_was_unavailable() -> None:
+    """A refusal an operator cannot explain is a refusal they will disable."""
+    registry = PolicyHookRegistry()
+    registry.register(OPAHook(policy_path="/nonexistent.rego", opa_binary="/nonexistent/opa"))
+    decisive = registry.first_decisive(_req())
+    assert "unavailable" in decisive.reason.lower()
+    assert decisive.error
+
+
+def test_unavailable_is_never_reported_as_all_hooks_abstained() -> None:
+    """The exact collapse this change exists to prevent."""
+    registry = PolicyHookRegistry()
+    registry.register(_Unreachable())
+    decisive = registry.first_decisive(_req())
+    assert "abstained" not in decisive.reason.lower()
+
+
+def test_a_genuine_no_match_still_abstains() -> None:
+    """An engine that ANSWERED with no opinion must keep answering that.
+
+    The over-correction guard: if every quiet path became a denial, a policy set
+    with no rule for an action would start refusing it, which is a different bug
+    in the same place.
+    """
+    registry = PolicyHookRegistry()
+    registry.register(_Abstains())
+    assert registry.first_decisive(_req()).verdict == HookVerdict.ABSTAIN
+
+
+def test_fail_open_treats_an_unavailable_engine_as_no_opinion() -> None:
+    """The per-deployment switch, finally reachable.
+
+    Before this it was consulted only for exceptions escaping `hook.evaluate`, which
+    catches everything - so no configuration of the flag changed any outcome.
+    """
+    registry = PolicyHookRegistry(fail_open=True)
+    registry.register(_Unreachable())
+    assert registry.first_decisive(_req()).verdict == HookVerdict.ABSTAIN
+
+
+def test_fail_open_keeps_evaluating_later_hooks() -> None:
+    """Treating it as no-opinion means CONTINUING, not stopping with a default.
+
+    A registry that returned its default on the first unavailable hook would silently
+    drop every engine registered after it.
+    """
+    registry = PolicyHookRegistry(fail_open=True)
+    registry.register(_Unreachable())
+    registry.register(_Allows())
+    assert registry.first_decisive(_req()).verdict == HookVerdict.ALLOW
+
+
+def test_an_unavailable_engine_outranks_a_later_allow_when_failing_closed() -> None:
+    """Order matters: the boundary stops at the engine that could not speak.
+
+    Otherwise a permissive hook registered behind a broken one would answer for it,
+    which is the failure mode dressed as working.
+    """
+    registry = PolicyHookRegistry(fail_open=False)
+    registry.register(_Unreachable())
+    registry.register(_Allows())
+    assert registry.first_decisive(_req()).verdict == HookVerdict.DENY


### PR DESCRIPTION
## What

`HookVerdict.UNAVAILABLE`, and a decision boundary that fails closed on it.

**Scope item 2 of #4912 only.** I explained the slice on the issue: item 1's attach point is meant to be #4907's org admission surface, which does not exist yet, so wiring cannot be built without pre-empting that design. Item 2 is wrong on its own terms today and makes item 1 land on a boundary that already fails closed.

## The defect

Every failure inside `OPAHook.evaluate` returned `ABSTAIN` — missing binary, non-zero exit, timeout, unparseable output, any exception. `first_decisive` then fell through to its all-abstained default, which is *also* `ABSTAIN`.

So these two produced the same verdict:

- the policy engine could not be reached
- the policy was reached and had no rule for this request

They have opposite safety properties. Reporting the first as the second makes a broken decision boundary look like a permissive one.

`fail_open` existed for exactly this and **could never fire**: it was consulted only for exceptions escaping `hook.evaluate`, and that method catches everything. No configuration of the flag changed any outcome.

## How

`evaluate()` reports what happened (`UNAVAILABLE`); `first_decisive` is the single place that decides what unavailability *means*. Resolving it in both is how the flag ended up on a path that could never run — so the escaping-exception branch no longer picks `ALLOW`/`DENY` itself.

Fail-closed (default) turns it into a `DENY` whose reason says the engine was unavailable. `fail_open` treats it as no-opinion and **continues to the next hook**, rather than stopping with the default — otherwise a registry would silently drop every engine registered behind a broken one.

## Two judgement calls, and one is a correction to the issue

- **OPA's "empty result" stays `ABSTAIN`.** The engine ran, exited zero, and answered with nothing. That is a genuine no-match, and this verdict is about availability. I flagged this on the issue as the one of six I can argue both ways.
- **`CedarHook`'s `ABSTAIN` stays too, which the issue did not expect.** It says "and one in `CedarHook`", but reading it: Cedar here is an in-process pattern match with no external engine to be unreachable, and its abstain reads *"No Cedar policy for action X"* — an answer, not a failure. Changing it would have made a working no-match start denying.

## Tests

Seven new, three of which are red before the change. The ones I'd point at:

- **`test_a_genuine_no_match_still_abstains`** — the over-correction guard. If every quiet path became a denial, a policy set with no rule for an action would start refusing it: a different bug in the same place.
- **`test_fail_open_keeps_evaluating_later_hooks`** — pins that "no opinion" means *continuing*, not returning a default.
- **`test_an_unavailable_engine_outranks_a_later_allow_when_failing_closed`** — a permissive hook behind a broken one must not answer for it.

Three existing tests pinned the old behaviour. Updated rather than deleted, and the `fail_open` pair now assert through `first_decisive`, which is where the flag actually became observable.

## Blast radius

**Nothing consults the registry yet** — that is scope item 1, and the reason #4912 was filed. So no live decision path changes behaviour here. This makes the boundary correct before it is given traffic.

## Checklist

- [x] `ruff check src/` and `ruff format` pass
- [ ] `pyright src/` — not run clean, and not by this change; repo-wide advisory scope is red on `main` (#4864)
- [x] `scripts/run_tests.py`: 30 passed (`test_policy_engine_unavailable` 7, `test_external_policy_hook` 23)
- [x] New code has type hints

### Documentation duty

- [x] README — N/A, no user-visible surface yet
- [x] `docs/operations/` — N/A until item 1 gives operators a path that consults this; the `fail_open` semantics are documented on the class where a caller meets them
- [x] `docs/api/` — N/A, no public schema change
- [x] `agents-md sync` — N/A, no new module
- [x] Tests cover the documented behaviour