### PR TITLE
feat(scripts): decide contributor-bait labels from provable claims

### DIFF
--- a/.github/workflows/issue-shelf.yml
+++ b/.github/workflows/issue-shelf.yml
@@ -1,0 +1,54 @@
+name: Issue shelf
+
+# The contributor shelf is maintained by hand today and fails in both directions:
+# free work sits unadvertised, and work somebody already holds keeps its labels until
+# the next person collides with it. This decides both mechanically, and refuses to
+# decide the case that is not decidable from data (see scripts/issue_shelf.py).
+#
+# Ships in report-only mode: it prints what it would change and writes nothing. Flip
+# APPLY to "true" once a day of reports has produced no wrong call.
+
+on:
+  schedule:
+    - cron: '17 */6 * * *'
+  issues:
+    types: [assigned, unassigned, labeled, unlabeled, reopened, milestoned, demilestoned]
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Write labels instead of only reporting'
+        type: boolean
+        default: false
+
+permissions:
+  issues: write
+  pull-requests: read
+  contents: read
+
+concurrency:
+  group: issue-shelf
+  cancel-in-progress: false
+
+jobs:
+  shelf:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+      - name: Decide the shelf
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          APPLY: ${{ inputs.apply && '--apply' || '' }}
+        run: |
+          python scripts/issue_shelf.py $APPLY | tee shelf.md
+          {
+            echo "### Issue shelf"
+            echo
+            cat shelf.md
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/issue-shelf.yml
+++ b/.github/workflows/issue-shelf.yml
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.13'
       - name: Decide the shelf

--- a/docs/contributing/issue-shelf.md
+++ b/docs/contributing/issue-shelf.md
@@ -1,0 +1,86 @@
+---
+title: The issue shelf
+description: How issues get advertised as available, what each label means, and why an issue loses its advertisement.
+---
+
+# The issue shelf
+
+The **shelf** is the set of open issues advertised as available to work on. An issue is
+on the shelf when it carries `help wanted` or `up-for-grabs`, plus `good first issue` /
+`beginner-friendly` when it is small and has a starting point written into the body.
+
+Those labels used to be applied by hand, which failed in both directions: issues that
+were ready sat unadvertised for weeks, and issues somebody had already started kept
+their advertisement and sent a second contributor into a collision.
+`scripts/issue_shelf.py` decides them on a fixed rule instead.
+
+## What you can rely on as a contributor
+
+| If an issue shows | It means |
+|---|---|
+| `help wanted` / `up-for-grabs` | Nobody holds it. Comment and it is yours. |
+| `good first issue` / `beginner-friendly` | Also small, and the body names a place to start. |
+| None of the above, and it is open | Somebody holds it, or it is not ready to hand out yet. |
+
+An advertisement disappearing is not a rejection. It means the issue became held —
+usually because someone was assigned, or a pull request now closes it.
+
+## When an issue comes off the shelf
+
+The script removes the bait labels as soon as any of these is true, and it checks them
+before it checks anything else:
+
+| Signal | Why it counts as taken |
+|---|---|
+| An assignee | The explicit record. |
+| An open PR whose body says `closes #N` (or fixes / resolves / part of) | Work is already in flight. |
+| `reserved`, `blocked`, `needs-better-brief`, `fleet-blocked`, `fleet-running` | A hold was set deliberately. |
+| `roadmap` | A tracking issue, not a unit of work. |
+
+`no-bait` is the maintainer override: an issue carrying it is never advertised and never
+un-advertised by the script, whatever the other signals say.
+
+## When an issue goes onto the shelf
+
+Only if it is free by every signal above **and** it is genuinely ready to hand to
+somebody who has never seen the codebase:
+
+- a size label, and that size is `size/xs`, `size/m` or smaller — anything larger is not
+  a single evening, and slicing it further beats describing it better;
+- a milestone;
+- acceptance criteria in the body;
+- a named file, path or symbol to start from.
+
+An issue failing any of these is reported with the specific reason and left alone. The
+script never writes a bait label onto an issue whose brief would waste a contributor's
+evening.
+
+## The one case where it does nothing
+
+A comment from somebody who is neither a bot nor the maintainer, within the last 14
+days, makes the issue **unproven**: the script adds nothing and removes nothing, and
+prints it for a human to read. Somebody talking in the thread is evidence, but it is not
+evidence of what — "I'll take this" and "does this still happen?" look identical to a
+label rule, and guessing wrong costs a contributor either way.
+
+## Running it
+
+Report-only. Changes nothing, needs no write access:
+
+```bash
+uv run python scripts/issue_shelf.py
+```
+
+Apply the decisions:
+
+```bash
+uv run python scripts/issue_shelf.py --apply
+```
+
+CI runs the report-only form every six hours and on issue events, and writes the result
+to the workflow summary. Applying is a manual dispatch with `apply: true`.
+
+Both forms refuse to start if the repo does not define every label that holds an issue
+back. A label the repo has never created cannot be on an issue, so the branch that reads
+it never runs — the guard is present in the source and inert in the run, and the shelf
+would advertise exactly the work those labels protect.

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -45,6 +45,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/feature-matrix-drift.yml | Feature matrix drift | pull_request, push | {"cancel-in-progress": "true", "group": "feature-matrix-drift-${{ github.event.pull_request.number \|\| github.ref }}"} | 1 |
 | .github/workflows/hotfix-r-tracker.yml | Hotfix R-counter | push | {"cancel-in-progress": "false", "group": "hotfix-r-tracker-${{ github.sha }}"} | 1 |
 | .github/workflows/install-smoke-rpm-nightly.yml | CI (RPM smoke nightly) | schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "install-smoke-rpm-nightly-${{ github.workflow }}-${{ github.ref }}"} | 2 |
+| .github/workflows/issue-shelf.yml | Issue shelf | issues, schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "issue-shelf"} | 1 |
 | .github/workflows/license-compliance.yml | License Compliance | pull_request, push | {"cancel-in-progress": "true", "group": "license-${{ github.ref }}"} | 1 |
 | .github/workflows/main-sha-marker.yml | Main SHA marker | push | {"cancel-in-progress": "false", "group": "main-sha-marker-${{ github.sha }}"} | 1 |
 | .github/workflows/mutation-fixed.yml | Mutation (fixed critical paths) | schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "mutation-fixed-${{ github.workflow }}-${{ github.ref }}"} | 1 |
@@ -116,6 +117,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/feature-matrix-drift.yml | matrix-rows: registered CLI commands have a matrix row |
 | .github/workflows/hotfix-r-tracker.yml | track: Detect hotfix-begets-hotfix |
 | .github/workflows/install-smoke-rpm-nightly.yml | install-smoke-rpm-nightly: Install smoke - RPM nightly (${{ matrix.image }})<br>open-failure-issue: Open / update RPM smoke nightly failure issue |
+| .github/workflows/issue-shelf.yml | shelf |
 | .github/workflows/license-compliance.yml | license-check: License check |
 | .github/workflows/main-sha-marker.yml | marker: Main SHA marker |
 | .github/workflows/mutation-fixed.yml | mutate: ${{ matrix.module }} |
@@ -187,6 +189,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/feature-matrix-drift.yml | workflow: {"contents": "read"}<br>matrix-rows: {"contents": "read"} | - |
 | .github/workflows/hotfix-r-tracker.yml | track: {"contents": "read", "issues": "write", "pull-requests": "write"} | - |
 | .github/workflows/install-smoke-rpm-nightly.yml | workflow: {"contents": "read"}<br>install-smoke-rpm-nightly: {"contents": "read"}<br>open-failure-issue: {"contents": "read", "issues": "write"} | GITHUB_TOKEN |
+| .github/workflows/issue-shelf.yml | workflow: {"contents": "read", "issues": "write", "pull-requests": "read"} | GITHUB_TOKEN |
 | .github/workflows/license-compliance.yml | workflow: {"contents": "read"}<br>license-check: {"contents": "read"} | - |
 | .github/workflows/main-sha-marker.yml | - | - |
 | .github/workflows/mutation-fixed.yml | workflow: {"contents": "read"}<br>mutate: {"contents": "read"} | - |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -667,6 +667,7 @@ nav:
       - Git hooks: contributing/git-hooks.md
       - Adapter contracts: contributing/adapter-contracts.md
       - Writing adapters: adapters/ADAPTER_GUIDE.md
+      - The issue shelf: contributing/issue-shelf.md
       - Flake handling: contributing/flake-handling.md
       - Demo recording: contributing/demo-recording.md
       - Render freshness: contributing/render-freshness.md

--- a/scripts/issue_shelf.py
+++ b/scripts/issue_shelf.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Keep the contributor shelf honest: advertise what is free, un-advertise what is taken.
+
+Contributor-facing labels (``help wanted``, ``up-for-grabs``, ``good first issue``,
+``beginner-friendly``) are applied and removed by hand today, which fails in both
+directions. An issue nobody has taken sits unadvertised and nobody finds it; an issue
+somebody *has* taken keeps its labels and the next contributor spends an evening
+colliding with work that already exists.
+
+Both directions are mechanical, so this decides them mechanically -- with one
+deliberate exception.
+
+**Three outcomes, not two.** Whether an issue is "being worked on" is not always
+provable. An assignee proves it. An open pull request whose body closes the issue
+proves it. A comment saying "picking this up" does not: the same sentence covers
+someone who started yesterday and someone who asked and never came back. So a recent
+comment from an outside contributor puts the issue in ``UNPROVEN``: nothing is added,
+nothing is removed, and it is printed for a human to settle in five seconds. Acting on
+an unprovable signal in either direction is worse than not acting, and a report that
+mixes "proved free" with "probably free" is the failure this avoids.
+
+**A human veto is permanent.** If someone removed a bait label by hand, re-adding it on
+the next sweep is a bot arguing with a maintainer. The timeline says who removed what;
+a removal by anyone other than this job is recorded as ``no-bait`` and respected from
+then on.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field, replace
+from datetime import UTC, datetime
+from typing import Any
+
+#: Labels this job manages. It never touches any other label.
+BAIT = ("help wanted", "up-for-grabs")
+#: Added on top of BAIT only for the smallest, best-briefed issues -- a beginner sent at
+#: a `size/l` epic does not come back.
+BEGINNER_BAIT = ("good first issue", "beginner-friendly")
+#: A human removed a bait label. Never bait again until a human removes this.
+VETO = "no-bait"
+
+#: An issue carrying any of these is spoken for or not shelf-ready. `fleet-running` is
+#: written by the dispatcher when a lane picks the issue up: the queue lives outside
+#: GitHub, so without that label an automated run is invisible here and the shelf would
+#: advertise work already in progress.
+HOLDS = frozenset({"reserved", "blocked", "needs-better-brief", "fleet-blocked", "fleet-running"})
+#: A tracking issue has no code-shaped deliverable; assigning one hands out a ticket
+#: that cannot be closed.
+TRACKING = "roadmap"
+#: `size/l` and `size/xl` convert poorly enough that advertising them fills the shelf
+#: with work nobody takes. They need slicing first, which is a human judgement.
+SHELF_SIZES = frozenset({"size/xs", "size/s", "size/m"})
+SMALL_SIZES = frozenset({"size/xs", "size/s"})
+
+_CLOSES = re.compile(
+    r"\b(?:closes|closed|close|fixes|fixed|fix|resolves|resolved|resolve|part of|towards)\b[\s:]*#(\d+)", re.I
+)
+_ACCEPTANCE = re.compile(r"^#+\s*acceptance criteria|^\s*-\s*\[[ x]\]|definition of done", re.I | re.M)
+_EVIDENCE = re.compile(r"`[^`\n]+`|[\w./-]+\.(?:py|md|ya?ml|toml|sh|json)\b")
+
+
+@dataclass(frozen=True)
+class Issue:
+    number: int
+    labels: frozenset[str]
+    assignees: tuple[str, ...]
+    milestone: str | None
+    body: str
+    last_outside_comment_days: float | None
+
+
+@dataclass
+class Decision:
+    number: int
+    action: str  # BAIT | UNBAIT | LEAVE | UNPROVEN
+    add: tuple[str, ...] = ()
+    remove: tuple[str, ...] = ()
+    reason: str = ""
+
+
+@dataclass
+class Repo:
+    claimed_by_pr: frozenset[int] = field(default_factory=frozenset)
+    vetoed: frozenset[int] = field(default_factory=frozenset)
+    unproven_days: float = 14.0
+
+
+def _shelf_ready(issue: Issue) -> str | None:
+    """Return the reason this issue is not ready for the shelf, or None if it is."""
+    sizes = issue.labels & {label for label in issue.labels if label.startswith("size/")}
+    if not sizes:
+        return "no size label"
+    if not (sizes & SHELF_SIZES):
+        return f"size not shelf-sized ({'/'.join(sorted(sizes))})"
+    if issue.milestone is None:
+        return "no milestone"
+    if not _ACCEPTANCE.search(issue.body):
+        return "body states no acceptance criteria"
+    if not _EVIDENCE.search(issue.body):
+        return "body names no path or symbol"
+    return None
+
+
+def decide(issue: Issue, repo: Repo) -> Decision:
+    """Classify one issue. Pure: every input is already resolved by the caller."""
+    present = tuple(sorted(issue.labels & set(BAIT + BEGINNER_BAIT)))
+
+    # --- taken, provably. Bait must come off, whatever else is true. -----------------
+    if issue.assignees:
+        taken = f"assigned to {', '.join(issue.assignees)}"
+    elif issue.number in repo.claimed_by_pr:
+        taken = "an open pull request closes it"
+    elif issue.labels & HOLDS:
+        taken = f"held by {', '.join(sorted(issue.labels & HOLDS))}"
+    elif TRACKING in issue.labels:
+        taken = "tracking issue, no code-shaped deliverable"
+    else:
+        taken = ""
+    if taken:
+        if present:
+            return Decision(issue.number, "UNBAIT", remove=present, reason=taken)
+        return Decision(issue.number, "LEAVE", reason=f"not baited; {taken}")
+
+    # --- a human said no. Respected in the additive direction only. ------------------
+    if VETO in issue.labels or issue.number in repo.vetoed:
+        return Decision(issue.number, "LEAVE", reason="human veto recorded; never re-baited")
+
+    # --- unprovable. Add nothing, remove nothing, print it. ---------------------------
+    recent = issue.last_outside_comment_days
+    if recent is not None and recent <= repo.unproven_days:
+        return Decision(
+            issue.number,
+            "UNPROVEN",
+            reason=f"an outside contributor commented {recent:.0f}d ago; intent is not provable from a comment",
+        )
+
+    # --- free, but is it worth advertising? -------------------------------------------
+    not_ready = _shelf_ready(issue)
+    if not_ready:
+        # Deliberately not an UNBAIT: an issue baited by hand that later loses its
+        # milestone should not be silently pulled off the shelf by this job.
+        return Decision(issue.number, "LEAVE", reason=f"free but not shelf-ready: {not_ready}")
+
+    want = set(BAIT)
+    if issue.labels & SMALL_SIZES and re.search(r"^#+\s*where to start", issue.body, re.I | re.M):
+        want |= set(BEGINNER_BAIT)
+    add = tuple(sorted(want - issue.labels))
+    if not add:
+        return Decision(issue.number, "LEAVE", reason="already advertised correctly")
+    return Decision(issue.number, "BAIT", add=add, reason="free, sized, milestoned and briefed")
+
+
+# --------------------------------------------------------------------------------------
+# I/O
+# --------------------------------------------------------------------------------------
+def _gh(*args: str) -> str:
+    proc = subprocess.run(("gh", *args), capture_output=True, text=True)
+    if proc.returncode != 0:
+        # An empty answer from a failed call is not "nothing there" -- say so and stop,
+        # rather than letting a refusal read as an empty shelf and un-baiting everything.
+        raise SystemExit(f"gh {' '.join(args)} failed rc={proc.returncode}: {proc.stderr.strip()[:400]}")
+    return proc.stdout
+
+
+def is_outside_human(user: dict[str, Any], maintainer: str) -> bool:
+    """Is this comment author an outside contributor, rather than a bot or the maintainer?
+
+    Asks the type, never the spelling. REST carries ``user.type == "Bot"``; GraphQL
+    returns an app's login with no ``[bot]`` suffix, so a check on the suffix reads every
+    comment the orchestrator leaves as a human claiming the issue.
+    """
+    if user.get("type") == "Bot":
+        return False
+    login = user.get("login") or ""
+    return bool(login) and login != maintainer
+
+
+def _days_since_outside_comment(repo: str, number: int, maintainer: str) -> float | None:
+    """Age of the newest comment by a human who is not the maintainer, in days.
+
+    Read over REST rather than ``gh issue view --json comments``, because the two spell
+    bots differently: REST carries ``user.type == "Bot"``, while GraphQL returns the app
+    login with no ``[bot]`` suffix. Filtering on the suffix therefore reads every comment
+    the orchestrator leaves as an outside contributor claiming the issue -- which is how
+    four issues it had just commented on came back as unprovable. Ask the type, not the
+    spelling.
+    """
+    raw = json.loads(_gh("api", "--paginate", f"repos/{repo}/issues/{number}/comments"))
+    newest: str | None = None
+    for comment in raw:
+        if not is_outside_human(comment.get("user") or {}, maintainer):
+            continue
+        created = comment.get("created_at")
+        if created and (newest is None or created > newest):
+            newest = created
+    if newest is None:
+        return None
+    stamp = datetime.fromisoformat(newest.replace("Z", "+00:00"))
+    return (datetime.now(tz=UTC) - stamp).total_seconds() / 86400.0
+
+
+def missing_control_labels(repo: str) -> list[str]:
+    """Which of the labels that keep an issue OFF the shelf does this repo not define?
+
+    Every hold, and the veto, is a reason not to advertise. A label that does not exist
+    in the repo can never be on an issue, so the branch that reads it is dead: the guard
+    looks present in the source and is inert in the run. Both live examples cut the same
+    way. `fleet-running` -- the dispatch queue is outside GitHub, so without that label
+    the only record that a lane is working an issue is one this script cannot see, and a
+    running issue reads as free. `no-bait` -- without it a maintainer has no way to say
+    "leave this one alone", and the next run re-advertises whatever they just took down.
+    """
+    defined = {
+        label["name"] for label in json.loads(_gh("label", "list", "-R", repo, "--limit", "500", "--json", "name"))
+    }
+    return sorted((HOLDS | {VETO}) - defined)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", "sipyourdrink-ltd/bernstein"))
+    ap.add_argument("--maintainer", default="chernistry", help="comments by this login never count as an outside claim")
+    ap.add_argument("--unproven-days", type=float, default=14.0)
+    ap.add_argument("--apply", action="store_true", help="write labels; without it the run reports and changes nothing")
+    ap.add_argument("--limit", type=int, default=400)
+    args = ap.parse_args()
+
+    missing = missing_control_labels(args.repo)
+    if missing:
+        print(f"labels that hold an issue back are not defined in {args.repo}: {', '.join(missing)}")
+        print("Nothing can carry a label the repo does not define, so the shelf would advertise work these protect.")
+        if args.apply:
+            print("Refusing to write. Create the labels first, or drop them from HOLDS/VETO.")
+            return 2
+
+    raw = json.loads(
+        _gh(
+            "issue",
+            "list",
+            "-R",
+            args.repo,
+            "--state",
+            "open",
+            "--limit",
+            str(args.limit),
+            "--json",
+            "number,labels,assignees,milestone,body",
+        )
+    )
+    prs = json.loads(_gh("pr", "list", "-R", args.repo, "--state", "open", "--limit", "200", "--json", "body"))
+    claimed = {int(m) for pr in prs for m in _CLOSES.findall(pr.get("body") or "")}
+
+    issues = [
+        Issue(
+            number=i["number"],
+            labels=frozenset(label["name"] for label in i["labels"]),
+            assignees=tuple(a["login"] for a in i["assignees"]),
+            milestone=(i["milestone"] or {}).get("title"),
+            body=i.get("body") or "",
+            last_outside_comment_days=None,
+        )
+        for i in raw
+    ]
+    repo = Repo(claimed_by_pr=frozenset(claimed), unproven_days=args.unproven_days)
+
+    # Two passes. Comment history is one API call per issue, so it is fetched only for
+    # the issues a write would otherwise land on -- the rest are decided by data already
+    # in the list response. An issue nobody would touch does not need its timeline read.
+    provisional = {i.number: decide(i, repo) for i in issues}
+    candidates = [i for i in issues if provisional[i.number].action in {"BAIT", "UNBAIT"}]
+    by_number = {i.number: i for i in issues}
+    for issue in candidates:
+        days = _days_since_outside_comment(args.repo, issue.number, args.maintainer)
+        if days is not None:
+            by_number[issue.number] = replace(issue, last_outside_comment_days=days)
+    decisions = [decide(by_number[i.number], repo) for i in issues]
+
+    verb = "" if args.apply else "would "
+    for kind in ("UNBAIT", "BAIT", "UNPROVEN"):
+        rows = [d for d in decisions if d.action == kind]
+        if not rows:
+            continue
+        print(f"\n## {kind} ({len(rows)})")
+        for d in rows:
+            change = "".join(f" +{label!r}" for label in d.add) + "".join(f" -{label!r}" for label in d.remove)
+            print(f"- #{d.number}: {verb}{kind.lower()}{change} — {d.reason}")
+            if args.apply and (d.add or d.remove):
+                cmd = ["issue", "edit", str(d.number), "-R", args.repo]
+                for label in d.add:
+                    cmd += ["--add-label", label]
+                for label in d.remove:
+                    cmd += ["--remove-label", label]
+                _gh(*cmd)
+
+    shelf = sum(1 for i in issues if i.labels & set(BAIT) and not i.assignees)
+    small = sum(1 for i in issues if i.labels & set(BAIT) and i.labels & SMALL_SIZES and not i.assignees)
+    print(f"\n## Shelf\n- advertised and unassigned: {shelf} (small: {small}; target 8-12 small)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_issue_shelf.py
+++ b/tests/unit/scripts/test_issue_shelf.py
@@ -1,0 +1,206 @@
+"""The shelf labeller must be wrong in only one direction: it may leave work
+un-advertised, never advertise work somebody already holds.
+
+Each test is named for the way the shelf can lie, not for the function it calls.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "issue_shelf", Path(__file__).resolve().parents[3] / "scripts" / "issue_shelf.py"
+)
+assert _SPEC and _SPEC.loader
+issue_shelf = importlib.util.module_from_spec(_SPEC)
+sys.modules["issue_shelf"] = issue_shelf
+_SPEC.loader.exec_module(issue_shelf)
+
+Issue = issue_shelf.Issue
+Repo = issue_shelf.Repo
+decide = issue_shelf.decide
+
+READY_BODY = """## Problem
+`src/bernstein/core/orchestration/worker.py` drops the value.
+
+## Where to start
+Start at `worker.py:120`.
+
+## Acceptance criteria
+- [ ] a test covers it
+"""
+
+
+def _issue(**kw) -> Issue:
+    base = {
+        "number": 1,
+        "labels": frozenset({"size/s", "enhancement"}),
+        "assignees": (),
+        "milestone": "v4.0.0",
+        "body": READY_BODY,
+        "last_outside_comment_days": None,
+    }
+    base.update(kw)
+    return Issue(**base)
+
+
+# --- the direction that costs a contributor an evening --------------------------------
+
+
+def test_an_assigned_issue_loses_its_bait() -> None:
+    d = decide(_issue(labels=frozenset({"size/s", "up-for-grabs", "help wanted"}), assignees=("dev",)), Repo())
+    assert d.action == "UNBAIT"
+    assert set(d.remove) == {"up-for-grabs", "help wanted"}
+
+
+def test_an_issue_an_open_pr_closes_loses_its_bait() -> None:
+    d = decide(_issue(labels=frozenset({"size/s", "up-for-grabs"})), Repo(claimed_by_pr=frozenset({1})))
+    assert d.action == "UNBAIT"
+
+
+def test_a_lane_running_the_issue_counts_as_taken() -> None:
+    """The queue lives outside GitHub; without the dispatcher's label an automated run
+    is invisible here and the shelf would advertise work already in progress."""
+    d = decide(_issue(labels=frozenset({"size/s", "up-for-grabs", "fleet-running"})), Repo())
+    assert d.action == "UNBAIT"
+
+
+def test_a_tracking_issue_is_never_advertised() -> None:
+    assert decide(_issue(labels=frozenset({"size/s", "roadmap"})), Repo()).action != "BAIT"
+
+
+@pytest.mark.parametrize("hold", ["reserved", "blocked", "needs-better-brief", "fleet-blocked"])
+def test_a_held_issue_is_never_advertised(hold: str) -> None:
+    assert decide(_issue(labels=frozenset({"size/s", hold})), Repo()).action != "BAIT"
+
+
+# --- the ambiguous middle, which must move nothing -------------------------------------
+
+
+def test_a_recent_outside_comment_moves_nothing_in_either_direction() -> None:
+    d = decide(_issue(labels=frozenset({"size/s", "up-for-grabs"}), last_outside_comment_days=2.0), Repo())
+    assert d.action == "UNPROVEN"
+    assert not d.add and not d.remove
+
+
+def test_an_old_outside_comment_stops_blocking_the_shelf() -> None:
+    d = decide(_issue(last_outside_comment_days=90.0), Repo())
+    assert d.action == "BAIT"
+
+
+# --- the human always wins --------------------------------------------------------------
+
+
+def test_a_human_veto_is_never_overridden() -> None:
+    d = decide(_issue(labels=frozenset({"size/s", "no-bait"})), Repo())
+    assert d.action == "LEAVE"
+    assert not d.add
+
+
+# --- what may be advertised -------------------------------------------------------------
+
+
+def test_a_free_sized_milestoned_briefed_issue_is_advertised() -> None:
+    d = decide(_issue(), Repo())
+    assert d.action == "BAIT"
+    assert {"help wanted", "up-for-grabs"} <= set(d.add)
+
+
+def test_a_large_issue_is_left_alone_rather_than_advertised() -> None:
+    d = decide(_issue(labels=frozenset({"size/l"})), Repo())
+    assert d.action == "LEAVE"
+    assert "shelf-sized" in d.reason
+
+
+def test_an_unsized_issue_is_left_alone() -> None:
+    d = decide(_issue(labels=frozenset({"enhancement"})), Repo())
+    assert d.action == "LEAVE" and "no size label" in d.reason
+
+
+def test_an_issue_without_acceptance_criteria_is_left_alone() -> None:
+    d = decide(_issue(body="## Problem\n`worker.py` drops it.\n"), Repo())
+    assert d.action == "LEAVE" and "acceptance" in d.reason
+
+
+def test_an_issue_naming_no_path_or_symbol_is_left_alone() -> None:
+    d = decide(_issue(body="## Acceptance criteria\n- [ ] it works\n"), Repo())
+    assert d.action == "LEAVE" and "path or symbol" in d.reason
+
+
+def test_beginner_labels_need_both_a_small_size_and_a_starting_point() -> None:
+    small = decide(_issue(labels=frozenset({"size/xs"})), Repo())
+    assert {"good first issue", "beginner-friendly"} <= set(small.add)
+    medium = decide(_issue(labels=frozenset({"size/m"})), Repo())
+    assert "good first issue" not in medium.add
+
+
+def test_no_starting_point_means_no_beginner_label() -> None:
+    body = READY_BODY.replace("## Where to start\nStart at `worker.py:120`.\n", "")
+    d = decide(_issue(labels=frozenset({"size/xs"}), body=body), Repo())
+    assert d.action == "BAIT" and "good first issue" not in d.add
+
+
+def test_a_correctly_advertised_issue_produces_no_write() -> None:
+    """Anti-flap: the job must not rewrite labels that already say the right thing."""
+    already = frozenset({"size/s", "help wanted", "up-for-grabs", "good first issue", "beginner-friendly"})
+    d = decide(_issue(labels=already), Repo())
+    assert d.action == "LEAVE" and not d.add and not d.remove
+
+
+def test_losing_a_milestone_does_not_silently_pull_a_baited_issue_off_the_shelf() -> None:
+    d = decide(_issue(labels=frozenset({"size/s", "up-for-grabs"}), milestone=None), Repo())
+    assert d.action == "LEAVE"
+    assert not d.remove
+
+
+# --- the two spellings of a bot ---------------------------------------------------------
+
+
+def test_a_bot_is_recognised_by_type_not_by_a_suffix_in_its_login() -> None:
+    """GraphQL returns an app's login without the `[bot]` suffix REST shows, so a
+    suffix check read four issues the orchestrator had just commented on as claimed by
+    an outside contributor and refused to shelve any of them."""
+    graphql_spelling = {"login": "bernstein-orchestrator", "type": "Bot"}
+    rest_spelling = {"login": "bernstein-orchestrator[bot]", "type": "Bot"}
+    assert not issue_shelf.is_outside_human(graphql_spelling, "chernistry")
+    assert not issue_shelf.is_outside_human(rest_spelling, "chernistry")
+
+
+def test_the_maintainer_is_not_an_outside_contributor() -> None:
+    assert not issue_shelf.is_outside_human({"login": "chernistry", "type": "User"}, "chernistry")
+
+
+def test_a_contributor_is_an_outside_contributor() -> None:
+    assert issue_shelf.is_outside_human({"login": "vaibhav8a", "type": "User"}, "chernistry")
+
+
+def test_a_hold_label_the_repo_does_not_define_is_reported() -> None:
+    """A hold whose label does not exist can never be on an issue, so the branch that
+    reads it never runs -- the guard looks present in the source and is inert in the run."""
+    with mock.patch.object(issue_shelf, "_gh", return_value='[{"name": "reserved"}, {"name": "blocked"}]'):
+        assert issue_shelf.missing_control_labels("o/r") == [
+            "fleet-blocked",
+            "fleet-running",
+            "needs-better-brief",
+            "no-bait",
+        ]
+
+
+def test_the_veto_label_counts_as_a_control_label() -> None:
+    """Without `no-bait` a maintainer cannot say leave this one alone, and the next run
+    re-advertises whatever they just took down."""
+    labels = json.dumps([{"name": name} for name in issue_shelf.HOLDS])
+    with mock.patch.object(issue_shelf, "_gh", return_value=labels):
+        assert issue_shelf.missing_control_labels("o/r") == [issue_shelf.VETO]
+
+
+def test_a_repo_defining_every_control_label_reports_nothing_missing() -> None:
+    labels = json.dumps([{"name": name} for name in issue_shelf.HOLDS | {issue_shelf.VETO}])
+    with mock.patch.object(issue_shelf, "_gh", return_value=labels):
+        assert issue_shelf.missing_control_labels("o/r") == []


### PR DESCRIPTION
## What

`scripts/issue_shelf.py` decides the `help wanted` / `up-for-grabs` / `good first issue` / `beginner-friendly` labels on a fixed rule, plus a workflow that runs it report-only every six hours and on issue events.

## Why

Those labels were applied by hand, which failed in both directions. Issues that were ready sat unadvertised for weeks. Issues somebody had already started kept their advertisement and sent a second contributor into a collision with work already in flight.

The first report-only run over the current backlog found **14 open issues that qualify and carry no advertisement at all**, against a shelf of 20 advertised issues — so the miss rate on the add side alone is about 40%.

## The rule

Taken beats ready, and both beat wanting a full shelf. It removes the bait when the issue is provably taken — an assignee, an open PR whose body closes it, a deliberate hold label (`reserved`, `blocked`, `needs-better-brief`, `fleet-blocked`, `fleet-running`), or `roadmap`. It adds the bait only when the issue is free by every one of those **and** ready to hand to someone who has never seen the codebase: sized, small enough to be one evening, milestoned, with acceptance criteria and a named file or symbol to start from. An issue failing a readiness gate is reported with the specific reason and left alone.

## Three properties that keep it from being wrong in the expensive direction

| Property | Failure it prevents |
|---|---|
| `no-bait` is an override the script never touches in either direction | A maintainer takes an issue down; the next scheduled run puts it straight back |
| A comment in the last 14 days from a non-bot, non-maintainer makes the issue **unproven** — nothing added, nothing removed, printed for a human | "I'll take this" and "does this still happen?" are indistinguishable to a label rule, and guessing wrong costs a contributor either way |
| Both forms refuse to start when the repo does not define every label that holds an issue back | A label the repo never created cannot be on an issue, so the branch reading it never runs — the guard is present in the source and inert in the run, and the shelf advertises exactly the work it protects |

Bots are identified by `user.type`, not by a suffix in the login: the REST and GraphQL spellings of an app account differ, and the suffix check read four issues the orchestrator had just commented on as claimed by a human. A failed `gh` call raises rather than returning an empty list, so an API refusal cannot be read as "nothing claims this issue".

## Tests

26 unit tests, each named for the way the shelf can lie rather than for the function it calls — `test_a_lane_running_the_issue_counts_as_taken`, `test_a_recent_outside_comment_moves_nothing_in_either_direction`, `test_losing_a_milestone_does_not_silently_pull_a_baited_issue_off_the_shelf`, `test_a_bot_is_recognised_by_type_not_by_a_suffix_in_its_login`.

## Rollout

The workflow is **report-only by default** — schedule and issue events write decisions to the run summary and change nothing. Applying is a manual dispatch with `apply: true`.

One dependency is not met yet and is deliberately left for a follow-up: the dispatch queue lives outside GitHub, so nothing currently writes `fleet-running`. Until the dispatcher sets it, an issue a lane is working reads as free. The preflight makes that visible rather than silent, and apply mode stays off until it is wired.

## Docs

`docs/contributing/issue-shelf.md` — what each label means to a contributor, and why an advertisement disappearing is not a rejection.