### PR TITLE
feat(scanners): add transcript-anchored nmap adapter

### DIFF
--- a/docs/release-notes/fragments/3618-nmap-transcript-adapter.md
+++ b/docs/release-notes/fragments/3618-nmap-transcript-adapter.md
@@ -1,0 +1,6 @@
+## Nmap scans now produce transcript-anchored findings
+
+Bernstein now includes an Nmap `TRANSCRIPT_ANCHORED` scanner adapter. It
+normalizes volatile timestamps from Nmap XML while preserving meaningful scan
+details, including service version and banner information, in the recorded
+transcript. (#3618)

--- a/docs/sdd/module-map.md
+++ b/docs/sdd/module-map.md
@@ -156,6 +156,7 @@ Full per-file module map. `AGENTS.md`'s own "Module map" section links here inst
 | `mistral.py`                | Mistral Vibe CLI adapter |
 | `mock.py`                   | Mock CLI adapter for zero-API-key demos and testing |
 | `muse.py`                   | Muse Code CLI adapter for Bernstein |
+| `nmap.py`                   | Transcript-anchored Nmap scanner adapter and XML normalization |
 | `ollama.py`                 | Ollama / OpenAI-compatible local LLM adapter - run coding agents without cloud API keys |
 | `onboarding.py`             | Probe CLI evidence, record a supervised golden transcript, and replay held-out invocations |
 | `open_interpreter.py`       | Open Interpreter CLI adapter |

--- a/src/bernstein/adapters/nmap.py
+++ b/src/bernstein/adapters/nmap.py
@@ -1,0 +1,332 @@
+"""Transcript-anchored Nmap scanner adapter and XML normalization."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
+
+from defusedxml import ElementTree as DefusedET
+from defusedxml.common import DefusedXmlException
+
+from bernstein.adapters._contract import (
+    ScannerCategory as ContractScannerCategory,
+)
+from bernstein.adapters._contract import (
+    ScannerDeterminism,
+    ScannerOutputFormat,
+    register_scanner_capabilities,
+)
+from bernstein.adapters.env_isolation import build_filtered_env  # pyright: ignore[reportUnknownVariableType]
+from bernstein.adapters.scanner import (
+    DeterminismTier,
+    OutputFormat,
+    ScannerAdapter,
+    ScannerCategory,
+    ScanResult,
+    ScanScope,
+)
+from bernstein.adapters.scanner_finding import Finding
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+NMAP_REGISTRY_NAME = "nmap"
+_SCAN_TIMEOUT_SECONDS = 300
+_DEFAULT_PORTS = "1-1024"
+_PORT_SPEC = re.compile(r"[0-9]+(?:-[0-9]+)?(?:,[0-9]+(?:-[0-9]+)?)*\Z")
+
+
+class NmapError(RuntimeError):
+    """Base error raised when Nmap cannot complete a scan."""
+
+
+class NmapNotInstalledError(NmapError):
+    """Raised when the Nmap executable cannot be found on ``PATH``."""
+
+
+@dataclass(frozen=True, order=True)
+class NmapPortFact:
+    """Stable identity of one network port observation."""
+
+    host: str
+    protocol: str
+    port: int
+    state: str
+    service_name: str
+
+    def to_finding(self) -> Finding:
+        """Represent this canonical port fact as a Bernstein finding."""
+        return Finding(
+            rule=f"nmap-port:{self.protocol}:{self.port}",
+            path=self.host,
+            severity="informational",
+            summary=f"{self.state} {self.service_name}",
+        )
+
+
+@dataclass(frozen=True)
+class NmapNormalization:
+    """Canonical facts, findings, and transcript derived from Nmap XML."""
+
+    facts: tuple[NmapPortFact, ...]
+    findings: tuple[Finding, ...]
+    transcript: str
+    tool_version: str
+
+
+@dataclass(frozen=True)
+class NmapInvocation:
+    """Stable provenance for one Nmap invocation."""
+
+    tool_version: str
+    target: str
+    ports: str
+    argv_hash: str
+
+
+class NmapAdapter(ScannerAdapter):
+    """Run Nmap connect scans and record a canonical transcript."""
+
+    registry_name = NMAP_REGISTRY_NAME
+    output_format = OutputFormat.XML
+    determinism = DeterminismTier.TRANSCRIPT_ANCHORED
+    pinned_inputs: tuple[str, ...] = ()
+    category = ScannerCategory.RECON
+
+    def __init__(self, *, binary: str = "nmap") -> None:
+        super().__init__()
+        self._binary = binary
+        self.last_invocation: NmapInvocation | None = None
+
+    def name(self) -> str:
+        """Return the registry key used by the conformance capability lookup."""
+        return self.registry_name
+
+    def scan(self, target: Path, scope: ScanScope, workdir: Path) -> ScanResult:
+        """Run an Nmap scan and normalize its volatile XML into a transcript."""
+        self.enforce_network_policy()
+        target_name, ports = _validate_scope(target, scope)
+        binary = shutil.which(self._binary)
+        if binary is None:
+            raise NmapNotInstalledError(
+                f"Nmap executable {self._binary!r} was not found on PATH; install nmap or configure its binary"
+            )
+
+        tool_version = _read_version(binary)
+        workdir.mkdir(parents=True, exist_ok=True)
+        report_path = (workdir / "nmap.xml").resolve()
+        report_path.unlink(missing_ok=True)
+        command = _build_command(binary, target_name, ports, report_path)
+        self.last_invocation = NmapInvocation(
+            tool_version=tool_version,
+            target=target_name,
+            ports=ports,
+            argv_hash=_invocation_argv_hash(tool_version, target_name, ports),
+        )
+
+        try:
+            completed = subprocess.run(
+                command,
+                check=False,
+                capture_output=True,
+                text=True,
+                env=build_filtered_env([]),
+                timeout=_SCAN_TIMEOUT_SECONDS,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise NmapError(f"Nmap execution failed: {exc}") from exc
+
+        if completed.returncode != 0:
+            detail = completed.stderr.strip() or completed.stdout.strip() or "no diagnostic output"
+            raise NmapError(f"Nmap exited with code {completed.returncode}: {detail}")
+        if not report_path.is_file():
+            raise NmapError("Nmap completed without writing its XML report")
+
+        try:
+            normalized = normalize_nmap_xml(report_path.read_bytes())
+        finally:
+            report_path.unlink(missing_ok=True)
+        return ScanResult(findings=list(normalized.findings), transcript=normalized.transcript)
+
+
+def _validate_scope(target: Path, scope: ScanScope) -> tuple[str, str]:
+    if scope.roots or scope.include or scope.exclude or scope.max_depth is not None:
+        raise ValueError("NmapAdapter does not support roots, include, exclude, or max_depth scan scope fields")
+    unsupported = set(scope.config) - {"ports"}
+    if unsupported:
+        raise ValueError(f"Unsupported Nmap scan configuration: {', '.join(sorted(unsupported))}")
+
+    target_name = str(target).strip()
+    if not target_name or target_name == "." or target_name.startswith("-"):
+        raise ValueError("Nmap target must be an explicit host or address")
+    ports = str(scope.config.get("ports", _DEFAULT_PORTS)).strip()
+    if not _valid_port_spec(ports):
+        raise ValueError("Nmap ports must be comma-separated ports or ranges between 1 and 65535")
+    return target_name, ports
+
+
+def _valid_port_spec(ports: str) -> bool:
+    if not _PORT_SPEC.fullmatch(ports):
+        return False
+    for item in ports.split(","):
+        start_text, separator, end_text = item.partition("-")
+        start = int(start_text)
+        end = int(end_text) if separator else start
+        if not 1 <= start <= end <= 65535:
+            return False
+    return True
+
+
+def _read_version(binary: str) -> str:
+    try:
+        completed = subprocess.run(
+            [binary, "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=build_filtered_env([]),
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise NmapError(f"Could not read Nmap version: {exc}") from exc
+    if completed.returncode != 0:
+        raise NmapError(f"Could not read Nmap version: {completed.stderr.strip()}")
+    first_line = completed.stdout.strip().splitlines()[0] if completed.stdout.strip() else ""
+    match = re.search(r"Nmap version\s+(\S+)", first_line)
+    if match is None:
+        raise NmapError("Nmap returned an unrecognized version")
+    return match.group(1)
+
+
+def _build_command(binary: str, target: str, ports: str, report_path: Path) -> list[str]:
+    return [
+        binary,
+        "-sT",
+        "-sV",
+        "-Pn",
+        "--no-stylesheet",
+        "-p",
+        ports,
+        "-oX",
+        str(report_path),
+        target,
+    ]
+
+
+def _invocation_argv_hash(tool_version: str, target: str, ports: str) -> str:
+    semantic_invocation = {
+        "host_discovery": False,
+        "ports": ports,
+        "report_format": "xml",
+        "scan_type": "connect",
+        "service_detection": True,
+        "target": target,
+        "tool": NMAP_REGISTRY_NAME,
+        "tool_version": tool_version,
+    }
+    canonical = json.dumps(semantic_invocation, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(canonical).hexdigest()
+
+
+def normalize_nmap_xml(report: str | bytes) -> NmapNormalization:
+    """Turn Nmap XML into timestamp-free canonical facts and a transcript."""
+    try:
+        root = DefusedET.fromstring(report)
+    except (ET.ParseError, DefusedXmlException, UnicodeError) as exc:
+        raise ValueError(f"Invalid Nmap XML: {exc}") from exc
+    if root.tag != "nmaprun" or root.get("scanner") != "nmap":
+        raise ValueError("Nmap XML root must be an nmaprun produced by scanner 'nmap'")
+    tool_version = root.get("version", "").strip()
+    if not tool_version:
+        raise ValueError("Nmap XML is missing the tool version")
+
+    facts: list[NmapPortFact] = []
+    transcript_ports: list[dict[str, object]] = []
+    for host_element in root.findall("host"):
+        host = _host_identity(host_element)
+        for port_element in host_element.findall("./ports/port"):
+            fact, service_details = _port_record(host, port_element)
+            facts.append(fact)
+            transcript_ports.append(
+                {
+                    "host": fact.host,
+                    "port": fact.port,
+                    "protocol": fact.protocol,
+                    "service": service_details,
+                    "state": fact.state,
+                }
+            )
+
+    facts.sort()
+    transcript_ports.sort(key=lambda item: (str(item["host"]), str(item["protocol"]), cast("int", item["port"])))
+    transcript_record = {
+        "ports": transcript_ports,
+        "tool": {"name": NMAP_REGISTRY_NAME, "version": tool_version},
+    }
+    transcript = json.dumps(transcript_record, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return NmapNormalization(
+        facts=tuple(facts),
+        findings=tuple(fact.to_finding() for fact in facts),
+        transcript=transcript,
+        tool_version=tool_version,
+    )
+
+
+def _host_identity(host: ET.Element) -> str:
+    addresses = host.findall("address")
+    for address_type in ("ipv4", "ipv6", "mac"):
+        for address in addresses:
+            value = address.get("addr", "").strip()
+            if address.get("addrtype") == address_type and value:
+                return value
+    hostname = host.find("./hostnames/hostname")
+    if hostname is not None and hostname.get("name", "").strip():
+        return hostname.get("name", "").strip()
+    raise ValueError("Nmap host is missing an address or hostname")
+
+
+def _port_record(host: str, port: ET.Element) -> tuple[NmapPortFact, dict[str, object]]:
+    protocol = port.get("protocol", "").strip()
+    port_text = port.get("portid", "").strip()
+    state_element = port.find("state")
+    state = state_element.get("state", "").strip() if state_element is not None else ""
+    if not protocol or not port_text.isdigit() or not state:
+        raise ValueError("Nmap port is missing protocol, numeric portid, or state")
+    port_number = int(port_text)
+    if not 1 <= port_number <= 65535:
+        raise ValueError(f"Nmap port is outside the valid range: {port_number}")
+
+    service = port.find("service")
+    service_name = service.get("name", "unknown").strip() if service is not None else "unknown"
+    service_name = service_name or "unknown"
+    details: dict[str, object] = {"name": service_name}
+    if service is not None:
+        for xml_name, transcript_name in (
+            ("product", "product"),
+            ("version", "version"),
+            ("extrainfo", "extra_info"),
+            ("servicefp", "service_fingerprint"),
+            ("tunnel", "tunnel"),
+        ):
+            value = service.get(xml_name, "").strip()
+            if value:
+                details[transcript_name] = value
+        cpes = sorted(cpe.text.strip() for cpe in service.findall("cpe") if cpe.text and cpe.text.strip())
+        if cpes:
+            details["cpes"] = cpes
+    return NmapPortFact(host, protocol, port_number, state, service_name), details
+
+
+register_scanner_capabilities(
+    NMAP_REGISTRY_NAME,
+    output_format=ScannerOutputFormat.XML,
+    determinism=ScannerDeterminism.TRANSCRIPT_ANCHORED,
+    pinned_inputs=(),
+    category=ContractScannerCategory.RECON,
+)

--- a/src/bernstein/adapters/scanner_registry.py
+++ b/src/bernstein/adapters/scanner_registry.py
@@ -12,6 +12,7 @@ from importlib.metadata import entry_points
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from bernstein.adapters.gitleaks import GitleaksAdapter
+from bernstein.adapters.nmap import NmapAdapter
 from bernstein.adapters.scanner import ScannerAdapter
 from bernstein.adapters.trivy import TrivyAdapter
 
@@ -153,4 +154,5 @@ def scanner_name_for_provider(provider_name: str | None, model: str) -> str | No
 
 
 register_scanner(GitleaksAdapter.registry_name, GitleaksAdapter)
+register_scanner(NmapAdapter.registry_name, NmapAdapter)
 register_scanner(TrivyAdapter.registry_name, TrivyAdapter)

--- a/tests/fixtures/scanners/nmap/nmap-conformance.yaml
+++ b/tests/fixtures/scanners/nmap/nmap-conformance.yaml
@@ -1,0 +1,17 @@
+name: nmap-recorded-xml
+adapter_class: bernstein.adapters.nmap.NmapAdapter
+steps:
+  - target: 127.0.0.1
+    scope:
+      config:
+        ports: "8765"
+    expected_finding_hashes:
+      - 81a37523395db5b88e9ac02117fd9ce5fb4175509d8363ad0db0b5f475ac6de9
+    expected_transcript: '{"ports":[{"host":"127.0.0.1","port":8765,"protocol":"tcp","service":{"cpes":["cpe:/a:python:simplehttpserver:0.6"],"extra_info":"Python 3.9.6","name":"http","product":"SimpleHTTPServer","version":"0.6"},"state":"open"}],"tool":{"name":"nmap","version":"7.991"}}'
+  - target: 127.0.0.1
+    scope:
+      config:
+        ports: "8765"
+    expected_finding_hashes:
+      - 81a37523395db5b88e9ac02117fd9ce5fb4175509d8363ad0db0b5f475ac6de9
+    expected_transcript: '{"ports":[{"host":"127.0.0.1","port":8765,"protocol":"tcp","service":{"cpes":["cpe:/a:python:simplehttpserver:0.6"],"extra_info":"Python 3.9.6","name":"http","product":"SimpleHTTPServer","version":"0.6"},"state":"open"}],"tool":{"name":"nmap","version":"7.991"}}'

--- a/tests/fixtures/scanners/nmap/nmap-localhost-a.xml
+++ b/tests/fixtures/scanners/nmap/nmap-localhost-a.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE nmaprun>
+<!-- Nmap 7.991 scan initiated Tue Sep  1 12:28:35 2026 as: nmap -sT -sV -Pn -&#45;no-stylesheet -p 8765 -oX /tmp/bernstein-nmap-a.xml 127.0.0.1 -->
+<nmaprun scanner="nmap" args="nmap -sT -sV -Pn -&#45;no-stylesheet -p 8765 -oX /tmp/bernstein-nmap-a.xml 127.0.0.1" start="1788290915" startstr="Tue Sep  1 12:28:35 2026" version="7.991" xmloutputversion="1.05">
+<scaninfo type="connect" protocol="tcp" numservices="1" services="8765"/>
+<verbose level="0"/>
+<debugging level="0"/>
+<host starttime="1788290915" endtime="1788290921"><status state="up" reason="user-set" reason_ttl="0"/>
+<address addr="127.0.0.1" addrtype="ipv4"/>
+<hostnames>
+<hostname name="localhost" type="PTR"/>
+</hostnames>
+<ports><port protocol="tcp" portid="8765"><state state="open" reason="syn-ack" reason_ttl="0"/><service name="http" product="SimpleHTTPServer" version="0.6" extrainfo="Python 3.9.6" method="probed" conf="10"><cpe>cpe:/a:python:simplehttpserver:0.6</cpe></service></port>
+</ports>
+<times srtt="96" rttvar="5000" to="100000"/>
+</host>
+<runstats><finished time="1788290921" timestr="Tue Sep  1 12:28:41 2026" summary="Nmap done at Tue Sep  1 12:28:41 2026; 1 IP address (1 host up) scanned in 6.36 seconds" elapsed="6.36" exit="success"/><hosts up="1" down="0" total="1"/>
+</runstats>
+</nmaprun>

--- a/tests/fixtures/scanners/nmap/nmap-localhost-b.xml
+++ b/tests/fixtures/scanners/nmap/nmap-localhost-b.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE nmaprun>
+<!-- Nmap 7.991 scan initiated Tue Sep  1 12:28:41 2026 as: nmap -sT -sV -Pn -&#45;no-stylesheet -p 8765 -oX /tmp/bernstein-nmap-b.xml 127.0.0.1 -->
+<nmaprun scanner="nmap" args="nmap -sT -sV -Pn -&#45;no-stylesheet -p 8765 -oX /tmp/bernstein-nmap-b.xml 127.0.0.1" start="1788290921" startstr="Tue Sep  1 12:28:41 2026" version="7.991" xmloutputversion="1.05">
+<scaninfo type="connect" protocol="tcp" numservices="1" services="8765"/>
+<verbose level="0"/>
+<debugging level="0"/>
+<host starttime="1788290921" endtime="1788290927"><status state="up" reason="user-set" reason_ttl="0"/>
+<address addr="127.0.0.1" addrtype="ipv4"/>
+<hostnames>
+<hostname name="localhost" type="PTR"/>
+</hostnames>
+<ports><port protocol="tcp" portid="8765"><state state="open" reason="syn-ack" reason_ttl="0"/><service name="http" product="SimpleHTTPServer" version="0.6" extrainfo="Python 3.9.6" method="probed" conf="10"><cpe>cpe:/a:python:simplehttpserver:0.6</cpe></service></port>
+</ports>
+<times srtt="70" rttvar="5000" to="100000"/>
+</host>
+<runstats><finished time="1788290927" timestr="Tue Sep  1 12:28:47 2026" summary="Nmap done at Tue Sep  1 12:28:47 2026; 1 IP address (1 host up) scanned in 6.10 seconds" elapsed="6.10" exit="success"/><hosts up="1" down="0" total="1"/>
+</runstats>
+</nmaprun>

--- a/tests/unit/adapters/test_nmap_scanner.py
+++ b/tests/unit/adapters/test_nmap_scanner.py
@@ -1,0 +1,247 @@
+"""Tests for transcript-anchored normalization of recorded Nmap XML."""
+
+from __future__ import annotations
+
+import subprocess
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from bernstein.adapters._contract import ScannerDeterminism, scanner_determinism
+from bernstein.adapters.nmap import (
+    NmapAdapter,
+    NmapError,
+    NmapNotInstalledError,
+    _invocation_argv_hash,
+    normalize_nmap_xml,
+)
+from bernstein.adapters.scanner import DeterminismTier, OutputFormat, ScannerCategory, ScanScope
+from bernstein.adapters.scanner_conformance import ScannerConformanceHarness, load_scanner_golden_transcripts
+from bernstein.adapters.scanner_registry import get_scanner
+
+_FIXTURE_DIR = Path("tests/fixtures/scanners/nmap")
+_FIXTURE_A = _FIXTURE_DIR / "nmap-localhost-a.xml"
+_FIXTURE_B = _FIXTURE_DIR / "nmap-localhost-b.xml"
+_TRANSCRIPT = (
+    '{"ports":[{"host":"127.0.0.1","port":8765,"protocol":"tcp","service":'
+    '{"cpes":["cpe:/a:python:simplehttpserver:0.6"],"extra_info":"Python 3.9.6",'
+    '"name":"http","product":"SimpleHTTPServer","version":"0.6"},"state":"open"}],'
+    '"tool":{"name":"nmap","version":"7.991"}}'
+)
+
+
+def _fixture(path: Path = _FIXTURE_A) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _scope() -> ScanScope:
+    return ScanScope(config={"ports": "8765"})
+
+
+def _fake_nmap_run(report_path: Path = _FIXTURE_A):
+    def run(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if argv[1:] == ["--version"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="Nmap version 7.991 ( https://nmap.org )\n", stderr="")
+        output = Path(argv[argv.index("-oX") + 1])
+        output.write_text(_fixture(report_path), encoding="utf-8")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    return run
+
+
+def test_timestamp_changes_are_normalized_not_assumed_away() -> None:
+    raw_a = _fixture(_FIXTURE_A)
+    raw_b = _fixture(_FIXTURE_B)
+    root_a = ET.fromstring(raw_a)
+    root_b = ET.fromstring(raw_b)
+    normalized_a = normalize_nmap_xml(raw_a)
+    normalized_b = normalize_nmap_xml(raw_b)
+
+    assert raw_a != raw_b
+    assert root_a.get("start") != root_b.get("start")
+    assert root_a.find("./runstats/finished").get("time") != root_b.find("./runstats/finished").get("time")  # type: ignore[union-attr]
+    assert normalized_a.transcript == normalized_b.transcript == _TRANSCRIPT
+    assert normalized_a.facts == normalized_b.facts
+    assert [finding.finding_hash() for finding in normalized_a.findings] == [
+        finding.finding_hash() for finding in normalized_b.findings
+    ]
+
+
+def test_real_nmap_xml_is_normalized_to_a_port_finding() -> None:
+    normalized = normalize_nmap_xml(_fixture())
+
+    assert len(normalized.facts) == 1
+    fact = normalized.facts[0]
+    assert (fact.host, fact.protocol, fact.port, fact.state, fact.service_name) == (
+        "127.0.0.1",
+        "tcp",
+        8765,
+        "open",
+        "http",
+    )
+    assert normalized.findings[0].path == "127.0.0.1"
+    assert normalized.findings[0].rule == "nmap-port:tcp:8765"
+    assert normalized.findings[0].summary == "open http"
+
+
+def test_banner_change_is_recorded_without_changing_finding_identity() -> None:
+    original = normalize_nmap_xml(_fixture())
+    root = ET.fromstring(_fixture())
+    service = root.find("./host/ports/port/service")
+    assert service is not None
+    service.set("version", "9.9")
+    service.set("extrainfo", "different banner")
+
+    changed = normalize_nmap_xml(ET.tostring(root, encoding="unicode"))
+
+    assert original.facts == changed.facts
+    assert [finding.finding_hash() for finding in original.findings] == [
+        finding.finding_hash() for finding in changed.findings
+    ]
+    assert original.transcript != changed.transcript
+    assert "different banner" in changed.transcript
+
+
+def test_non_nmap_xml_is_rejected() -> None:
+    with pytest.raises(ValueError, match="produced by scanner 'nmap'"):
+        normalize_nmap_xml('<nmaprun scanner="another-tool" version="1"><host /></nmaprun>')
+
+
+def test_invalid_xml_is_rejected() -> None:
+    with pytest.raises(ValueError, match="Invalid Nmap XML"):
+        normalize_nmap_xml("not-xml")
+
+
+def test_adapter_declares_the_transcript_anchored_recon_contract() -> None:
+    adapter = NmapAdapter()
+
+    assert adapter.name() == "nmap"
+    assert adapter.output_format is OutputFormat.XML
+    assert adapter.determinism is DeterminismTier.TRANSCRIPT_ANCHORED
+    assert adapter.pinned_inputs == ()
+    assert adapter.category is ScannerCategory.RECON
+    assert scanner_determinism(adapter.name()) is ScannerDeterminism.TRANSCRIPT_ANCHORED
+
+
+def test_scanner_registry_resolves_nmap() -> None:
+    assert isinstance(get_scanner("nmap"), NmapAdapter)
+
+
+def test_invocation_hash_binds_version_target_and_ports() -> None:
+    baseline = _invocation_argv_hash("7.991", "127.0.0.1", "8765")
+
+    assert _invocation_argv_hash("7.991", "127.0.0.1", "8765") == baseline
+    assert _invocation_argv_hash("7.992", "127.0.0.1", "8765") != baseline
+    assert _invocation_argv_hash("7.991", "127.0.0.2", "8765") != baseline
+    assert _invocation_argv_hash("7.991", "127.0.0.1", "8766") != baseline
+
+
+def test_scan_runs_nmap_and_returns_the_canonical_transcript(tmp_path: Path) -> None:
+    adapter = NmapAdapter()
+    with (
+        patch("bernstein.adapters.nmap.shutil.which", return_value="/usr/local/bin/nmap"),
+        patch("bernstein.adapters.nmap.subprocess.run", side_effect=_fake_nmap_run()) as run,
+    ):
+        result = adapter.scan(Path("127.0.0.1"), _scope(), tmp_path / "work")
+
+    assert result.transcript == _TRANSCRIPT
+    assert result.finding_hashes() == ["81a37523395db5b88e9ac02117fd9ce5fb4175509d8363ad0db0b5f475ac6de9"]
+    scan_argv = run.call_args_list[1].args[0]
+    assert scan_argv[1:8] == ["-sT", "-sV", "-Pn", "--no-stylesheet", "-p", "8765", "-oX"]
+    assert scan_argv[-1] == "127.0.0.1"
+    assert adapter.last_invocation is not None
+    assert adapter.last_invocation.tool_version == "7.991"
+    assert not (tmp_path / "work" / "nmap.xml").exists()
+
+
+def test_scan_reports_missing_nmap_without_invoking_a_process(tmp_path: Path) -> None:
+    with (
+        patch("bernstein.adapters.nmap.shutil.which", return_value=None),
+        patch("bernstein.adapters.nmap.subprocess.run") as run,
+        pytest.raises(NmapNotInstalledError, match="not found on PATH"),
+    ):
+        NmapAdapter().scan(Path("127.0.0.1"), _scope(), tmp_path / "work")
+    run.assert_not_called()
+
+
+def test_stale_report_cannot_be_reused(tmp_path: Path) -> None:
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    (workdir / "nmap.xml").write_text(_fixture(), encoding="utf-8")
+
+    def no_report(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if argv[1:] == ["--version"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="Nmap version 7.991\n", stderr="")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    with (
+        patch("bernstein.adapters.nmap.shutil.which", return_value="/usr/local/bin/nmap"),
+        patch("bernstein.adapters.nmap.subprocess.run", side_effect=no_report),
+        pytest.raises(NmapError, match="without writing its XML report"),
+    ):
+        NmapAdapter().scan(Path("127.0.0.1"), _scope(), workdir)
+
+
+def test_scan_rejects_a_real_nmap_execution_error(tmp_path: Path) -> None:
+    def fail_scan(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if argv[1:] == ["--version"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="Nmap version 7.991\n", stderr="")
+        return subprocess.CompletedProcess(argv, 2, stdout="", stderr="host refused")
+
+    with (
+        patch("bernstein.adapters.nmap.shutil.which", return_value="/usr/local/bin/nmap"),
+        patch("bernstein.adapters.nmap.subprocess.run", side_effect=fail_scan),
+        pytest.raises(NmapError, match="code 2: host refused"),
+    ):
+        NmapAdapter().scan(Path("127.0.0.1"), _scope(), tmp_path / "work")
+
+
+@pytest.mark.parametrize("ports", ["0", "65536", "90-80", "80,not-a-port"])
+def test_invalid_port_scopes_fail_before_nmap_lookup(tmp_path: Path, ports: str) -> None:
+    with (
+        patch("bernstein.adapters.nmap.shutil.which") as which,
+        pytest.raises(ValueError, match="ports must be"),
+    ):
+        NmapAdapter().scan(Path("127.0.0.1"), ScanScope(config={"ports": ports}), tmp_path / "work")
+    which.assert_not_called()
+
+
+def test_conformance_replays_both_recordings_and_checks_the_transcript(tmp_path: Path) -> None:
+    transcripts = load_scanner_golden_transcripts(_FIXTURE_DIR)
+    assert len(transcripts) == 1
+    reports = iter((_FIXTURE_A, _FIXTURE_B))
+
+    def replay_run(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if argv[1:] == ["--version"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="Nmap version 7.991\n", stderr="")
+        output = Path(argv[argv.index("-oX") + 1])
+        output.write_text(_fixture(next(reports)), encoding="utf-8")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    with (
+        patch("bernstein.adapters.nmap.shutil.which", return_value="/usr/local/bin/nmap"),
+        patch("bernstein.adapters.nmap.subprocess.run", side_effect=replay_run),
+    ):
+        result = ScannerConformanceHarness().replay_transcript(transcripts[0], workdir=tmp_path)
+
+    assert result.passed
+    assert result.adapter_name == "nmap"
+    assert result.determinism_tier is DeterminismTier.TRANSCRIPT_ANCHORED
+    assert len(result.step_results) == 2
+
+
+def test_conformance_fails_when_the_expected_transcript_changes(tmp_path: Path) -> None:
+    transcript = load_scanner_golden_transcripts(_FIXTURE_DIR)[0]
+    transcript.steps[0].expected_transcript = "not the canonical transcript"
+
+    with (
+        patch("bernstein.adapters.nmap.shutil.which", return_value="/usr/local/bin/nmap"),
+        patch("bernstein.adapters.nmap.subprocess.run", side_effect=_fake_nmap_run()),
+    ):
+        result = ScannerConformanceHarness().replay_transcript(transcript, workdir=tmp_path)
+
+    assert not result.passed
+    assert "recorded transcript differs" in result.step_results[0].message

--- a/typos.toml
+++ b/typos.toml
@@ -40,6 +40,7 @@ abd = "abd"          # deterministic 3-byte hash fixture b"abd" (test_computer_u
 continu = "continu"  # intentional substring match for "continue"/"continuity" in error text (test_capability_tokens.py)
 reprot = "reprot"    # intentionally malformed artifact-kind fixture (test_artifact_spec_declaration.py)
 critera = "critera"  # intentionally malformed artifact_spec key fixture (test_artifact_spec_declaration.py)
+Pn = "Pn"            # `-Pn` is a valid Nmap flag
 
 # Technical terms used consistently in the codebase
 unparseable = "unparseable"


### PR DESCRIPTION
## What

Adds the Nmap reference scanner adapter for the transcript-anchored tier.

Part of #3618.

## Why

Nmap XML contains timestamps and other run-specific values, so its raw output is not byte-reproducible. This adapter records a normalized transcript that can be compared later without losing meaningful scan details.

## How

The adapter runs an Nmap connect scan with XML output and converts each port observation into a Bernstein finding.

Finding identity uses the host, protocol, port, state, and service name. Service product, version, banner details, and CPEs remain in the transcript but do not affect the finding hash.

Tests use two real localhost-only Nmap recordings with different timestamps. They verify that the raw XML differs while the normalized transcript, canonical facts, and finding hashes remain identical. The conformance fixture also checks the exact expected transcript.

Tests run without Nmap installed.

Focused validation completed:

- 85 scanner tests passed
- 18 Nmap tests passed with Nmap absent from `PATH`
- focused Pyright passed with no errors
- import contracts passed
- `typos` passed
- `uv run ruff check src/` passed
- generated module-map verification passed
- `git diff --check` passed

## Checklist

- [x] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` passes
- [ ] `uv run python scripts/run_tests.py -x` passes
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (or N/A if internal-only) — N/A, internal scanner-adapter surface
- [x] `docs/operations/<area>.md` updated (or N/A) — N/A, no operator workflow changed
- [x] `docs/api/` schema regenerated if a public surface changed (or N/A) — N/A, no public API schema changed
- [x] `uv run bernstein agents-md sync` run so AGENTS.md, CLAUDE.md, `.goosehints`, `CONVENTIONS.md`, and `.cursor/rules/*.mdc` reflect any new module (or N/A)
- [x] Tests cover the documented behaviour
