### PR TITLE
feat(security): record every external policy evaluation in the audit chain (#4912)

### DIFF
--- a/docs/release-notes/fragments/4912-external-policy-decision-records.md
+++ b/docs/release-notes/fragments/4912-external-policy-decision-records.md
@@ -1,0 +1,14 @@
+## Record every external policy evaluation in the audit chain
+
+`PolicyHookRegistry` now accepts an audit chain and appends one
+`external_policy.decision` record per hook evaluation — allow, deny, abstain and
+unavailable alike. Each record carries the engine name, the SHA-256 of the policy
+that decided, the request's identifying fields, the verdict, the measured
+latency, and a digest of the engine's error output. `UNAVAILABLE` is recorded as
+itself rather than folded into `abstain`, so an operator can show offline that a
+run stopped because a named policy engine could not answer, at a named chain
+position. `OPAHook` now stamps its responses with the policy file's digest read
+at evaluation time. Recording is opt-in; a registry without a chain decides as
+before.
+
+(#4912)

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -9102,6 +9102,98 @@ def record_tracker_pipeline_sweep(
     )
 
 
+#: Issue #4912 -- emitted once per external policy engine evaluation (OPA,
+#: Cedar), for every outcome and not only refusals. The event carries the engine
+#: name, the digest of the policy that decided, the request's identifying fields,
+#: the verdict, the measured latency, and a digest of the engine's own error
+#: output when it produced one. ``UNAVAILABLE`` is recorded as itself: an engine
+#: that could not answer and a policy with no matching rule have opposite safety
+#: properties, and a log that spells both ``abstain`` rebuilds in the evidence
+#: layer the conflation the decision layer removed. Recording abstentions too is
+#: what makes "the engine was consulted and had no rule" distinguishable from
+#: "the engine was never consulted".
+EVENT_EXTERNAL_POLICY_DECISION = "external_policy.decision"
+
+
+def record_external_policy_decision(
+    *,
+    chain: AuditChainStore,
+    engine: str,
+    verdict: str,
+    reason: str,
+    action: str,
+    resource: str,
+    request_digest: str,
+    agent_id: str = "",
+    role: str = "",
+    scope: str = "",
+    policy_digest: str = "",
+    error_digest: str = "",
+    latency_ms: float = 0.0,
+    actor: str = "external_policy",
+) -> AuditEvent:
+    """Append an ``external_policy.decision`` event into *chain* (#4912).
+
+    Anchors one external policy evaluation into the HMAC chain so an operator
+    can show, offline and from the log alone, that a named engine was asked a
+    named question and gave a named answer at a named chain position. The
+    refusal case is the point: a run stopped by an unreachable policy engine
+    otherwise leaves nothing behind that distinguishes it from a run stopped by
+    a policy that deliberately said no, or from one that was never checked.
+
+    Digests are bare lower-case SHA-256 hex, matching ``HookResponse.policy_digest``.
+    The request's identifying fields are recorded in the clear because a refusal
+    receipt that does not say what was refused cannot be acted on; the caller's
+    free-form ``metadata`` is bound only through *request_digest*, never copied.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        engine: Name of the hook that answered (``opa``, ``cedar``, ...).
+        verdict: The engine's own verdict -- ``allow``, ``deny``, ``abstain`` or
+            ``unavailable``. Never the registry's resolution of it.
+        reason: The engine's human-readable explanation.
+        action: The requested action.
+        resource: The resource acted upon.
+        request_digest: SHA-256 over the RFC 8785 canonical form of the whole
+            request, ``metadata`` included, so a holder of the request can
+            recompute it.
+        agent_id: Requesting agent identifier, when known.
+        role: Requesting agent's role, when known.
+        scope: Task scope, when known.
+        policy_digest: SHA-256 of the policy that produced the verdict, or ``""``
+            when the engine could not name one.
+        error_digest: SHA-256 of the engine's error output, or ``""``. Pins the
+            failure exactly, so two runs' failures compare by hash rather than by
+            matching the free-text *reason*.
+        latency_ms: Measured evaluation latency in milliseconds.
+        actor: Recorded actor; defaults to ``"external_policy"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded in
+        its details payload.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_EXTERNAL_POLICY_DECISION,
+        actor=actor,
+        resource_type="external_policy_decision",
+        resource_id=request_digest,
+        details={
+            "engine": engine,
+            "verdict": verdict,
+            "reason": reason,
+            "action": action,
+            "resource": resource,
+            "agent_id": agent_id,
+            "role": role,
+            "scope": scope,
+            "request_digest": request_digest,
+            "policy_digest": policy_digest,
+            "error_digest": error_digest,
+            "latency_ms": latency_ms,
+        },
+    )
+
+
 __all__ = [
     "AGENT_FRESH_RESTART_ON_RETRY",
     "EVENT_A2A_MESSAGE_RECEIPT",
@@ -9150,6 +9242,7 @@ __all__ = [
     "EVENT_EVAL_GATE_VERDICT",
     "EVENT_EVIDENCE_BUNDLE",
     "EVENT_EXPECTATION_EXPIRED",
+    "EVENT_EXTERNAL_POLICY_DECISION",
     "EVENT_FEED_RENDER_FAILURE",
     "EVENT_FLEET_CONN_CREATE",
     "EVENT_FLEET_CONN_REFUSE",
@@ -9302,6 +9395,7 @@ __all__ = [
     "record_eval_gate_verdict",
     "record_evidence_bundle",
     "record_expectation_expired",
+    "record_external_policy_decision",
     "record_fleet_conn_create",
     "record_fleet_conn_refuse",
     "record_fleet_conn_resolve",

--- a/src/bernstein/core/security/external_policy_hook.py
+++ b/src/bernstein/core/security/external_policy_hook.py
@@ -80,7 +80,7 @@ class HookRequest:
     metadata: dict[str, Any] = field(default_factory=dict[str, Any])
 
 
-def request_digest(request: HookRequest) -> str:
+def _request_digest(request: HookRequest) -> str:
     """Return the SHA-256 digest of *request* in RFC 8785 canonical form.
 
     The digest covers every field including ``metadata``, so a holder of the
@@ -567,26 +567,24 @@ class PolicyHookRegistry:
             List of responses from all hooks.
         """
         responses: list[HookResponse] = []
-        digest = request_digest(request) if self._audit_chain is not None else ""
+        digest = _request_digest(request) if self._audit_chain is not None else ""
         for hook in self._hooks:
             try:
                 response = hook.evaluate(request)
-                responses.append(response)
             except Exception as exc:
                 # An escaping exception is an engine that did not answer, like any other
                 # unavailability. Reported as UNAVAILABLE rather than resolved to
                 # ALLOW/DENY here so that ONE place decides what unavailability means -
                 # `first_decisive`, which honours `fail_open`. Deciding it twice is how
                 # the flag came to be consulted on a path that could never run.
-                responses.append(
-                    HookResponse(
-                        hook_name=hook.name,
-                        verdict=HookVerdict.UNAVAILABLE,
-                        reason=f"Hook error: {exc}",
-                        error=str(exc),
-                    ),
+                response = HookResponse(
+                    hook_name=hook.name,
+                    verdict=HookVerdict.UNAVAILABLE,
+                    reason=f"Hook error: {exc}",
+                    error=str(exc),
                 )
-            self._record(request, responses[-1], digest)
+            responses.append(response)
+            self._record(request, response, digest)
         return responses
 
     def _record(self, request: HookRequest, response: HookResponse, digest: str) -> None:

--- a/src/bernstein/core/security/external_policy_hook.py
+++ b/src/bernstein/core/security/external_policy_hook.py
@@ -19,6 +19,7 @@ Usage::
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import shutil
@@ -29,9 +30,19 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.security.agent_card_signer import canonicalize_jcs
+
+if TYPE_CHECKING:
+    from bernstein.core.security.audit_chain import AuditChainStore
 
 logger = logging.getLogger(__name__)
+
+
+def _sha256_hex(data: bytes) -> str:
+    """Return the bare lower-case SHA-256 hex digest of *data*."""
+    return hashlib.sha256(data).hexdigest()
 
 
 class HookVerdict(StrEnum):
@@ -69,6 +80,27 @@ class HookRequest:
     metadata: dict[str, Any] = field(default_factory=dict[str, Any])
 
 
+def request_digest(request: HookRequest) -> str:
+    """Return the SHA-256 digest of *request* in RFC 8785 canonical form.
+
+    The digest covers every field including ``metadata``, so a holder of the
+    original request can recompute it and match it against a chain record whose
+    payload deliberately does not carry the caller's free-form context.
+    """
+    return _sha256_hex(
+        canonicalize_jcs(
+            {
+                "action": request.action,
+                "resource": request.resource,
+                "agent_id": request.agent_id,
+                "role": request.role,
+                "scope": request.scope,
+                "metadata": request.metadata,
+            },
+        ),
+    )
+
+
 @dataclass(frozen=True)
 class HookResponse:
     """Response from an external policy hook.
@@ -79,7 +111,9 @@ class HookResponse:
         reason: Explanation of the verdict.
         latency_ms: Time taken for the hook evaluation in milliseconds.
         error: Error message if the hook failed.
-        policy_digest: SHA-256 digest of the policy text that produced this verdict (for Cedar).
+        policy_digest: SHA-256 digest of the policy that produced this verdict --
+            the policy text for Cedar, the policy file's bytes for OPA. Empty when
+            the engine could not name a policy (an unreadable file, say).
     """
 
     hook_name: str
@@ -136,6 +170,20 @@ class OPAHook(ExternalPolicyHook):
     def name(self) -> str:
         return "opa"
 
+    def _current_policy_digest(self) -> str:
+        """Return the SHA-256 of the policy file as it stands on disk right now.
+
+        Read per evaluation rather than cached at construction: a decision record
+        names the policy that produced *this* verdict, and a policy file edited
+        under a long-lived hook would otherwise be attested by a digest of the
+        bytes it no longer has. An unreadable file yields ``""`` -- the engine
+        could not name a policy, which is exactly what an empty digest means.
+        """
+        try:
+            return _sha256_hex(self._policy_path.read_bytes())
+        except OSError:
+            return ""
+
     def evaluate(self, request: HookRequest) -> HookResponse:
         """Query OPA with the request and return the verdict.
 
@@ -146,6 +194,7 @@ class OPAHook(ExternalPolicyHook):
             ALLOW, DENY, or ABSTAIN based on OPA evaluation.
         """
         start = time.monotonic()
+        policy_digest = self._current_policy_digest()
         input_data = {
             "input": {
                 "action": request.action,
@@ -195,6 +244,7 @@ class OPAHook(ExternalPolicyHook):
                     verdict=HookVerdict.UNAVAILABLE,
                     reason=f"OPA evaluation failed: {result.stderr.strip()}",
                     latency_ms=latency,
+                    policy_digest=policy_digest,
                     error=result.stderr.strip(),
                 )
 
@@ -209,12 +259,14 @@ class OPAHook(ExternalPolicyHook):
                         verdict=HookVerdict.ALLOW,
                         reason="Allowed by OPA policy",
                         latency_ms=latency,
+                        policy_digest=policy_digest,
                     )
                 return HookResponse(
                     hook_name=self.name,
                     verdict=HookVerdict.DENY,
                     reason="Denied by OPA policy",
                     latency_ms=latency,
+                    policy_digest=policy_digest,
                 )
 
             # Deliberately ABSTAIN, not UNAVAILABLE: OPA ran, exited zero and answered
@@ -225,6 +277,7 @@ class OPAHook(ExternalPolicyHook):
                 verdict=HookVerdict.ABSTAIN,
                 reason="OPA returned empty result",
                 latency_ms=latency,
+                policy_digest=policy_digest,
             )
 
         except FileNotFoundError:
@@ -234,6 +287,7 @@ class OPAHook(ExternalPolicyHook):
                 verdict=HookVerdict.UNAVAILABLE,
                 reason="OPA binary not found",
                 latency_ms=latency,
+                policy_digest=policy_digest,
                 error="opa not found on PATH",
             )
         except subprocess.TimeoutExpired:
@@ -243,6 +297,7 @@ class OPAHook(ExternalPolicyHook):
                 verdict=HookVerdict.UNAVAILABLE,
                 reason="OPA evaluation timed out",
                 latency_ms=latency,
+                policy_digest=policy_digest,
                 error="timeout",
             )
         except Exception as exc:
@@ -254,6 +309,7 @@ class OPAHook(ExternalPolicyHook):
                 verdict=HookVerdict.UNAVAILABLE,
                 reason=f"OPA hook error: {exc}",
                 latency_ms=latency,
+                policy_digest=policy_digest,
                 error=str(exc),
             )
         finally:
@@ -452,6 +508,13 @@ class PolicyHookRegistry:
     "no rule matched" have opposite safety properties, and reporting the first as the
     second makes a broken decision boundary look like a permissive one (#4912).
 
+    When an audit chain is supplied, every hook evaluation appends one
+    ``external_policy.decision`` record to it - allow, deny, abstain and
+    unavailable alike. A refusal an operator cannot demonstrate afterwards is a
+    refusal they can only assert, and an evidence trail that carried only
+    refusals could not distinguish an engine that was consulted and had no rule
+    from one that was never consulted at all (#4912).
+
     Args:
         default_verdict: Verdict when all hooks abstain.
         fail_open: If True, an engine that cannot answer is treated as having no
@@ -459,16 +522,20 @@ class PolicyHookRegistry:
             This used to be consulted only for exceptions escaping ``hook.evaluate``,
             which cannot happen because that method catches everything - so the flag
             was unreachable. It is now the per-deployment switch it was written to be.
+        audit_chain: Optional chain store receiving one decision record per hook
+            evaluation. Recording is opt-in; an unwired registry still decides.
     """
 
     def __init__(
         self,
         default_verdict: HookVerdict = HookVerdict.ABSTAIN,
         fail_open: bool = False,
+        audit_chain: AuditChainStore | None = None,
     ) -> None:
         self._hooks: list[ExternalPolicyHook] = []
         self._default_verdict = default_verdict
         self._fail_open = fail_open
+        self._audit_chain = audit_chain
 
     @property
     def hooks(self) -> list[ExternalPolicyHook]:
@@ -487,6 +554,12 @@ class PolicyHookRegistry:
     def evaluate(self, request: HookRequest) -> list[HookResponse]:
         """Evaluate a request against all registered hooks.
 
+        Each response is appended to the audit chain when one is configured, so
+        the record set matches the evaluation set exactly. A failure to record is
+        not swallowed: it propagates, because a decision boundary that keeps
+        deciding after its evidence trail has stopped being written is the silent
+        failure this module exists to remove.
+
         Args:
             request: The permission request.
 
@@ -494,6 +567,7 @@ class PolicyHookRegistry:
             List of responses from all hooks.
         """
         responses: list[HookResponse] = []
+        digest = request_digest(request) if self._audit_chain is not None else ""
         for hook in self._hooks:
             try:
                 response = hook.evaluate(request)
@@ -512,7 +586,38 @@ class PolicyHookRegistry:
                         error=str(exc),
                     ),
                 )
+            self._record(request, responses[-1], digest)
         return responses
+
+    def _record(self, request: HookRequest, response: HookResponse, digest: str) -> None:
+        """Append one decision record for *response*, if a chain is configured.
+
+        The engine's own verdict is written down, never the registry's resolution
+        of it: an ``UNAVAILABLE`` engine that :meth:`first_decisive` turns into a
+        denial is recorded as unavailable, so the chain says why the run stopped
+        rather than only that it did.
+        """
+        chain = self._audit_chain
+        if chain is None:
+            return
+
+        from bernstein.core.security.audit_chain import record_external_policy_decision
+
+        record_external_policy_decision(
+            chain=chain,
+            engine=response.hook_name,
+            verdict=response.verdict.value,
+            reason=response.reason,
+            action=request.action,
+            resource=request.resource,
+            agent_id=request.agent_id,
+            role=request.role,
+            scope=request.scope,
+            request_digest=digest,
+            policy_digest=response.policy_digest,
+            error_digest=_sha256_hex(response.error.encode("utf-8")) if response.error else "",
+            latency_ms=response.latency_ms,
+        )
 
     def first_decisive(self, request: HookRequest) -> HookResponse:
         """Evaluate hooks and return the first decisive response.

--- a/tests/unit/test_external_policy_audit_chain.py
+++ b/tests/unit/test_external_policy_audit_chain.py
@@ -22,6 +22,9 @@ import hashlib
 import json
 import stat
 from pathlib import Path
+from typing import cast
+
+import pytest
 
 from bernstein.core.security.agent_card_signer import canonicalize_jcs
 from bernstein.core.security.audit_chain import (
@@ -62,6 +65,15 @@ def _fake_opa(tmp_path: Path, name: str, body: str) -> str:
     script.write_text(f"#!/bin/sh\n{body}\n", encoding="utf-8")
     script.chmod(script.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
     return str(script)
+
+
+class _Allows(ExternalPolicyHook):
+    @property
+    def name(self) -> str:
+        return "permissive"
+
+    def evaluate(self, request: HookRequest) -> HookResponse:
+        return HookResponse(hook_name=self.name, verdict=HookVerdict.ALLOW, reason="ok")
 
 
 class _Abstains(ExternalPolicyHook):
@@ -224,3 +236,24 @@ def test_registry_without_a_chain_appends_nothing(tmp_path: Path) -> None:
 
     assert registry.first_decisive(_req()).verdict == HookVerdict.DENY
     assert not list(tmp_path.rglob("*.jsonl"))
+
+
+class _BrokenChain:
+    """A chain store whose append always fails."""
+
+    def log_with_prev_digest(self, **kwargs: object) -> object:
+        raise OSError("audit chain is read-only")
+
+
+def test_a_chain_that_cannot_be_written_stops_the_decision(tmp_path: Path) -> None:
+    """10. Evidence failure is decision failure, never a silent grant.
+
+    A registry configured to record and unable to record must not keep answering
+    as if it were: the caller gets an error and grants nothing, rather than an
+    allow whose justification was never written down.
+    """
+    registry = PolicyHookRegistry(audit_chain=cast(AuditChainStore, _BrokenChain()))
+    registry.register(_Allows())
+
+    with pytest.raises(OSError, match="read-only"):
+        registry.first_decisive(_req())

--- a/tests/unit/test_external_policy_audit_chain.py
+++ b/tests/unit/test_external_policy_audit_chain.py
@@ -1,0 +1,226 @@
+"""Every external policy evaluation leaves a record in the audit chain (#4912).
+
+`PolicyHookRegistry` resolved OPA and Cedar verdicts and returned them to its
+caller. Nothing was written down. An operator whose run stopped because the
+policy engine was unreachable had the refusal and no way to show, later and
+offline, that it happened, which engine could not answer, or which policy was
+being asked.
+
+These tests pin the record: one entry per hook evaluation -- allow, deny,
+abstain and unavailable alike -- carrying the engine name, the policy digest,
+the request fields, the verdict, and the latency, chained so a verifier holding
+only the log can check it.
+
+`UNAVAILABLE` is recorded as itself. Collapsing it to `ABSTAIN` in the log would
+rebuild, in the evidence layer, exactly the conflation #4971 removed from the
+decision layer.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import stat
+from pathlib import Path
+
+from bernstein.core.security.agent_card_signer import canonicalize_jcs
+from bernstein.core.security.audit_chain import (
+    EVENT_EXTERNAL_POLICY_DECISION,
+    AuditChainStore,
+)
+from bernstein.core.security.external_policy_hook import (
+    ExternalPolicyHook,
+    HookRequest,
+    HookResponse,
+    HookVerdict,
+    OPAHook,
+    PolicyHookRegistry,
+)
+
+_KEY = b"0" * 32
+
+_ALLOW_REGO = 'package bernstein.authz\n\ndefault allow = false\n\nallow {\n  input.action == "read"\n}\n'
+
+
+def _req() -> HookRequest:
+    return HookRequest(
+        action="deploy",
+        resource="prod/cluster-a",
+        agent_id="agent-1",
+        role="backend",
+        scope="release",
+    )
+
+
+def _events(chain: AuditChainStore) -> list[dict[str, object]]:
+    return [dict(ev.details) for ev in chain.query(event_type=EVENT_EXTERNAL_POLICY_DECISION)]
+
+
+def _fake_opa(tmp_path: Path, name: str, body: str) -> str:
+    """Write an executable stand-in for the ``opa`` binary and return its path."""
+    script = tmp_path / name
+    script.write_text(f"#!/bin/sh\n{body}\n", encoding="utf-8")
+    script.chmod(script.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return str(script)
+
+
+class _Abstains(ExternalPolicyHook):
+    @property
+    def name(self) -> str:
+        return "quiet"
+
+    def evaluate(self, request: HookRequest) -> HookResponse:
+        return HookResponse(hook_name=self.name, verdict=HookVerdict.ABSTAIN, reason="no rule")
+
+
+def test_unavailable_engine_is_recorded_as_unavailable_not_abstain(tmp_path: Path) -> None:
+    """1. The load-bearing one: the refusal receipt names unavailability.
+
+    A record that said ``abstain`` here would be indistinguishable from a policy
+    that simply had no rule, which is the defect this issue is about.
+    """
+    chain = AuditChainStore(tmp_path / "audit", key=_KEY)
+    registry = PolicyHookRegistry(audit_chain=chain)
+    registry.register(OPAHook(policy_path=tmp_path / "absent.rego", opa_binary="/nonexistent/opa"))
+
+    decisive = registry.first_decisive(_req())
+    assert decisive.verdict == HookVerdict.DENY
+
+    records = _events(chain)
+    assert len(records) == 1
+    assert records[0]["verdict"] == HookVerdict.UNAVAILABLE.value
+    assert records[0]["verdict"] != HookVerdict.ABSTAIN.value
+    assert records[0]["engine"] == "opa"
+
+
+def test_nonzero_exit_records_the_stderr_digest(tmp_path: Path) -> None:
+    """2. A failing engine's own words are pinned by hash, not copied into the log."""
+    policy = tmp_path / "p.rego"
+    policy.write_text(_ALLOW_REGO, encoding="utf-8")
+    opa = _fake_opa(tmp_path, "opa-broken", 'echo "rego_parse_error: unexpected token" >&2\nexit 1')
+
+    chain = AuditChainStore(tmp_path / "audit", key=_KEY)
+    registry = PolicyHookRegistry(audit_chain=chain)
+    registry.register(OPAHook(policy_path=policy, opa_binary=opa))
+
+    decisive = registry.first_decisive(_req())
+    assert decisive.verdict == HookVerdict.DENY
+
+    (record,) = _events(chain)
+    assert record["verdict"] == HookVerdict.UNAVAILABLE.value
+    expected = hashlib.sha256(b"rego_parse_error: unexpected token").hexdigest()
+    assert record["error_digest"] == expected
+
+
+def test_deny_record_carries_the_policy_digest_of_the_file_on_disk(tmp_path: Path) -> None:
+    """3. The record names which policy denied, checkable against the file."""
+    policy = tmp_path / "p.rego"
+    policy.write_text(_ALLOW_REGO, encoding="utf-8")
+    opa = _fake_opa(tmp_path, "opa-deny", 'echo \'{"result":[{"expressions":[{"value":false}]}]}\'')
+
+    chain = AuditChainStore(tmp_path / "audit", key=_KEY)
+    registry = PolicyHookRegistry(audit_chain=chain)
+    registry.register(OPAHook(policy_path=policy, opa_binary=opa))
+
+    decisive = registry.first_decisive(_req())
+    assert decisive.verdict == HookVerdict.DENY
+
+    (record,) = _events(chain)
+    assert record["verdict"] == HookVerdict.DENY.value
+    assert record["policy_digest"] == hashlib.sha256(policy.read_bytes()).hexdigest()
+
+
+def test_an_abstaining_engine_still_leaves_proof_it_was_consulted(tmp_path: Path) -> None:
+    """4. "Consulted, no rule matched" must be distinguishable from "never consulted"."""
+    chain = AuditChainStore(tmp_path / "audit", key=_KEY)
+    registry = PolicyHookRegistry(audit_chain=chain)
+    registry.register(_Abstains())
+
+    registry.first_decisive(_req())
+
+    (record,) = _events(chain)
+    assert record["engine"] == "quiet"
+    assert record["verdict"] == HookVerdict.ABSTAIN.value
+
+
+def test_every_hook_that_ran_gets_its_own_record(tmp_path: Path) -> None:
+    """5. The record set equals the evaluation set, in evaluation order."""
+    chain = AuditChainStore(tmp_path / "audit", key=_KEY)
+    registry = PolicyHookRegistry(audit_chain=chain)
+    registry.register(_Abstains())
+    registry.register(OPAHook(policy_path=tmp_path / "absent.rego", opa_binary="/nonexistent/opa"))
+
+    registry.first_decisive(_req())
+
+    records = _events(chain)
+    assert [r["engine"] for r in records] == ["quiet", "opa"]
+
+
+def test_decision_records_chain_and_the_chain_verifies(tmp_path: Path) -> None:
+    """6. The refusal is provable offline: chained, at a named position."""
+    chain = AuditChainStore(tmp_path / "audit", key=_KEY)
+    registry = PolicyHookRegistry(audit_chain=chain)
+    registry.register(OPAHook(policy_path=tmp_path / "absent.rego", opa_binary="/nonexistent/opa"))
+
+    registry.first_decisive(_req())
+
+    (record,) = _events(chain)
+    assert record["prev_chain_digest"]
+    ok, errors = chain.verify()
+    assert ok, errors
+
+
+def test_request_fields_are_recorded_and_the_request_digest_recomputes(tmp_path: Path) -> None:
+    """7. An operator can tell what was asked, and re-derive the digest from it."""
+    chain = AuditChainStore(tmp_path / "audit", key=_KEY)
+    registry = PolicyHookRegistry(audit_chain=chain)
+    registry.register(_Abstains())
+
+    request = _req()
+    registry.first_decisive(request)
+
+    (record,) = _events(chain)
+    assert record["action"] == "deploy"
+    assert record["resource"] == "prod/cluster-a"
+    assert record["agent_id"] == "agent-1"
+    assert record["role"] == "backend"
+    assert record["scope"] == "release"
+    assert isinstance(record["latency_ms"], float)
+
+    expected = hashlib.sha256(
+        canonicalize_jcs(
+            {
+                "action": "deploy",
+                "resource": "prod/cluster-a",
+                "agent_id": "agent-1",
+                "role": "backend",
+                "scope": "release",
+                "metadata": {},
+            },
+        ),
+    ).hexdigest()
+    assert record["request_digest"] == expected
+
+
+def test_request_metadata_never_reaches_the_record_verbatim(tmp_path: Path) -> None:
+    """8. Caller-supplied context is bound by hash, not copied into the chain."""
+    chain = AuditChainStore(tmp_path / "audit", key=_KEY)
+    registry = PolicyHookRegistry(audit_chain=chain)
+    registry.register(_Abstains())
+
+    registry.first_decisive(
+        HookRequest(action="deploy", resource="prod", metadata={"ticket": "SECRET-123"}),
+    )
+
+    (record,) = _events(chain)
+    assert "SECRET-123" not in json.dumps(record)
+    assert record["request_digest"]
+
+
+def test_registry_without_a_chain_appends_nothing(tmp_path: Path) -> None:
+    """9. Recording is opt-in; an unwired registry still decides."""
+    registry = PolicyHookRegistry()
+    registry.register(OPAHook(policy_path=tmp_path / "absent.rego", opa_binary="/nonexistent/opa"))
+
+    assert registry.first_decisive(_req()).verdict == HookVerdict.DENY
+    assert not list(tmp_path.rglob("*.jsonl"))

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -6022,6 +6022,7 @@ class TestAdaptivePollingBackoff:
         assert hasattr(orch, "_idle_multiplier")
         assert orch._idle_multiplier == 1
 
+
 # --- Reverse task-to-session index ---
 
 

--- a/verify_cli/bernstein_verify_receipt/__main__.py
+++ b/verify_cli/bernstein_verify_receipt/__main__.py
@@ -75,9 +75,7 @@ def cli() -> None:
     show_default=True,
     help="Which format(s) to verify.",
 )
-@click.option(
-    "--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details."
-)
+@click.option("--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details.")
 def verify_cmd(
     receipt_path: Path,
     jwk_path: Path | None,

--- a/verify_cli/bernstein_verify_receipt/verify.py
+++ b/verify_cli/bernstein_verify_receipt/verify.py
@@ -291,8 +291,7 @@ def verify_subject_binding(receipt: dict[str, Any]) -> tuple[CheckResult, str]:
                 "subject_binding",
                 ok=False,
                 detail=(
-                    f"recomputed head {recomputed[:16]}… "
-                    f"!= range.head_sha256 {range_head[:16]}…"
+                    f"recomputed head {recomputed[:16]}… != range.head_sha256 {range_head[:16]}…"
                 ),
             ),
             recomputed,
@@ -418,10 +417,7 @@ def verify_intoto(receipt: dict[str, Any], public_key: Any, recomputed_head: str
         return CheckResult(
             "intoto",
             ok=False,
-            detail=(
-                f"recomputed head {recomputed_head[:16]}… "
-                f"not in statement subject digests"
-            ),
+            detail=(f"recomputed head {recomputed_head[:16]}… not in statement subject digests"),
         )
     return CheckResult("intoto", ok=True, detail="DSSE/in-toto verified, subject bound to head")
 
@@ -469,8 +465,7 @@ def verify_transparency(
             "transparency",
             ok=False,
             detail=(
-                f"STH subject {subject_sha256[:16]}… "
-                f"!= recomputed head {recomputed_head[:16]}…"
+                f"STH subject {subject_sha256[:16]}… != recomputed head {recomputed_head[:16]}…"
             ),
         )
 
@@ -510,10 +505,7 @@ def verify_transparency(
             return CheckResult(
                 "transparency",
                 ok=False,
-                detail=(
-                    f"inclusion proof root {proven_root[:16]}… "
-                    f"!= STH root {root_hash[:16]}…"
-                ),
+                detail=(f"inclusion proof root {proven_root[:16]}… != STH root {root_hash[:16]}…"),
             )
     return CheckResult(
         "transparency", ok=True, detail="RFC6962 STH signed, root + inclusion proof verified"


### PR DESCRIPTION
## What

Scope item 3 of #4912: every external policy evaluation now appends a decision
record to the HMAC audit chain.

Adds `external_policy.decision` and `record_external_policy_decision` to
`audit_chain`, gives `PolicyHookRegistry` an optional `audit_chain`, and makes
`OPAHook` stamp its responses with the digest of the policy file that decided.

Explicitly not in this PR:

- Item 1, the permission-path wiring. It attaches to the org admission surface
  in #4907, which does not exist yet; a temporary attach point would have to be
  unpicked when it lands.
- Item 2, the `UNAVAILABLE` verdict. Already shipped in #4971.
- Any in-process Rego or Cedar evaluator, and any new policy syntax.
- The `bernstein.yaml` default for `fail_open`. Still outstanding, listed below.

## Why

`PolicyHookRegistry` resolved a verdict and handed it back to its caller.
Nothing was written down, so nothing about an external policy decision survived
the process that made it.

Since #4971 an engine that cannot answer denies, which is the right verdict and
an unexplainable one after the fact. An operator whose run stopped has a refusal
they can assert and cannot demonstrate: no record of which engine was asked,
which policy it was asked about, what was requested, or whether the stop came
from a policy that deliberately said no, an engine that could not be reached, or
a check that never ran at all. Those three have very different remediations and
the same visible outcome.

The record closes that. A refusal is provable offline, from the log alone, at a
named chain position.

## How

`record_external_policy_decision` writes one entry per hook evaluation carrying
the engine name, the verdict, the reason, the policy digest, the request's
identifying fields, a canonical request digest, a digest of the engine's error
output, and the measured latency. `PolicyHookRegistry.evaluate` appends one for
every response it collects.

Three judgements worth stating, since each could reasonably have gone the other
way:

**Abstentions are recorded, not only allow / deny / unavailable.** The issue
lists three outcomes. Recording only those would leave a log in which "the
engine was consulted and had no matching rule" and "the engine was never
consulted" are indistinguishable -- the same conflation the verdict layer
already refuses to make, rebuilt one layer up. One record per evaluation keeps
the record set equal to the evaluation set.

**The engine's own verdict is recorded, never the registry's resolution of it.**
An `UNAVAILABLE` engine that `first_decisive` turns into a denial is written
down as `unavailable`, so the chain says why the run stopped rather than only
that it did.

**A failed append is not swallowed.** It propagates. A decision boundary that
keeps deciding after its evidence trail has stopped being written is exactly the
silent failure this module exists to remove.

`OPAHook` previously left `policy_digest` empty -- only Cedar named its policy --
so an OPA record could not say which policy produced the verdict. It now reads
the digest per evaluation rather than caching it at construction, so a policy
file edited under a long-lived hook is not attested by bytes it no longer has.

Request `metadata` is caller-supplied free-form context and is bound only through
the request digest, never copied into the chain. The identifying fields (action,
resource, agent id, role, scope) are recorded in the clear: a refusal receipt
that does not say what was refused cannot be acted on.

## Tests

`tests/unit/test_external_policy_audit_chain.py`. Tests 1-8 failed on the
unmodified tree -- first on the missing event constant, then, once the recorder
existed, on the absent records. Test 9 is the control and passed throughout,
which is what makes it a control.

1. `test_unavailable_engine_is_recorded_as_unavailable_not_abstain` --
   **load-bearing.** A missing OPA binary denies, and the chain entry says
   `unavailable`. An entry saying `abstain` here would be indistinguishable from
   a policy with no matching rule, which is the defect the issue names.
2. `test_nonzero_exit_records_the_stderr_digest` -- a real subprocess exiting
   non-zero with stderr; the record carries the SHA-256 of that stderr.
3. `test_deny_record_carries_the_policy_digest_of_the_file_on_disk` -- an OPA
   denial's `policy_digest` equals the SHA-256 of the `.rego` file's bytes.
4. `test_an_abstaining_engine_still_leaves_proof_it_was_consulted` -- the first
   judgement above, asserted.
5. `test_every_hook_that_ran_gets_its_own_record` -- record set equals
   evaluation set, in evaluation order.
6. `test_decision_records_chain_and_the_chain_verifies` -- the entry embeds
   `prev_chain_digest` and `chain.verify()` passes: provable offline.
7. `test_request_fields_are_recorded_and_the_request_digest_recomputes` -- the
   digest is recomputed in the test from the request, pinning its definition.
8. `test_request_metadata_never_reaches_the_record_verbatim` -- a secret-shaped
   metadata value does not appear anywhere in the entry.
9. `test_registry_without_a_chain_appends_nothing` -- recording is opt-in and an
   unwired registry still decides.

Tests 2 and 3 drive a real executable stand-in for `opa` through
`subprocess.run`, so the failure paths are exercised where they actually occur
rather than through a patched `evaluate`.

`tests/unit/test_external_policy_hook.py` (23) and
`tests/unit/test_policy_engine_unavailable.py` (7) still pass unchanged.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes -- the changed modules report the same 16
      pre-existing errors as `origin/main` (all in the Cedar parser, untouched
      here and the subject of a separate issue); no new ones
- [x] `uv run python scripts/run_tests.py -x` green across all 56 audit, audit-chain
      and external-policy test files (`test_audit*`, `test_*audit_chain*`, plus the
      two policy-hook files). Touching `audit_chain` makes `--affected origin/main`
      select 1474 files, effectively the whole suite, which is the CI lane's job
      rather than a local run
- [x] New code has type hints

### Documentation duty

- [ ] User-visible README section updated -- N/A, no user-visible surface; the
      registry still has no caller (item 1)
- [ ] `docs/operations/<area>.md` updated -- N/A, nothing operable until item 1
      wires the registry into a decision path
- [ ] `docs/api/` schema regenerated -- N/A, no public API schema change
- [x] `uv run bernstein agents-md sync` run -- no module-map change, so it
      produced no diff
- [x] Tests cover the documented behaviour

Part of #4912

## Remaining

- **Item 1** -- the permission/admission path consults the registry. Gated on
  the org admission surface in #4907.
- The `fail_open` default made explicit in `bernstein.yaml`. It belongs with
  item 1: the file has no external-policy section at all, and adding one before
  there is a path that reads it would ship a setting that changes nothing.
