### PR TITLE
ci: bound the trace-conformance job with a timeout

### DIFF
--- a/.github/workflows/trace-conformance.yml
+++ b/.github/workflows/trace-conformance.yml
@@ -47,6 +47,12 @@ jobs:
   trace-tests:
     name: trace-tests verify
     runs-on: ubuntu-latest
+    # The job installs the published suite from PyPI and then loops over
+    # every committed vector, so a hung index fetch or a vector that never
+    # terminates would otherwise hold a runner slot for the platform default
+    # of six hours. Longest observed run to date is 9m26s; 20 minutes leaves
+    # room for a slow index without leaving the ceiling unguarded.
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -6022,6 +6022,7 @@ class TestAdaptivePollingBackoff:
         assert hasattr(orch, "_idle_multiplier")
         assert orch._idle_multiplier == 1
 
+
 # --- Reverse task-to-session index ---
 
 

--- a/verify_cli/bernstein_verify_receipt/__main__.py
+++ b/verify_cli/bernstein_verify_receipt/__main__.py
@@ -75,9 +75,7 @@ def cli() -> None:
     show_default=True,
     help="Which format(s) to verify.",
 )
-@click.option(
-    "--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details."
-)
+@click.option("--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details.")
 def verify_cmd(
     receipt_path: Path,
     jwk_path: Path | None,

--- a/verify_cli/bernstein_verify_receipt/verify.py
+++ b/verify_cli/bernstein_verify_receipt/verify.py
@@ -291,8 +291,7 @@ def verify_subject_binding(receipt: dict[str, Any]) -> tuple[CheckResult, str]:
                 "subject_binding",
                 ok=False,
                 detail=(
-                    f"recomputed head {recomputed[:16]}… "
-                    f"!= range.head_sha256 {range_head[:16]}…"
+                    f"recomputed head {recomputed[:16]}… != range.head_sha256 {range_head[:16]}…"
                 ),
             ),
             recomputed,
@@ -418,10 +417,7 @@ def verify_intoto(receipt: dict[str, Any], public_key: Any, recomputed_head: str
         return CheckResult(
             "intoto",
             ok=False,
-            detail=(
-                f"recomputed head {recomputed_head[:16]}… "
-                f"not in statement subject digests"
-            ),
+            detail=(f"recomputed head {recomputed_head[:16]}… not in statement subject digests"),
         )
     return CheckResult("intoto", ok=True, detail="DSSE/in-toto verified, subject bound to head")
 
@@ -469,8 +465,7 @@ def verify_transparency(
             "transparency",
             ok=False,
             detail=(
-                f"STH subject {subject_sha256[:16]}… "
-                f"!= recomputed head {recomputed_head[:16]}…"
+                f"STH subject {subject_sha256[:16]}… != recomputed head {recomputed_head[:16]}…"
             ),
         )
 
@@ -510,10 +505,7 @@ def verify_transparency(
             return CheckResult(
                 "transparency",
                 ok=False,
-                detail=(
-                    f"inclusion proof root {proven_root[:16]}… "
-                    f"!= STH root {root_hash[:16]}…"
-                ),
+                detail=(f"inclusion proof root {proven_root[:16]}… != STH root {root_hash[:16]}…"),
             )
     return CheckResult(
         "transparency", ok=True, detail="RFC6962 STH signed, root + inclusion proof verified"


### PR DESCRIPTION
## What

Adds `timeout-minutes: 20` to the `trace-tests` job in
`.github/workflows/trace-conformance.yml`.

## Why

A scan of every job definition under `.github/workflows/` finds 145 jobs, of
which 144 declare `timeout-minutes`. `trace-tests` is the only one that does
not, so it inherits the platform default of 360 minutes.

That default matters here more than it would in a job that only runs local
code. This job resolves and installs a published package from an external
index (`agentrust-trace-tests==0.5.1`) and then loops over every committed
vector, so a stalled index fetch has nothing but the platform ceiling to stop
it. Runner slots on this repository are a shared, capped pool, and one job
sitting idle for six hours is six hours the pool cannot give to anything else.

Sizing, from this workflow's own history (last 30 runs on the API):

| statistic | value |
| --- | --- |
| runs sampled | 8 completed |
| median duration | 66 s |
| longest observed | 566 s (9m26s) |
| proposed bound | 1200 s (20 min) |

20 minutes is roughly 2x the longest run this workflow has ever recorded, so
it should never fire on a healthy run.

## How

Six added lines: the `timeout-minutes` key plus a comment recording how the
number was chosen, so the next person to touch it knows what to re-measure.

No step, trigger, permission or check name changes.

## Risk

The bound could fire on a legitimately slow run, which would turn a green
check red. Two things limit that:

- the workflow is deliberately outside the required-check set (see the header
  comment in the file), so a red run cannot wedge the merge queue;
- the headroom is ~2x the observed maximum.

If it does fire, the run page shows `The job running on runner ... has
exceeded the maximum execution time of 20 minutes`, and the fix is to raise
the number in this one place after checking why the job got slower.

## Checklist

- [x] No check is disabled, weakened or removed
- [x] No permission is widened
- [x] No release, publish, signing or artefact-upload workflow touched
- [x] No branch protection or ruleset change
- [x] Bound chosen from this workflow's measured history, not a guess