### PR TITLE
docs: scope the replay claim in the social preview meta and the steering page

### DIFF
--- a/docs/operations/fleet-steering.md
+++ b/docs/operations/fleet-steering.md
@@ -84,8 +84,8 @@ receipt.
 
 ## Replay classification
 
-Because every consumed steering message is a journal step, a steered run
-replays byte-identically and is distinguishable from a tampered one:
+Because every consumed steering message is a journal step, a steered run's
+journal replays byte-identically and is distinguishable from a tampered one:
 `classify_steering_run()` reads a worker's journal and returns one of:
 
 - `clean` - the journal's Merkle chain verifies and carries no steering

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -6,11 +6,11 @@
   <meta property="og:site_name" content="Bernstein Documentation" />
   <meta property="og:type" content="website" />
   <meta property="og:title" content="Bernstein - The Open-Source Governance Layer for AI Agents" />
-  <meta property="og:description" content="No model in the coordination loop, so parallel runs in per-task git worktrees replay byte-identically. Signed lineage plus an opt-in HMAC audit chain." />
+  <meta property="og:description" content="No model in the coordination loop, so replaying a plan reproduces its task graph byte-identically. Signed lineage plus an opt-in HMAC audit chain, verified offline." />
   <meta property="og:url" content="https://bernstein.readthedocs.io/" />
   <meta property="og:image" content="https://bernstein.readthedocs.io/en/latest/assets/banner_one_command_1536x1024.png" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Bernstein - The Open-Source Governance Layer for AI Agents" />
-  <meta name="twitter:description" content="No model in the coordination loop, so parallel runs in per-task git worktrees replay byte-identically. Signed lineage plus an opt-in HMAC audit chain." />
+  <meta name="twitter:description" content="No model in the coordination loop, so replaying a plan reproduces its task graph byte-identically. Signed lineage plus an opt-in HMAC audit chain, verified offline." />
   <meta name="twitter:image" content="https://bernstein.readthedocs.io/en/latest/assets/banner_one_command_1536x1024.png" />
 {% endblock %}


### PR DESCRIPTION
The unqualified replay claim was scoped across the distribution surfaces in #4956, but two places were missed.

`docs/overrides/main.html` carries the `og:description` and `twitter:description` for the docs site — the text every social preview card renders when a docs link is shared. It still read "parallel runs in per-task git worktrees replay byte-identically", which claims more than the code guarantees: replay covers the internal `call_llm` path, `internal_llm_provider` defaults to `none`, and the CLI-adapter path records nothing. `docs/operations/deterministic-replay.md:237` scopes the byte-identical guarantee to the receipt, and the task graph is what a plan reproduces.

`docs/operations/fleet-steering.md` said "a steered run replays byte-identically". The paragraph is about steering messages being journal steps, and the sentences after it are about the journal's Merkle chain — so the claim is scoped by context but not by the sentence. Scoped to the journal, which is what `classify_steering_run()` actually reads.

Both now use the wording #4956 settled on. `README.md:46` and `docs/reference/capabilities.md:37` were checked and are already correctly scoped — capabilities.md in particular is precise about the outer DAG replaying while inner execution stays stochastic. The two historical release notes that mention byte-identical replay describe hash inputs in a past release and are left as written.
