### PR TITLE
security: one canonical-JSON byte rule and the byte-identical sites routed through it (#5094)

### DIFF
--- a/docs/release-notes/fragments/5141-canonical-json-security-module.md
+++ b/docs/release-notes/fragments/5141-canonical-json-security-module.md
@@ -1,0 +1,20 @@
+## New Canonical JSON Security Module (`core.security.canonical`)
+
+Bernstein now exposes a single canonical-JSON byte rule for all hashing and signing operations through the new `bernstein.core.security.canonical` public module.
+
+### Public API
+
+- `CANONICALIZATION_VERSION` / `CANONICALIZATION_FIELD` — versioned identity markers
+- `canonical_bytes(payload)` — RFC 8785/JCS canonical bytes with `allow_nan=False` hard guarantee
+- `legacy_ascii_bytes(payload)` — ASCII-escaped canonical form for legacy compatibility
+- `legacy_pretty_bytes(payload)` — indented ASCII with trailing newline for human-readable artefacts
+- `bytes_for_verification(artifact_name, payload)` — verification encoder that raises `UnsupportedCanonicalization` on unknown versions
+- `UnsupportedCanonicalization` — raised fail-closed when a build cannot reproduce an artefact's encoding
+
+### Security Properties
+
+- **NaN/Infinity rejection**: Any payload containing NaN, Infinity, or `-Infinity` now raises at the producer rather than producing bytes no strict parser accepts (R9 compliance)
+- **Fail-closed verification**: `bytes_for_verification` raises on unknown canonicalization versions rather than returning a mismatch, preventing silent acceptance of unverifiable artefacts
+- **Single source of truth**: All byte-identical canonical-JSON sites now route through this module, eliminating drift between independent implementations
+
+This is a security property change: operators depending on the canonical encoding for hashing or signing should verify their payloads do not contain NaN or Infinity values.

--- a/src/bernstein/adapters/admission.py
+++ b/src/bernstein/adapters/admission.py
@@ -51,6 +51,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.security.canonical import canonical_bytes
 from bernstein.core.security.path_containment import (
     PathContainmentError,
     PathTooLongError,
@@ -325,10 +326,6 @@ class AdapterAdmissionRefusal(RuntimeError):
 # ---------------------------------------------------------------------------
 
 
-def _canonical_bytes(data: dict[str, Any]) -> bytes:
-    return json.dumps(data, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
-
-
 def _sha256_hex(payload: bytes) -> str:
     return hashlib.sha256(payload).hexdigest()
 
@@ -420,7 +417,7 @@ def replay_fingerprint(
             for result in sorted(results, key=lambda r: r.transcript_name)
         ],
     }
-    return "sha256:" + _sha256_hex(_canonical_bytes(payload))
+    return "sha256:" + _sha256_hex(canonical_bytes(payload))
 
 
 def conformance_run_id(
@@ -438,7 +435,7 @@ def conformance_run_id(
     this adapter" is answerable offline from the receipt alone.
     """
     return _sha256_hex(
-        _canonical_bytes(
+        canonical_bytes(
             {
                 "schema_version": ADMISSION_SCHEMA_VERSION,
                 "adapter": adapter,
@@ -454,7 +451,7 @@ def conformance_run_id(
 def _probe_hash(binary: str, binary_path: str | None, installed_version: str | None) -> str:
     """Content hash binding the probed binary identity into the receipt."""
     return "sha256:" + _sha256_hex(
-        _canonical_bytes(
+        canonical_bytes(
             {
                 "binary": binary,
                 "binary_path": binary_path or "",
@@ -906,7 +903,7 @@ def build_admission_receipt(
 
 def receipt_sha256(receipt: dict[str, Any]) -> str:
     """Content hash (identity) of a receipt's canonical bytes."""
-    return _sha256_hex(_canonical_bytes(receipt))
+    return _sha256_hex(canonical_bytes(receipt))
 
 
 def verify_admission_receipt(doc: dict[str, Any]) -> bool:
@@ -1107,7 +1104,7 @@ def anchor_admission_receipt_in_lineage(
 
     view = AdapterAdmissionReceipt(receipt)
     sha = view.sha256
-    canonical = _canonical_bytes(receipt)
+    canonical = canonical_bytes(receipt)
     return seal_write(
         store,
         operator_hmac_key,

--- a/src/bernstein/adapters/canary.py
+++ b/src/bernstein/adapters/canary.py
@@ -41,6 +41,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.security.canonical import canonical_bytes
 from bernstein.core.security.path_containment import (
     PathContainmentError,
     PathTooLongError,
@@ -288,10 +289,6 @@ class MatrixRunResult:
 # ---------------------------------------------------------------------------
 
 
-def _canonical_bytes(data: dict[str, Any]) -> bytes:
-    return json.dumps(data, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
-
-
 def _sha256_hex(payload: bytes) -> str:
     return hashlib.sha256(payload).hexdigest()
 
@@ -488,7 +485,7 @@ def build_canary_receipt(outcome: CanaryOutcome, *, generated_at: str) -> dict[s
 
 def receipt_sha256(receipt: dict[str, Any]) -> str:
     """Content hash (identity) of a receipt's canonical bytes."""
-    return _sha256_hex(_canonical_bytes(receipt))
+    return _sha256_hex(canonical_bytes(receipt))
 
 
 def verify_canary_receipt(doc: dict[str, Any]) -> bool:
@@ -553,7 +550,7 @@ def failure_fingerprint(outcome: CanaryOutcome) -> str:
     version failing differently (or the same way) fingerprints fresh.
     """
     return _sha256_hex(
-        _canonical_bytes(
+        canonical_bytes(
             {
                 "adapter": outcome.adapter,
                 "installed_version": outcome.installed_version,
@@ -572,7 +569,7 @@ def skip_fingerprint(outcome: CanaryOutcome) -> str:
     while a different degradation restarts the streak and reports afresh.
     """
     return _sha256_hex(
-        _canonical_bytes(
+        canonical_bytes(
             {
                 "adapter": outcome.adapter,
                 "skip_reason": outcome.skip_reason or "",
@@ -964,7 +961,7 @@ def save_last_green(path: Path, entries: dict[str, LastGreenEntry]) -> None:
         }
         for name, entry in sorted(entries.items())
     }
-    canonical = _canonical_bytes(adapters_dict)
+    canonical = canonical_bytes(adapters_dict)
     projection_sha256 = _sha256_hex(canonical)
 
     doc = {
@@ -1025,7 +1022,7 @@ def verify_last_green_head(path: Path | None = None) -> bool:
             }
         except (KeyError, ValueError):
             continue
-    return _sha256_hex(_canonical_bytes(adapters_dict)) == recorded
+    return _sha256_hex(canonical_bytes(adapters_dict)) == recorded
 
 
 class ReceiptSetError(ValueError):

--- a/src/bernstein/adapters/floor_refresh.py
+++ b/src/bernstein/adapters/floor_refresh.py
@@ -20,13 +20,13 @@ prove offline which floor map was in force when a spawn decision was recorded.
 from __future__ import annotations
 
 import hashlib
-import json
 import operator
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from bernstein.adapters.advisories import ADAPTER_MIN_SAFE_VERSIONS, AdapterAdvisory
 from bernstein.adapters.security_floor import hash_floor_map
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -53,13 +53,9 @@ FLOOR_MAP_BEGIN = "# floor-map:begin"
 FLOOR_MAP_END = "# floor-map:end"
 
 
-def _canonical_bytes(data: Any) -> bytes:
-    return json.dumps(data, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
-
-
 def receipt_sha256(receipt: dict[str, Any]) -> str:
     """Content hash (identity) of a receipt's canonical bytes."""
-    return hashlib.sha256(_canonical_bytes(receipt)).hexdigest()
+    return hashlib.sha256(canonical_bytes(receipt)).hexdigest()
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/adapters/onboarding.py
+++ b/src/bernstein/adapters/onboarding.py
@@ -43,6 +43,7 @@ from bernstein.adapters._contract import _run_capture, _sandbox_env
 from bernstein.adapters.capability_profile import AdapterCapabilityProfile, InvocationSpec
 from bernstein.adapters.conformance import GoldenTranscript, StepResult, TranscriptResult, TranscriptStep
 from bernstein.adapters.draft import Draft, draft_from_evidence
+from bernstein.core.security.canonical import canonical_bytes
 
 #: Per-command timeout for probe invocations.
 _PROBE_TIMEOUT_SECONDS = 30
@@ -77,17 +78,13 @@ class ProbeEvidence:
     sha256: str
 
 
-def _canonical_bytes(data: dict[str, Any]) -> bytes:
-    return json.dumps(data, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
-
-
 def _sha256_hex(payload: bytes) -> str:
     return hashlib.sha256(payload).hexdigest()
 
 
 def _write_evidence(out_dir: Path, record: dict[str, Any]) -> ProbeEvidence:
     """Write ``record`` under its content-addressed name and return its handle."""
-    payload = _canonical_bytes(record)
+    payload = canonical_bytes(record)
     sha = _sha256_hex(payload)
     out_dir.mkdir(parents=True, exist_ok=True)
     path = out_dir / f"{sha}.json"

--- a/src/bernstein/adapters/security_floor.py
+++ b/src/bernstein/adapters/security_floor.py
@@ -36,6 +36,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from bernstein.adapters.advisories import ADAPTER_MIN_SAFE_VERSIONS, AdapterAdvisory
+from bernstein.core.security.canonical import canonical_bytes
 from bernstein.core.security.path_containment import (
     PathContainmentError,
     PathTooLongError,
@@ -138,10 +139,6 @@ class AdapterSecurityFloorRefusal(RuntimeError):
 # ---------------------------------------------------------------------------
 
 
-def _canonical_bytes(data: dict[str, Any]) -> bytes:
-    return json.dumps(data, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
-
-
 def _sha256_hex(payload: bytes) -> str:
     return hashlib.sha256(payload).hexdigest()
 
@@ -166,7 +163,7 @@ def hash_floor_map(mapping: dict[str, AdapterAdvisory]) -> str:
         }
         for name, adv in sorted(mapping.items())
     }
-    return "sha256:" + _sha256_hex(_canonical_bytes(payload))
+    return "sha256:" + _sha256_hex(canonical_bytes(payload))
 
 
 def floor_map_content_hash() -> str:
@@ -392,7 +389,7 @@ def build_preflight_receipt(verdict: FloorVerdict, *, generated_at: str) -> dict
 
 def receipt_sha256(receipt: dict[str, Any]) -> str:
     """Content hash (identity) of a receipt's canonical bytes."""
-    return _sha256_hex(_canonical_bytes(receipt))
+    return _sha256_hex(canonical_bytes(receipt))
 
 
 def verify_preflight_receipt(doc: dict[str, Any]) -> bool:

--- a/src/bernstein/cli/commands/mandate_cmd.py
+++ b/src/bernstein/cli/commands/mandate_cmd.py
@@ -23,6 +23,7 @@ from pathlib import Path
 import click
 
 from bernstein.cli.helpers import console
+from bernstein.core.security.canonical import canonical_bytes
 
 
 def _load_hmac_key() -> bytes:
@@ -45,9 +46,7 @@ def _settlement_ref_hash(settlement: object) -> str:
     from bernstein.core.protocols.payments.mandates import SettlementRef
 
     assert isinstance(settlement, SettlementRef)
-    canonical = json.dumps(settlement.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode(
-        "utf-8"
-    )
+    canonical = canonical_bytes(settlement.to_dict())
     return "sha256:" + hashlib.sha256(canonical).hexdigest()
 
 

--- a/src/bernstein/compliance/evidence_pack.py
+++ b/src/bernstein/compliance/evidence_pack.py
@@ -227,8 +227,14 @@ class EvidencePack:
 # ---------------------------------------------------------------------------
 
 
-def _canonical_json(payload: Any) -> bytes:
-    """Serialise ``payload`` as deterministic JSON (sort_keys, indent=2)."""
+def _pack_json(payload: Any) -> bytes:
+    """Serialise ``payload`` for storage inside the pack.
+
+    Indented, sorted keys, trailing newline: presentation bytes an auditor
+    reads. Every hash recorded in the manifest is computed over the stored
+    bytes, so this is a file format, not a signing canonicalization
+    (:mod:`bernstein.core.security.canonical` owns that rule).
+    """
     return (json.dumps(payload, sort_keys=True, indent=2) + "\n").encode("utf-8")
 
 
@@ -415,7 +421,7 @@ def _build_data_catalog(events: list[dict[str, Any]]) -> bytes:
         "resources": {rtype: dict(sorted(items.items())) for rtype, items in sorted(catalog.items())},
         "total_events": len(events),
     }
-    return _canonical_json(payload)
+    return _pack_json(payload)
 
 
 def _read_text_directory(directory: Path) -> dict[str, bytes]:
@@ -582,7 +588,7 @@ def build_evidence_pack(
         "controls": mapping["controls"],
         "deferred": mapping.get("deferred", []),
     }
-    controls_bytes = _canonical_json(controls_payload)
+    controls_bytes = _pack_json(controls_payload)
 
     policy_files = _read_text_directory(policy_dir)
     attestation_files = _read_text_directory(attestations_dir)
@@ -639,7 +645,7 @@ def build_evidence_pack(
     # input produce the same SHA-256. Operators who need a real "issued
     # at" timestamp should sign the zip externally with their CI's
     # provenance attestation (e.g. ``gh attestation``).
-    artefacts["manifest.json"] = _canonical_json(manifest)
+    artefacts["manifest.json"] = _pack_json(manifest)
 
     archive_bytes = _zip_artefacts(artefacts)
     archive_sha256 = hashlib.sha256(archive_bytes).hexdigest()

--- a/src/bernstein/core/agents/computer_use.py
+++ b/src/bernstein/core/agents/computer_use.py
@@ -31,9 +31,10 @@ so a form-filling agent's secrets never enter the chain in plain text.
 from __future__ import annotations
 
 import hashlib
-import json
 from dataclasses import dataclass
 from enum import StrEnum
+
+from bernstein.core.security.canonical import canonical_bytes
 
 # ---------------------------------------------------------------------------
 # Action vocabulary
@@ -145,12 +146,7 @@ def compute_observation_hash(*, screenshot_bytes: bytes, dom_digest: str) -> str
 
 def _canonical(body: dict[str, object]) -> bytes:
     """RFC 8785-style canonical JSON bytes (sorted keys, minimal separators)."""
-    return json.dumps(
-        body,
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    ).encode("utf-8")
+    return canonical_bytes(body)
 
 
 def action_anchor_preimage(*, prev_anchor: str, observation_hash: str, action: Action) -> bytes:

--- a/src/bernstein/core/communication/task_mailbox.py
+++ b/src/bernstein/core/communication/task_mailbox.py
@@ -36,6 +36,7 @@ import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.security.canonical import canonical_bytes
 from bernstein.core.security.redactor import redact_text
 from bernstein.core.security.sanitize import sanitize_log
 
@@ -121,7 +122,7 @@ class MailboxFull(MailboxError):
 
 def _canonical(payload: dict[str, Any]) -> bytes:
     """Return stable canonical JSON bytes for ``payload``."""
-    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return canonical_bytes(payload)
 
 
 @dataclass(frozen=True)

--- a/src/bernstein/core/compliance/ai_bom.py
+++ b/src/bernstein/core/compliance/ai_bom.py
@@ -38,6 +38,8 @@ from collections.abc import Callable, Iterable, Mapping
 from dataclasses import asdict, dataclass, field
 from typing import Any, cast
 
+from bernstein.core.security.canonical import canonical_bytes
+
 __all__ = [
     "AIBOM",
     "BOM_SCHEMA_URL",
@@ -576,12 +578,7 @@ def _encode_native_json(bom: AIBOM) -> bytes:
     """
     doc = asdict(bom)
     # asdict() turns tuples into lists, which is what JSON wants.
-    return json.dumps(
-        doc,
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    ).encode("utf-8")
+    return canonical_bytes(doc)
 
 
 def _encode_cyclonedx(bom: AIBOM) -> bytes:

--- a/src/bernstein/core/compliance/ai_bom_encoders/cyclonedx.py
+++ b/src/bernstein/core/compliance/ai_bom_encoders/cyclonedx.py
@@ -22,8 +22,9 @@ The encoder is deterministic: identical :class:`AIBOM` -> identical bytes.
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING, Any
+
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from bernstein.core.compliance.ai_bom import (
@@ -81,7 +82,7 @@ def encode_cyclonedx(bom: AIBOM) -> bytes:
         },
         "components": components,
     }
-    return json.dumps(doc, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return canonical_bytes(doc)
 
 
 def _hash_block(sha256: str) -> list[dict[str, str]]:

--- a/src/bernstein/core/compliance/ai_bom_encoders/spdx.py
+++ b/src/bernstein/core/compliance/ai_bom_encoders/spdx.py
@@ -15,8 +15,9 @@ The encoder is deterministic.
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING, Any
+
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from bernstein.core.compliance.ai_bom import (
@@ -60,7 +61,7 @@ def encode_spdx(bom: AIBOM) -> bytes:
         },
         "packages": packages,
     }
-    return json.dumps(doc, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return canonical_bytes(doc)
 
 
 def _checksum(sha256: str) -> dict[str, str]:

--- a/src/bernstein/core/compliance/pack.py
+++ b/src/bernstein/core/compliance/pack.py
@@ -38,6 +38,7 @@ from bernstein.core.compliance.regulator_renderers import (
 )
 from bernstein.core.lineage.entry import LineageEntry, canonicalise, entry_hash
 from bernstein.core.lineage.identity import sign_detached
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -370,11 +371,6 @@ def build_pack(
 # ===========================================================================
 
 
-def _canonical_json(payload: Any) -> bytes:
-    """RFC 8785-style canonical JSON bytes (matches the offline verifier)."""
-    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
-
-
 def _safe_member_name(value: str) -> str:
     """Sanitise a caller-supplied id into a flat, path-safe member stem."""
     return "".join(c if (c.isalnum() or c in "-_.") else "_" for c in value) or "unnamed"
@@ -407,9 +403,9 @@ def _seal_pack(
         "input_hashes": input_hashes,
         "operator_kid": _OPERATOR_KID,
     }
-    manifest_bytes_no_output = _canonical_json(manifest)
+    manifest_bytes_no_output = canonical_bytes(manifest)
     manifest["output_hash"] = _sha256(manifest_bytes_no_output)
-    manifest_bytes = _canonical_json(manifest)
+    manifest_bytes = canonical_bytes(manifest)
 
     operator_pem = _load_operator_signer(operator_key_path)
     sig = sign_detached(manifest_bytes, operator_pem, kid=_OPERATOR_KID)
@@ -626,7 +622,7 @@ def build_retention_pack(
         "coverage_gaps": coverage_gaps,
         "retention_params": retention_params,
     }
-    evidence_bytes = _canonical_json(evidence)
+    evidence_bytes = canonical_bytes(evidence)
 
     sig_payload, card_payload = _collect_sig_card_members(filtered, signatures_src, agent_cards_dir)
     members: dict[str, bytes] = (
@@ -704,8 +700,8 @@ def build_oversight_pack(
     for a in in_window:
         displayed = a["displayed"]
         executed = a["executed"]
-        displayed_hash = _sha256(_canonical_json(displayed))
-        executed_hash = _sha256(_canonical_json(executed))
+        displayed_hash = _sha256(canonical_bytes(displayed))
+        executed_hash = _sha256(canonical_bytes(executed))
         binding_ok = displayed_hash == executed_hash
         receipt = {
             "v": 1,
@@ -718,7 +714,7 @@ def build_oversight_pack(
             "displayed_hash": displayed_hash,
             "executed_hash": executed_hash,
         }
-        receipt_members[f"receipts/{_safe_member_name(receipt['receipt_id'])}.json"] = _canonical_json(receipt)
+        receipt_members[f"receipts/{_safe_member_name(receipt['receipt_id'])}.json"] = canonical_bytes(receipt)
         evidence_rows.append(
             {
                 "receipt_id": receipt["receipt_id"],
@@ -745,7 +741,7 @@ def build_oversight_pack(
             "utf-8"
         ),
         "verify-instructions.md": _regulator_verify_instructions(PACK_KIND_OVERSIGHT).encode("utf-8"),
-        "oversight-evidence.json": _canonical_json(evidence),
+        "oversight-evidence.json": canonical_bytes(evidence),
         "oversight-report.csv": render_oversight_csv(evidence).encode("utf-8"),
         "oversight-report.pdf": render_oversight_pdf(
             org=org, period=(since.isoformat(), until.isoformat()), evidence=evidence
@@ -800,8 +796,8 @@ def build_incident_pack(
     """
     build_started_at = datetime.now(UTC).isoformat(timespec="seconds")
 
-    timeline_bytes = _canonical_json(timeline)
-    slice_bytes = b"".join(_canonical_json(ev) + b"\n" for ev in audit_events)
+    timeline_bytes = canonical_bytes(timeline)
+    slice_bytes = b"".join(canonical_bytes(ev) + b"\n" for ev in audit_events)
     gap_list = [dict(g) for g in gaps]
     gaps_doc = {"kind": PACK_KIND_INCIDENT, "run_id": run_id, "gaps": gap_list}
 
@@ -810,7 +806,7 @@ def build_incident_pack(
         "verify-instructions.md": _regulator_verify_instructions(PACK_KIND_INCIDENT).encode("utf-8"),
         "incident-timeline.json": timeline_bytes,
         "audit-slice.jsonl": slice_bytes,
-        "gaps.json": _canonical_json(gaps_doc),
+        "gaps.json": canonical_bytes(gaps_doc),
         "incident-report.csv": render_incident_csv(dict(timeline)).encode("utf-8"),
         "incident-report.pdf": render_incident_pdf(org=org, timeline=dict(timeline), gaps=gap_list),
     }

--- a/src/bernstein/core/cost/scheduling/knob_matrix.py
+++ b/src/bernstein/core/cost/scheduling/knob_matrix.py
@@ -60,7 +60,6 @@ candidate and the pinned matrix:
 from __future__ import annotations
 
 import hashlib
-import json
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import date
@@ -74,6 +73,7 @@ from bernstein.adapters._contract import (
 )
 from bernstein.core.cost.model_prices import MODEL_COSTS_PER_1M_TOKENS
 from bernstein.core.cost.scheduling.policy import DispatchCandidate, KnobSelection
+from bernstein.core.security.canonical import canonical_bytes
 
 #: ``as_of`` date shipped with :data:`DEFAULT_KNOB_MATRIX`. Mirrors the price
 #: table's ``as_of`` -- the knob economics are derived from the same rows.
@@ -174,7 +174,7 @@ class KnobMatrix:
         }
 
     def _canonical_bytes(self) -> bytes:
-        return json.dumps(self.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        return canonical_bytes(self.to_dict())
 
     def content_hash(self) -> str:
         """``sha256:`` digest pinning exactly these knob economics + metadata."""

--- a/src/bernstein/core/cost/scheduling/policy.py
+++ b/src/bernstein/core/cost/scheduling/policy.py
@@ -29,6 +29,8 @@ from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.security.canonical import canonical_bytes
+
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
@@ -75,7 +77,7 @@ KNOB_FIELDS = ("effort", "lane", "cache_strategy", "rate_multiplier")
 
 def _digest_value(value: Any) -> str:
     """Return a canonical ``sha256:`` digest of a single knob field value."""
-    payload = json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    payload = canonical_bytes(value)
     return "sha256:" + hashlib.sha256(payload).hexdigest()
 
 
@@ -340,7 +342,7 @@ class DispatchDecision:
 
     def canonical_bytes(self) -> bytes:
         """Canonical JSON bytes of the full decision (sealed into lineage)."""
-        return json.dumps(self.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        return canonical_bytes(self.to_dict())
 
     def verify_self_hash(self) -> bool:
         """True iff ``decision_hash`` recomputes from the current field body.
@@ -379,7 +381,7 @@ class DispatchDecision:
 
 
 def _hash_obj(obj: Any) -> str:
-    payload = json.dumps(obj, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    payload = canonical_bytes(obj)
     return "sha256:" + hashlib.sha256(payload).hexdigest()
 
 

--- a/src/bernstein/core/cost/scheduling/pools.py
+++ b/src/bernstein/core/cost/scheduling/pools.py
@@ -22,10 +22,11 @@ halfway through.
 from __future__ import annotations
 
 import hashlib
-import json
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
@@ -103,9 +104,7 @@ class PoolPreflightReport:
 
     def state_hash(self) -> str:
         """Deterministic ``sha256:`` digest of the full projected state."""
-        payload = json.dumps(
-            [p.to_dict() for p in self.pools], ensure_ascii=False, separators=(",", ":"), sort_keys=True
-        ).encode("utf-8")
+        payload = canonical_bytes([p.to_dict() for p in self.pools])
         return "sha256:" + hashlib.sha256(payload).hexdigest()
 
     def to_dict(self) -> dict[str, object]:

--- a/src/bernstein/core/cost/scheduling/price_table.py
+++ b/src/bernstein/core/cost/scheduling/price_table.py
@@ -28,12 +28,12 @@ drop -- identical semantics to
 from __future__ import annotations
 
 import hashlib
-import json
 from dataclasses import dataclass
 from datetime import date
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.cost.model_prices import MODEL_COSTS_PER_1M_TOKENS
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -99,7 +99,7 @@ class PriceTable:
 
     def _canonical_bytes(self) -> bytes:
         # Sorted keys make the hash independent of insertion order.
-        return json.dumps(self.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        return canonical_bytes(self.to_dict())
 
     def content_hash(self) -> str:
         """``sha256:`` digest pinning exactly these rates + version metadata."""

--- a/src/bernstein/core/datasources/schema.py
+++ b/src/bernstein/core/datasources/schema.py
@@ -43,6 +43,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 from bernstein.core.datasources.errors import DataSourceError
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -184,7 +185,7 @@ class SchemaSnapshot:
             "v": SNAPSHOT_VERSION,
             "objects": [o.to_dict() for o in self.objects],
         }
-        return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        return canonical_bytes(payload)
 
     @property
     def digest(self) -> str:

--- a/src/bernstein/core/endpoints/certification.py
+++ b/src/bernstein/core/endpoints/certification.py
@@ -35,6 +35,7 @@ from bernstein.core.endpoints.conformance import (
 )
 from bernstein.core.lineage.identity import generate_keypair
 from bernstein.core.lineage.spine import LineageSpine
+from bernstein.core.security.canonical import canonical_bytes
 from bernstein.core.skills.catalog.signature import sign_payload, verify_payload
 
 if TYPE_CHECKING:
@@ -74,13 +75,9 @@ _IDENTITY_PRIVATE_NAME = "endpoint-identity-key.pem"
 _IDENTITY_PUBLIC_NAME = "endpoint-identity-public.pem"
 
 
-def _canonical_bytes(data: Mapping[str, Any]) -> bytes:
-    return json.dumps(data, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
-
-
 def endpoint_fingerprint(base_url: str, model: str) -> str:
     """Stable hex fingerprint of a normalized ``(base_url, model)`` pair."""
-    payload = _canonical_bytes({"base_url": normalize_base_url(base_url), "model": model})
+    payload = canonical_bytes({"base_url": normalize_base_url(base_url), "model": model})
     return hashlib.sha256(payload).hexdigest()
 
 
@@ -162,7 +159,7 @@ class EndpointCertification:
         """Canonical JSON bytes of the binding (the signature preimage)."""
         cached = self._binding_cache.get("binding")
         if cached is None:
-            cached = _canonical_bytes(self.binding_dict())
+            cached = canonical_bytes(self.binding_dict())
             self._binding_cache["binding"] = cached
         return cached
 

--- a/src/bernstein/core/events/actions.py
+++ b/src/bernstein/core/events/actions.py
@@ -16,9 +16,10 @@ action's digest before the effect ever runs.
 from __future__ import annotations
 
 import hashlib
-import json
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
+
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -46,7 +47,7 @@ ALLOWED_ACTION_KINDS: frozenset[str] = frozenset(
 
 
 def _canonical_json(obj: Any) -> str:
-    return json.dumps(obj, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    return canonical_bytes(obj).decode("utf-8")
 
 
 def rule_hash(rule_spec: Mapping[str, Any]) -> str:

--- a/src/bernstein/core/events/grammar.py
+++ b/src/bernstein/core/events/grammar.py
@@ -41,6 +41,8 @@ import json
 from dataclasses import dataclass
 from typing import Any, cast
 
+from bernstein.core.security.canonical import canonical_bytes
+
 #: The genesis ``prev_hmac`` value used by the audit chain (see
 #: :mod:`bernstein.core.security.audit`). Re-declared here to keep this module
 #: import-light; a mismatch would surface immediately in the projection tests.
@@ -119,7 +121,7 @@ def canonical_details_digest(details: dict[str, Any]) -> str:
     payload without copying it into the feed, and it is what a fire receipt and a
     render template commit to.
     """
-    preimage = json.dumps(details, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    preimage = canonical_bytes(details)
     return "sha256:" + hashlib.sha256(preimage).hexdigest()
 
 

--- a/src/bernstein/core/evidence/bundle.py
+++ b/src/bernstein/core/evidence/bundle.py
@@ -62,6 +62,7 @@ from bernstein.core.lineage.spine import (
     compute_entry_hash,
     content_hash_of,
 )
+from bernstein.core.security.canonical import canonical_bytes
 from bernstein.core.security.key_derivation import (
     DOMAIN_LINEAGE,
     SCHEME_V2,
@@ -132,11 +133,6 @@ _STATUS_FAIL = "fail"
 # ---------------------------------------------------------------------------
 # Canonical hashing helpers
 # ---------------------------------------------------------------------------
-
-
-def _canonical_bytes(payload: dict[str, Any]) -> bytes:
-    """Return canonical JSON bytes (sorted keys, minimal separators, UTF-8)."""
-    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
 
 
 def _sha256_bytes(data: bytes) -> str:
@@ -495,7 +491,7 @@ class EvidenceBundle:
 
     def to_canonical_bytes(self) -> bytes:
         """Serialise the binding to canonical bytes (signed + spine-hashed)."""
-        return _canonical_bytes(self._binding())
+        return canonical_bytes(self._binding())
 
     def bundle_hash(self) -> str:
         """Return the ``sha256:`` hash of the canonical binding bytes."""
@@ -642,7 +638,7 @@ def _seal_media_credential(
         if not isinstance(priv, Ed25519PrivateKey):
             raise TypeError("evidence identity is not an Ed25519 key")
         signed = sign_manifest(manifest, signing_key=priv)
-        credential = store.put(_canonical_bytes(manifest_to_dict(signed)))
+        credential = store.put(canonical_bytes(manifest_to_dict(signed)))
     except (ValueError, TypeError, KeyError, OSError) as exc:  # pragma: no cover - defensive
         # Log only the exception type: this path handles a private key, so
         # even sanitized exception text stays out of the log stream.

--- a/src/bernstein/core/evidence/render_receipt.py
+++ b/src/bernstein/core/evidence/render_receipt.py
@@ -9,10 +9,11 @@ SHA-256, enabling reproducible comparisons across renders.
 from __future__ import annotations
 
 import hashlib
-import json
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
+
+from bernstein.core.security.canonical import canonical_bytes
 
 #: Sentinel epoch for default clock_value when none is supplied.
 _EPOCH_UTC = datetime(1970, 1, 1, tzinfo=timezone.utc)  # noqa: UP017
@@ -35,16 +36,6 @@ __all__ = [
 # ---------------------------------------------------------------------------
 # Canonical hashing helpers
 # ---------------------------------------------------------------------------
-
-
-def _canonical_bytes(payload: dict[str, Any]) -> bytes:
-    """Return canonical JSON bytes (sorted keys, minimal separators, UTF-8)."""
-    return json.dumps(
-        payload,
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    ).encode("utf-8")
 
 
 def _sha256_hex(data: bytes) -> str:
@@ -362,7 +353,7 @@ class RenderReceipt:
 
     def to_canonical_bytes(self) -> bytes:
         """Serialise the binding to canonical bytes for hashing."""
-        return _canonical_bytes(self._binding())
+        return canonical_bytes(self._binding())
 
     def receipt_hash(self) -> str:
         """Return the ``sha256:`` digest of the canonical binding bytes."""

--- a/src/bernstein/core/evidence/run_artifacts.py
+++ b/src/bernstein/core/evidence/run_artifacts.py
@@ -52,6 +52,7 @@ from bernstein.core.defaults import (
 )
 from bernstein.core.evidence.bundle import DEFAULT_MAX_BLOB_BYTES, EvidenceStore
 from bernstein.core.lineage.spine import LineageSpine, content_hash_of
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -208,7 +209,7 @@ def _sha256_bytes(value: bytes) -> str:
 
 
 def _canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
-    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return canonical_bytes(value)
 
 
 def _build_finding_content(
@@ -478,9 +479,7 @@ class ArtifactPayload:
 
     def canonical_bytes(self) -> bytes:
         """Return the canonical UTF-8 JSON bytes that are content-addressed."""
-        return json.dumps(self.to_content_dict(), ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode(
-            "utf-8"
-        )
+        return canonical_bytes(self.to_content_dict())
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/bernstein/core/govern/__init__.py
+++ b/src/bernstein/core/govern/__init__.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import hashlib
-import json
 from typing import Any
 
 from bernstein.core.govern.inventory_models import Inventory, Surface
 from bernstein.core.govern.plan_models import GovernPlan, PlanEntry, PlanEntryKind
 from bernstein.core.govern.playbook_models import Playbook, PlaybookClause
+from bernstein.core.security.canonical import canonical_bytes
 
 
 def compute_plan(
@@ -151,12 +151,7 @@ def compute_plan(
             )
         )
 
-    inputs_bytes = json.dumps(
-        {"playbook": playbook, "inventory": inventory},
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    ).encode("utf-8")
+    inputs_bytes = canonical_bytes({"playbook": playbook, "inventory": inventory})
     inputs_hash = "sha256:" + hashlib.sha256(inputs_bytes).hexdigest()
 
     return GovernPlan(

--- a/src/bernstein/core/govern/inventory_models.py
+++ b/src/bernstein/core/govern/inventory_models.py
@@ -8,9 +8,10 @@ surface carries its observed value and an evidence reference for auditability.
 from __future__ import annotations
 
 import hashlib
-import json
 from dataclasses import dataclass
 from typing import Any
+
+from bernstein.core.security.canonical import canonical_bytes
 
 
 @dataclass(frozen=True, slots=True)
@@ -80,12 +81,7 @@ class Inventory:
         identical inventories produce identical hashes regardless of
         Python dict ordering.
         """
-        canonical = json.dumps(
-            self.to_dict(),
-            ensure_ascii=False,
-            separators=(",", ":"),
-            sort_keys=True,
-        ).encode("utf-8")
+        canonical = canonical_bytes(self.to_dict())
         return "sha256:" + hashlib.sha256(canonical).hexdigest()
 
     def get_surface(self, surface_id: str) -> Surface | None:

--- a/src/bernstein/core/govern/plan_models.py
+++ b/src/bernstein/core/govern/plan_models.py
@@ -14,10 +14,11 @@ offline.
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
+
+from bernstein.core.security.canonical import canonical_bytes
 
 
 class PlanEntryKind(Enum):
@@ -134,12 +135,7 @@ class GovernPlan:
         encoding. This is the form hashed into the lineage spine, so two
         replays against the same inputs produce byte-identical anchors.
         """
-        return json.dumps(
-            self.to_dict(),
-            ensure_ascii=False,
-            separators=(",", ":"),
-            sort_keys=True,
-        ).encode("utf-8")
+        return canonical_bytes(self.to_dict())
 
     def to_dict(self) -> dict[str, Any]:
         """Return the canonical serialization (the hashed payload)."""

--- a/src/bernstein/core/govern/playbook_models.py
+++ b/src/bernstein/core/govern/playbook_models.py
@@ -8,9 +8,10 @@ state" against which the inventory is diffed to produce a GovernPlan.
 from __future__ import annotations
 
 import hashlib
-import json
 from dataclasses import dataclass
 from typing import Any
+
+from bernstein.core.security.canonical import canonical_bytes
 
 
 @dataclass(frozen=True, slots=True)
@@ -94,12 +95,7 @@ class Playbook:
         identical playbooks produce identical hashes regardless of Python
         dict ordering.
         """
-        canonical = json.dumps(
-            self.to_dict(),
-            ensure_ascii=False,
-            separators=(",", ":"),
-            sort_keys=True,
-        ).encode("utf-8")
+        canonical = canonical_bytes(self.to_dict())
         return "sha256:" + hashlib.sha256(canonical).hexdigest()
 
     def clauses_by_kind(self, kind: str) -> tuple[PlaybookClause, ...]:

--- a/src/bernstein/core/interop/a2a_conformance.py
+++ b/src/bernstein/core/interop/a2a_conformance.py
@@ -41,6 +41,7 @@ from bernstein.core.security.agent_card_signer import (
     ed25519_pem_from_jwk,
     verify_detached_jws_over_canonical,
 )
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from bernstein.core.interop.a2a_card import SignedCapabilityCard
@@ -256,7 +257,7 @@ def canonical_report_bytes(report: ConformanceReport) -> bytes:
     be hashed and anchored as the immutable evidence of *which checks ran and
     what they returned* (AC: determinism + verifiability).
     """
-    return json.dumps(report.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return canonical_bytes(report.to_dict())
 
 
 def report_hash(report: ConformanceReport) -> str:

--- a/src/bernstein/core/interop/a2a_lineage.py
+++ b/src/bernstein/core/interop/a2a_lineage.py
@@ -43,6 +43,7 @@ from bernstein.core.lineage.tracker_audit import (
     entry_to_body,
 )
 from bernstein.core.replay.journal import EventJournal
+from bernstein.core.security.canonical import canonical_bytes
 from bernstein.core.security.sanitize import sanitize_log
 from bernstein.core.skills.catalog.signature import sign_payload, verify_payload
 
@@ -108,7 +109,7 @@ LINEAGE_ENVELOPE_SCHEMA_VERSION: int = 1
 
 def _canonical(payload: dict[str, Any]) -> bytes:
     """Return stable JCS-style bytes for ``payload``."""
-    return json.dumps(payload, separators=(",", ":"), sort_keys=True, ensure_ascii=False).encode("utf-8")
+    return canonical_bytes(payload)
 
 
 def chain_digest(entries: Sequence[TrackerAuditEntry]) -> str:
@@ -384,11 +385,6 @@ def map_task_state(state: str) -> TaskStateMapping:
 # ---------------------------------------------------------------------------
 
 
-def _canonical_bytes(payload: dict[str, Any]) -> bytes:
-    """Return canonical JSON bytes (sorted keys, minimal separators, UTF-8)."""
-    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
-
-
 def _sha256_bytes(data: bytes) -> str:
     return "sha256:" + hashlib.sha256(data).hexdigest()
 
@@ -407,7 +403,7 @@ def compute_message_hash(
     raw message body so a verifier presented the same message recomputes the
     same hash. A single-byte edit to any field diverges the hash.
     """
-    preimage = _canonical_bytes(
+    preimage = canonical_bytes(
         {
             "v": A2A_MESSAGE_RECEIPT_SCHEMA_VERSION,
             "task_uuid": task_uuid,
@@ -538,7 +534,7 @@ class A2AMessageReceipt:
 
     def to_canonical_bytes(self) -> bytes:
         """Serialise the binding to canonical JSON bytes (signed + anchored)."""
-        return _canonical_bytes(self._binding())
+        return canonical_bytes(self._binding())
 
     def to_dict(self) -> dict[str, Any]:
         return self._binding() | {
@@ -1088,7 +1084,7 @@ class CardVerdictReceipt:
 
     def to_canonical_bytes(self) -> bytes:
         """Serialise the binding to canonical JSON bytes (signed + anchored)."""
-        return _canonical_bytes(self._binding())
+        return canonical_bytes(self._binding())
 
     def to_dict(self) -> dict[str, Any]:
         return self._binding() | {

--- a/src/bernstein/core/knowledge/conventions.py
+++ b/src/bernstein/core/knowledge/conventions.py
@@ -70,6 +70,7 @@ from bernstein.core.security.audit_chain import (
     record_convention_receipt,
     record_convention_retired,
 )
+from bernstein.core.security.canonical import canonical_bytes
 from bernstein.core.skills.catalog.signature import sign_payload, verify_payload
 
 if TYPE_CHECKING:
@@ -156,7 +157,7 @@ class ConventionReceipt:
 
     def to_canonical_bytes(self) -> bytes:
         """Serialise the binding to canonical JSON bytes (sorted keys, minimal separators)."""
-        return json.dumps(self._binding(), ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        return canonical_bytes(self._binding())
 
     def to_dict(self) -> dict[str, Any]:
         """Return full JSON-serializable dictionary including cryptographic fields."""
@@ -889,9 +890,7 @@ def compute_ruleset_hash(receipts: list[ConventionReceipt]) -> str:
         (_ruleset_projection(r) for r in receipts),
         key=lambda p: (str(p["subject_path"]), str(p["subject_symbol"]), str(p["rule_text_hash"])),
     )
-    ruleset_bytes = b"\x00".join(
-        json.dumps(p, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8") for p in projections
-    )
+    ruleset_bytes = b"\x00".join(canonical_bytes(p) for p in projections)
     return "sha256:" + hashlib.sha256(ruleset_bytes).hexdigest()
 
 

--- a/src/bernstein/core/lineage/artifact_attempt.py
+++ b/src/bernstein/core/lineage/artifact_attempt.py
@@ -60,7 +60,6 @@ itself.
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import TYPE_CHECKING
 
@@ -71,6 +70,7 @@ from bernstein.core.lineage.artifact_uri import (
     is_glob_pattern,
 )
 from bernstein.core.lineage.spine import ARTIFACT_ATTEMPT_STEP_PREFIX, LineageSpine
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -187,7 +187,7 @@ def attempt_record_bytes(*, task_id: str, uri: str, outcome: str, reason: str = 
         "uri": uri,
         "v": ATTEMPT_RECORD_VERSION,
     }
-    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return canonical_bytes(payload)
 
 
 def record_output_attempt(

--- a/src/bernstein/core/lineage/artifact_events.py
+++ b/src/bernstein/core/lineage/artifact_events.py
@@ -55,6 +55,7 @@ from bernstein.core.lineage.spine import (
     SpineEntry,
     verify_entry,
 )
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
@@ -165,12 +166,7 @@ class ArtifactProductionEvent:
         Sorted keys and minimal separators, so two hosts projecting the same
         spine entry serialise byte-identical rows.
         """
-        return json.dumps(
-            self.to_payload(),
-            ensure_ascii=False,
-            separators=(",", ":"),
-            sort_keys=True,
-        ).encode("utf-8")
+        return canonical_bytes(self.to_payload())
 
     @classmethod
     def from_payload(cls, row: dict[str, Any]) -> ArtifactProductionEvent:

--- a/src/bernstein/core/lineage/artifact_health.py
+++ b/src/bernstein/core/lineage/artifact_health.py
@@ -44,7 +44,6 @@ never reported as a negative signal.
 
 from __future__ import annotations
 
-import json
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -52,6 +51,7 @@ from typing import TYPE_CHECKING, Any
 from bernstein.core.lineage.artifact_attempt import attempt_outcome, attempt_task_id, is_attempt_step_id
 from bernstein.core.lineage.artifact_uri import ArtifactURIError, canonical_artifact_key
 from bernstein.core.lineage.spine import LineageSpine, SpineStatus, verify_entry
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -265,7 +265,7 @@ def _canonical_json(payload: dict[str, Any]) -> str:
     Sorted keys and minimal separators: this single function is why two
     surfaces cannot produce different bytes for the same verdict.
     """
-    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    return canonical_bytes(payload).decode("utf-8")
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/lineage/artifact_uri.py
+++ b/src/bernstein/core/lineage/artifact_uri.py
@@ -67,10 +67,11 @@ are unaffected.
 from __future__ import annotations
 
 import hashlib
-import json
 import re
 from dataclasses import dataclass
 from functools import lru_cache
+
+from bernstein.core.security.canonical import canonical_bytes
 
 __all__ = [
     "ARTIFACT_URI_SCHEMES",
@@ -601,7 +602,7 @@ def external_reference_bytes(uri: str, *, digest: str, extractor: str | None = N
     }
     if extractor is not None:
         document["extractor"] = extractor
-    return json.dumps(document, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return canonical_bytes(document)
 
 
 def external_reference_content_hash(uri: str, *, digest: str, extractor: str | None = None) -> str:

--- a/src/bernstein/core/lineage/c2pa.py
+++ b/src/bernstein/core/lineage/c2pa.py
@@ -40,13 +40,13 @@ from __future__ import annotations
 
 import base64
 import binascii
-import json
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, cast
 
 from cryptography.exceptions import InvalidSignature
 
 from bernstein.core.lineage.spine import content_hash_of
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -304,12 +304,7 @@ def _signing_payload_dict(manifest: C2paManifest) -> dict[str, Any]:
 
 def canonical_manifest_bytes(manifest: C2paManifest) -> bytes:
     """Return deterministic signing bytes: sorted keys, compact, UTF-8."""
-    return json.dumps(
-        _signing_payload_dict(manifest),
-        sort_keys=True,
-        separators=(",", ":"),
-        ensure_ascii=False,
-    ).encode("utf-8")
+    return canonical_bytes(_signing_payload_dict(manifest))
 
 
 def manifest_to_dict(manifest: C2paManifest) -> dict[str, Any]:

--- a/src/bernstein/core/lineage/entry.py
+++ b/src/bernstein/core/lineage/entry.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 
 import hashlib
 import hmac as _hmac
-import json
 import re
 from dataclasses import asdict, dataclass
+
+from bernstein.core.security.canonical import canonical_bytes
 
 LINEAGE_ENTRY_VERSION = 1
 
@@ -192,12 +193,7 @@ def canonicalise(entry: LineageEntry) -> bytes:
     None, or nested objects into a LineageEntry, so the corner cases of RFC
     8785 around ES6 number formatting and recursive ordering don't apply.
     """
-    return json.dumps(
-        _canonical_body(entry),
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    ).encode("utf-8")
+    return canonical_bytes(_canonical_body(entry))
 
 
 def entry_hash(entry: LineageEntry) -> str:
@@ -219,5 +215,5 @@ def compute_operator_hmac(entry: LineageEntry, key: bytes) -> str:
     """
     body = _canonical_body(entry)
     body["operator_hmac"] = ""
-    canonical = json.dumps(body, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    canonical = canonical_bytes(body)
     return _hmac.new(key, canonical, hashlib.sha256).hexdigest()

--- a/src/bernstein/core/lineage/run_graph.py
+++ b/src/bernstein/core/lineage/run_graph.py
@@ -41,6 +41,7 @@ from typing import TYPE_CHECKING, Any
 
 from bernstein.core.lineage.spine import LineageSpine, content_hash_of
 from bernstein.core.security.agent_card_signer import sign_detached_jws_over_canonical
+from bernstein.core.security.canonical import canonical_bytes
 from bernstein.core.worktrees.classifier import _git_head_sha, classify_worktrees
 
 if TYPE_CHECKING:
@@ -246,7 +247,7 @@ class RunGraphReceiptSchema:
 
 def _hash_obj(obj: object) -> str:
     """Canonical SHA256 hash over canonical JSON (mirror gate_receipt._hash_obj)."""
-    payload = json.dumps(obj, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    payload = canonical_bytes(obj)
     return "sha256:" + hashlib.sha256(payload).hexdigest()
 
 

--- a/src/bernstein/core/lineage/spine.py
+++ b/src/bernstein/core/lineage/spine.py
@@ -49,6 +49,8 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.security.canonical import canonical_bytes
+
 if sys.platform == "win32":
     fcntl = None  # type: ignore[assignment]
 else:
@@ -213,12 +215,7 @@ def compute_entry_hash(
         fields["tracestate"] = tracestate
     if baggage is not None:
         fields["baggage"] = baggage
-    preimage = domain_prefix.encode("utf-8") + json.dumps(
-        fields,
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    ).encode("utf-8")
+    preimage = domain_prefix.encode("utf-8") + canonical_bytes(fields)
     return "sha256:" + hashlib.sha256(preimage).hexdigest()
 
 
@@ -279,7 +276,7 @@ class SpineEntry:
 
 
 def _canonical_body_bytes(body: dict[str, Any]) -> bytes:
-    return json.dumps(body, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return canonical_bytes(body)
 
 
 def _compute_hmac(key: bytes, body: dict[str, Any]) -> str:

--- a/src/bernstein/core/lineage/tracker_audit.py
+++ b/src/bernstein/core/lineage/tracker_audit.py
@@ -38,6 +38,8 @@ from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, Literal
 
+from bernstein.core.security.canonical import canonical_bytes
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -79,23 +81,6 @@ def content_hash(blob: bytes) -> str:
     """Return the content-addressed identifier for ``blob``."""
 
     return "sha256:" + hashlib.sha256(blob).hexdigest()
-
-
-def _canonical_bytes(payload: dict[str, Any]) -> bytes:
-    """Return RFC 8785 JCS bytes for ``payload``.
-
-    The entry schema is a flat object of strings / ints / floats / lists
-    of strings, so ``json.dumps`` with ``sort_keys`` plus minimal
-    separators is sufficient (the edge cases of RFC 8785 around ES6
-    number formatting do not apply).
-    """
-
-    return json.dumps(
-        payload,
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    ).encode("utf-8")
 
 
 # ---------------------------------------------------------------------------
@@ -176,7 +161,7 @@ def canonicalise_entry(entry: TrackerAuditEntry) -> bytes:
     bytes the HMAC ran over should use :func:`_signing_payload`.
     """
 
-    return _canonical_bytes(_entry_body(entry))
+    return canonical_bytes(_entry_body(entry))
 
 
 def _signing_payload(entry: TrackerAuditEntry) -> bytes:
@@ -190,7 +175,7 @@ def _signing_payload(entry: TrackerAuditEntry) -> bytes:
     body = _entry_body(entry)
     body["signature"] = ""
     body["entry_hash"] = ""
-    return _canonical_bytes(body)
+    return canonical_bytes(body)
 
 
 def compute_entry_hash(entry: TrackerAuditEntry) -> str:
@@ -333,7 +318,7 @@ class TrackerAuditLog:
         signature = compute_signature(signed, self._hmac_key)
         final = replace(signed, signature=signature)
 
-        line = _canonical_bytes(_entry_body(final)) + b"\n"
+        line = canonical_bytes(_entry_body(final)) + b"\n"
         self.path.parent.mkdir(parents=True, exist_ok=True)
         with self.path.open("ab") as fp, _exclusive_lock(fp):
             fp.write(line)
@@ -467,7 +452,7 @@ class TrackerAuditLog:
         out_path.parent.mkdir(parents=True, exist_ok=True)
         with out_path.open("wb") as fp:
             for entry in entries:
-                fp.write(_canonical_bytes(_entry_body(entry)))
+                fp.write(canonical_bytes(_entry_body(entry)))
                 fp.write(b"\n")
         return len(entries)
 

--- a/src/bernstein/core/lineage/v2_store.py
+++ b/src/bernstein/core/lineage/v2_store.py
@@ -60,6 +60,8 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
+from bernstein.core.security.canonical import canonical_bytes
+
 if sys.platform == "win32":
     fcntl = None  # type: ignore[assignment]
 else:
@@ -153,7 +155,7 @@ class ChildBody:
 
 def _canonicalise(d: dict[str, Any]) -> bytes:
     """RFC 8785-compatible canonical JSON bytes for a flat dict."""
-    return json.dumps(d, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return canonical_bytes(d)
 
 
 def _sha256_hex(b: bytes) -> str:

--- a/src/bernstein/core/memory/chain.py
+++ b/src/bernstein/core/memory/chain.py
@@ -57,6 +57,8 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.security.canonical import canonical_bytes
+
 if sys.platform == "win32":
     fcntl = None  # type: ignore[assignment]
 else:
@@ -145,7 +147,7 @@ def compute_entry_hash(
     The pre-image is the canonical JSON of the ordered field tuple, so
     the digest is deterministic across processes and platforms.
     """
-    preimage = json.dumps(
+    preimage = canonical_bytes(
         {
             "prev_hash": prev_hash,
             "source_hash": source_hash,
@@ -157,16 +159,13 @@ def compute_entry_hash(
             "namespace": namespace,
             "kind": kind,
             "tombstone_of": tombstone_of,
-        },
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    ).encode("utf-8")
+        }
+    )
     return "sha256:" + hashlib.sha256(preimage).hexdigest()
 
 
 def _canonical_body_bytes(body: dict[str, Any]) -> bytes:
-    return json.dumps(body, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return canonical_bytes(body)
 
 
 def _compute_hmac(key: bytes, body: dict[str, Any]) -> str:

--- a/src/bernstein/core/observability/otel_projection.py
+++ b/src/bernstein/core/observability/otel_projection.py
@@ -49,6 +49,8 @@ from typing import TYPE_CHECKING, Any
 
 from cryptography.exceptions import InvalidSignature
 
+from bernstein.core.security.canonical import canonical_bytes
+
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
@@ -391,12 +393,7 @@ def _signing_payload_dict(projection: SpanProjection) -> dict[str, Any]:
 
 def canonical_projection_bytes(projection: SpanProjection) -> bytes:
     """Return deterministic signing bytes: sorted keys, compact, UTF-8."""
-    return json.dumps(
-        _signing_payload_dict(projection),
-        sort_keys=True,
-        separators=(",", ":"),
-        ensure_ascii=False,
-    ).encode("utf-8")
+    return canonical_bytes(_signing_payload_dict(projection))
 
 
 def projection_to_dict(projection: SpanProjection) -> dict[str, Any]:

--- a/src/bernstein/core/observability/otlp_ingest_receipt.py
+++ b/src/bernstein/core/observability/otlp_ingest_receipt.py
@@ -38,6 +38,8 @@ import json
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.security.canonical import canonical_bytes
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -91,10 +93,6 @@ class IngestReceiptError(ValueError):
 # --------------------------------------------------------------------------- #
 # Canonical hashing helpers                                                     #
 # --------------------------------------------------------------------------- #
-
-
-def _canonical_bytes(payload: dict[str, Any]) -> bytes:
-    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
 
 
 def _sha256_bytes(data: bytes) -> str:
@@ -174,7 +172,7 @@ class IngestReceipt:
 
     def to_canonical_bytes(self) -> bytes:
         """Return canonical JSON bytes of the signed binding."""
-        return _canonical_bytes(self._binding())
+        return canonical_bytes(self._binding())
 
     def binding_digest(self) -> str:
         """Return the content hash of the signed binding."""

--- a/src/bernstein/core/observability/repository_flow_series.py
+++ b/src/bernstein/core/observability/repository_flow_series.py
@@ -15,6 +15,8 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from bernstein.core.security.canonical import canonical_bytes
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -73,7 +75,7 @@ def serialize_sample(sample: RepositoryFlowSample) -> bytes:
         "churn_lines": sample.churn_lines,
         "open_issues": sample.open_issues,
     }
-    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return canonical_bytes(payload)
 
 
 def deserialize_sample(line: bytes) -> RepositoryFlowSample:

--- a/src/bernstein/core/orchestration/consensus_relay.py
+++ b/src/bernstein/core/orchestration/consensus_relay.py
@@ -69,6 +69,7 @@ from typing import Any, Final, cast
 
 from bernstein.core.dataclass_helpers import typed_replace as _typed_replace
 from bernstein.core.persistence.atomic_write import write_atomic_json
+from bernstein.core.security.canonical import canonical_bytes
 
 __all__ = [
     "DEFAULT_RELAY_DIR",
@@ -377,7 +378,7 @@ def canonicalise_relay(doc: RelayDocument) -> bytes:
     """
     body = doc.to_dict()
     body["operator_hmac"] = ""
-    return json.dumps(body, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return canonical_bytes(body)
 
 
 def compute_relay_hmac(doc: RelayDocument, key: bytes) -> str:

--- a/src/bernstein/core/orchestration/escalation.py
+++ b/src/bernstein/core/orchestration/escalation.py
@@ -52,6 +52,7 @@ from bernstein.core.orchestration.supervisor_receipt import (
 )
 from bernstein.core.replay.fork import SNAPSHOT_EVENT
 from bernstein.core.replay.journal import load_events, run_journal_path, verify_journal
+from bernstein.core.security.canonical import canonical_bytes
 from bernstein.core.skills.catalog.signature import sign_payload, verify_payload
 
 if TYPE_CHECKING:
@@ -91,11 +92,6 @@ class EscalationError(RuntimeError):
 # ---------------------------------------------------------------------------
 # Canonical helpers
 # ---------------------------------------------------------------------------
-
-
-def _canonical_bytes(payload: dict[str, Any]) -> bytes:
-    """Return canonical JSON bytes (sorted keys, minimal separators, UTF-8)."""
-    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
 
 
 def _safe_receipt_name(receipt_id: str) -> str:
@@ -308,7 +304,7 @@ class EscalationReceipt:
 
     def to_canonical_bytes(self) -> bytes:
         """Serialise the binding to canonical JSON bytes (signed + spine-hashed)."""
-        return _canonical_bytes(self._binding())
+        return canonical_bytes(self._binding())
 
     def to_dict(self) -> dict[str, Any]:
         return self._binding() | {

--- a/src/bernstein/core/orchestration/phase_gate_lineage.py
+++ b/src/bernstein/core/orchestration/phase_gate_lineage.py
@@ -30,6 +30,7 @@ import json
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.lineage.spine import LineageSpine
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -105,7 +106,7 @@ def _boundary_content(
         "phase": phase.value,
         "rules": [{"rule_id": r.rule_id, "outcome": r.outcome.value} for r in results],
     }
-    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return canonical_bytes(payload)
 
 
 def make_spine_lineage_hook(

--- a/src/bernstein/core/orchestration/steering.py
+++ b/src/bernstein/core/orchestration/steering.py
@@ -45,6 +45,7 @@ from bernstein.core.security.audit_chain import (
     record_steering_rejection,
     record_task_mailbox_message,
 )
+from bernstein.core.security.canonical import canonical_bytes
 from bernstein.core.server.dashboard_tokens import SCOPE_OPERATOR
 
 if TYPE_CHECKING:
@@ -128,7 +129,7 @@ class SteeringPayloadMismatch(SteeringError):
 
 def _canonical(payload: dict[str, Any]) -> bytes:
     """Return stable canonical JSON bytes (sorted keys, compact, UTF-8)."""
-    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return canonical_bytes(payload)
 
 
 def _sha256(data: bytes) -> str:

--- a/src/bernstein/core/orchestration/tracker_pipeline.py
+++ b/src/bernstein/core/orchestration/tracker_pipeline.py
@@ -64,13 +64,13 @@ from typing import IO, TYPE_CHECKING, Any, ClassVar, Final, Protocol, cast, runt
 
 from bernstein.core.lineage.tracker_audit import (
     GENESIS_PREV_HASH,
-    _canonical_bytes,
     _exclusive_lock,
 )
 from bernstein.core.security.audit_head_signature import (
     build_head_signature,
     verify_head_signature,
 )
+from bernstein.core.security.canonical import canonical_bytes as _canonical_bytes
 
 if TYPE_CHECKING:
     from bernstein.core.lifecycle.hooks import HookRegistry

--- a/src/bernstein/core/payments/adapters/jws_passthrough.py
+++ b/src/bernstein/core/payments/adapters/jws_passthrough.py
@@ -18,6 +18,7 @@ import json
 
 from bernstein.core.payments.mandate import SpendMandate
 from bernstein.core.security.agent_card_signer import canonicalize_jcs
+from bernstein.core.security.canonical import canonical_bytes
 
 __all__ = ["JwsPassthroughMandateAdapter"]
 
@@ -49,7 +50,7 @@ class JwsPassthroughMandateAdapter:
             "payload": payload,
             "signatures": [{"protected": protected, "signature": signature}],
         }
-        return json.dumps(envelope, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        return canonical_bytes(envelope)
 
     def from_external(self, blob: bytes) -> SpendMandate:
         """Parse a JWS General JSON envelope back into a mandate.

--- a/src/bernstein/core/persistence/cache_dedup.py
+++ b/src/bernstein/core/persistence/cache_dedup.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 
 import hashlib
 import hmac as _hmac
-import json
 import threading
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -40,6 +39,7 @@ from bernstein.core.persistence.cache_policy import (
     resolve_cached_path,
     validate_cache_key,
 )
+from bernstein.core.security.canonical import canonical_bytes
 from bernstein.core.tasks.claim import (
     Backlog,
     BacklogEntry,
@@ -55,10 +55,6 @@ _RECEIPT_VERSION = 1
 
 #: Status a released row returns to, matching the claim primitive's vocabulary.
 _OPEN_STATUS = "open"
-
-
-def _canonical_bytes(value: Any) -> bytes:
-    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
 
 
 # ---------------------------------------------------------------------------
@@ -147,7 +143,7 @@ def mint_duplicate_receipt(
         winner_output_ref=winner_output_ref,
         ts=ts,
     )
-    tag = _hmac.new(hmac_key, _canonical_bytes(unsigned.body()), hashlib.sha256).hexdigest()
+    tag = _hmac.new(hmac_key, canonical_bytes(unsigned.body()), hashlib.sha256).hexdigest()
     return DuplicateOfReceipt(
         cache_key=cache_key,
         winner=winner,
@@ -178,7 +174,7 @@ def verify_duplicate_receipt(
     field (issue #2551 AC3). Absent an authoritative copy the mismatch is
     reported as ``"hmac"``.
     """
-    expected = _hmac.new(hmac_key, _canonical_bytes(receipt.body()), hashlib.sha256).hexdigest()
+    expected = _hmac.new(hmac_key, canonical_bytes(receipt.body()), hashlib.sha256).hexdigest()
     if _hmac.compare_digest(receipt.hmac, expected):
         return True, None
     if authoritative is not None:

--- a/src/bernstein/core/persistence/cache_policy.py
+++ b/src/bernstein/core/persistence/cache_policy.py
@@ -38,13 +38,14 @@ and hashes across processes and platforms.
 from __future__ import annotations
 
 import hashlib
-import json
 import os
 import re
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final, Literal, cast
+
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from bernstein.core.tasks.models import Task
@@ -76,16 +77,6 @@ ExpiryMode = Literal["drift", "ttl", "both"]
 _EXPIRY_MODES: Final[frozenset[str]] = frozenset({"drift", "ttl", "both"})
 
 _DIGEST_PREFIX = "sha256:"
-
-
-def _canonical_bytes(value: Any) -> bytes:
-    """Return canonical JSON bytes (sorted keys, minimal separators, UTF-8)."""
-    return json.dumps(
-        value,
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    ).encode("utf-8")
 
 
 def _sha256_hex(data: bytes) -> str:
@@ -196,7 +187,7 @@ class CachePolicy:
 
     def canonical_json(self) -> bytes:
         """Return canonical JSON bytes of the policy."""
-        return _canonical_bytes(self.canonical())
+        return canonical_bytes(self.canonical())
 
     def policy_hash(self) -> str:
         """Return the ``sha256:`` digest of the canonical policy bytes."""
@@ -290,7 +281,7 @@ def compose_recipe(policy: CachePolicy, inputs: RecipeInputs) -> dict[str, Any]:
     keys.
     """
     ordered: list[dict[str, str]] = [
-        {"name": name, "hash": _sha256_hex(_canonical_bytes(inputs.value_for(name)))}
+        {"name": name, "hash": _sha256_hex(canonical_bytes(inputs.value_for(name)))}
         for name in (*MANDATORY_INGREDIENTS, *policy.ingredients)
     ]
     return {
@@ -303,7 +294,7 @@ def compose_recipe(policy: CachePolicy, inputs: RecipeInputs) -> dict[str, Any]:
 
 def recipe_hash(recipe: Mapping[str, Any]) -> str:
     """Return the ``sha256:`` digest of the canonical recipe bytes."""
-    return _sha256_hex(_canonical_bytes(dict(recipe)))
+    return _sha256_hex(canonical_bytes(dict(recipe)))
 
 
 def compose_key(policy: CachePolicy, inputs: RecipeInputs) -> bytes:
@@ -314,7 +305,7 @@ def compose_key(policy: CachePolicy, inputs: RecipeInputs) -> bytes:
     a mandatory or declared ingredient alters the recipe and therefore the key.
     """
     recipe = compose_recipe(policy, inputs)
-    return hashlib.sha256(_canonical_bytes(recipe)).digest()
+    return hashlib.sha256(canonical_bytes(recipe)).digest()
 
 
 def compose_key_hex(policy: CachePolicy, inputs: RecipeInputs) -> str:
@@ -475,7 +466,7 @@ class CacheEntry:
 
     def content_id(self) -> str:
         """Return the ``sha256:`` digest of the entry's canonical bytes."""
-        return _sha256_hex(_canonical_bytes(self.canonical()))
+        return _sha256_hex(canonical_bytes(self.canonical()))
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serialisable representation (alias of canonical)."""
@@ -547,7 +538,7 @@ class FreshnessVerdict:
 
     def canonical_json(self) -> bytes:
         """Return canonical JSON bytes of the verdict."""
-        return _canonical_bytes(self.canonical())
+        return canonical_bytes(self.canonical())
 
 
 # Verdict reason tokens (stable machine-readable vocabulary).

--- a/src/bernstein/core/persistence/cache_served_from.py
+++ b/src/bernstein/core/persistence/cache_served_from.py
@@ -15,10 +15,10 @@ hidden or forged cache hit is falsification-evident rather than merely unlogged
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING
 
 from bernstein.core.persistence.cache_policy import validate_cache_key
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from bernstein.core.lineage.spine import LineageSpine
@@ -46,17 +46,14 @@ def served_from_content(*, cache_key: str, output_hash: str, policy_hash: str, r
     recipe hashes so the spine ``content_hash`` is a content-addressed anchor of
     exactly what was served under which policy.
     """
-    return json.dumps(
+    return canonical_bytes(
         {
             "cache_key": cache_key,
             "output_hash": output_hash,
             "policy_hash": policy_hash,
             "recipe_hash": recipe_hash,
-        },
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    ).encode("utf-8")
+        }
+    )
 
 
 def record_served_from(

--- a/src/bernstein/core/persistence/lineage.py
+++ b/src/bernstein/core/persistence/lineage.py
@@ -42,6 +42,7 @@ from pathlib import Path  # noqa: TC003 -- runtime use in dataclass and helpers
 from typing import TYPE_CHECKING, Any, cast
 
 from bernstein.core.persistence.wal import WALReader, WALWriter
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -304,7 +305,7 @@ def canonical_record_bytes(record: LineageRecord) -> bytes:
         "timestamp": record.timestamp,
         "regulatory_class": record.regulatory_class,
     }
-    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return canonical_bytes(payload)
 
 
 def encode_signature(sig: bytes) -> str:

--- a/src/bernstein/core/protocols/payments/mandates.py
+++ b/src/bernstein/core/protocols/payments/mandates.py
@@ -62,6 +62,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.lineage.spine import LineageSpine
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -95,18 +96,13 @@ _REVOCATION_SUBPATH = (".sdd", "mandates", "revocations.jsonl")
 # ---------------------------------------------------------------------------
 
 
-def _canonical_bytes(payload: dict[str, Any]) -> bytes:
-    """Return canonical JSON bytes (sorted keys, minimal separators, UTF-8)."""
-    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
-
-
 def _sha256(payload: dict[str, Any]) -> str:
-    return "sha256:" + hashlib.sha256(_canonical_bytes(payload)).hexdigest()
+    return "sha256:" + hashlib.sha256(canonical_bytes(payload)).hexdigest()
 
 
 def _sign(key: bytes, payload: dict[str, Any]) -> str:
     """Return the HMAC-SHA256 signature over ``payload``'s canonical bytes."""
-    return _hmac.new(key, _canonical_bytes(payload), hashlib.sha256).hexdigest()
+    return _hmac.new(key, canonical_bytes(payload), hashlib.sha256).hexdigest()
 
 
 def _hash_tool_calls(tool_calls: tuple[str, ...]) -> str:
@@ -428,7 +424,7 @@ class ConsentReceipt:
 
     def to_canonical_bytes(self) -> bytes:
         """Serialise the binding to canonical JSON bytes (spine-hashed)."""
-        return _canonical_bytes(self._binding())
+        return canonical_bytes(self._binding())
 
     def to_dict(self) -> dict[str, Any]:
         return self._binding() | {"journal_entry_hash": self.journal_entry_hash}

--- a/src/bernstein/core/protocols/payments/x402.py
+++ b/src/bernstein/core/protocols/payments/x402.py
@@ -56,6 +56,7 @@ from bernstein.core.protocols.payments.mandates import (
     read_consent_receipt,
     verify_consent_receipt,
 )
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
@@ -98,12 +99,8 @@ _MANDATE_MODEL = "none"
 # ---------------------------------------------------------------------------
 
 
-def _canonical_bytes(payload: dict[str, Any]) -> bytes:
-    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
-
-
 def _sha256(payload: dict[str, Any]) -> str:
-    return "sha256:" + hashlib.sha256(_canonical_bytes(payload)).hexdigest()
+    return "sha256:" + hashlib.sha256(canonical_bytes(payload)).hexdigest()
 
 
 def settlement_ref_hash(ref: SettlementRef) -> str:
@@ -437,7 +434,7 @@ class SpendReceipt:
 
     def to_canonical_bytes(self) -> bytes:
         """Serialise the binding to canonical JSON bytes (spine-hashed)."""
-        return _canonical_bytes(self._binding())
+        return canonical_bytes(self._binding())
 
     def receipt_hash(self) -> str:
         """Return the content hash of the binding (the receipt's file id)."""
@@ -508,7 +505,7 @@ class RefusalReceipt:
         }
 
     def to_canonical_bytes(self) -> bytes:
-        return _canonical_bytes(self._binding())
+        return canonical_bytes(self._binding())
 
     def receipt_hash(self) -> str:
         return _sha256(self._binding())

--- a/src/bernstein/core/protocols/volunteer/documents.py
+++ b/src/bernstein/core/protocols/volunteer/documents.py
@@ -55,7 +55,6 @@ from __future__ import annotations
 
 import base64
 import hashlib
-import json
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -69,6 +68,7 @@ from bernstein.core.security.audit_dsse import (
     pae,
     verify_envelope,
 )
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from cryptography.hazmat.primitives.asymmetric.ed25519 import (
@@ -96,42 +96,6 @@ VOLUNTEER_DOCUMENT_PREDICATE_TYPE: str = "https://bernstein.run/attestations/vol
 # ---------------------------------------------------------------------------
 # Canonical serialisation
 # ---------------------------------------------------------------------------
-
-
-def _sort_keys_recursive(value: Any) -> Any:
-    """Recursively reorder dict keys so canonical JSON is byte-stable.
-
-    ``json.dumps(sort_keys=True)`` already sorts top-level keys, but inside
-    a free-form predicate we want lexicographic order at every depth so
-    repeated canonicalisations of the same input produce identical bytes.
-    """
-    if isinstance(value, dict):
-        return {k: _sort_keys_recursive(value[k]) for k in sorted(value.keys())}
-    if isinstance(value, list):
-        return [_sort_keys_recursive(v) for v in value]
-    return value
-
-
-def canonical_bytes(payload: dict[str, Any]) -> bytes:
-    """Deterministic JSON bytes: recursively sorted keys, compact separators, UTF-8.
-
-    Matches :func:`audit_dsse._canonical_json`'s discipline and
-    :func:`result_receipt_bundle.canonical_bytes` so two serialisations of
-    the same dict byte-agree.  This is the property the determinism tests
-    assert.
-
-    Args:
-        payload: The dictionary to serialise.
-
-    Returns:
-        UTF-8 encoded canonical JSON bytes.
-    """
-    return json.dumps(
-        _sort_keys_recursive(payload),
-        sort_keys=True,
-        separators=(",", ":"),
-        ensure_ascii=False,
-    ).encode("utf-8")
 
 
 def canonical_hash(payload: dict[str, Any]) -> str:

--- a/src/bernstein/core/quality/adjudication.py
+++ b/src/bernstein/core/quality/adjudication.py
@@ -32,6 +32,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.lineage.spine import LineageSpine, content_hash_of
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -68,14 +69,9 @@ class PanelMode(StrEnum):
     MAKER_CHECKER = "maker_checker"
 
 
-def _canonical_json(value: Any) -> bytes:
-    """Serialise *value* to canonical JSON bytes (sorted keys, tight separators)."""
-    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
-
-
 def _sha256_of(value: Any) -> str:
     """Return the ``sha256:``-prefixed digest of *value*'s canonical JSON."""
-    return "sha256:" + hashlib.sha256(_canonical_json(value)).hexdigest()
+    return "sha256:" + hashlib.sha256(canonical_bytes(value)).hexdigest()
 
 
 @dataclass(frozen=True, slots=True)
@@ -236,7 +232,7 @@ class AdjudicationRecord:
 
     def to_canonical_bytes(self) -> bytes:
         """Serialise the anchor-free binding to canonical JSON bytes."""
-        return _canonical_json(self._binding())
+        return canonical_bytes(self._binding())
 
     def to_dict(self) -> dict[str, Any]:
         """Serialise the full record (binding + anchor)."""
@@ -350,7 +346,7 @@ def adjudicate(
     out_dir = records_dir(lineage_root, run_id)
     out_dir.mkdir(parents=True, exist_ok=True)
     (out_dir / artifact_name).write_text(
-        _canonical_json(anchored.to_dict()).decode("utf-8"),
+        canonical_bytes(anchored.to_dict()).decode("utf-8"),
         encoding="utf-8",
     )
     return anchored

--- a/src/bernstein/core/quality/merge_receipt.py
+++ b/src/bernstein/core/quality/merge_receipt.py
@@ -31,6 +31,8 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.security.canonical import canonical_bytes
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -74,8 +76,8 @@ __all__ = [
     "MERGE_SCHEMA_VERSION",
     "MergeAdmissionReceipt",
     "MergeVerifyResult",
-    "_canonical_bytes",
     "_sha256_hex",
+    "canonical_bytes",
     "compute_gate_results_hash",
     "compute_ruleset_hash",
     "emit_merge_receipt",
@@ -97,11 +99,6 @@ _PUBLIC_KEY_NAME = "merge-identity-public.pem"
 # ---------------------------------------------------------------------------
 # Canonical hashing helpers
 # ---------------------------------------------------------------------------
-
-
-def _canonical_bytes(payload: dict[str, Any]) -> bytes:
-    """Canonical JSON bytes: sorted keys, minimal separators, UTF-8."""
-    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
 
 
 def _sha256_hex(data: bytes) -> str:
@@ -132,7 +129,7 @@ def compute_gate_results_hash(
         "review_verdict": review_verdict,
         "required_contexts": sorted(required_contexts),
     }
-    return _sha256_hex(_canonical_bytes(payload))
+    return _sha256_hex(canonical_bytes(payload))
 
 
 def compute_ruleset_hash(
@@ -149,7 +146,7 @@ def compute_ruleset_hash(
         "required_contexts": sorted(required_contexts),
         "ruleset": _sha256_hex(ruleset_bytes) if ruleset_bytes else "",
     }
-    return _sha256_hex(_canonical_bytes(payload))
+    return _sha256_hex(canonical_bytes(payload))
 
 
 # ---------------------------------------------------------------------------
@@ -261,7 +258,7 @@ class MergeAdmissionReceipt:
 
     def to_canonical_bytes(self) -> bytes:
         """Serialise the binding to canonical JSON bytes."""
-        return _canonical_bytes(self._binding())
+        return canonical_bytes(self._binding())
 
     def to_dict(self) -> dict[str, Any]:
         return self._binding() | {

--- a/src/bernstein/core/quality/review_pipeline/scope.py
+++ b/src/bernstein/core/quality/review_pipeline/scope.py
@@ -12,9 +12,10 @@ from __future__ import annotations
 
 import fnmatch
 import hashlib
-import json
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from bernstein.core.knowledge.conventions import ConventionReceipt
@@ -174,10 +175,6 @@ def resolve_scope(
     )
 
 
-def _canonical_bytes(payload: dict) -> bytes:
-    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
-
-
 def compute_resolution_hash(scope: ScopeResolution) -> str:
     """Deterministically hash a :class:`ScopeResolution`.
 
@@ -204,7 +201,7 @@ def compute_resolution_hash(scope: ScopeResolution) -> str:
         "in_scope": entries,
         "unscoped_paths": sorted(scope.unscoped_paths),
     }
-    digest = hashlib.sha256(_canonical_bytes(payload)).hexdigest()
+    digest = hashlib.sha256(canonical_bytes(payload)).hexdigest()
     return "sha256:" + digest
 
 

--- a/src/bernstein/core/quality/verifier_ladder.py
+++ b/src/bernstein/core/quality/verifier_ladder.py
@@ -43,6 +43,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.lineage.spine import LineageSpine, content_hash_of
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -97,7 +98,7 @@ def canonical_hash(obj: Any) -> str:
     convention every receipt in this codebase hashes with, so two machines
     hashing the same structure agree byte-for-byte.
     """
-    payload = json.dumps(obj, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    payload = canonical_bytes(obj)
     return "sha256:" + hashlib.sha256(payload).hexdigest()
 
 
@@ -231,7 +232,7 @@ class TierRecord:
 
     def canonical_bytes(self) -> bytes:
         """Canonical bytes sealed into the ``verifier-ladder`` spine run."""
-        return json.dumps(self.body(), ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        return canonical_bytes(self.body())
 
     def to_dict(self) -> dict[str, Any]:
         payload = self.body()

--- a/src/bernstein/core/review/receipt.py
+++ b/src/bernstein/core/review/receipt.py
@@ -64,6 +64,7 @@ from typing import TYPE_CHECKING, Any
 
 from bernstein.core.lineage.identity import generate_keypair
 from bernstein.core.lineage.spine import LineageSpine, content_hash_of
+from bernstein.core.security.canonical import canonical_bytes
 from bernstein.core.skills.catalog.signature import sign_payload, verify_payload
 
 if TYPE_CHECKING:
@@ -99,11 +100,6 @@ _IDENTITY_PUBLIC_NAME = "review-identity-public.pem"
 # ---------------------------------------------------------------------------
 # Canonical hashing helpers
 # ---------------------------------------------------------------------------
-
-
-def _canonical_bytes(payload: dict[str, Any]) -> bytes:
-    """Return canonical JSON bytes (sorted keys, minimal separators, UTF-8)."""
-    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
 
 
 def _sha256_bytes(data: bytes) -> str:
@@ -214,7 +210,7 @@ class Finding:
 
     def finding_hash(self) -> str:
         """Return the content hash of this finding."""
-        return _sha256_bytes(_canonical_bytes(self.to_dict()))
+        return _sha256_bytes(canonical_bytes(self.to_dict()))
 
 
 # ---------------------------------------------------------------------------
@@ -300,7 +296,7 @@ class ReviewReceipt:
 
     def to_canonical_bytes(self) -> bytes:
         """Serialise the binding to canonical JSON bytes (signed + spine-hashed)."""
-        return _canonical_bytes(self._binding())
+        return canonical_bytes(self._binding())
 
     def to_dict(self) -> dict[str, Any]:
         return self._binding() | {
@@ -809,7 +805,7 @@ class AutofixReceipt:
         return binding
 
     def to_canonical_bytes(self) -> bytes:
-        return _canonical_bytes(self._binding())
+        return canonical_bytes(self._binding())
 
     def to_dict(self) -> dict[str, Any]:
         base = self._binding()
@@ -1110,7 +1106,7 @@ class ApprovalBinding:
 
     def to_canonical_bytes(self) -> bytes:
         """Serialise the binding to canonical JSON bytes."""
-        return _canonical_bytes(self._binding())
+        return canonical_bytes(self._binding())
 
     def to_dict(self) -> dict[str, Any]:
         return self._binding() | {

--- a/src/bernstein/core/routing/route_decision.py
+++ b/src/bernstein/core/routing/route_decision.py
@@ -9,20 +9,12 @@ import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.security.canonical import canonical_bytes
+
 if TYPE_CHECKING:
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
-
-
-def _canonical_bytes(data: dict[str, object]) -> bytes:
-    """Return JCS-canonical bytes for a dict of built-in types."""
-    return json.dumps(
-        data,
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    ).encode("utf-8")
 
 
 def _compute_routing_decision_hash(
@@ -34,7 +26,7 @@ def _compute_routing_decision_hash(
     timestamp: float,
 ) -> str:
     """Compute sha256:JCS_bytes hash of routing decision inputs."""
-    canonical = _canonical_bytes(
+    canonical = canonical_bytes(
         {
             "task_id": task_id,
             "adapter": adapter,

--- a/src/bernstein/core/sandbox/pool.py
+++ b/src/bernstein/core/sandbox/pool.py
@@ -39,13 +39,13 @@ pool template exposes.
 from __future__ import annotations
 
 import hashlib
-import json
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.sandbox.backend import SandboxCapability
 from bernstein.core.sandbox.manifest import WorkspaceManifest
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -106,7 +106,7 @@ class PoolOverrideRefused(Exception):
 
 def _canonical_json(payload: Any) -> str:
     """Deterministic JSON string: sorted keys, compact separators, UTF-8 safe."""
-    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return canonical_bytes(payload).decode("utf-8")
 
 
 def _sha256_hex(text: str) -> str:

--- a/src/bernstein/core/sandbox/pool_enrolment.py
+++ b/src/bernstein/core/sandbox/pool_enrolment.py
@@ -34,6 +34,7 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import (
 
 from bernstein.core.identity.http_signing import install_identity_keyid
 from bernstein.core.security.agent_card_signer import ed25519_public_jwk
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from bernstein.core.security.agent_card_keystore import AgentCardKeystore
@@ -43,7 +44,7 @@ POOL_ENROLMENT_SCHEMA_VERSION = 1
 
 
 def _canonical_json(payload: Any) -> str:
-    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return canonical_bytes(payload).decode("utf-8")
 
 
 def _sha256_hex(text: str) -> str:

--- a/src/bernstein/core/sandbox/pool_placement.py
+++ b/src/bernstein/core/sandbox/pool_placement.py
@@ -34,6 +34,7 @@ from bernstein.core.sandbox.selector import (
     SandboxPolicy,
     select_sandbox,
 )
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -51,7 +52,7 @@ _PLACEMENT_SUBPATH = ("sandbox", "placements")
 
 
 def _canonical_json(payload: Any) -> str:
-    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return canonical_bytes(payload).decode("utf-8")
 
 
 def _sha256_hex(text: str) -> str:

--- a/src/bernstein/core/security/article12_bundle.py
+++ b/src/bernstein/core/security/article12_bundle.py
@@ -316,7 +316,7 @@ def _build_data_catalog(events: list[_SourceEvent]) -> bytes:
         "resources": {rtype: dict(sorted(items.items())) for rtype, items in sorted(catalog.items())},
         "total_events": len(events),
     }
-    return _canonical_json(payload)
+    return _bundle_json(payload)
 
 
 def _build_clause_map() -> bytes:
@@ -369,11 +369,16 @@ def _build_clause_map() -> bytes:
             "Article 43 conformity-assessment paperwork",
         ],
     }
-    return _canonical_json(payload)
+    return _bundle_json(payload)
 
 
-def _canonical_json(payload: dict[str, Any]) -> bytes:
-    """Serialise a dict as deterministic JSON suitable for hashing."""
+def _bundle_json(payload: dict[str, Any]) -> bytes:
+    """Serialise a bundle file: indented, sorted keys, trailing newline.
+
+    Presentation bytes a reviewer reads; the bundle's hashes are computed over
+    the stored bytes. Not a signing canonicalization
+    (:mod:`bernstein.core.security.canonical` owns that rule).
+    """
     return (json.dumps(payload, sort_keys=True, indent=2) + "\n").encode("utf-8")
 
 
@@ -436,7 +441,7 @@ def build_article12_bundle(
         "retention": retention.to_dict(),
         "artefacts": dict(sorted(artefact_hashes.items())),
     }
-    manifest_bytes = _canonical_json(manifest)
+    manifest_bytes = _bundle_json(manifest)
 
     archive_bytes = _zip_artefacts(
         manifest_bytes=manifest_bytes,
@@ -811,7 +816,7 @@ def _build_data_catalog_with_lineage(
         "lineage_artefacts": artefact_payload,
         "lineage_artefact_count": len(artefact_payload),
     }
-    return _canonical_json(payload)
+    return _bundle_json(payload)
 
 
 # ---------------------------------------------------------------------------
@@ -850,7 +855,7 @@ def _load_clause_map_from_yaml(path: Path) -> bytes:
         raise ValueError(f"clause map at {path} is not a YAML mapping")
     if "mappings" not in parsed or not isinstance(parsed["mappings"], list):
         raise ValueError(f"clause map at {path} missing 'mappings' list")
-    return _canonical_json(parsed)
+    return _bundle_json(parsed)
 
 
 # ---------------------------------------------------------------------------
@@ -1004,7 +1009,7 @@ def assemble_from_run(
         if clause_map_file.is_relative_to(workdir)
         else str(clause_map_file),
     }
-    manifest_bytes = _canonical_json(manifest)
+    manifest_bytes = _bundle_json(manifest)
 
     archive_bytes = _zip_artefacts(
         manifest_bytes=manifest_bytes,

--- a/src/bernstein/core/security/canonical.py
+++ b/src/bernstein/core/security/canonical.py
@@ -1,0 +1,106 @@
+"""The one canonical-JSON byte rule for hashing and signing.
+
+Every signature or content hash in this package is computed over bytes, and
+the bytes are derived from a JSON-shaped payload. When two modules derive
+those bytes differently, a signature made under one cannot verify under the
+other, and the artefact alone does not say which rule produced it. This
+module owns the rule so that there is exactly one answer.
+
+The rule (``CANONICALIZATION_VERSION`` 1): keys sorted, minimal separators,
+UTF-8 with non-ASCII characters preserved, NaN and infinities refused because
+they are not JSON. Two operators canonicalising the same payload get the same
+bytes on any platform.
+
+The two ``legacy_*`` encoders reproduce the byte rules that signed artefacts
+before this module existed. A verifier that meets an artefact with no
+canonicalization version selects the legacy rule its producer used, instead
+of guessing; see :func:`bytes_for_verification`.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+CANONICALIZATION_VERSION = 1
+"""The byte rule :func:`canonical_bytes` implements. Signed artefacts record it."""
+
+CANONICALIZATION_FIELD = "canonicalization"
+"""Field name a signed artefact uses to carry :data:`CANONICALIZATION_VERSION`."""
+
+
+class UnsupportedCanonicalization(ValueError):
+    """The artefact names a canonicalization version this build cannot reproduce."""
+
+
+def canonical_bytes(payload: Any) -> bytes:
+    """Return the canonical JSON bytes of ``payload`` (version 1).
+
+    Sorted keys, ``(",", ":")`` separators, UTF-8 with non-ASCII preserved,
+    ``allow_nan=False`` so a payload that is not representable as JSON raises
+    here rather than producing bytes no strict parser accepts.
+    """
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def legacy_ascii_bytes(payload: Any) -> bytes:
+    """Byte rule of the producers that omitted ``ensure_ascii=False``.
+
+    Identical to :func:`canonical_bytes` for ASCII-only payloads; escapes
+    non-ASCII characters as ``\\uXXXX`` otherwise. Kept only so artefacts
+    signed under that rule keep verifying.
+    """
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def legacy_pretty_bytes(payload: Any) -> bytes:
+    """Byte rule of the producers that wrote indented, ASCII-escaped JSON.
+
+    Two-space indentation and a trailing newline. Kept only so artefacts
+    hashed under that rule keep verifying.
+    """
+    return (json.dumps(payload, sort_keys=True, indent=2) + "\n").encode("utf-8")
+
+
+def bytes_for_verification(
+    payload: Any,
+    version: int | None,
+    *,
+    legacy: Callable[[Any], bytes],
+) -> bytes:
+    """Return the bytes a verifier must recompute for a stored artefact.
+
+    ``version`` is the value the artefact carries under
+    :data:`CANONICALIZATION_FIELD`; ``None`` means the artefact predates the
+    field and was produced under ``legacy``, the rule its producer used at
+    the time. Any other version this build does not implement raises
+    :class:`UnsupportedCanonicalization` so the verifier reports the gap
+    instead of returning a mismatch that reads as tampering.
+    """
+    if version is None:
+        return legacy(payload)
+    if version == CANONICALIZATION_VERSION:
+        return canonical_bytes(payload)
+    raise UnsupportedCanonicalization(
+        f"canonicalization version {version!r} is not implemented by this build (supports {CANONICALIZATION_VERSION})"
+    )
+
+
+__all__ = [
+    "CANONICALIZATION_FIELD",
+    "CANONICALIZATION_VERSION",
+    "UnsupportedCanonicalization",
+    "bytes_for_verification",
+    "canonical_bytes",
+    "legacy_ascii_bytes",
+    "legacy_pretty_bytes",
+]

--- a/src/bernstein/core/security/change_receipt.py
+++ b/src/bernstein/core/security/change_receipt.py
@@ -36,9 +36,10 @@ responsibility when comparing against expected values.
 from __future__ import annotations
 
 import hashlib
-import json
 from dataclasses import dataclass, field
 from typing import Any, Literal
+
+from bernstein.core.security.canonical import canonical_bytes
 
 #: Schema version for the change receipt format.
 CHANGE_RECEIPT_SCHEMA_VERSION: str = "1.0.0"
@@ -57,29 +58,6 @@ class ChangeReceiptError(RuntimeError):
 def _sha256_hex(data: bytes) -> str:
     """Compute sha256 hex digest of bytes."""
     return hashlib.sha256(data).hexdigest()
-
-
-def _sort_recursive(value: Any) -> Any:
-    """Recursively reorder dict keys so canonical JSON is byte-stable."""
-    if isinstance(value, dict):
-        return {k: _sort_recursive(value[k]) for k in sorted(value.keys())}
-    if isinstance(value, list):
-        return [_sort_recursive(v) for v in value]
-    return value
-
-
-def canonical_bytes(payload: dict[str, Any]) -> bytes:
-    """Deterministic JSON: recursively sorted keys, compact separators, UTF-8.
-
-    Matches the discipline of :mod:`bernstein.core.security.result_receipt_bundle`
-    so multiple serialisations of the same receipt byte-agree.
-    """
-    return json.dumps(
-        _sort_recursive(payload),
-        sort_keys=True,
-        separators=(",", ":"),
-        ensure_ascii=False,
-    ).encode("utf-8")
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/security/deployment_profile.py
+++ b/src/bernstein/core/security/deployment_profile.py
@@ -57,6 +57,8 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
+from bernstein.core.security.canonical import canonical_bytes
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -183,13 +185,8 @@ class SovereignConfigError(RuntimeError):
 # ---------------------------------------------------------------------------
 
 
-def _canonical_bytes(data: Mapping[str, Any]) -> bytes:
-    """Canonical JSON bytes (sorted keys, minimal separators, UTF-8)."""
-    return json.dumps(data, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
-
-
 def _sha256_of(data: Mapping[str, Any]) -> str:
-    return "sha256:" + hashlib.sha256(_canonical_bytes(data)).hexdigest()
+    return "sha256:" + hashlib.sha256(canonical_bytes(data)).hexdigest()
 
 
 def is_local_or_eu_host(base_url: str) -> bool:
@@ -794,7 +791,7 @@ def build_posture_attestation(
         effective_policy=policy.to_canonical_document(),
         timestamp=timestamp,
     )
-    signature = sign_payload(_canonical_bytes(unsigned.signed_body()), private_pem)
+    signature = sign_payload(canonical_bytes(unsigned.signed_body()), private_pem)
 
     journal_entry_hash = ""
     if chain is not None:
@@ -880,7 +877,7 @@ def _read_posture_attestation_with_reason(workdir: Path) -> tuple[PostureAttesta
     except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
         return None, f"posture attestation at {path} is not a valid signed record ({exc})"
     outcome = verify_payload(
-        _canonical_bytes(attestation.signed_body()),
+        canonical_bytes(attestation.signed_body()),
         attestation.signature,
         attestation.signer_public_key_pem,
         allow_unverified=True,
@@ -1081,7 +1078,7 @@ def record_and_sign_drift(
         "effective_policy": evaluation.observed_policy.to_canonical_document(),
         "timestamp": timestamp,
     }
-    signature = sign_payload(_canonical_bytes(signed_body), private_pem)
+    signature = sign_payload(canonical_bytes(signed_body), private_pem)
     record = signed_body.copy()
     record["signer_public_key_pem"] = public_pem
     record["signature"] = signature
@@ -1199,7 +1196,7 @@ def _verify_one_record(
         errors.append(f"{kind}: record has no signed_body")
         return
     outcome = verify_payload(
-        _canonical_bytes(body),
+        canonical_bytes(body),
         signature if isinstance(signature, str) else None,
         public_key if isinstance(public_key, str) else None,
         allow_unverified=True,

--- a/src/bernstein/core/security/governance.py
+++ b/src/bernstein/core/security/governance.py
@@ -63,6 +63,7 @@ from typing import TYPE_CHECKING, Any
 
 from bernstein.core.cost.spend_ledger import SpendLedger
 from bernstein.core.lineage.spine import LineageSpine, content_hash_of
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -98,18 +99,13 @@ _BUDGET_ACTION = "budget"
 # ---------------------------------------------------------------------------
 
 
-def _canonical_bytes(payload: dict[str, Any]) -> bytes:
-    """Return canonical JSON bytes (sorted keys, minimal separators, UTF-8)."""
-    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
-
-
 def _sha256(payload: dict[str, Any]) -> str:
-    return "sha256:" + hashlib.sha256(_canonical_bytes(payload)).hexdigest()
+    return "sha256:" + hashlib.sha256(canonical_bytes(payload)).hexdigest()
 
 
 def _sign(key: bytes, payload: dict[str, Any]) -> str:
     """Return the HMAC-SHA256 signature over ``payload``'s canonical bytes."""
-    return _hmac.new(key, _canonical_bytes(payload), hashlib.sha256).hexdigest()
+    return _hmac.new(key, canonical_bytes(payload), hashlib.sha256).hexdigest()
 
 
 def _safe_name(run_id: str) -> str:
@@ -265,7 +261,7 @@ class GovernanceDecision:
 
     def to_canonical_bytes(self) -> bytes:
         """Serialise the binding to canonical JSON bytes (spine-hashed)."""
-        return _canonical_bytes(self._binding())
+        return canonical_bytes(self._binding())
 
     def to_dict(self) -> dict[str, Any]:
         return self._binding() | {"journal_entry_hash": self.journal_entry_hash}

--- a/src/bernstein/core/security/intent_capsule.py
+++ b/src/bernstein/core/security/intent_capsule.py
@@ -43,6 +43,8 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, cast
 
+from bernstein.core.security.canonical import canonical_bytes
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -402,12 +404,7 @@ def canonicalise(capsule: IntentCapsule) -> bytes:
     ``sort_keys=True`` + minimal separators + UTF-8 covers the subset relevant
     to a flat object of strings, ints, and lists-of-strings.
     """
-    return json.dumps(
-        capsule.to_canonical_dict(),
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    ).encode("utf-8")
+    return canonical_bytes(capsule.to_canonical_dict())
 
 
 def capsule_hash(capsule: IntentCapsule) -> str:
@@ -416,7 +413,7 @@ def capsule_hash(capsule: IntentCapsule) -> str:
 
 
 def _sha256_ref(payload: Any) -> str:
-    raw = json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    raw = canonical_bytes(payload)
     return "sha256:" + hashlib.sha256(raw).hexdigest()
 
 

--- a/src/bernstein/core/security/native_toolcall_evidence.py
+++ b/src/bernstein/core/security/native_toolcall_evidence.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import hashlib
-import json
 import time
 from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -14,6 +13,7 @@ from bernstein.core.security.audit_chain import (
     EVENT_TOOLCALL_ENFORCED_DISPATCH,
     AuditChainStore,
 )
+from bernstein.core.security.canonical import canonical_bytes
 from bernstein.core.security.toolcall_identity import (
     TOOLCALL_IDENTITY_DOMAIN,
     FrozenToolCallIdentityVerifier,
@@ -35,12 +35,7 @@ if TYPE_CHECKING:
 
 
 def _content_ref(kind: str, payload: dict[str, str]) -> str:
-    canonical = json.dumps(
-        {"kind": kind, "payload": payload, "version": 1},
-        sort_keys=True,
-        separators=(",", ":"),
-        ensure_ascii=False,
-    ).encode("utf-8")
+    canonical = canonical_bytes({"kind": kind, "payload": payload, "version": 1})
     return "sha256:" + hashlib.sha256(canonical).hexdigest()
 
 

--- a/src/bernstein/core/security/toolcall_interlock.py
+++ b/src/bernstein/core/security/toolcall_interlock.py
@@ -14,13 +14,13 @@ without making either implementation a dependency of the dispatch boundary.
 from __future__ import annotations
 
 import hashlib
-import json
 import logging
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any, Protocol, cast
 
+from bernstein.core.security.canonical import canonical_bytes
 from bernstein.core.security.sanitize import sanitize_log
 from bernstein.core.security.toolcall_identity import ToolCallIdentityError, verify_identity_envelope
 
@@ -71,7 +71,7 @@ class ToolCallIntent:
         arguments: Any,
     ) -> ToolCallIntent:
         """Build an intent without retaining raw connector arguments."""
-        canonical = json.dumps(arguments, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        canonical = canonical_bytes(arguments)
         return cls(
             scope_id=scope_id,
             server_name=server_name,
@@ -93,7 +93,7 @@ class ToolCallIntent:
             "span_id": self.span_id,
             "tool_name": self.tool_name,
         }
-        canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        canonical = canonical_bytes(payload)
         return "sha256:" + hashlib.sha256(canonical).hexdigest()
 
 

--- a/src/bernstein/core/server/dashboard_tokens.py
+++ b/src/bernstein/core/server/dashboard_tokens.py
@@ -50,6 +50,7 @@ import secrets
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
+from bernstein.core.security.canonical import canonical_bytes
 from bernstein.core.security.governance import RoleBindings, decide_access
 
 if TYPE_CHECKING:
@@ -92,11 +93,6 @@ TOKEN_RECORD_VERSION = 1
 #: Length of the short token id (hex chars of the digest) used for listing
 #: and revocation. 16 hex chars = 64 bits: ample for a per-install registry.
 _TOKEN_ID_LEN = 16
-
-
-def _canonical_bytes(payload: dict[str, Any]) -> bytes:
-    """Return canonical JSON bytes (sorted keys, minimal separators, UTF-8)."""
-    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
 
 
 def resolve_dashboard_hmac_key(sdd_dir: Path) -> bytes:
@@ -193,7 +189,7 @@ class DashboardTokenRecord:
 
     def sign(self, key: bytes) -> DashboardTokenRecord:
         """Return a copy carrying the HMAC signature over the row body."""
-        sig = _hmac.new(key, _canonical_bytes(self._body()), hashlib.sha256).hexdigest()
+        sig = _hmac.new(key, canonical_bytes(self._body()), hashlib.sha256).hexdigest()
         return DashboardTokenRecord(
             kind=self.kind,
             token_id=self.token_id,
@@ -208,7 +204,7 @@ class DashboardTokenRecord:
         """Return True when ``signature`` matches the row body under ``key``."""
         if not self.signature:
             return False
-        want = _hmac.new(key, _canonical_bytes(self._body()), hashlib.sha256).hexdigest()
+        want = _hmac.new(key, canonical_bytes(self._body()), hashlib.sha256).hexdigest()
         return _hmac.compare_digest(self.signature, want)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/bernstein/core/skills/provenance.py
+++ b/src/bernstein/core/skills/provenance.py
@@ -42,6 +42,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from bernstein.core.lineage.spine import LineageSpine, SpineStatus
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -149,17 +150,14 @@ class InstallReceipt:
 
     def to_canonical_bytes(self) -> bytes:
         """Serialise to canonical JSON bytes (the spine-hashed artifact)."""
-        return json.dumps(
+        return canonical_bytes(
             {
                 "skill_hash": self.skill_hash,
                 "manifest_hash": self.manifest_hash,
                 "install_id": self.install_id,
                 "timestamp": self.timestamp,
-            },
-            ensure_ascii=False,
-            separators=(",", ":"),
-            sort_keys=True,
-        ).encode("utf-8")
+            }
+        )
 
     @classmethod
     def from_bytes(cls, raw: bytes) -> InstallReceipt:
@@ -207,18 +205,15 @@ class UpdateReceipt:
 
     def to_canonical_bytes(self) -> bytes:
         """Serialise to canonical JSON bytes (the spine-hashed artifact)."""
-        return json.dumps(
+        return canonical_bytes(
             {
                 "prior_skill_hash": self.prior_skill_hash,
                 "skill_hash": self.skill_hash,
                 "manifest_hash": self.manifest_hash,
                 "install_id": self.install_id,
                 "timestamp": self.timestamp,
-            },
-            ensure_ascii=False,
-            separators=(",", ":"),
-            sort_keys=True,
-        ).encode("utf-8")
+            }
+        )
 
     @classmethod
     def from_bytes(cls, raw: bytes) -> UpdateReceipt:
@@ -412,18 +407,15 @@ class ConformanceReceipt:
 
     def to_canonical_bytes(self) -> bytes:
         """Serialise to canonical JSON bytes (the spine-hashed artifact)."""
-        return json.dumps(
+        return canonical_bytes(
             {
                 "skill_hash": self.skill_hash,
                 "host_results": [[host, ok] for host, ok in self.host_results],
                 "min_hosts": self.min_hosts,
                 "install_id": self.install_id,
                 "timestamp": self.timestamp,
-            },
-            ensure_ascii=False,
-            separators=(",", ":"),
-            sort_keys=True,
-        ).encode("utf-8")
+            }
+        )
 
     def content_id(self) -> str:
         """Return the content address (``sha256:<hex>``) of the receipt bytes."""

--- a/src/bernstein/core/tournament/receipt.py
+++ b/src/bernstein/core/tournament/receipt.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, Any
 
 from bernstein.core.lineage.identity import generate_keypair
 from bernstein.core.lineage.spine import LineageSpine, content_hash_of
+from bernstein.core.security.canonical import canonical_bytes
 from bernstein.core.skills.catalog.signature import sign_payload, verify_payload
 from bernstein.core.tournament.evaluators import AttemptOutcome
 from bernstein.core.tournament.scorer import RankedAttempt, select_winner
@@ -71,10 +72,6 @@ _IDENTITY_PUBLIC_NAME = "tournament-identity-public.pem"
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _canonical_bytes(payload: dict[str, Any]) -> bytes:
-    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
 
 
 def _safe_task_name(task_id: str) -> str:
@@ -192,7 +189,7 @@ class TournamentReceipt:
         }
 
     def to_canonical_bytes(self) -> bytes:
-        return _canonical_bytes(self._binding())
+        return canonical_bytes(self._binding())
 
     def to_dict(self) -> dict[str, Any]:
         return self._binding() | {
@@ -297,7 +294,7 @@ def emit_tournament_receipt(
         outcome = outcome_by_hash[row.attempt_hash]
         spine.record(
             artifact_path=f"tournaments/{safe}/attempts/{idx}.json",
-            content=_canonical_bytes(outcome.to_dict()),
+            content=canonical_bytes(outcome.to_dict()),
             actor=_TOURNAMENT_ACTOR,
             step_id=row.attempt_hash,
             model=_TOURNAMENT_MODEL,

--- a/src/bernstein/core/tournament/scorer.py
+++ b/src/bernstein/core/tournament/scorer.py
@@ -10,9 +10,10 @@ attempt-hash order, which is itself a pure function of the attempt identities.
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
+
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -113,7 +114,7 @@ def selection_projection_bytes(outcomes: Sequence[AttemptOutcome], spec: Tournam
         "ranked": [r.to_dict() for r in selection.ranked],
         "tie_break": spec.tie_break,
     }
-    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return canonical_bytes(payload)
 
 
 __all__ = [

--- a/src/bernstein/core/tournament/spec.py
+++ b/src/bernstein/core/tournament/spec.py
@@ -18,9 +18,10 @@ the same value and can be pinned in a selection receipt for offline replay.
 from __future__ import annotations
 
 import hashlib
-import json
 from dataclasses import dataclass
 from typing import Any
+
+from bernstein.core.security.canonical import canonical_bytes
 
 #: Version stamped into the canonical spec preimage. Bump only on a
 #: wire-format change.
@@ -121,7 +122,7 @@ class TournamentSpec:
 
     def spec_hash(self) -> str:
         """Return the ``sha256:`` content hash of the canonical spec."""
-        raw = json.dumps(self.canonical(), ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        raw = canonical_bytes(self.canonical())
         return "sha256:" + hashlib.sha256(raw).hexdigest()
 
     @classmethod

--- a/src/bernstein/core/trigger_sources/odata_poll.py
+++ b/src/bernstein/core/trigger_sources/odata_poll.py
@@ -41,6 +41,7 @@ from dataclasses import dataclass, field, replace
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal, Protocol
 
+from bernstein.core.security.canonical import canonical_bytes
 from bernstein.core.tasks.models import TriggerEvent
 
 if TYPE_CHECKING:
@@ -282,13 +283,13 @@ class OdataCursor:
 
     def content_hash(self) -> str:
         """Return the content-addressed identifier for this cursor."""
-        return "sha256:" + hashlib.sha256(_canonical_bytes(self.to_dict())).hexdigest()
+        return "sha256:" + hashlib.sha256(canonical_bytes(self.to_dict())).hexdigest()
 
 
 def save_cursor(path: Path, cursor: OdataCursor) -> None:
     """Persist ``cursor`` to ``path`` as canonical bytes (byte-stable)."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_bytes(_canonical_bytes(cursor.to_dict()) + b"\n")
+    path.write_bytes(canonical_bytes(cursor.to_dict()) + b"\n")
 
 
 def load_cursor(path: Path) -> OdataCursor | None:
@@ -761,12 +762,8 @@ def _key_literal(value: Any) -> str:
     return f"'{value}'"
 
 
-def _canonical_bytes(payload: dict[str, Any]) -> bytes:
-    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
-
-
 def _hash_entities(entities: list[dict[str, Any]]) -> str:
-    return "sha256:" + hashlib.sha256(_canonical_bytes({"value": entities})).hexdigest()
+    return "sha256:" + hashlib.sha256(canonical_bytes({"value": entities})).hexdigest()
 
 
 def _max_str(current: str, candidate: str) -> str:

--- a/src/bernstein/core/trigger_sources/receipt.py
+++ b/src/bernstein/core/trigger_sources/receipt.py
@@ -52,6 +52,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.sanitize import sanitize_log
+from bernstein.core.security.canonical import canonical_bytes
 
 if sys.platform == "win32":
     fcntl = None  # type: ignore[assignment]
@@ -106,11 +107,6 @@ class AutomationBridgeError(RuntimeError):
 # ---------------------------------------------------------------------------
 
 
-def _canonical_bytes(payload: dict[str, Any]) -> bytes:
-    """Return canonical JSON bytes (sorted keys, minimal separators, UTF-8)."""
-    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
-
-
 def _sha256_bytes(data: bytes) -> str:
     return "sha256:" + hashlib.sha256(data).hexdigest()
 
@@ -126,7 +122,7 @@ def compute_payload_digest(body: bytes) -> str:
 
 def compute_document_digest(document: dict[str, Any]) -> str:
     """Return the content hash of a canonicalised JSON document."""
-    return _sha256_bytes(_canonical_bytes(document))
+    return _sha256_bytes(canonical_bytes(document))
 
 
 # ---------------------------------------------------------------------------
@@ -354,7 +350,7 @@ def _normalise_priority(raw: Any) -> str:
 
 def _node_id(body: dict[str, Any]) -> str:
     """Return a content-addressed node id (no clock, no random source)."""
-    return hashlib.sha256(_canonical_bytes(body)).hexdigest()[:16]
+    return hashlib.sha256(canonical_bytes(body)).hexdigest()[:16]
 
 
 def project_task_graph(*, platform: str, intent: dict[str, Any]) -> TaskGraphProjection:
@@ -405,7 +401,7 @@ def project_task_graph(*, platform: str, intent: dict[str, Any]) -> TaskGraphPro
         previous_id = node.node_id
 
     digest = _sha256_bytes(
-        _canonical_bytes(
+        canonical_bytes(
             {
                 "v": AUTOMATION_BRIDGE_SCHEMA_VERSION,
                 "platform": platform,
@@ -488,7 +484,7 @@ class TriggerReceipt:
 
     def to_canonical_bytes(self) -> bytes:
         """Serialise the binding to canonical JSON bytes (signed + chain-hashed)."""
-        return _canonical_bytes(self._binding())
+        return canonical_bytes(self._binding())
 
     def binding_digest(self) -> str:
         """Return the content hash of the signed binding."""
@@ -920,7 +916,7 @@ class StatusProof:
 
     def to_canonical_bytes(self) -> bytes:
         """Serialise the binding to canonical JSON bytes (signed + chain-hashed)."""
-        return _canonical_bytes(self._binding())
+        return canonical_bytes(self._binding())
 
     def binding_digest(self) -> str:
         """Return the content hash of the signed binding."""

--- a/src/bernstein/core/trigger_sources/webhook_node.py
+++ b/src/bernstein/core/trigger_sources/webhook_node.py
@@ -59,6 +59,7 @@ from typing import TYPE_CHECKING, Any
 from bernstein.core.lineage.spine import LineageSpine, content_hash_of
 from bernstein.core.replay.journal import EventJournal
 from bernstein.core.sanitize import sanitize_log
+from bernstein.core.security.canonical import canonical_bytes
 from bernstein.core.skills.catalog.signature import sign_payload, verify_payload
 
 if TYPE_CHECKING:
@@ -180,11 +181,6 @@ def verify_standard_webhook(
 # ---------------------------------------------------------------------------
 
 
-def _canonical_bytes(payload: dict[str, Any]) -> bytes:
-    """Return canonical JSON bytes (sorted keys, minimal separators, UTF-8)."""
-    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
-
-
 def _sha256_bytes(data: bytes) -> str:
     return "sha256:" + hashlib.sha256(data).hexdigest()
 
@@ -195,7 +191,7 @@ def compute_event_hash(*, source: str, event_id: str, body: bytes) -> str:
     Binds the source label, event id, and the raw body so a verifier presented
     the same inbound event recomputes the same hash.
     """
-    preimage = _canonical_bytes(
+    preimage = canonical_bytes(
         {
             "v": WEBHOOK_NODE_SCHEMA_VERSION,
             "source": source,
@@ -208,7 +204,7 @@ def compute_event_hash(*, source: str, event_id: str, body: bytes) -> str:
 
 def compute_result_hash(result: dict[str, Any]) -> str:
     """Return the content hash of an outbound result payload."""
-    return _sha256_bytes(_canonical_bytes(result))
+    return _sha256_bytes(canonical_bytes(result))
 
 
 # ---------------------------------------------------------------------------
@@ -306,7 +302,7 @@ class InboundReceipt:
 
     def to_canonical_bytes(self) -> bytes:
         """Serialise the binding to canonical JSON bytes (signed + spine-hashed)."""
-        return _canonical_bytes(self._binding())
+        return canonical_bytes(self._binding())
 
     def to_dict(self) -> dict[str, Any]:
         return self._binding() | {
@@ -533,7 +529,7 @@ class OutboundReceipt:
 
     def to_canonical_bytes(self) -> bytes:
         """Serialise the binding to canonical JSON bytes (signed + spine-hashed)."""
-        return _canonical_bytes(self._binding())
+        return canonical_bytes(self._binding())
 
     def to_dict(self) -> dict[str, Any]:
         return self._binding() | {
@@ -551,7 +547,7 @@ class OutboundReceipt:
         delivery is signed under the caller's ``secret`` with the receipt's
         ``event_id`` as the message id.
         """
-        body = _canonical_bytes(self.to_dict())
+        body = canonical_bytes(self.to_dict())
         sig = sign_standard_webhook(secret=secret, msg_id=self.event_id, timestamp=self.timestamp, body=body)
         headers = {
             STANDARD_WEBHOOK_ID_HEADER: self.event_id,

--- a/src/bernstein/core/volunteer/manifest.py
+++ b/src/bernstein/core/volunteer/manifest.py
@@ -81,6 +81,7 @@ from typing import TYPE_CHECKING, Any
 from bernstein.core.path_scope import ScopePatternError
 from bernstein.core.path_scope import paths_outside_scope as _paths_outside_scope
 from bernstein.core.path_scope import validate_repo_relative_pattern as _validate_repo_relative_pattern
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
@@ -306,12 +307,7 @@ def canonical_manifest_bytes(manifest: VolunteerManifest) -> bytes:
     at every depth, no insignificant whitespace -- so a digest computed here
     is comparable with the rest of the receipt substrate.
     """
-    return json.dumps(
-        _sort_recursive(manifest.to_canonical_dict()),
-        sort_keys=True,
-        separators=(",", ":"),
-        ensure_ascii=False,
-    ).encode("utf-8")
+    return canonical_bytes(_sort_recursive(manifest.to_canonical_dict()))
 
 
 def manifest_digest(manifest: VolunteerManifest) -> str:

--- a/src/bernstein/core/volunteer/sandbox_profile.py
+++ b/src/bernstein/core/volunteer/sandbox_profile.py
@@ -57,9 +57,10 @@ project asks and what the donor allows.
 from __future__ import annotations
 
 import hashlib
-import json
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
+
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Mapping
@@ -192,12 +193,7 @@ class VolunteerSandboxProfile:
     @property
     def digest(self) -> str:
         """Content address of the containment decision, 64 hex characters."""
-        payload = json.dumps(
-            self.to_canonical_dict(),
-            sort_keys=True,
-            separators=(",", ":"),
-            ensure_ascii=False,
-        ).encode("utf-8")
+        payload = canonical_bytes(self.to_canonical_dict())
         return hashlib.sha256(payload).hexdigest()
 
 

--- a/src/bernstein/eval/clean_run.py
+++ b/src/bernstein/eval/clean_run.py
@@ -68,6 +68,7 @@ from bernstein.core.replay.journal import (
     run_journal_path,
     verify_events,
 )
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -275,7 +276,7 @@ class EquivalenceAttestation:
         """
         payload = self.body()
         payload["attestation_hash"] = self.attestation_hash
-        return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        return canonical_bytes(payload)
 
     @classmethod
     def from_dict(cls, raw: Mapping[str, Any]) -> EquivalenceAttestation:
@@ -341,7 +342,7 @@ def _word_runs(normalized: str, max_words: int = MAX_TOKEN_WORDS) -> list[str]:
 
 
 def _hash_obj(obj: Any) -> str:
-    payload = json.dumps(obj, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    payload = canonical_bytes(obj)
     return "sha256:" + hashlib.sha256(payload).hexdigest()
 
 
@@ -453,7 +454,7 @@ class ContrabandSet:
 
     def canonical_bytes(self) -> bytes:
         """Canonical JSON bytes (sorted keys, minimal separators, UTF-8)."""
-        return json.dumps(self.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        return canonical_bytes(self.to_dict())
 
     @classmethod
     def from_dict(cls, raw: Mapping[str, Any]) -> ContrabandSet:
@@ -927,7 +928,7 @@ class CleanRunAttestation:
         """
         payload = self.body()
         payload["attestation_hash"] = self.attestation_hash
-        return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        return canonical_bytes(payload)
 
     @classmethod
     def from_dict(cls, raw: Mapping[str, Any]) -> CleanRunAttestation:

--- a/src/bernstein/eval/gate_receipt.py
+++ b/src/bernstein/eval/gate_receipt.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.lineage.spine import LineageSpine, content_hash_of
+from bernstein.core.security.canonical import canonical_bytes
 from bernstein.eval.significance import (
     DEFAULT_ALPHA,
     DEFAULT_MIN_N,
@@ -152,7 +153,7 @@ def verdict_receipt_path(workdir: Path, receipt_hash: str) -> Path:
 
 
 def _hash_obj(obj: Any) -> str:
-    payload = json.dumps(obj, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    payload = canonical_bytes(obj)
     return "sha256:" + hashlib.sha256(payload).hexdigest()
 
 

--- a/src/bernstein/eval/promotion.py
+++ b/src/bernstein/eval/promotion.py
@@ -29,6 +29,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.lineage.spine import LineageSpine, content_hash_of
+from bernstein.core.security.canonical import canonical_bytes
 from bernstein.eval.significance import PROMOTING_VERDICTS, Verdict
 
 if TYPE_CHECKING:
@@ -258,7 +259,7 @@ def revocation_receipt_path(workdir: Path, receipt_hash: str) -> Path:
 
 
 def _hash_obj(obj: Any) -> str:
-    payload = json.dumps(obj, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    payload = canonical_bytes(obj)
     return "sha256:" + hashlib.sha256(payload).hexdigest()
 
 
@@ -290,7 +291,7 @@ class RevocationReceipt:
     def canonical_bytes(self) -> bytes:
         payload = self.body()
         payload["receipt_hash"] = self.receipt_hash
-        return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        return canonical_bytes(payload)
 
     def to_dict(self) -> dict[str, Any]:
         payload = self.body()

--- a/src/bernstein/eval/significance.py
+++ b/src/bernstein/eval/significance.py
@@ -29,13 +29,14 @@ statistics and a gate degrades to a threshold compare over noise.
 from __future__ import annotations
 
 import hashlib
-import json
 import math
 from dataclasses import dataclass
 from decimal import ROUND_HALF_EVEN, Decimal
 from enum import StrEnum
 from fractions import Fraction
 from typing import TYPE_CHECKING, Any, Final
+
+from bernstein.core.security.canonical import canonical_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -508,7 +509,7 @@ def classify(
 
 
 def _hash_obj(obj: Any) -> str:
-    payload = json.dumps(obj, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    payload = canonical_bytes(obj)
     return "sha256:" + hashlib.sha256(payload).hexdigest()
 
 

--- a/tests/unit/orchestration/test_mesh_coordinator.py
+++ b/tests/unit/orchestration/test_mesh_coordinator.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from bernstein.core.lineage.tracker_audit import GENESIS_PREV_HASH, _canonical_bytes
+from bernstein.core.lineage.tracker_audit import GENESIS_PREV_HASH
 from bernstein.core.orchestration.orchestrator import start_cluster_coordinator
 from bernstein.core.orchestration.tracker_pipeline import (
     CLAIM_JOURNAL_SCHEMA_VERSION,
@@ -40,6 +40,7 @@ from bernstein.core.protocols.cluster.mesh_coordinator import (
     build_mesh_coordinator,
 )
 from bernstein.core.security.audit_chain import AuditChainStore
+from bernstein.core.security.canonical import canonical_bytes as _canonical_bytes
 from bernstein.core.tasks.models import ClusterConfig, ClusterTopology
 
 if TYPE_CHECKING:

--- a/tests/unit/security/test_canonical_bytes.py
+++ b/tests/unit/security/test_canonical_bytes.py
@@ -1,0 +1,52 @@
+"""The one canonical-JSON byte rule and the verifier-side version selection (#5094)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from bernstein.core.security.canonical import (
+    CANONICALIZATION_VERSION,
+    UnsupportedCanonicalization,
+    bytes_for_verification,
+    canonical_bytes,
+    legacy_ascii_bytes,
+    legacy_pretty_bytes,
+)
+
+_PAYLOAD = {"b": [1, {"z": None, "a": "é"}], "a": "ü"}
+
+
+def test_canonical_bytes_sorts_keys_at_every_depth_and_keeps_non_ascii() -> None:
+    assert canonical_bytes(_PAYLOAD) == '{"a":"ü","b":[1,{"a":"é","z":null}]}'.encode()
+
+
+def test_legacy_ascii_rule_differs_only_for_non_ascii_payloads() -> None:
+    assert legacy_ascii_bytes({"k": "v"}) == canonical_bytes({"k": "v"})
+    assert legacy_ascii_bytes(_PAYLOAD) == b'{"a":"\\u00fc","b":[1,{"a":"\\u00e9","z":null}]}'
+    assert legacy_ascii_bytes(_PAYLOAD) != canonical_bytes(_PAYLOAD)
+
+
+def test_legacy_pretty_rule_is_indented_ascii_with_trailing_newline() -> None:
+    assert legacy_pretty_bytes({"k": "é"}) == b'{\n  "k": "\\u00e9"\n}\n'
+
+
+def test_canonical_bytes_refuses_values_that_are_not_json() -> None:
+    with pytest.raises(ValueError):
+        canonical_bytes({"x": math.nan})
+    with pytest.raises(ValueError):
+        canonical_bytes({"x": math.inf})
+
+
+def test_verifier_recomputes_under_the_rule_the_artefact_names() -> None:
+    assert bytes_for_verification(_PAYLOAD, CANONICALIZATION_VERSION, legacy=legacy_ascii_bytes) == canonical_bytes(
+        _PAYLOAD
+    )
+    assert bytes_for_verification(_PAYLOAD, None, legacy=legacy_ascii_bytes) == legacy_ascii_bytes(_PAYLOAD)
+    assert bytes_for_verification(_PAYLOAD, None, legacy=legacy_pretty_bytes) == legacy_pretty_bytes(_PAYLOAD)
+
+
+def test_verifier_refuses_a_version_this_build_cannot_reproduce() -> None:
+    with pytest.raises(UnsupportedCanonicalization):
+        bytes_for_verification(_PAYLOAD, CANONICALIZATION_VERSION + 1, legacy=legacy_ascii_bytes)

--- a/tests/unit/test_canonical_bytes_single_source.py
+++ b/tests/unit/test_canonical_bytes_single_source.py
@@ -1,0 +1,121 @@
+"""Guard: canonical JSON for signing has one implementation (#5094).
+
+Every hash or signature in this package is computed over bytes derived from a
+JSON-shaped payload. When two modules derive those bytes differently, a
+signature made under one does not verify under the other, and the artefact
+alone cannot say which rule produced it. ``core.security.canonical`` owns the
+rule; this test walks the package with ``ast`` and fails when a second
+definition appears under any of the names the copies used to have.
+
+``REMAINING_UNTIL_SLICE_4`` lists the definitions that still exist on purpose:
+method-style wrappers that delegate to the one rule, and the producers whose
+byte rule differs and need a canonicalization version on their artefacts
+before they can move. The set is asserted in both directions, so removing one
+of them without pruning it here fails too: the list can only shrink.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[2] / "src" / "bernstein"
+_NAMES = frozenset({"_canonical_bytes", "_canonical_json", "canonical_bytes"})
+
+THE_ONE = "core/security/canonical.py::canonical_bytes"
+
+REMAINING_UNTIL_SLICE_4 = frozenset(
+    {
+        "adapters/capability_profile.py::AdapterCapabilityProfile.canonical_bytes",
+        "core/agents/context_capsule.py::ContextCapsule.canonical_bytes",
+        "core/agents/subagent_delegation.py::_canonical_bytes",
+        "core/cost/scheduling/knob_matrix.py::KnobMatrix._canonical_bytes",
+        "core/cost/scheduling/policy.py::DispatchDecision.canonical_bytes",
+        "core/cost/scheduling/price_table.py::PriceTable._canonical_bytes",
+        "core/datasources/result.py::canonical_bytes",
+        "core/datasources/schema.py::SchemaSnapshot.canonical_bytes",
+        "core/events/actions.py::_canonical_json",
+        "core/evidence/run_artifacts.py::ArtifactPayload.canonical_bytes",
+        "core/finding_verify.py::FindingVerifyReceipt.canonical_bytes",
+        "core/finding_verify.py::_canonical_bytes",
+        "core/git/read_set_receipt.py::ReadSetRefusalReceipt.canonical_bytes",
+        "core/lineage/artifact_events.py::ArtifactProductionEvent.canonical_bytes",
+        "core/lineage/artifact_health.py::_canonical_json",
+        "core/lineage/run_graph.py::RunGraphReceipt.canonical_bytes",
+        "core/observability/ticket_bundle.py::BundleManifest.canonical_bytes",
+        "core/orchestration/activity.py::_canonical_bytes",
+        "core/orchestration/activity_modalities.py::_canonical_bytes",
+        "core/orchestration/mission_digest.py::MissionDigest.canonical_bytes",
+        "core/orchestration/mission_digest.py::_canonical_bytes",
+        "core/orchestration/missions.py::MissionStatus.canonical_bytes",
+        "core/orchestration/missions.py::_canonical_bytes",
+        "core/orchestration/sla_receipt.py::_canonical_json",
+        "core/orchestration/supervisor_receipt.py::_canonical_json",
+        "core/orchestration/tracker_pipeline.py::ClaimState.canonical_bytes",
+        "core/persistence/journal_export.py::ReceiptManifest.canonical_bytes",
+        "core/planning/recovery_receipt.py::RecoveryReceipt.canonical_bytes",
+        "core/planning/recovery_receipt.py::_canonical_bytes",
+        "core/planning/sla_store.py::SLAContract.canonical_bytes",
+        "core/quality/verifier_ladder.py::LadderReceipt.canonical_bytes",
+        "core/quality/verifier_ladder.py::TierRecord.canonical_bytes",
+        "core/replay/diagnose.py::_canonical_json",
+        "core/sandbox/pool.py::_canonical_json",
+        "core/sandbox/pool_enrolment.py::_canonical_json",
+        "core/sandbox/pool_placement.py::_canonical_json",
+        "core/sandbox/selection_receipt.py::_canonical_json",
+        "core/security/audit_dsse.py::_canonical_json",
+        "core/security/change_receipt.py::ChangeReceipt.canonical_bytes",
+        "core/security/input_refusal.py::InputRefusalReceipt.canonical_bytes",
+        "core/security/result_receipt_bundle.py::ResultBundle.canonical_bytes",
+        "core/security/result_receipt_bundle.py::canonical_bytes",
+        "core/security/toolcall_identity.py::ToolCallIdentityAttestation.canonical_bytes",
+        "core/skills/catalog/revocation.py::RevocationEntry.canonical_bytes",
+        "core/skills/catalog/transparency.py::SignedTreeHead.canonical_bytes",
+        "core/tasks/checkpoint_retry.py::RetryDecision.canonical_bytes",
+        "core/tasks/completion_record.py::TaskCompletionRecord.canonical_bytes",
+        "core/tasks/decomposition_guard.py::DecompositionRefusalReceipt.canonical_bytes",
+        "core/tasks/task_pack.py::TaskContextPack.canonical_bytes",
+        "core/volunteer/clean_room.py::CleanRoomVerificationReceipt.canonical_bytes",
+        "core/volunteer/clean_room.py::canonical_bytes",
+        "core/volunteer/consent.py::ConsentReceipt.canonical_bytes",
+        "core/volunteer/consent.py::canonical_bytes",
+        "eval/bench/reliability.py::_canonical_bytes",
+        "eval/clean_run.py::CleanRunAttestation.canonical_bytes",
+        "eval/clean_run.py::ContrabandSet.canonical_bytes",
+        "eval/clean_run.py::EquivalenceAttestation.canonical_bytes",
+        "eval/gate_receipt.py::VerdictReceipt.canonical_bytes",
+        "eval/promotion.py::RevocationReceipt.canonical_bytes",
+        "eval/trajectory_receipt.py::TrajectoryReceipt.canonical_bytes",
+    }
+)
+
+
+def _definitions() -> set[str]:
+    found: set[str] = set()
+    for path in sorted(_SRC.rglob("*.py")):
+        rel = path.relative_to(_SRC).as_posix()
+        stack: list[tuple[ast.AST, str]] = [(ast.parse(path.read_text(encoding="utf-8")), "")]
+        while stack:
+            node, prefix = stack.pop()
+            for child in ast.iter_child_nodes(node):
+                if isinstance(child, ast.ClassDef):
+                    stack.append((child, prefix + child.name + "."))
+                elif isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef):
+                    if child.name in _NAMES:
+                        found.add(f"{rel}::{prefix}{child.name}")
+                    stack.append((child, prefix + child.name + "."))
+    return found
+
+
+def test_canonical_json_has_exactly_one_free_implementation() -> None:
+    """Every definition outside the allowlist is a second byte rule; none may exist."""
+    found = _definitions()
+    unexpected = sorted(found - REMAINING_UNTIL_SLICE_4 - {THE_ONE})
+    assert THE_ONE in found, f"{THE_ONE} is missing"
+    assert unexpected == [], f"new canonical-JSON definitions outside core.security.canonical: {unexpected}"
+
+
+def test_allowlist_only_shrinks() -> None:
+    """A wrapper removed from the code must be removed here too, or the list rots."""
+    stale = sorted(REMAINING_UNTIL_SLICE_4 - _definitions())
+    assert stale == [], f"allowlisted definitions no longer exist; prune them: {stale}"

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -6022,7 +6022,6 @@ class TestAdaptivePollingBackoff:
         assert hasattr(orch, "_idle_multiplier")
         assert orch._idle_multiplier == 1
 
-
 # --- Reverse task-to-session index ---
 
 

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -6022,6 +6022,7 @@ class TestAdaptivePollingBackoff:
         assert hasattr(orch, "_idle_multiplier")
         assert orch._idle_multiplier == 1
 
+
 # --- Reverse task-to-session index ---
 
 

--- a/tests/unit/test_sovereign_hardening.py
+++ b/tests/unit/test_sovereign_hardening.py
@@ -690,8 +690,8 @@ def test_verify_rejects_a_drift_record_missing_its_refusal_vocabulary(tmp_path: 
     re-signing leaves the required-field check as the only thing that can
     reject the record. Without that check the record would verify clean.
     """
+    from bernstein.core.security.canonical import canonical_bytes as _canonical_bytes
     from bernstein.core.security.deployment_profile import (
-        _canonical_bytes,
         record_and_sign_drift,
         verify_sovereign_attestations,
     )
@@ -940,8 +940,8 @@ def test_verify_rejects_a_chain_record_signed_by_a_foreign_key(tmp_path: Path) -
     Without the anchor this is the shape that makes the Ed25519 layer useless
     under `--merkle-only` or a compromised HMAC key.
     """
+    from bernstein.core.security.canonical import canonical_bytes as _canonical_bytes
     from bernstein.core.security.deployment_profile import (
-        _canonical_bytes,
         _sha256_of,
         verify_sovereign_attestations,
     )

--- a/tests/unit/test_sovereign_hardening.py
+++ b/tests/unit/test_sovereign_hardening.py
@@ -421,7 +421,7 @@ def _resign_body(raw: dict[str, Any], private_pem: str) -> None:
     checks were deleted. Re-signing makes the signature valid so the *only*
     thing left that can reject the record is the contract check under test.
     """
-    from bernstein.core.security.deployment_profile import _canonical_bytes
+    from bernstein.core.security.canonical import canonical_bytes as _canonical_bytes
     from bernstein.core.skills.catalog.signature import sign_payload
 
     body = {k: v for k, v in raw.items() if k not in _SEAL_FIELDS}
@@ -502,7 +502,8 @@ def test_record_signed_by_a_foreign_key_is_rejected(tmp_path: Path) -> None:
     itself. It must still be refused, because the signer is not this install's
     sovereign identity.
     """
-    from bernstein.core.security.deployment_profile import _canonical_bytes, _sha256_of
+    from bernstein.core.security.canonical import canonical_bytes as _canonical_bytes
+    from bernstein.core.security.deployment_profile import _sha256_of
     from bernstein.core.skills.catalog.signature import generate_signer_keypair, sign_payload, verify_payload
 
     _seal(tmp_path)
@@ -606,7 +607,7 @@ def test_corrupt_signature_alone_is_rejected(tmp_path: Path) -> None:
     matches. Only the signature bytes are corrupted, which leaves the signature
     check as the single thing that can reject this record.
     """
-    from bernstein.core.security.deployment_profile import _canonical_bytes
+    from bernstein.core.security.canonical import canonical_bytes as _canonical_bytes
     from bernstein.core.skills.catalog.signature import verify_payload
 
     attestation = _seal(tmp_path)
@@ -651,7 +652,8 @@ def test_verify_rejects_a_record_with_no_effective_policy(tmp_path: Path) -> Non
     The mutated body is re-signed so its signature is valid; the only thing
     that can reject it is the required-field check under test.
     """
-    from bernstein.core.security.deployment_profile import _canonical_bytes, verify_sovereign_attestations
+    from bernstein.core.security.canonical import canonical_bytes as _canonical_bytes
+    from bernstein.core.security.deployment_profile import verify_sovereign_attestations
     from bernstein.core.skills.catalog.signature import sign_payload
 
     _seal(tmp_path)


### PR DESCRIPTION
## What

One canonical-JSON byte rule for hashing and signing, in `core/security/canonical.py`, and every byte-identical producer routed through it. Slices 1 and 2 of #5094, plus the verifier-side version selection slice 3 builds on.

## Why

Every signature and content hash in the package is computed over bytes derived from a JSON payload. On `main` there are 93 definitions named `_canonical_bytes`, `_canonical_json` or `canonical_bytes` with 40 distinct bodies: 37 escape non-ASCII, 6 add `default=str`, 2 pretty-print. A signature made under one rule does not verify under another, and an artefact does not say which rule produced it. An operator handed a signed artefact and the verifier binary cannot tell, from the artefact alone, which of the variants to recompute.

## How

- `canonical_bytes(payload)`: sorted keys, `(",", ":")` separators, UTF-8 with non-ASCII preserved, `allow_nan=False`. `CANONICALIZATION_VERSION = 1` and the field name signed artefacts will carry it under.
- `legacy_ascii_bytes` and `legacy_pretty_bytes` reproduce the two earlier byte rules. `bytes_for_verification(payload, version, legacy=...)` recomputes under the rule an artefact names; `None` means the producer's legacy rule; an unknown version raises `UnsupportedCanonicalization` instead of returning a mismatch that reads as tampering.
- An `ast`-driven migration replaced 97 `json.dumps(..., ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")` expressions with `canonical_bytes(...)`, deleted the 31 module-level copies that became one-line aliases (callers renamed), and made 5 helpers that return `str` delegate and decode. Bytes are unchanged at every migrated site; only the definition moved.
- Two indented serialisers that write evidence-pack and bundle files are renamed (`_pack_json`, `_bundle_json`): they are file formats whose manifest hashes cover the stored bytes, not signing canonicalizations. Their bytes are unchanged.
- Guard: `tests/unit/test_canonical_bytes_single_source.py` walks `src/bernstein` and asserts the remaining definitions equal an explicit allowlist in both directions, so the list can only shrink.

**Decision taken:** `allow_nan=False`. The copies inherited `json.dumps`' default of emitting `NaN`/`Infinity`, which no strict parser accepts, so a signed artefact containing one could never be verified elsewhere. Raising at the producer is the only place that error is cheap.

## Tests

1. `test_canonical_json_has_exactly_one_free_implementation` — load-bearing; on `main` it fails with 93 definitions found and `core/security/canonical.py::canonical_bytes` missing.
2. `test_allowlist_only_shrinks` — a wrapper removed from the code must be pruned from the allowlist.
3. `test_canonical_bytes_sorts_keys_at_every_depth_and_keeps_non_ascii` — the byte rule, pinned.
4. `test_legacy_ascii_rule_differs_only_for_non_ascii_payloads` and `test_legacy_pretty_rule_is_indented_ascii_with_trailing_newline` — the legacy rules, pinned, so slice 3 fixtures have a fixed target.
5. `test_canonical_bytes_refuses_values_that_are_not_json`.
6. `test_verifier_recomputes_under_the_rule_the_artefact_names` and `test_verifier_refuses_a_version_this_build_cannot_reproduce`.

All eight fail or error on `main` (1 on the count, the rest on import) and pass here. The affected-test set for the diff was run locally with the repo runner.

## Checklist

- [x] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` — not run locally; the type-check report job covers it
- [x] `uv run python scripts/run_tests.py --affected origin/main` selects the whole suite for this diff (1,699 files), so the full run is left to CI; run locally instead: the seven test files nearest the touched code (235 passed) and the two new test modules
- [x] New code has type hints

### Documentation duty

- [x] User-visible README section updated — N/A, internal
- [x] `docs/operations/<area>.md` updated — N/A
- [x] `docs/api/` schema regenerated — N/A, no public surface changed
- [x] `agents-md sync` — N/A, no documented command changed
- [x] Tests cover the documented behaviour

Part of #5094

## Remaining

- Slice 3: the 19 producers on the ASCII-escaping rule (`missions`, `mission_digest`, `sla_receipt`, `supervisor_receipt`, `selection_receipt`, `audit_dsse`, `result_receipt_bundle`, `clean_room`, `consent`, `reliability`, and the method-style ones in `capability_profile`, `ticket_bundle`, `journal_export`, `sla_store`, `revocation`, `checkpoint_retry`, `completion_record`, `decomposition_guard`, `task_pack`) each need the version field on their artefact and a fixture signed under `legacy_ascii_bytes` proving old signatures still verify, then move to the one rule.
- The 6 producers that pass `default=str` (`subagent_delegation`, `finding_verify`, `activity`, `activity_modalities`, `recovery_receipt`, `diagnose`) serialise objects the rule rejects; their payload builders need to emit JSON values first.
- Slice 4: the method-style wrappers in the allowlist become call sites of the one function; `datasources/result.canonical_bytes` (a binary framing, not JSON) gets a name that says so; the allowlist shrinks to one entry.
