### PR TITLE
feat(tasks): add content-addressed completion exports

### DIFF
--- a/docs/operations/worker-contracts.md
+++ b/docs/operations/worker-contracts.md
@@ -27,6 +27,12 @@ A successful terminal payload:
   "contract": "worker-completion/v1",
   "summary": "Added JWT refresh-token rotation and tests.",
   "files_changed": ["src/auth/jwt.py", "tests/test_jwt.py"],
+  "exports": [
+    {
+      "path": "src/auth/jwt.py",
+      "content_hash": "sha256:51ca74681851d3c8928452b5a3509a1da8d1586b857c4d6caade044c28c89f98"
+    }
+  ],
   "verification": {"command": "pytest tests/test_jwt.py", "exit_code": 0},
   "receipt_ref": "lineage:task-9f3a"
 }
@@ -36,6 +42,7 @@ A successful terminal payload:
 |-------|----------|-------|
 | `summary` | yes | Non-empty string, capped at 2000 characters. |
 | `files_changed` | no | List of non-empty path strings. |
+| `exports` | no | Content-addressed outputs as `{path, content_hash}` objects. Hashes use canonical `sha256:<64 lowercase hex>` form. |
 | `verification` | no | `{command, exit_code}` - a step the worker ran before completing. |
 | `receipt_ref` | no | Optional lineage/receipt reference. |
 
@@ -67,6 +74,7 @@ At the completion API boundary the payload is validated against the closed
 schema:
 
 - Unknown top-level fields are rejected.
+- Unknown export fields and malformed export content hashes are rejected.
 - Unknown refusal kinds are rejected.
 - Missing required fields (per shape and per refusal kind) are rejected.
 - Malformed JSON is rejected.

--- a/docs/release-notes/fragments/5002-completion-exports.md
+++ b/docs/release-notes/fragments/5002-completion-exports.md
@@ -1,0 +1,5 @@
+## Worker completions can identify produced content
+
+Worker completion payloads may now include content-addressed `exports` entries
+that pair an artifact path with its canonical SHA-256 digest. Existing
+`worker-completion/v1` payloads remain valid without the new field. #5002

--- a/src/bernstein/core/tasks/contracts.py
+++ b/src/bernstein/core/tasks/contracts.py
@@ -6,7 +6,8 @@ to say so. This module defines the closed contract both terminal shapes
 must satisfy at the completion API boundary:
 
 * :class:`WorkerCompletion` - a successful terminal payload (summary,
-  files changed, optional verification evidence, optional receipt ref).
+  files changed, optional content-addressed exports, optional verification
+  evidence, optional receipt ref).
 * :class:`WorkerRefusal` - a typed refusal with a closed
   :class:`RefusalKind` taxonomy and per-kind machine-readable fields.
 * :class:`ContractViolation` - raised when a payload fails validation;
@@ -28,6 +29,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any, cast
@@ -38,6 +40,8 @@ WORKER_CONTRACT_VERSION = "worker-completion/v1"
 
 #: Hard cap for the completion summary, in characters.
 SUMMARY_MAX_CHARS = 2000
+
+_CONTENT_HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 
 class RefusalKind(StrEnum):
@@ -82,6 +86,18 @@ class VerificationEvidence:
 
 
 @dataclass(frozen=True)
+class CompletionExport:
+    """Content-addressed artifact produced by a worker completion."""
+
+    path: str
+    content_hash: str
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a JSON-safe representation."""
+        return {"path": self.path, "content_hash": self.content_hash}
+
+
+@dataclass(frozen=True)
 class WorkerCompletion:
     """Validated successful terminal payload."""
 
@@ -89,6 +105,7 @@ class WorkerCompletion:
     files_changed: tuple[str, ...] = ()
     verification: VerificationEvidence | None = None
     receipt_ref: str | None = None
+    exports: tuple[CompletionExport, ...] = ()
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-safe representation including the contract tag."""
@@ -101,6 +118,8 @@ class WorkerCompletion:
             data["verification"] = self.verification.to_dict()
         if self.receipt_ref is not None:
             data["receipt_ref"] = self.receipt_ref
+        if self.exports:
+            data["exports"] = [export.to_dict() for export in self.exports]
         return data
 
 
@@ -211,7 +230,37 @@ def _parse_verification(payload: dict[str, Any]) -> VerificationEvidence | None:
     return VerificationEvidence(command=command, exit_code=exit_code)
 
 
-_COMPLETION_KEYS = frozenset({"contract", "summary", "files_changed", "verification", "receipt_ref"})
+def _parse_exports(payload: dict[str, Any]) -> tuple[CompletionExport, ...]:
+    """Validate optional content-addressed completion exports."""
+    raw = payload.get("exports")
+    if raw is None:
+        return ()
+    if not isinstance(raw, list):
+        raise ContractViolation("$.exports", "must be a list of objects")
+    items = cast("list[object]", raw)
+    exports: list[CompletionExport] = []
+    for i, item in enumerate(items):
+        item_path = f"$.exports[{i}]"
+        if not isinstance(item, dict):
+            raise ContractViolation(item_path, "must be an object")
+        obj = cast("dict[str, Any]", item)
+        for key in obj:
+            if key not in ("path", "content_hash"):
+                raise ContractViolation(f"{item_path}.{key}", "unknown field")
+        path = obj.get("path")
+        if not isinstance(path, str) or not path.strip():
+            raise ContractViolation(f"{item_path}.path", "must be a non-empty string")
+        content_hash = obj.get("content_hash")
+        if not isinstance(content_hash, str) or _CONTENT_HASH_RE.fullmatch(content_hash) is None:
+            raise ContractViolation(
+                f"{item_path}.content_hash",
+                "must be a canonical sha256:<64 lowercase hex> digest",
+            )
+        exports.append(CompletionExport(path=path, content_hash=content_hash))
+    return tuple(exports)
+
+
+_COMPLETION_KEYS = frozenset({"contract", "summary", "files_changed", "verification", "receipt_ref", "exports"})
 _REFUSAL_BASE_KEYS = frozenset({"contract", "kind", "detail"})
 _REFUSAL_KIND_KEYS: dict[RefusalKind, frozenset[str]] = {
     RefusalKind.SCOPE_EXCEEDED: frozenset({"proposed_split"}),
@@ -243,6 +292,7 @@ def parse_completion(payload: dict[str, Any]) -> WorkerCompletion:
     summary = _require_str(payload, "summary", max_chars=SUMMARY_MAX_CHARS)
     files_changed = _parse_string_list(payload, "files_changed")
     verification = _parse_verification(payload)
+    exports = _parse_exports(payload)
     receipt_ref_raw = payload.get("receipt_ref")
     receipt_ref: str | None = None
     if receipt_ref_raw is not None:
@@ -254,6 +304,7 @@ def parse_completion(payload: dict[str, Any]) -> WorkerCompletion:
         files_changed=files_changed,
         verification=verification,
         receipt_ref=receipt_ref,
+        exports=exports,
     )
 
 

--- a/templates/roles/_includes/completion_contract.md
+++ b/templates/roles/_includes/completion_contract.md
@@ -12,6 +12,7 @@ curl -s -w '\n%{http_code}' -X POST http://127.0.0.1:8052/tasks/{{TASK_ID}}/comp
 Payload fields:
 - `summary` (required): what was done, max 2000 characters.
 - `files_changed`: repo-relative paths you modified.
+- `exports` (optional): produced artifacts as `{"path": "<repo-relative path>", "content_hash": "sha256:<64 lowercase hex>"}` objects. Existing producers may omit this field.
 - `verification`: the command you ran to verify the work and its exit code; use `null` only when nothing was runnable.
 - `receipt_ref` (optional): hash or reference to a receipt artefact.
 

--- a/tests/unit/test_completion_template_include.py
+++ b/tests/unit/test_completion_template_include.py
@@ -50,6 +50,11 @@ class TestIncludeFile:
         body = _INCLUDE_PATH.read_text(encoding="utf-8")
         assert "/tasks/{{TASK_ID}}/complete" in body
 
+    def test_include_documents_content_addressed_exports(self) -> None:
+        body = _INCLUDE_PATH.read_text(encoding="utf-8")
+        assert "`exports`" in body
+        assert '"content_hash"' in body
+
 
 # ---------------------------------------------------------------------------
 # Renderer {{INCLUDE}} directive

--- a/tests/unit/test_worker_contracts.py
+++ b/tests/unit/test_worker_contracts.py
@@ -128,6 +128,48 @@ class TestParseCompletion:
         assert isinstance(result, WorkerCompletion)
         assert result.verification is None
 
+    def test_payload_without_exports_is_backward_compatible(self) -> None:
+        payload = _completion_payload()
+        result = parse_terminal_payload(payload)
+        assert isinstance(result, WorkerCompletion)
+        assert result.exports == ()
+        assert result.to_dict() == payload
+
+    def test_exports_entry_round_trips(self) -> None:
+        exports = [{"path": "dist/report.json", "content_hash": "sha256:" + "a" * 64}]
+        result = parse_terminal_payload(_completion_payload(exports=exports))
+        assert isinstance(result, WorkerCompletion)
+        assert result.to_dict()["exports"] == exports
+
+    def test_exports_content_hash_must_be_canonical_sha256(self) -> None:
+        exports = [{"path": "dist/report.json", "content_hash": "not-a-content-hash"}]
+        with pytest.raises(ContractViolation) as exc_info:
+            parse_terminal_payload(_completion_payload(exports=exports))
+        assert exc_info.value.path == "$.exports[0].content_hash"
+
+    def test_exports_entry_rejects_unknown_field(self) -> None:
+        exports = [
+            {
+                "path": "dist/report.json",
+                "content_hash": "sha256:" + "a" * 64,
+                "size": 42,
+            }
+        ]
+        with pytest.raises(ContractViolation) as exc_info:
+            parse_terminal_payload(_completion_payload(exports=exports))
+        assert exc_info.value.path == "$.exports[0].size"
+
+    def test_exports_distinguish_different_content_at_same_path(self) -> None:
+        first = parse_terminal_payload(
+            _completion_payload(exports=[{"path": "src/foo.py", "content_hash": "sha256:" + "a" * 64}])
+        )
+        second = parse_terminal_payload(
+            _completion_payload(exports=[{"path": "src/foo.py", "content_hash": "sha256:" + "b" * 64}])
+        )
+        assert isinstance(first, WorkerCompletion)
+        assert isinstance(second, WorkerCompletion)
+        assert first.to_dict() != second.to_dict()
+
     def test_unknown_top_level_field_rejected(self) -> None:
         with pytest.raises(ContractViolation) as exc_info:
             parse_terminal_payload(_completion_payload(extra_field="nope"))


### PR DESCRIPTION
## What

Add optional content-addressed `exports` to worker completion records without changing `worker-completion/v1` compatibility.

## Why

`files_changed` identifies paths but not the bytes written there. Two runs that produce different content at the same path therefore serialize to the same completion record, and a later consumer cannot tell whether the path still contains the artifact the worker described.

Closes #5002.

## How

- Add a frozen `CompletionExport` value with a self-contained `path` and `content_hash`.
- Parse `exports` as an optional closed list at the completion boundary.
- Require canonical `sha256:<64 lowercase hex>` digests and report nested JSONPath errors.
- Omit empty exports during serialization so existing payloads continue to round-trip unchanged.
- Document the additive field in the worker prompt, operator guide, and release notes.

Producer-side hash calculation and lineage-store resolution remain out of scope as requested.

## Verification

The five issue-specified tests were run before implementation and all failed against the old contract for the expected reasons (`exports` was absent or rejected at `$.exports`). After the change:

- `uv run --python 3.13 ruff check src/`
- `uv run --python 3.13 lint-imports`
- `uv run --python 3.13 pyright src/bernstein/core/tasks/contracts.py`
- `uv run --python 3.13 python scripts/run_tests.py tests/unit/test_worker_contracts.py tests/unit/test_completion_template_include.py tests/unit/test_template_compress_validate.py tests/unit/test_unreleased_notes_rotation.py` (99 passed)
- release-notes gate (passed)

The full isolated runner was also attempted with `uv run --python 3.13 python scripts/run_tests.py -x`. It stopped at an unrelated Windows baseline failure in `tests/unit/adapters/test_adapter_onboard_record.py::test_record_round_trip_and_replay_stays_process_free`, where a `.py` smoke fixture exits 1 when invoked as a CLI. This PR does not touch the adapter onboarding path.

## Checklist

- [x] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` passes (the full Windows environment reports existing errors outside the changed module; the changed module passes with 0 errors)
- [ ] `uv run python scripts/run_tests.py -x` passes (blocked by the unrelated Windows baseline failure documented above)
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (N/A: internal completion contract)
- [x] `docs/operations/<area>.md` updated
- [x] `docs/api/` schema regenerated if a public surface changed (N/A: no generated schema changed)
- [x] `uv run bernstein agents-md sync` run so AGENTS.md, CLAUDE.md, `.goosehints`, `CONVENTIONS.md`, and `.cursor/rules/*.mdc` reflect any new module (N/A: no module added)
- [x] Tests cover the documented behaviour
