### PR TITLE
docs: release-note fragment for feed-pinned Trivy database verification

### DIFF
--- a/docs/release-notes/fragments/4961-trivy-db-pin-verification.md
+++ b/docs/release-notes/fragments/4961-trivy-db-pin-verification.md
@@ -1,0 +1,16 @@
+## Feed-pinned Trivy scans verify the database they were pinned to
+
+A feed-pinned Trivy scan used to record whichever database digest the caller
+supplied, without checking it against the database Trivy would actually load.
+The adapter now hashes `<cache-dir>/db/trivy.db` before the scan and compares
+it to the pin, so a record can no longer assert a database that was never
+present.
+
+Two failure modes are reported separately, because they are opposite
+situations: a missing database raises `TrivyError` naming the path to download
+to, and a database whose bytes do not match the pin raises `TrivyError` naming
+both the expected and the observed digest. Both fail before Trivy runs, so a
+mismatched scan produces no findings and no record.
+
+The scope key is `scope.config["db_pin"]`, and the recorded invocation hash now
+binds the observed `db_identity` rather than the caller's assertion. #3618


### PR DESCRIPTION
Follow-up to #4961, which landed without a release-note fragment.

The change is user-visible: a feed-pinned scan that previously recorded whatever digest it was handed now refuses to run when the database on disk does not match, and surfaces a \`TrivyError\` at scan time. The two failure modes it introduces — database missing, and database present but not the pinned one — need to be findable by someone reading the notes rather than the adapter.

Docs only; no code paths touched.