### PR TITLE
docs: state the conformance level a software-only install actually reaches

### DIFF
--- a/docs/observability/trace-export.md
+++ b/docs/observability/trace-export.md
@@ -85,16 +85,24 @@ Install it (or resolve it via `uv run --with`):
 pip install agentrust-trace-tests
 ```
 
-Then verify a record file against the TRACE v0.2 schema at Level 1
-(checks claims beyond the bare schema, including cross-field invariants):
+Then verify a record file against the TRACE v0.2 schema:
 
 ```bash
-trace-tests verify --record <file> --level 1
+trace-tests verify --record <file> --level 0
 ```
 
-Level 0 validates the schema and signature only; Level 1 adds
-cross-field invariants such as SPIFFE subject scoping and delegation
-parent-child hash binding. Use Level 1 for production records.
+Level 0 validates the schema, the SPIFFE subject, the `cnf.jwk` key type,
+the Ed25519 signature, the policy and runtime digests, and the build
+provenance — eight checks. Every record this exporter writes passes it.
+
+**Level 1 is not reachable from a software-only install, by design.** It
+adds two requirements that are properties of the deployment rather than of
+the record: `runtime.platform` must name a hardware TEE (`software-only`
+is rejected as development-mode), and the verifier must supply its own
+expected nonce. Running `--level 1` against a software-only record fails
+`TR-RTE-001` and `TR-RTE-004` while every other check passes. Claim Level 0
+for a software-only deployment; Level 1 describes a record produced inside
+a TEE and checked by a verifier that issued the nonce.
 
 ### Vectors for testing
 
@@ -112,7 +120,7 @@ Run the reference suite against any one:
 ```bash
 uv run --with agentrust-trace-tests==0.5.1 trace-tests verify \
     --record tests/fixtures/trust-record-vectors/single-execution-trust-record.json \
-    --level 1 --max-age 999999999999
+    --level 0 --max-age 999999999999
 ```
 
 (`--max-age` is set far above the default 24 h window because the


### PR DESCRIPTION
## What

`docs/observability/trace-export.md` instructed operators to verify exported
trust records with `trace-tests verify --record <file> --level 1`, and stated
"Use Level 1 for production records". That command fails against every record
this exporter produces.

## Measured, not assumed

All four committed vectors under `tests/fixtures/trust-record-vectors/`:

| Level | Result | Checks | Failures |
|---|---|---|---|
| 1 | FAIL | 14 | `TR-RTE-001`, `TR-RTE-004` |
| 0 | PASS | 8 | none |

`TR-RTE-001` rejects `runtime.platform: "software-only"` as development-mode --
Level 1 requires the platform to name a hardware TEE. `TR-RTE-004` requires the
*verifier* to supply its own expected nonce. Both are properties of the
deployment and of the verification call, not of the record, so no exporter
change reaches Level 1 from a software-only install. Everything else already
passes at Level 1: SPIFFE subject scoping, Ed25519 signature verification,
policy bundle hash, runtime measurement digest, SLSA provenance.

## Why the suite did not catch it

It never disagreed with the code -- `tests/unit/test_trust_record_conformance.py::test_vector_passes_level_0`
has always invoked `--level 0`. Only the prose disagreed with both. Docs-only
change; no behaviour changes.

## Changes

- Document Level 0 as the claim for a software-only deployment, and enumerate
  the eight checks it covers.
- State plainly which two checks Level 1 adds, why they are unreachable
  software-only, and what a Level 1 record would require (a TEE, and a verifier
  that issued the nonce).
- Fix both `--level 1` invocations a reader would copy.

Anyone publishing a conformance claim from this page was pointed at a level the
install cannot reach. Overstating a conformance level is worse than accurately
claiming the lower one.
