### PR TITLE
fix(ci): keep the branch-protection marker labels under GitHub's description cap

### DIFF
--- a/scripts/toggle_branch_protection_audit_marker.py
+++ b/scripts/toggle_branch_protection_audit_marker.py
@@ -29,11 +29,13 @@ LABEL_DRIFT = "branch-protection-drift"
 TITLE_UNREACHABLE = "Branch protection audit cannot read live rulesets (auth/credential failure)"
 TITLE_DRIFT = "Branch protection audit detected ruleset drift on main"
 
-DESC_UNREACHABLE = (
-    "Open while branch protection audit cannot read live rulesets (credential or network failure); "
-    "closed automatically on recovery"
-)
-DESC_DRIFT = "Open while live branch protection disagrees with in-tree invariants; closed automatically on recovery"
+# GitHub caps a label description at 100 characters and rejects a longer one
+# with HTTP 422. `gh label create --force` then fails, and because
+# ensure_label only warns, the marker issue is opened with a label that was
+# never created. That is fatal for the drift path, whose label does not
+# already exist. Keep both of these under the cap; the test pins it.
+DESC_UNREACHABLE = "Open while the audit cannot read live rulesets; closed automatically on recovery"
+DESC_DRIFT = "Open while live branch protection disagrees with in-tree invariants; closed on recovery"
 
 
 def _gh(args: list[str]) -> str:

--- a/tests/unit/test_adapter_contract.py
+++ b/tests/unit/test_adapter_contract.py
@@ -225,8 +225,7 @@ class TestAdapterContract:
         if spawn_mod is not None:
             if hasattr(spawn_mod, "_has_q_login_cache") and not spawn_mod._has_q_login_cache():
                 pytest.skip(
-                    "AWS Q Developer login cache not present on this host "
-                    "(run `q login` once before exercising spawn)",
+                    "AWS Q Developer login cache not present on this host (run `q login` once before exercising spawn)",
                 )
             if hasattr(spawn_mod, "_detect_tool") and spawn_mod._detect_tool() is None:
                 pytest.skip("No IaC CLI (terraform or pulumi) on PATH")

--- a/tests/unit/test_branch_protection_audit_workflow_yaml.py
+++ b/tests/unit/test_branch_protection_audit_workflow_yaml.py
@@ -155,3 +155,56 @@ def test_branch_protection_audit_canary_still_defines_the_required_contexts() ->
 def test_branch_protection_audit_step_is_not_advisory() -> None:
     workflow_text = _workflow_text()
     assert "continue-on-error: true" not in workflow_text
+
+
+# ---------------------------------------------------------------------------
+# Marker labels
+# ---------------------------------------------------------------------------
+# GitHub rejects a label description longer than 100 characters with HTTP 422.
+# ensure_label() only warns on failure, so an over-long description does not
+# stop the run - it leaves the label uncreated and the marker issue is opened
+# asking for a label that is not there. For `branch-protection-unreachable`
+# that went unnoticed because the label already existed, created by hand, with
+# an empty description. `branch-protection-drift` does not exist at all, so the
+# one path that reports live branch protection drifting away from the in-tree
+# invariants could never have labelled its own issue.
+_GITHUB_LABEL_DESCRIPTION_MAX = 100
+
+
+def _marker_module() -> object:
+    """Load the marker script by path; it lives in scripts/, not the package."""
+    import importlib.util
+
+    path = Path(__file__).resolve().parents[2] / "scripts" / "toggle_branch_protection_audit_marker.py"
+    spec = importlib.util.spec_from_file_location("_bp_marker", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_marker_label_descriptions_fit_the_github_limit() -> None:
+    """Every description the script sends to `gh label create` must be writable."""
+    module = _marker_module()
+    over = {
+        name: len(value)
+        for name in ("DESC_UNREACHABLE", "DESC_DRIFT")
+        for value in [cast(str, getattr(module, name))]
+        if len(value) > _GITHUB_LABEL_DESCRIPTION_MAX
+    }
+    assert not over, (
+        f"label descriptions over GitHub's {_GITHUB_LABEL_DESCRIPTION_MAX}-character cap: {over}. "
+        "gh label create returns HTTP 422 and ensure_label only warns, so the label is "
+        "never created and the marker issue is opened unlabelled."
+    )
+
+
+def test_both_marker_paths_create_their_label_before_opening_an_issue() -> None:
+    """Neither failure mode may rely on its label already existing."""
+    module = _marker_module()
+    source = Path(cast(str, module.__file__)).read_text(encoding="utf-8")
+    for constant in ("LABEL_UNREACHABLE", "LABEL_DRIFT"):
+        assert f"ensure_label(repo, {constant}" in source, (
+            f"{constant} is used without ensure_label; on a repository where that label "
+            "does not exist yet the marker issue cannot be created at all"
+        )


### PR DESCRIPTION
## What

Both marker label descriptions in `scripts/toggle_branch_protection_audit_marker.py` were longer than GitHub's 100-character cap, so every `gh label create --force` the script issued failed with HTTP 422.

| Constant | Was | Now |
|---|---|---|
| `DESC_UNREACHABLE` | 126 chars | 80 |
| `DESC_DRIFT` | 101 chars | 87 |

## Why it mattered

`ensure_label()` only warns on failure, so the run carries on and opens the marker issue regardless. That hid the bug in one direction and made it fatal in the other:

- `branch-protection-unreachable` already existed as a label, created by hand, so the marker issue got labelled anyway. To this day that label carries an empty description — the create call has never once succeeded.
- `branch-protection-drift` **does not exist in this repository.** Its label is created by the same call, on the same code path, immediately before the issue. So the one mechanism that reports live branch protection drifting away from the in-tree invariants has never been able to label its own issue, and has never been exercised.

Today's scheduled run made it visible: `Warning: could not ensure label branch-protection-unreachable: ... HTTP 422: Validation Failed ... description is too long (maximum is 100 characters)`.

## What proves it

Two tests in `tests/unit/test_branch_protection_audit_workflow_yaml.py`:

1. `test_marker_label_descriptions_fit_the_github_limit` — every description the script sends to `gh label create` is writable. Run against the previous constants it fails naming both lengths: `{'DESC_UNREACHABLE': 126, 'DESC_DRIFT': 101}`.
2. `test_both_marker_paths_create_their_label_before_opening_an_issue` — neither failure mode may rely on its label already existing, which is what made the drift path silently unreachable.

```
uv run python scripts/run_tests.py tests/unit/test_branch_protection_audit_workflow_yaml.py
```

11 passed.

## Not in this PR

The audit itself is currently failing for a different and unrelated reason — `Bad credentials (HTTP 401)` reading the live ruleset — which is a credential matter for the operator, tracked in #5007. This PR only makes the reporting path able to work once it is.
