### PR TITLE
fix(pr): compose every number in the body from the branch diff

### DIFF
--- a/docs/release-notes/fragments/pr-body-one-authority.md
+++ b/docs/release-notes/fragments/pr-body-one-authority.md
@@ -1,0 +1,17 @@
+## Every number in a pull-request description now describes the same diff
+
+`bernstein pr` composed one body from two sources. The commit list and the
+provenance hash were asked of `git diff <base>..<branch>`; the "Full diff-stat"
+block was taken from the run's wrap-up file, which records what was in the
+agent's worktree when it finished. When a later stage removed the run's own
+config edit from the commit, nothing rewrote that snapshot, so descriptions
+shipped a diff-stat naming a file the branch does not contain — unreconcilable
+with the Files tab, and a config change published in a public description after
+the diff had been cleaned of it. The diff-stat is now asked of the branch like
+the rest, and falls back to the recorded value only when git cannot answer.
+
+The opening line counted per-commit churn, so a file added and removed on the
+same branch was still counted and its lines counted twice: one body opened
+"7 files · +534 / -41" over a diff GitHub rendered as 6 files, +498 / -3. It now
+states the net diff, with the commit sum kept as the fallback when git cannot
+answer.

--- a/src/bernstein/cli/commands/pr_cmd.py
+++ b/src/bernstein/cli/commands/pr_cmd.py
@@ -186,11 +186,20 @@ def _enrich_summary_with_git(summary: SessionSummary, cwd: Path) -> SessionSumma
     base_rev = _base_rev(cwd, summary.base_branch)
     errors: list[str] = []
 
-    diff_stat = summary.diff_stat
-    if not diff_stat:
-        diff_stat, error = _diff_stat(cwd, base_rev, branch)
-        if error:
-            errors.append(f"diff --stat: {error}")
+    # Asked of git every time, never taken from the state file. The wrap-up
+    # records what was in the agent's worktree when it finished, which is a
+    # different question: files the run touched and a later stage removed from
+    # the commit are still in that snapshot. Published as "Full diff-stat" it
+    # named `bernstein.yaml` on four branches that do not contain it -- so the
+    # body leaked a config change the strip stage had already taken out of the
+    # diff, and a reviewer comparing the block to the Files tab saw two
+    # different changes. The commits and the provenance hash below are already
+    # asked of `base..branch`; this now comes from the same place, so every
+    # number in the body describes the same bytes.
+    diff_stat, error = _diff_stat(cwd, base_rev, branch)
+    if error:
+        errors.append(f"diff --stat: {error}")
+        diff_stat = summary.diff_stat
 
     commits = summary.commits
     if not commits:

--- a/src/bernstein/core/integrations/pr_gen.py
+++ b/src/bernstein/core/integrations/pr_gen.py
@@ -1123,11 +1123,26 @@ def _format_evidence(evidence: EvidenceSummary) -> str:
 def _churn(session: SessionSummary) -> tuple[int, int, int] | None:
     """Return ``(files, added, removed)`` for the branch, or ``None``.
 
-    The commits are the first source because they carry per-file numbers.
-    The diff-stat's summary line is the fallback for a session whose commits
-    were not parsed.  ``None`` means neither could say, which is the case a
-    headline must not invent a number for.
+    The diff-stat summary line is the first source because it is the net
+    change: what the Files tab shows a reviewer six inches above this line.
+    Summing the commits instead counts a path once per commit that touched it,
+    so a file added and then removed on the same branch is still counted and
+    its lines are counted twice. That is a true statement about the branch and
+    the wrong answer to "how big is this pull request" -- it published "7 files
+    - +534 / -41" over a diff GitHub rendered as 6 files, +498 / -3.
+
+    The commits remain the fallback for a session whose diff-stat git could not
+    answer. ``None`` means neither could say, which is the case a headline must
+    not invent a number for.
     """
+    match = _DIFF_STAT_SUMMARY_RE.search(session.diff_stat)
+    if match:
+        return (
+            int(match.group("files")),
+            int(match.group("added") or 0),
+            int(match.group("removed") or 0),
+        )
+
     paths: dict[str, tuple[int, int]] = {}
     for commit in session.commits:
         if commit.is_merge:
@@ -1138,13 +1153,6 @@ def _churn(session: SessionSummary) -> tuple[int, int, int] | None:
     if paths:
         return len(paths), sum(a for a, _ in paths.values()), sum(r for _, r in paths.values())
 
-    match = _DIFF_STAT_SUMMARY_RE.search(session.diff_stat)
-    if match:
-        return (
-            int(match.group("files")),
-            int(match.group("added") or 0),
-            int(match.group("removed") or 0),
-        )
     return None
 
 

--- a/tests/unit/cli/test_pr_cmd_base_rev.py
+++ b/tests/unit/cli/test_pr_cmd_base_rev.py
@@ -131,3 +131,56 @@ def test_the_wrap_up_placeholder_is_not_an_answer(tmp_path: Path) -> None:
     summary = load_session_summary("S-1", workdir=tmp_path)
 
     assert summary.diff_stat == ""
+
+
+def test_a_wrap_up_diff_stat_never_survives_into_the_description(
+    clones: tuple[Path, Path],
+) -> None:
+    """The incident: four published bodies rendered a "Full diff-stat" block
+    naming ``bernstein.yaml`` on branches that do not contain it.
+
+    The wrap-up records what was in the agent's worktree when it finished. A
+    later stage removes the run's own config edit from the commit, but nothing
+    rewrites that snapshot, so the file name still shipped in the body -- a
+    config change published in a public description after the diff was cleaned
+    of it, and a block a reviewer could not reconcile with the Files tab. The
+    diff-stat has to be asked of ``base..branch``, like the commits and the
+    provenance hash already are.
+    """
+    _upstream, clone = clones
+    _work_branch(clone)
+
+    stale = SessionSummary(
+        session_id="T-3",
+        goal="g",
+        branch="work",
+        base_branch="main",
+        diff_stat=" bernstein.yaml | 34 ++++++++++--------\n 1 file changed, 22 insertions(+), 12 deletions(-)",
+    )
+    enriched = _enrich_summary_with_git(stale, clone)
+
+    assert enriched.git_error == ""
+    assert "bernstein.yaml" not in enriched.diff_stat, "the worktree snapshot was published as the branch diff"
+    assert "feature.py" in enriched.diff_stat
+
+
+def test_an_unreadable_diff_stat_falls_back_rather_than_publishing_nothing(
+    clones: tuple[Path, Path],
+) -> None:
+    """Preferring git must not mean discarding the only answer available when
+    git cannot give one -- an empty block reads as a branch that changed
+    nothing, which is a different claim from "this could not be read"."""
+    _upstream, clone = clones
+    _work_branch(clone)
+
+    stale = SessionSummary(
+        session_id="T-4",
+        goal="g",
+        branch="does-not-exist",
+        base_branch="main",
+        diff_stat=" feature.py | 2 ++\n 1 file changed, 2 insertions(+)",
+    )
+    enriched = _enrich_summary_with_git(stale, clone)
+
+    assert enriched.git_error != "", "a branch git cannot resolve was reported as readable"
+    assert "feature.py" in enriched.diff_stat

--- a/tests/unit/test_pr_description_from_change.py
+++ b/tests/unit/test_pr_description_from_change.py
@@ -103,7 +103,15 @@ def _summary(**overrides: object) -> SessionSummary:
         "branch": "agent/abcdef12",
         "base_branch": "main",
         "primary_role": "engineer",
-        "diff_stat": " src/bernstein/core/storage/keys.py | 124 +++++\n 1 file changed",
+        # Consistent with FEATURE_COMMIT on purpose: 120 + 4 and 90 + 0. A branch
+        # whose only commit touches two files cannot have a base..branch diff-stat
+        # naming one, and the headline reads the diff-stat, so a fixture that
+        # disagrees with itself tests a state git cannot produce.
+        "diff_stat": (
+            " src/bernstein/core/storage/keys.py | 124 +++++++++--\n"
+            " tests/unit/test_store_keys.py      |  90 ++++++++\n"
+            " 2 files changed, 210 insertions(+), 4 deletions(-)"
+        ),
         "gates": (
             GateResult(name="lint", passed=True, detail="ruff: 0 findings"),
             GateResult(name="tests", passed=True, detail="pytest: 812 passed"),
@@ -705,3 +713,55 @@ def test_ranking_is_untouched_by_the_rendering_change() -> None:
     assert not is_housekeeping_commit(WIP_FOLD_IN_COMMIT)
     ranked = rank_commits((WIP_BUT_DESCRIPTIVE_COMMIT, WIP_FOLD_IN_COMMIT))
     assert ranked[0] is WIP_FOLD_IN_COMMIT
+
+
+# ---------------------------------------------------------------------------
+# Every number in the body describes the same bytes
+# ---------------------------------------------------------------------------
+
+
+def test_the_headline_states_the_net_diff_not_the_churn_across_commits() -> None:
+    """The incident: a body opened "7 files - +534 / -41" over a diff the Files
+    tab rendered as 6 files, +498 / -3.
+
+    Summing the commits counts a path once per commit that touched it, so a file
+    added and then removed on the same branch is still counted and its lines are
+    counted twice. Both statements are true about the branch; only one answers
+    the question a reviewer is asking six inches below GitHub's own count.
+    """
+    added_then_removed = _commit("111111111111", "feat: add a helper", [("src/tmp.py", 30, 0)])
+    reverted = _commit("222222222222", "revert: drop the helper again", [("src/tmp.py", 0, 30)])
+    body = build_pr_body(
+        _summary(
+            commits=(added_then_removed, reverted),
+            diff_stat=" 0 files changed",
+        )
+    )
+    headline = body.splitlines()[0]
+
+    assert "**0 files**" in headline
+    assert "1 file" not in headline
+    assert "+30" not in headline
+
+
+def test_a_diff_stat_git_could_answer_beats_the_commit_sum() -> None:
+    """When the two disagree, the net diff is the one published."""
+    churn = _commit("333333333333", "feat: three files", [("a.py", 10, 0), ("b.py", 20, 0), ("c.py", 5, 5)])
+    body = build_pr_body(
+        _summary(
+            commits=(churn,),
+            diff_stat=" a.py | 10 +\n 1 file changed, 10 insertions(+), 0 deletions(-)",
+        )
+    )
+    headline = body.splitlines()[0]
+
+    assert "**1 file** · +10 / -0" in headline
+
+
+def test_the_commit_sum_is_still_the_fallback_when_git_could_not_answer() -> None:
+    """An unreadable diff-stat must not silence the headline entirely -- the
+    commits are a worse answer than the net diff and a much better one than none."""
+    body = build_pr_body(_summary(commits=(FEATURE_COMMIT,), diff_stat=""))
+    headline = body.splitlines()[0]
+
+    assert "**2 files** · +210 / -4" in headline


### PR DESCRIPTION
## What a reader sees today

Six fleet-published descriptions, each checked against what the Files tab renders for the same PR:

| PR | Body headline | GitHub Files tab | "Full diff-stat" block |
|---|---|---|---|
| #4952 | 3 files · +173 / -29 | 3 files, +173 / -29 | `bernstein.yaml` — **not on the branch** |
| #4951 | *(none)* | 1 file, +94 / -0 | `bernstein.yaml` — **not on the branch** |
| #4950 | 7 files · +534 / -41 | **6 files, +498 / -3** | 22 files, most **not on the branch** |
| #4948 | *(none)* | 1 file, +9 / -9 | matches |
| #4945 | 7 files · +684 / -63 | **6 files, +631 / -10** | matches |
| #4944 | 3 files · +370 / -21 | **3 files, +349 / -0** | `bernstein.yaml`, `test_adapter_contract.py` — **neither on the branch** |

## Why

One description, two sources.

The commit list and the provenance hash are asked of `git diff <base>..<branch>`. The diff-stat block was taken from the run's wrap-up file, which records what was in the agent's worktree when it finished — a different question. When a later stage removes the run's own config edit from the commit, nothing rewrites that snapshot, so the file name still ships in the body. That is a config change published in a public description *after* the diff was cleaned of it, and a block a reviewer cannot reconcile with the Files tab.

The headline had the same shape from the other side: it summed per-commit churn, counting a path once per commit that touched it, so a file added and then removed on the same branch is still counted and its lines counted twice. Both statements are true about the branch. Only the net diff answers the question a reviewer is asking six inches under GitHub's own count.

## Change

- The diff-stat is asked of `base..branch`, like the commits and the provenance hash already are. The recorded value is the fallback for when git cannot answer — an empty block would read as a branch that changed nothing, which is a different claim from "this could not be read".
- The headline states the net diff; the commit sum stays as the fallback.
- The fixture in `test_pr_description_from_change` carried a diff-stat naming one file next to a commit touching two — a state no branch can be in, and the reason the headline's source went unquestioned. It now agrees with itself.

## Verification

Five new tests, each named for the way a body lied. The three that pin the defects were run against the unfixed code first and fail there:

```
FAILED test_a_wrap_up_diff_stat_never_survives_into_the_description
FAILED test_the_headline_states_the_net_diff_not_the_churn_across_commits
FAILED test_a_diff_stat_git_could_answer_beats_the_commit_sum
```

The two clone-shape tests use real git, because the defect was in which revision the real git commands were pointed at. The other two pin the fallbacks, so preferring git does not become discarding the only answer available when git cannot give one.

`89 passed` across `test_pr_gen.py`, `test_pr_description_from_change.py`, `test_pr_cmd_base_rev.py`; ruff and mypy clean.