### PR TITLE
fix(compliance): describe the system by what it governs, from one string

### DIFF
--- a/packages/cursor-plugin/rules/bernstein-context.mdc
+++ b/packages/cursor-plugin/rules/bernstein-context.mdc
@@ -1,14 +1,17 @@
 ---
-description: Bernstein orchestrator context - always active when working in a Bernstein-managed project
+description: Bernstein governance-layer context - always active when working in a Bernstein-managed project
 alwaysApply: true
 ---
 
-# Bernstein Orchestrator Context
+# Bernstein Context
 
-You are working in a project managed by **Bernstein**, a deterministic orchestrator for
-CLI coding agents. Bernstein runs at `http://127.0.0.1:8052` and coordinates parallel
-CLI coding agents, one git worktree per task. There is no model in its coordination
-loop, so the same plan replays to a byte-identical task graph.
+You are working in a project managed by **Bernstein**, the governance layer for AI
+agents. Bernstein runs at `http://127.0.0.1:8052`: a deterministic scheduler runs agents
+in parallel, gates what they produce, and records every step. CLI coding agents work out
+of the box, one git worktree per task, and the same layer governs any agent workload -
+the deliverable can be a diff, a research report, a dataset, or an audit evidence pack.
+There is no model in its coordination loop, so the same plan replays to a byte-identical
+task graph.
 
 ## Key concepts
 

--- a/src/bernstein/compliance/eu_ai_act.py
+++ b/src/bernstein/compliance/eu_ai_act.py
@@ -22,6 +22,12 @@ from enum import StrEnum
 from pathlib import Path  # noqa: TC003
 from typing import Any
 
+from bernstein.system_description import (
+    DEPLOYMENT_CONTEXT,
+    INTENDED_USE,
+    SYSTEM_DESCRIPTION,
+)
+
 _NOT_APPLICABLE = "Not applicable"
 
 logger = logging.getLogger(__name__)
@@ -1107,15 +1113,20 @@ def _write_json(path: Path, data: Any) -> None:
 def bernstein_descriptor(
     version: str = "1.0.0",
     *,
-    deployment_context: str = "Self-hosted multi-agent orchestration platform",
+    deployment_context: str = DEPLOYMENT_CONTEXT,
     metadata: dict[str, Any] | None = None,
 ) -> SystemDescriptor:
-    """Return a pre-configured SystemDescriptor for the Bernstein orchestration system.
+    """Return a pre-configured SystemDescriptor for the Bernstein governance layer.
 
-    Bernstein is an orchestration platform for short-lived CLI coding agents.
-    It is not itself a decision-making AI in an Annex III high-risk domain, but
-    it may orchestrate agents that perform high-risk tasks.  The descriptor
-    captures those nuances so operators can generate a meaningful evidence package.
+    Bernstein is the governance layer for AI agent workloads: it runs agents in
+    parallel, gates what they produce, and records every step. It is not itself a
+    decision-making AI in an Annex III high-risk domain, but it may govern agents
+    that perform high-risk tasks.  The descriptor captures those nuances so
+    operators can generate a meaningful evidence package.
+
+    The strings come from :mod:`bernstein.system_description` rather than being
+    written here: this one lands verbatim in the artifact handed to an assessor,
+    and it previously described a narrower system than the one assessed (#5004).
 
     Args:
         version: Bernstein release version.
@@ -1205,16 +1216,8 @@ def bernstein_descriptor(
     return SystemDescriptor(
         name="Bernstein",
         version=version,
-        description=(
-            "Multi-agent orchestration platform for CLI coding agents (Claude Code, Codex, Gemini CLI, etc.). "
-            "Bernstein spawns short-lived agents, assigns tasks from a shared backlog, "
-            "and merges results back into a git repository.  "
-            "It is orchestration middleware, not a decision-making AI system."
-        ),
-        intended_use=(
-            "Software development automation: code generation, refactoring, testing, "
-            "documentation, and security review - under human developer supervision."
-        ),
+        description=SYSTEM_DESCRIPTION,
+        intended_use=INTENDED_USE,
         deployment_context=deployment_context,
         # Bernstein itself is not in any Annex III high-risk domain
         processes_biometrics=False,

--- a/src/bernstein/core/routes/well_known.py
+++ b/src/bernstein/core/routes/well_known.py
@@ -68,6 +68,7 @@ from bernstein.core.security.agent_card_signer import (
     ed25519_public_jwk,
 )
 from bernstein.core.security.tenanting import DEFAULT_TENANT_ID
+from bernstein.system_description import SYSTEM_DESCRIPTION
 
 if TYPE_CHECKING:
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -82,14 +83,11 @@ router = APIRouter()
 HTTP_SIG_DIRECTORY_PATH = "/.well-known/http-message-signatures-directory"
 
 _AGENT_NAME = "bernstein"
-_AGENT_DESCRIPTION = (
-    "Bernstein is a deterministic orchestrator for short-lived CLI coding "
-    "agents (Claude Code, Codex, Gemini CLI, Aider, ...) over a file-based "
-    "task store.  No model sits in its coordination loop, so parallel runs "
-    "in per-task git worktrees replay byte-identically.  Clients submit "
-    "tasks, query status, and post cross-agent bulletins via the documented "
-    "endpoints below."
-)
+# One string for what this system is, shared with the EU AI Act evidence package. This
+# said "a deterministic orchestrator for short-lived CLI coding agents", which is the
+# description automated clients read, and it named the default workload as the whole
+# subject (#5004).
+_AGENT_DESCRIPTION = SYSTEM_DESCRIPTION
 _PROTOCOL_VERSION = "1.0"
 _DEFAULT_BASE_URL = "http://127.0.0.1:8052"
 _DOCS_URL = "https://github.com/sipyourdrink-ltd/bernstein"

--- a/src/bernstein/system_description.py
+++ b/src/bernstein/system_description.py
@@ -1,0 +1,51 @@
+"""How Bernstein describes ITSELF, in one place.
+
+Three code paths described a narrower system than the one that ships: the EU AI
+Act evidence package, the ``/.well-known/`` agent payload, and the Cursor rules
+that land in a user's editor. All three said "orchestrator for CLI coding
+agents", while ``README.md``, ``AGENTS.md``, ``pyproject.toml``, ``action.yml``
+and ``agents.txt`` had already been updated to describe the governance layer
+(#5004).
+
+The mismatch was not only wording. The recording, gating and verification path
+never inspects what an agent produces - a diff, a report, a dataset and an
+evidence pack travel it identically - so naming CLI coding agents as *the*
+subject understates the code it describes. One of the three lands verbatim in
+the artifact handed to an assessor.
+
+**CLI coding agents stay named.** They are the out-of-the-box path, and dropping
+them would swap one inaccuracy for another. The claim being fixed is that they
+are the only subject, not that they are a subject.
+
+These live in code rather than in docs, which is why a docs pass did not reach
+them and why they drifted in the first place. Kept here so the three read from
+one string: ``test_system_description.py`` pins that, and that the wording stays
+consistent with ``AGENTS.md``.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+#: What the system IS. Lands in the evidence package and at `/.well-known/`.
+SYSTEM_DESCRIPTION: Final[str] = (
+    "The governance layer for AI agents. A deterministic scheduler - no model in the "
+    "coordination loop - runs agents in parallel, gates what they produce, and records "
+    "every step, so a run can be verified after the fact, offline, from the artifacts "
+    "alone. CLI coding agents (Claude Code, Codex, Gemini CLI, and 40+ more) work out of "
+    "the box, and the same layer governs any agent workload. It is governance "
+    "middleware, not a decision-making AI system."
+)
+
+#: What it is FOR. Covers the deliverable classes the layer governs, not code alone.
+INTENDED_USE: Final[str] = (
+    "Governing agent workloads under human supervision: running agents in parallel, "
+    "gating what they produce, and recording every step for after-the-fact verification. "
+    "The deliverable can be a code diff, a research report, a dataset, or an audit "
+    "evidence pack - the recording and gating path treats them identically."
+)
+
+#: How it is deployed. The evidence package's default `deployment_context`.
+DEPLOYMENT_CONTEXT: Final[str] = "Self-hosted governance layer for AI agent workloads"
+
+__all__ = ["DEPLOYMENT_CONTEXT", "INTENDED_USE", "SYSTEM_DESCRIPTION"]

--- a/tests/unit/test_system_description.py
+++ b/tests/unit/test_system_description.py
@@ -1,0 +1,111 @@
+"""The system describes itself the same way everywhere (#5004).
+
+Three code paths described a narrower system than the one that ships: the EU AI
+Act evidence package, the ``/.well-known/`` agent payload, and the Cursor rules
+that land in a user's editor. All three said "orchestrator for CLI coding
+agents" while ``README.md``, ``AGENTS.md``, ``pyproject.toml``, ``action.yml``
+and ``agents.txt`` already described the governance layer.
+
+One of the three lands verbatim in the artifact handed to an assessor, so the
+package understated the scope of the system it assesses.
+
+The drift happened because these strings live in CODE rather than in docs, so a
+docs pass does not reach them. This is the part that keeps it fixed: without it
+the same three files drift again on the next change.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.compliance.eu_ai_act import bernstein_descriptor
+from bernstein.core.routes import well_known
+from bernstein.system_description import (
+    DEPLOYMENT_CONTEXT,
+    INTENDED_USE,
+    SYSTEM_DESCRIPTION,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: Words that name the system by what it governs. Asserted as a property of the wording
+#: rather than as an exact sentence: pinning the prose would redden on every edit and get
+#: the test deleted, while these are the terms whose ABSENCE was the defect.
+GOVERNANCE_TERMS = ("governance", "governs", "governing")
+
+
+def test_the_evidence_package_and_well_known_read_from_one_string() -> None:
+    """Equality, not similarity — the two cannot drift while they are one constant."""
+    assert bernstein_descriptor().description == SYSTEM_DESCRIPTION
+    assert well_known._AGENT_DESCRIPTION == SYSTEM_DESCRIPTION  # pyright: ignore[reportPrivateUsage]
+
+
+def test_the_assessor_facing_description_is_not_narrower_than_the_system() -> None:
+    """The defect, stated as a property: it described the default workload as the whole subject."""
+    descriptor = bernstein_descriptor()
+    assert any(term in descriptor.description.lower() for term in GOVERNANCE_TERMS)
+    assert any(term in descriptor.intended_use.lower() for term in GOVERNANCE_TERMS)
+    assert descriptor.deployment_context == DEPLOYMENT_CONTEXT
+
+
+def test_intended_use_covers_more_than_software_development() -> None:
+    """Criterion 3. The recording and gating path never inspects what an agent produced.
+
+    A diff, a report, a dataset and an evidence pack travel it identically, so an
+    intended-use naming code alone is narrower than the code it describes.
+    """
+    assert INTENDED_USE is bernstein_descriptor().intended_use
+    lowered = INTENDED_USE.lower()
+    assert "research" in lowered or "dataset" in lowered or "evidence" in lowered
+
+
+def test_cli_coding_agents_are_still_named() -> None:
+    """Criterion 2, and the over-correction guard.
+
+    They are the out-of-the-box path. Dropping them swaps one inaccuracy for another,
+    and the claim being fixed is that they were the ONLY subject, not that they are a
+    subject.
+    """
+    assert "cli coding agents" in SYSTEM_DESCRIPTION.lower()
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        Path("src/bernstein/compliance/eu_ai_act.py"),
+        Path("src/bernstein/core/routes/well_known.py"),
+        Path("packages/cursor-plugin/rules/bernstein-context.mdc"),
+    ],
+)
+def test_no_site_calls_the_product_an_orchestrator_for_cli_agents(path: Path) -> None:
+    """The exact phrasing that drifted, pinned at each of the three sites.
+
+    Narrow on purpose: "the orchestrator forwards / reaps / kills" names the COMPONENT,
+    which is still an orchestrator, and `adapters/base.py` really is the CLI-coding-agent
+    adapter base. Only descriptions of the PRODUCT are in scope.
+
+    Python COMMENTS are excluded: a comment recording what a string used to say is the
+    same kind of artifact as an ADR - it documents the change rather than making the
+    claim - and the note in `well_known.py` quoting the old wording would otherwise fail
+    this. Not excluded in the `.mdc`, where `#` opens a heading rather than a comment, and
+    the heading is one of the places the old wording lived.
+    """
+    lines = (REPO_ROOT / path).read_text(encoding="utf-8").lower().splitlines()
+    if path.suffix == ".py":
+        lines = [ln for ln in lines if not ln.strip().startswith("#")]
+    text = "\n".join(lines)
+    for phrase in ("orchestrator for cli coding", "orchestrator for short-lived cli"):
+        assert phrase not in text, f"{path} still describes the product as {phrase!r}"
+
+
+def test_the_wording_stays_consistent_with_agents_md() -> None:
+    """AGENTS.md is the curated description the rest of the project was updated to.
+
+    Checked on the claim rather than by string equality: AGENTS.md is generated prose and
+    this is a machine-readable field, so they are the same statement in two registers.
+    """
+    overview = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8").lower()
+    assert "governance layer" in overview
+    assert "governance layer" in SYSTEM_DESCRIPTION.lower()


### PR DESCRIPTION
## What

All six sites describe the governance layer, and the two machine-readable ones read from a single constant.

Fixes #5004.

## Why the shared constant, not six edits

Criterion 4 is the part that keeps this fixed, and I agree with the issue's reasoning about why: these strings drifted **because they live in code rather than docs**, so a docs pass never reached them. Six correct edits today drift again on the next change.

`bernstein.system_description` now holds `SYSTEM_DESCRIPTION`, `INTENDED_USE` and `DEPLOYMENT_CONTEXT`. The evidence package and `/.well-known/` read from it, so the test is an **equality** assertion rather than a similarity one — they cannot drift while they are one constant.

## The claim being fixed

Not "CLI coding agents are wrong" — that they were the **only** subject. The recording, gating and verification path never inspects what an agent produced: a diff, a report, a dataset and an evidence pack travel it identically.

**CLI coding agents stay named** (criterion 2), and there is a test pinning that, because dropping them swaps one inaccuracy for another.

`intended_use` now covers the deliverable classes the layer governs (criterion 3), which matters most on site 1 — that string lands in the artifact an assessor reads.

## Out of scope, deliberately

I followed the issue's exclusions and the drift test is scoped to match: `adapters/base.py` really is the CLI-coding-agent adapter base; the ADR and the release note are historical records; every *"the orchestrator forwards / reaps / kills"* names the **component**, which is still an orchestrator.

The test also excludes Python **comments** — the note I left in `well_known.py` quoting the old wording would otherwise fail it, and a comment recording what a string used to say documents the change rather than making the claim. Not excluded in the `.mdc`, where `#` opens a heading and the heading was one of the places the old wording lived.

## Tests

Eight in `test_system_description.py`, four confirmed red before the change.

The phrasing assertions check for *governance* terms rather than an exact sentence: pinning the prose would redden on every wording edit and get the test deleted, while those terms are the ones whose absence was the defect.

## On criterion 5

`bernstein compliance assess` re-run after the change: the evidence package regenerates, reports CONFORMANT, and the JSON is valid.

One honest note — **the description does not appear in that command's output package.** `evidence_package.json` from `assess` carries `system_name`, `system_version` and a `report`; the `SystemDescriptor.description` the issue points at is not inlined there in this configuration. So I verified the descriptor directly (`bernstein_descriptor().description`) and left the assess path alone. If there is a second generator that does inline it, point me at it and I will check that one too.

## Checklist

- [x] `ruff check src/` and `ruff format --check` pass
- [ ] `pyright src/` — not run clean, and not by this change; repo-wide advisory scope is red on `main` (#4864). The new module is three typed constants.
- [x] `scripts/run_tests.py`: 121 passed (`test_system_description` 8, `test_eu_ai_act` 43, `test_well_known` 17, `test_agents_md_generator` 53)
- [x] New code has type hints

### Documentation duty

- [x] README / `AGENTS.md` — already correct; this brings the code up to them rather than the other way round
- [x] `docs/operations/` — N/A
- [x] `docs/api/` — N/A, no schema change; the `/.well-known/` payload's shape is unchanged and only its description string moves
- [x] `agents-md sync` — the new module is internal to self-description and adds no surface; `test_agents_md_generator` is green
- [x] Tests cover the documented behaviour