### PR TITLE
feat: re-derive a run's coordination sequence from recorded inputs (#4213)

### DIFF
--- a/docs/operations/deterministic-replay.md
+++ b/docs/operations/deterministic-replay.md
@@ -224,6 +224,14 @@ Refusal codes: `underivable_step`, `head_mismatch`, `plan_missing`,
 `journal_unreadable`, `journal_not_found`. `--as-json` emits them alongside
 `step_index`, `rule`, `recorded_head` and `derived_head`.
 
+`plan.graph.full` is appended on normal ticks only (every sixth tick, and the
+first tick is always a fast tick), so a run that finished in fewer ticks than
+that recorded no planning output and re-derives to `plan_missing`. That is a
+gap in what the run recorded, not a fault in the run: there is nothing to
+re-derive the dependency gate from. For the same reason the dependency gate is
+skipped for claims that precede the first graph event, rather than reporting a
+missing input as a coordination fault.
+
 Capsule-governed finalization can seal the journal head and event count outside
 the journal. Where that seal exists, finished-journal identity and artifact
 provenance can share an independently committed root; most task journals do

--- a/docs/operations/deterministic-replay.md
+++ b/docs/operations/deterministic-replay.md
@@ -182,6 +182,47 @@ instead of the ambiguous former `ok` flag.
   divergence.
 - `bernstein replay <run-id> --from-step N` rebuilds a deterministic state
   projection over events `[0, N)`; two invocations are byte-identical.
+- `bernstein replay <run-id> --re-derive` re-derives the coordination sequence
+  from the recorded inputs and compares the re-derived head to the recorded
+  one (see below).
+
+### Coordination re-derivation (`--re-derive`)
+
+`--verify` recomputes the chain over the rows already on disk. That proves the
+journal was not edited afterwards; it does not prove the coordination sequence
+those rows record is the sequence the scheduler's rules produce. Without a
+second check the determinism property is enforced by code structure alone.
+
+`--re-derive` supplies that check. It reads the two things coordination does
+not choose - the recorded planning output (`plan.graph.full`) and the recorded
+per-task outcomes (`task_completed`, `task_verification_failed`,
+`task_retried`) - walks the run back through the coordination state machine,
+appends every accepted step to a **fresh journal in a throwaway sandbox**, and
+exits 0 only when the re-derived timing-excluded head equals the recorded head.
+
+What is an input and what is a decision:
+
+| Recorded fact | Treated as | Why |
+|---|---|---|
+| plan graph, leaf outcome, agent id, model, cost | input, carried verbatim | coordination did not choose it; re-derivation holds it fixed |
+| whether a task was claimable when it was claimed | decision, re-derived | this is the rule the scheduler applies |
+| whether an outcome belonged to a running task | decision, re-derived | an outcome with no outstanding claim is not a reachable step |
+| the chain over the resulting sequence | decision, re-derived | the head is computed from inputs, never copied |
+
+A step the rules cannot produce is reported by index **and** by the rule that
+refused it (`dependency_not_completed`, `task_already_claimed`,
+`task_not_in_plan`, `outcome_for_unclaimed_task`), so an injected outcome
+surfaces as a named first divergence rather than a bare hash difference. When
+every step is derivable but a payload differs, the pairwise divergence locator
+(`core/replay/diff.py`) names the first differing step instead.
+
+Re-derivation re-executes nothing: no adapter binary, no task server, no
+network, and no write outside the sandbox. Re-running the agents is a live
+re-run, which is a different operation.
+
+Refusal codes: `underivable_step`, `head_mismatch`, `plan_missing`,
+`journal_unreadable`, `journal_not_found`. `--as-json` emits them alongside
+`step_index`, `rule`, `recorded_head` and `derived_head`.
 
 Capsule-governed finalization can seal the journal head and event count outside
 the journal. Where that seal exists, finished-journal identity and artifact

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -2167,6 +2167,81 @@ def _print_verify_divergence(
     raise SystemExit(1)
 
 
+def _replay_rederive(*, run_id: str, sdd_dir: str, as_json: bool) -> None:
+    """Re-derive the run's coordination sequence and compare heads (issue #4213).
+
+    ``--verify`` recomputes the chain over the rows already on disk, which
+    proves the journal was not edited afterwards but says nothing about
+    whether the sequence it records is the one the scheduler's rules produce.
+    This verb closes that gap: it feeds the recorded planning output and the
+    recorded per-task outcomes back through the coordination state machine,
+    writes the accepted steps into a fresh journal in a throwaway sandbox, and
+    exits 0 only when the re-derived timing-excluded head equals the recorded
+    one. A step the rules cannot produce is reported by index and by the rule
+    that refused it, rather than as a bare hash difference.
+
+    The sandbox is a temporary directory: re-derivation is a read-only
+    question about a finished run, so it must not leave anything in the run
+    directory it is auditing.
+    """
+    import tempfile
+
+    from bernstein.core.replay.rederive import (
+        REASON_CODE_JOURNAL_NOT_FOUND,
+        REASON_CODE_UNDERIVABLE_STEP,
+        rederive_run,
+    )
+
+    runs_dir = Path(sdd_dir) / "runs"
+    journal_path = _resolve_journal_path(run_id, runs_dir)
+    if not journal_path.exists():
+        if as_json:
+            console.print_json(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "run_id": run_id,
+                        "reason_code": REASON_CODE_JOURNAL_NOT_FOUND,
+                        "reason": f"journal not found: {journal_path}",
+                    }
+                )
+            )
+        else:
+            console.print(f"[red]Journal not found:[/red] {journal_path}")
+        raise SystemExit(1)
+
+    with tempfile.TemporaryDirectory(prefix="bernstein-rederive-") as sandbox:
+        result = rederive_run(journal_path, sandbox=Path(sandbox))
+
+    payload = {
+        "ok": result.ok,
+        "run_id": result.run_id,
+        "recorded_head": result.recorded_head,
+        "derived_head": result.derived_head,
+        "step_count": result.step_count,
+        "step_index": result.divergent_index,
+        "reason": result.reason,
+        "reason_code": result.reason_code,
+        "rule": result.rule,
+    }
+    if as_json:
+        console.print_json(json.dumps(payload))
+    elif result.ok:
+        console.print(
+            f"[green]RE-DERIVED[/green] run [bold]{result.run_id}[/bold]: "
+            f"{result.step_count} coordination step(s) reproduce the recorded head"
+        )
+        console.print(f"[dim]head:[/dim] {result.derived_head}")
+    else:
+        label = "UNDERIVABLE STEP" if result.reason_code == REASON_CODE_UNDERIVABLE_STEP else "RE-DERIVE MISMATCH"
+        console.print(f"[red]{label}[/red] run [bold]{result.run_id}[/bold]: {result.reason}")
+        console.print(f"[dim]recorded head:[/dim] {result.recorded_head}")
+        console.print(f"[dim]derived head: [/dim] {result.derived_head}")
+
+    if not result.ok:
+        raise SystemExit(1)
+
+
 def _replay_from_step(*, run_id: str, sdd_dir: str, from_step: int, as_json: bool) -> None:
     """Rebuild deterministic run state by walking the journal to ``from_step``.
 
@@ -2234,6 +2309,14 @@ def _replay_from_step(*, run_id: str, sdd_dir: str, from_step: int, as_json: boo
     help="Rebuild deterministic run state by walking the journal to step N.",
 )
 @click.option(
+    "--re-derive",
+    "re_derive",
+    is_flag=True,
+    default=False,
+    help="Re-derive the coordination sequence from the recorded plan and outcomes "
+    "and compare the re-derived head to the recorded one.",
+)
+@click.option(
     "--yes-i-want-to-publish",
     "yes_i_want_to_publish",
     is_flag=True,
@@ -2278,6 +2361,7 @@ def replay_cmd(
     extra_context: str | None,
     verify: bool,
     from_step: int | None,
+    re_derive: bool,
     yes_i_want_to_publish: bool,
     fork_from: int | None,
     jump_to_failure: bool,
@@ -2300,6 +2384,7 @@ def replay_cmd(
       bernstein replay latest                     # replay most recent run
       bernstein replay 20240315-143022            # replay a specific run
       bernstein replay <RUN_ID> --verify          # recompute head, find divergence
+      bernstein replay <RUN_ID> --re-derive       # re-derive coordination, compare heads
       bernstein replay <RUN_ID> --from-step N     # rebuild state to step N
       bernstein replay diff RUN_A RUN_B           # first-divergence finder
       bernstein replay <AGENT_ID>                 # per-step journal view (#1799)
@@ -2380,6 +2465,9 @@ def replay_cmd(
     # rebuild a deterministic state projection for a prefix of the run.
     if verify:
         _replay_verify_journal(run_id=args[0], sdd_dir=sdd_dir, as_json=as_json)
+        return
+    if re_derive:
+        _replay_rederive(run_id=args[0], sdd_dir=sdd_dir, as_json=as_json)
         return
     if from_step is not None:
         _replay_from_step(run_id=args[0], sdd_dir=sdd_dir, from_step=from_step, as_json=as_json)

--- a/src/bernstein/core/replay/rederive.py
+++ b/src/bernstein/core/replay/rederive.py
@@ -1,0 +1,386 @@
+"""Hermetic re-derivation of a run's coordination sequence (issue #4213).
+
+``bernstein replay <run> --verify`` recomputes the Merkle chain over the rows
+that are already on disk. That proves the journal was not edited after the
+fact; it does not prove the coordination sequence those rows record is the
+sequence the scheduler's own rules produce. The determinism promise was
+therefore enforced by code structure alone, with no executable check an
+operator could run.
+
+This module supplies that check. It takes the two things the coordination
+layer does not choose - the **recorded plan** (``plan.graph.full``) and the
+**recorded per-task outcomes** (``task_completed`` / ``task_verification_failed``
+/ ``task_retried``) - and walks the recorded run through the coordination state
+machine the tick loop drives, refusing any step the rules could not have
+produced at that point. Accepted steps are appended to a *fresh* journal in a
+caller-supplied sandbox, so the re-derivation ends with a head computed from
+inputs rather than copied from the recorded chain. Exit criterion: the
+re-derived head equals the recorded head.
+
+What is an input and what is a decision
+---------------------------------------
+
+* **Inputs, carried verbatim.** The plan graph, the outcome each leaf agent
+  produced, and the observations that come with it (agent id, model, cost).
+  Coordination did not pick these; an operator re-deriving a run must be able
+  to hold them fixed.
+* **Decisions, re-derived.** Whether a task was claimable at the point it was
+  claimed, whether an outcome belonged to a task that was actually running,
+  and the chain that binds the resulting sequence together.
+
+Re-derivation deliberately does **not** re-execute agents (that is a live
+re-run) and needs no adapter binary, no task server and no network: it reads
+one JSONL file and writes another.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+from bernstein.core.replay.diff import (
+    REASON_CODE_NONE,
+    diff_event_logs,
+)
+from bernstein.core.replay.journal import (
+    _NON_DETERMINISTIC_FIELDS,  # pyright: ignore[reportPrivateUsage] - shared journal projection
+    EventJournal,
+    JournalPathError,
+    load_events,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+#: Journal event carrying the recorded planning output: the executed task
+#: graph with one entry per node (``id`` / ``role`` / ``title`` /
+#: ``depends_on``). Written by the orchestrator whenever the graph changes.
+PLAN_GRAPH_FULL_EVENT = "plan.graph.full"
+
+#: Journal event recording that coordination handed a task to an agent.
+TASK_CLAIMED_EVENT = "task_claimed"
+
+#: Recorded leaf outcomes. These are inputs to coordination, not decisions.
+TASK_COMPLETED_EVENT = "task_completed"
+TASK_VERIFICATION_FAILED_EVENT = "task_verification_failed"
+TASK_RETRIED_EVENT = "task_retried"
+
+# -- Refusal vocabulary ----------------------------------------------------
+# Machine-readable, so a caller branches on the class of failure rather than
+# on prose. ``REASON_CODE_NONE`` is re-exported from the divergence module so
+# the "nothing wrong" value has exactly one spelling repo-wide.
+
+#: The recorded sequence contains a step the coordination rules cannot produce.
+REASON_CODE_UNDERIVABLE_STEP = "underivable_step"
+
+#: Every step was derivable but the re-derived head differs from the recorded
+#: one, so some payload the chain commits to is not what was recorded.
+REASON_CODE_HEAD_MISMATCH = "head_mismatch"
+
+#: The run recorded no planning output, so there is no input to re-derive from.
+REASON_CODE_PLAN_MISSING = "plan_missing"
+
+#: The journal could not be read as a clean sequence of rows.
+REASON_CODE_JOURNAL_UNREADABLE = "journal_unreadable"
+
+#: No journal exists for the named run.
+REASON_CODE_JOURNAL_NOT_FOUND = "journal_not_found"
+
+# -- Rule names ------------------------------------------------------------
+# Which coordination rule refused the step. Reported alongside the index so
+# the operator is told *why* a step is underivable, not only where.
+
+#: A task was claimed while one of its recorded dependencies had not completed.
+RULE_DEPENDENCY_NOT_COMPLETED = "dependency_not_completed"
+
+#: A task was claimed while an earlier claim of it was still outstanding.
+RULE_TASK_ALREADY_CLAIMED = "task_already_claimed"
+
+#: A task outside the recorded plan was claimed.
+RULE_TASK_NOT_IN_PLAN = "task_not_in_plan"
+
+#: An outcome arrived for a task that was not claimed at that point.
+RULE_OUTCOME_FOR_UNCLAIMED_TASK = "outcome_for_unclaimed_task"
+
+#: No rule refused the step.
+RULE_NONE = ""
+
+_OUTCOME_EVENTS = frozenset(
+    {
+        TASK_COMPLETED_EVENT,
+        TASK_VERIFICATION_FAILED_EVENT,
+        TASK_RETRIED_EVENT,
+    }
+)
+
+
+@dataclass(frozen=True)
+class RederiveResult:
+    """Outcome of re-deriving one run's coordination sequence.
+
+    Attributes:
+        ok: ``True`` only when every step was derivable *and* the re-derived
+            head equals the recorded head.
+        run_id: The run whose journal was re-derived.
+        recorded_head: The head the recorded journal carries on its last row.
+        derived_head: The head of the freshly built sandbox journal, or the
+            empty string when the walk stopped before producing one.
+        step_count: Number of steps the re-derivation accepted.
+        divergent_index: 0-based index of the first step that could not be
+            derived, or at which the two journals first differ. ``None`` when
+            nothing diverged or the run was refused before the walk.
+        reason: Human-readable explanation.
+        reason_code: One of the ``REASON_CODE_*`` constants.
+        rule: The ``RULE_*`` constant naming the coordination rule that
+            refused the step, or :data:`RULE_NONE`.
+        derived_journal_path: Filesystem path of the sandbox journal.
+    """
+
+    ok: bool
+    run_id: str
+    recorded_head: str = ""
+    derived_head: str = ""
+    step_count: int = 0
+    divergent_index: int | None = None
+    reason: str = ""
+    reason_code: str = REASON_CODE_NONE
+    rule: str = RULE_NONE
+    derived_journal_path: str = ""
+
+
+class _CoordinationState:
+    """The per-task status the tick loop carries between steps.
+
+    Deliberately the smallest state that decides claimability: which tasks the
+    recorded plan declared, what each depends on, which have completed, and
+    which are claimed right now. Anything else on a row is an observation and
+    is carried through untouched.
+    """
+
+    def __init__(self) -> None:
+        self.depends_on: dict[str, tuple[str, ...]] = {}
+        self.planned: set[str] = set()
+        self.completed: set[str] = set()
+        self.claimed: set[str] = set()
+
+    def absorb_plan(self, payload: dict[str, Any]) -> None:
+        """Fold a recorded ``plan.graph.full`` payload into the known plan.
+
+        A run re-plans as work lands, so later graph events extend or restate
+        the node set. Folding rather than replacing keeps a task that was
+        claimed under an earlier revision of the graph derivable.
+        """
+        nodes: object = payload.get("nodes")
+        if not isinstance(nodes, list):
+            return
+        for node in cast("list[object]", nodes):
+            if not isinstance(node, dict):
+                continue
+            fields = cast("dict[str, object]", node)
+            task_id = str(fields.get("id", ""))
+            if not task_id:
+                continue
+            raw_deps: object = fields.get("depends_on")
+            deps = tuple(str(d) for d in cast("list[object]", raw_deps)) if isinstance(raw_deps, list) else ()
+            self.planned.add(task_id)
+            self.depends_on[task_id] = deps
+
+    def refuse_claim(self, task_id: str) -> tuple[str, str]:
+        """Return ``(rule, reason)`` when this claim is underivable, else ``(RULE_NONE, "")``.
+
+        The plan gate is skipped while no plan has been seen yet: the
+        orchestrator records the graph on the tick that builds it, so an
+        opening claim can legitimately precede the first graph event, and
+        refusing it would report a missing input as a coordination fault.
+        """
+        if self.planned and task_id not in self.planned:
+            return (
+                RULE_TASK_NOT_IN_PLAN,
+                f"task {task_id} was claimed but the recorded plan does not contain it",
+            )
+        if task_id in self.claimed:
+            return (
+                RULE_TASK_ALREADY_CLAIMED,
+                f"task {task_id} was claimed while an earlier claim of it was still outstanding",
+            )
+        unmet = [dep for dep in self.depends_on.get(task_id, ()) if dep not in self.completed]
+        if unmet:
+            return (
+                RULE_DEPENDENCY_NOT_COMPLETED,
+                f"task {task_id} was claimed before its dependencies completed: {', '.join(sorted(unmet))}",
+            )
+        return (RULE_NONE, "")
+
+    def refuse_outcome(self, event: str, task_id: str) -> tuple[str, str]:
+        """Return ``(rule, reason)`` when this outcome is underivable."""
+        if task_id not in self.claimed:
+            return (
+                RULE_OUTCOME_FOR_UNCLAIMED_TASK,
+                f"{event} arrived for task {task_id}, which was not claimed at this step",
+            )
+        return (RULE_NONE, "")
+
+    def apply(self, event: str, task_id: str) -> None:
+        """Advance the state for an already-accepted step."""
+        if event == TASK_CLAIMED_EVENT:
+            self.claimed.add(task_id)
+        elif event == TASK_COMPLETED_EVENT:
+            self.claimed.discard(task_id)
+            self.completed.add(task_id)
+        elif event == TASK_RETRIED_EVENT:
+            # A retry hands the task back to the pool, so the next claim of it
+            # is derivable again and its dependents stay blocked.
+            self.claimed.discard(task_id)
+            self.completed.discard(task_id)
+        elif event == TASK_VERIFICATION_FAILED_EVENT:
+            # Verification failure does not release the claim - the
+            # orchestrator decides between retry and reap on a later step -
+            # but it does mean the task has not completed.
+            self.completed.discard(task_id)
+
+
+def _payload_of(row: dict[str, Any]) -> dict[str, Any]:
+    """Strip the chain and wall-clock envelope, leaving the recorded payload."""
+    return {k: v for k, v in row.items() if k not in _NON_DETERMINISTIC_FIELDS and k != "event"}
+
+
+def rederive_run(journal_path: Path, *, sandbox: Path) -> RederiveResult:
+    """Re-derive a recorded run's coordination sequence into *sandbox*.
+
+    Args:
+        journal_path: Path to the recorded ``journal.jsonl``.
+        sandbox: Directory to build the fresh journal under. Treated as an
+            ``.sdd`` root, so the re-derived journal lands at
+            ``<sandbox>/runs/<run_id>/journal.jsonl``. Nothing is written
+            outside it and the recorded run directory is never touched.
+
+    Returns:
+        A :class:`RederiveResult`. ``ok`` is ``True`` only when every step was
+        derivable and the re-derived head equals the recorded head.
+    """
+    run_id = journal_path.parent.name
+
+    loaded = load_events(journal_path)
+    if loaded.discarded_line_indices:
+        joined = ", ".join(str(i) for i in loaded.discarded_line_indices)
+        return RederiveResult(
+            ok=False,
+            run_id=run_id,
+            reason=f"journal has unreadable physical line(s): {joined}",
+            reason_code=REASON_CODE_JOURNAL_UNREADABLE,
+        )
+
+    events = loaded.events
+    if not any(row.get("event") == PLAN_GRAPH_FULL_EVENT for row in events):
+        return RederiveResult(
+            ok=False,
+            run_id=run_id,
+            reason=(
+                f"run {run_id} recorded no {PLAN_GRAPH_FULL_EVENT} event, so there is no "
+                "planning output to re-derive the coordination sequence from"
+            ),
+            reason_code=REASON_CODE_PLAN_MISSING,
+        )
+
+    recorded_head = str(events[-1].get("event_hash", "")) if events else ""
+
+    try:
+        derived = EventJournal(run_id=run_id, sdd_dir=sandbox)
+    except JournalPathError as exc:
+        return RederiveResult(
+            ok=False,
+            run_id=run_id,
+            reason=f"cannot build a sandbox journal for run id {run_id!r}: {exc}",
+            reason_code=REASON_CODE_JOURNAL_UNREADABLE,
+        )
+
+    state = _CoordinationState()
+    for index, row in enumerate(events):
+        event = str(row.get("event", ""))
+        payload = _payload_of(row)
+
+        if event == PLAN_GRAPH_FULL_EVENT:
+            state.absorb_plan(payload)
+        elif event == TASK_CLAIMED_EVENT:
+            rule, reason = state.refuse_claim(str(payload.get("task_id", "")))
+            if rule != RULE_NONE:
+                return RederiveResult(
+                    ok=False,
+                    run_id=run_id,
+                    recorded_head=recorded_head,
+                    derived_head=derived.head(),
+                    step_count=index,
+                    divergent_index=index,
+                    reason=f"step {index}: {reason}",
+                    reason_code=REASON_CODE_UNDERIVABLE_STEP,
+                    rule=rule,
+                    derived_journal_path=str(derived.path),
+                )
+        elif event in _OUTCOME_EVENTS:
+            rule, reason = state.refuse_outcome(event, str(payload.get("task_id", "")))
+            if rule != RULE_NONE:
+                return RederiveResult(
+                    ok=False,
+                    run_id=run_id,
+                    recorded_head=recorded_head,
+                    derived_head=derived.head(),
+                    step_count=index,
+                    divergent_index=index,
+                    reason=f"step {index}: {reason}",
+                    reason_code=REASON_CODE_UNDERIVABLE_STEP,
+                    rule=rule,
+                    derived_journal_path=str(derived.path),
+                )
+
+        derived.record(event, **payload)
+        state.apply(event, str(payload.get("task_id", "")))
+
+    derived_head = derived.head()
+    if derived_head == recorded_head:
+        return RederiveResult(
+            ok=True,
+            run_id=run_id,
+            recorded_head=recorded_head,
+            derived_head=derived_head,
+            step_count=len(events),
+            reason=f"re-derived {len(events)} coordination step(s) to the recorded head",
+            derived_journal_path=str(derived.path),
+        )
+
+    # Every step was derivable, so the divergence is in what a step carried
+    # rather than in whether it could happen. Hand that to the pairwise
+    # divergence locator instead of growing a second comparator here.
+    divergence = diff_event_logs(journal_path, derived.path)
+    return RederiveResult(
+        ok=False,
+        run_id=run_id,
+        recorded_head=recorded_head,
+        derived_head=derived_head,
+        step_count=len(events),
+        divergent_index=divergence.index,
+        reason=(
+            f"re-derived head does not match the recorded head; {divergence.reason}"
+            if divergence.diverged
+            else "re-derived head does not match the recorded head"
+        ),
+        reason_code=REASON_CODE_HEAD_MISMATCH,
+        derived_journal_path=str(derived.path),
+    )
+
+
+__all__ = [
+    "PLAN_GRAPH_FULL_EVENT",
+    "REASON_CODE_HEAD_MISMATCH",
+    "REASON_CODE_JOURNAL_NOT_FOUND",
+    "REASON_CODE_JOURNAL_UNREADABLE",
+    "REASON_CODE_NONE",
+    "REASON_CODE_PLAN_MISSING",
+    "REASON_CODE_UNDERIVABLE_STEP",
+    "RULE_DEPENDENCY_NOT_COMPLETED",
+    "RULE_NONE",
+    "RULE_OUTCOME_FOR_UNCLAIMED_TASK",
+    "RULE_TASK_ALREADY_CLAIMED",
+    "RULE_TASK_NOT_IN_PLAN",
+    "RederiveResult",
+    "rederive_run",
+]

--- a/tests/unit/core/replay/test_rederive.py
+++ b/tests/unit/core/replay/test_rederive.py
@@ -1,0 +1,233 @@
+"""Hermetic coordination re-derivation over a recorded run journal (issue #4213).
+
+``bernstein replay <run> --verify`` recomputes the Merkle chain over the rows
+that are already on disk: it proves the journal was not edited, not that the
+coordination sequence it records is the sequence the scheduler's rules produce.
+These tests pin the second property - every coordination step is re-derived
+from the recorded plan and the recorded per-task outcomes, and the re-derived
+journal's timing-excluded head is compared to the recorded head.
+"""
+
+from __future__ import annotations
+
+import socket
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.replay.journal import EventJournal, load_events
+from bernstein.core.replay.rederive import (
+    REASON_CODE_HEAD_MISMATCH,
+    REASON_CODE_PLAN_MISSING,
+    REASON_CODE_UNDERIVABLE_STEP,
+    RULE_DEPENDENCY_NOT_COMPLETED,
+    RULE_OUTCOME_FOR_UNCLAIMED_TASK,
+    rederive_run,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _plan_nodes() -> list[dict[str, object]]:
+    """A two-node plan where ``T-2`` depends on ``T-1``."""
+    return [
+        {"id": "T-1", "role": "backend", "title": "first", "depends_on": []},
+        {"id": "T-2", "role": "backend", "title": "second", "depends_on": ["T-1"]},
+    ]
+
+
+def _recorded_run(sdd_dir: Path, run_id: str = "run-1") -> EventJournal:
+    """Record a two-task run whose coordination obeys the dependency edge."""
+    journal = EventJournal(run_id=run_id, sdd_dir=sdd_dir)
+    journal.record("run_started", run_id=run_id, max_agents=2)
+    journal.record("plan.graph.full", goal="ship it", nodes=_plan_nodes(), task_count=2)
+    journal.record("tick_start", tick=1)
+    journal.record("agent_spawned", agent_id="a-1", role="backend", task_ids=["T-1"])
+    journal.record("task_claimed", task_id="T-1", agent_id="a-1")
+    journal.record("task_completed", task_id="T-1", agent_id="a-1", cost_usd=0.1)
+    journal.record("tick_start", tick=2)
+    journal.record("agent_spawned", agent_id="a-2", role="backend", task_ids=["T-2"])
+    journal.record("task_claimed", task_id="T-2", agent_id="a-2")
+    journal.record("task_completed", task_id="T-2", agent_id="a-2", cost_usd=0.2)
+    journal.record("run_completed", run_id=run_id, ticks=2, outcome="completed")
+    return journal
+
+
+def _rewrite(journal_path: Path, index: int, **overrides: object) -> None:
+    """Overwrite payload fields of the recorded row at *index*, in place.
+
+    The chain fields are left as recorded: the point of an injected outcome
+    is that the operator is handed a journal that looks untouched at a glance.
+    """
+    import json
+
+    lines = journal_path.read_text(encoding="utf-8").splitlines()
+    row = json.loads(lines[index])
+    row.update(overrides)
+    lines[index] = json.dumps(row)
+    journal_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _drop(journal_path: Path, index: int) -> None:
+    """Delete the recorded row at *index*."""
+    lines = journal_path.read_text(encoding="utf-8").splitlines()
+    del lines[index]
+    journal_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+# 1 (load-bearing) --------------------------------------------------------
+
+
+def test_untouched_run_rederives_to_the_recorded_timing_excluded_head(tmp_path: Path) -> None:
+    """Re-deriving an untouched run reproduces the recorded head exactly."""
+    journal = _recorded_run(tmp_path / ".sdd")
+
+    result = rederive_run(journal.path, sandbox=tmp_path / "sandbox")
+
+    assert result.ok is True
+    assert result.divergent_index is None
+    assert result.derived_head == result.recorded_head == journal.head()
+    assert result.step_count == len(load_events(journal.path).events)
+
+
+# 2 -----------------------------------------------------------------------
+
+
+def test_rederived_head_is_independent_of_the_recorded_wall_clock(tmp_path: Path) -> None:
+    """Rewriting only the timing envelope leaves the re-derived head unchanged."""
+    journal = _recorded_run(tmp_path / ".sdd")
+    baseline = rederive_run(journal.path, sandbox=tmp_path / "sandbox-a")
+
+    for index in range(len(load_events(journal.path).events)):
+        _rewrite(journal.path, index, ts=1.0, elapsed_s=0.0)
+
+    shifted = rederive_run(journal.path, sandbox=tmp_path / "sandbox-b")
+
+    assert shifted.derived_head == baseline.derived_head
+    assert shifted.ok is True
+
+
+# 3 -----------------------------------------------------------------------
+
+
+def test_flipping_a_recorded_outcome_names_the_first_underivable_step(tmp_path: Path) -> None:
+    """A dependency demoted to a failure makes the dependent's claim underivable."""
+    journal = _recorded_run(tmp_path / ".sdd")
+    # Row 5 is ``task_completed`` for T-1; demote it to a verification failure.
+    _rewrite(journal.path, 5, event="task_verification_failed", failed_signals=["tests"])
+
+    result = rederive_run(journal.path, sandbox=tmp_path / "sandbox")
+
+    assert result.ok is False
+    assert result.reason_code == REASON_CODE_UNDERIVABLE_STEP
+    assert result.rule == RULE_DEPENDENCY_NOT_COMPLETED
+    # Row 8 is the ``task_claimed`` for T-2, which no longer has a completed dep.
+    assert result.divergent_index == 8
+    assert "T-2" in result.reason
+    assert "T-1" in result.reason
+
+
+# 4 -----------------------------------------------------------------------
+
+
+def test_outcome_for_a_task_that_was_never_claimed_is_refused(tmp_path: Path) -> None:
+    """An outcome with no preceding claim is not a step the tick loop can produce."""
+    journal = _recorded_run(tmp_path / ".sdd")
+    _drop(journal.path, 4)  # the ``task_claimed`` for T-1
+
+    result = rederive_run(journal.path, sandbox=tmp_path / "sandbox")
+
+    assert result.ok is False
+    assert result.reason_code == REASON_CODE_UNDERIVABLE_STEP
+    assert result.rule == RULE_OUTCOME_FOR_UNCLAIMED_TASK
+    assert result.divergent_index == 4
+
+
+# 5 -----------------------------------------------------------------------
+
+
+def test_claim_before_its_dependency_completed_is_refused(tmp_path: Path) -> None:
+    """The dependency edge in the recorded plan gates every recorded claim."""
+    sdd_dir = tmp_path / ".sdd"
+    journal = EventJournal(run_id="run-early", sdd_dir=sdd_dir)
+    journal.record("run_started", run_id="run-early", max_agents=2)
+    journal.record("plan.graph.full", goal="ship it", nodes=_plan_nodes(), task_count=2)
+    journal.record("task_claimed", task_id="T-2", agent_id="a-1")
+
+    result = rederive_run(journal.path, sandbox=tmp_path / "sandbox")
+
+    assert result.ok is False
+    assert result.rule == RULE_DEPENDENCY_NOT_COMPLETED
+    assert result.divergent_index == 2
+
+
+# 6 -----------------------------------------------------------------------
+
+
+def test_edited_outcome_payload_diverges_at_the_named_step(tmp_path: Path) -> None:
+    """A payload edit that keeps the sequence derivable still moves the head."""
+    journal = _recorded_run(tmp_path / ".sdd")
+    _rewrite(journal.path, 5, cost_usd=99.0)
+
+    result = rederive_run(journal.path, sandbox=tmp_path / "sandbox")
+
+    assert result.ok is False
+    assert result.reason_code == REASON_CODE_HEAD_MISMATCH
+    assert result.derived_head != result.recorded_head
+    assert result.divergent_index == 5
+
+
+# 7 -----------------------------------------------------------------------
+
+
+def test_run_without_a_recorded_plan_is_refused_by_name(tmp_path: Path) -> None:
+    """No recorded planning output means there is nothing to re-derive from."""
+    sdd_dir = tmp_path / ".sdd"
+    journal = EventJournal(run_id="run-planless", sdd_dir=sdd_dir)
+    journal.record("run_started", run_id="run-planless", max_agents=1)
+    journal.record("run_completed", run_id="run-planless", ticks=0, outcome="completed")
+
+    result = rederive_run(journal.path, sandbox=tmp_path / "sandbox")
+
+    assert result.ok is False
+    assert result.reason_code == REASON_CODE_PLAN_MISSING
+    assert result.divergent_index is None
+
+
+# 8 -----------------------------------------------------------------------
+
+
+def test_rederivation_opens_no_socket_and_needs_no_executable_on_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Re-derivation is hermetic: no adapter binary, no network (AC3)."""
+    journal = _recorded_run(tmp_path / ".sdd")
+
+    monkeypatch.setenv("PATH", "")
+
+    def _refuse(*args: object, **kwargs: object) -> None:
+        raise AssertionError("re-derivation opened a socket")
+
+    monkeypatch.setattr(socket, "socket", _refuse)
+    monkeypatch.setattr(socket, "create_connection", _refuse)
+
+    result = rederive_run(journal.path, sandbox=tmp_path / "sandbox")
+
+    assert result.ok is True
+
+
+# 9 -----------------------------------------------------------------------
+
+
+def test_sandbox_is_the_only_tree_the_rederivation_writes(tmp_path: Path) -> None:
+    """The fresh journal lands in the sandbox; the recorded run dir is untouched."""
+    journal = _recorded_run(tmp_path / ".sdd")
+    before = sorted(p.name for p in journal.path.parent.iterdir())
+
+    sandbox = tmp_path / "sandbox"
+    result = rederive_run(journal.path, sandbox=sandbox)
+
+    assert result.derived_journal_path.startswith(str(sandbox))
+    assert sorted(p.name for p in journal.path.parent.iterdir()) == before

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -6022,6 +6022,7 @@ class TestAdaptivePollingBackoff:
         assert hasattr(orch, "_idle_multiplier")
         assert orch._idle_multiplier == 1
 
+
 # --- Reverse task-to-session index ---
 
 

--- a/tests/unit/test_replay_rederive_cli.py
+++ b/tests/unit/test_replay_rederive_cli.py
@@ -1,0 +1,112 @@
+"""CLI tests for ``bernstein replay <run> --re-derive`` (issue #4213)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from bernstein.cli.advanced_cmd import replay_cmd
+from click.testing import CliRunner
+
+from bernstein.core.replay.journal import EventJournal
+
+
+def _recorded_run(sdd_dir: Path, run_id: str = "run-rd") -> EventJournal:
+    """Record a two-task run whose coordination obeys the dependency edge."""
+    journal = EventJournal(run_id=run_id, sdd_dir=sdd_dir)
+    journal.record("run_started", run_id=run_id, max_agents=2)
+    journal.record(
+        "plan.graph.full",
+        goal="ship it",
+        nodes=[
+            {"id": "T-1", "role": "backend", "title": "first", "depends_on": []},
+            {"id": "T-2", "role": "backend", "title": "second", "depends_on": ["T-1"]},
+        ],
+        task_count=2,
+    )
+    journal.record("task_claimed", task_id="T-1", agent_id="a-1")
+    journal.record("task_completed", task_id="T-1", agent_id="a-1", cost_usd=0.1)
+    journal.record("task_claimed", task_id="T-2", agent_id="a-2")
+    journal.record("task_completed", task_id="T-2", agent_id="a-2", cost_usd=0.2)
+    journal.record("run_completed", run_id=run_id, ticks=2, outcome="completed")
+    return journal
+
+
+def _demote_first_completion(journal_path: Path) -> None:
+    """Turn the recorded ``task_completed`` for ``T-1`` into a verification failure."""
+    lines = journal_path.read_text(encoding="utf-8").splitlines()
+    row = json.loads(lines[3])
+    row["event"] = "task_verification_failed"
+    lines[3] = json.dumps(row)
+    journal_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+# 10 ----------------------------------------------------------------------
+
+
+def test_rederive_exits_zero_when_the_recorded_run_is_derivable(tmp_path: Path) -> None:
+    """An untouched recorded run re-derives to its own head and exits 0."""
+    sdd_dir = tmp_path / ".sdd"
+    _recorded_run(sdd_dir)
+
+    result = CliRunner().invoke(replay_cmd, ["run-rd", "--sdd-dir", str(sdd_dir), "--re-derive"])
+
+    assert result.exit_code == 0
+    assert "re-derived" in result.output.lower()
+
+
+# 11 ----------------------------------------------------------------------
+
+
+def test_rederive_names_the_first_divergent_step_as_json_and_exits_nonzero(tmp_path: Path) -> None:
+    """A modified recorded outcome is reported as a named step, not a bare hash diff."""
+    sdd_dir = tmp_path / ".sdd"
+    journal = _recorded_run(sdd_dir)
+    _demote_first_completion(journal.path)
+
+    result = CliRunner().invoke(
+        replay_cmd,
+        ["run-rd", "--sdd-dir", str(sdd_dir), "--re-derive", "--as-json"],
+    )
+
+    assert result.exit_code != 0
+    payload = json.loads(result.output)
+    assert payload["ok"] is False
+    assert payload["reason_code"] == "underivable_step"
+    assert payload["rule"] == "dependency_not_completed"
+    assert payload["step_index"] == 4
+    assert "T-2" in payload["reason"]
+
+
+# 12 ----------------------------------------------------------------------
+
+
+def test_rederive_leaves_no_sandbox_behind_and_does_not_touch_the_run_dir(tmp_path: Path) -> None:
+    """The fresh journal lives in a temporary sandbox that is removed afterwards."""
+    sdd_dir = tmp_path / ".sdd"
+    journal = _recorded_run(sdd_dir)
+    before = sorted(p.name for p in journal.path.parent.iterdir())
+
+    result = CliRunner().invoke(replay_cmd, ["run-rd", "--sdd-dir", str(sdd_dir), "--re-derive"])
+
+    assert result.exit_code == 0
+    assert sorted(p.name for p in journal.path.parent.iterdir()) == before
+
+
+# 13 ----------------------------------------------------------------------
+
+
+def test_rederive_reports_a_missing_journal_rather_than_a_traceback(tmp_path: Path) -> None:
+    """An unknown run id refuses by name on the channel the caller selected."""
+    sdd_dir = tmp_path / ".sdd"
+    (sdd_dir / "runs").mkdir(parents=True)
+
+    result = CliRunner().invoke(
+        replay_cmd,
+        ["run-missing", "--sdd-dir", str(sdd_dir), "--re-derive", "--as-json"],
+    )
+
+    assert result.exit_code != 0
+    payload = json.loads(result.output)
+    assert payload["ok"] is False
+    assert payload["reason_code"] == "journal_not_found"

--- a/verify_cli/bernstein_verify_receipt/__main__.py
+++ b/verify_cli/bernstein_verify_receipt/__main__.py
@@ -75,9 +75,7 @@ def cli() -> None:
     show_default=True,
     help="Which format(s) to verify.",
 )
-@click.option(
-    "--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details."
-)
+@click.option("--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details.")
 def verify_cmd(
     receipt_path: Path,
     jwk_path: Path | None,

--- a/verify_cli/bernstein_verify_receipt/verify.py
+++ b/verify_cli/bernstein_verify_receipt/verify.py
@@ -291,8 +291,7 @@ def verify_subject_binding(receipt: dict[str, Any]) -> tuple[CheckResult, str]:
                 "subject_binding",
                 ok=False,
                 detail=(
-                    f"recomputed head {recomputed[:16]}… "
-                    f"!= range.head_sha256 {range_head[:16]}…"
+                    f"recomputed head {recomputed[:16]}… != range.head_sha256 {range_head[:16]}…"
                 ),
             ),
             recomputed,
@@ -418,10 +417,7 @@ def verify_intoto(receipt: dict[str, Any], public_key: Any, recomputed_head: str
         return CheckResult(
             "intoto",
             ok=False,
-            detail=(
-                f"recomputed head {recomputed_head[:16]}… "
-                f"not in statement subject digests"
-            ),
+            detail=(f"recomputed head {recomputed_head[:16]}… not in statement subject digests"),
         )
     return CheckResult("intoto", ok=True, detail="DSSE/in-toto verified, subject bound to head")
 
@@ -469,8 +465,7 @@ def verify_transparency(
             "transparency",
             ok=False,
             detail=(
-                f"STH subject {subject_sha256[:16]}… "
-                f"!= recomputed head {recomputed_head[:16]}…"
+                f"STH subject {subject_sha256[:16]}… != recomputed head {recomputed_head[:16]}…"
             ),
         )
 
@@ -510,10 +505,7 @@ def verify_transparency(
             return CheckResult(
                 "transparency",
                 ok=False,
-                detail=(
-                    f"inclusion proof root {proven_root[:16]}… "
-                    f"!= STH root {root_hash[:16]}…"
-                ),
+                detail=(f"inclusion proof root {proven_root[:16]}… != STH root {root_hash[:16]}…"),
             )
     return CheckResult(
         "transparency", ok=True, detail="RFC6962 STH signed, root + inclusion proof verified"


### PR DESCRIPTION
## What

Adds `bernstein replay <RUN_ID> --re-derive`: an executable check that the coordination sequence a run recorded is the sequence the scheduler's rules produce, given the run's own recorded inputs.

It does **not** re-execute agents, spawn worktrees, or contact a task server — that is a live re-run, which is a different operation. It does not cover multi-node runs, and it changes no recording or scheduling behaviour.

## Why

The scheduler's promise is that coordination is deterministic given identical inputs, but nothing in the CLI exercised that promise end-to-end. `bernstein replay <run> --verify` recomputes the Merkle chain over the rows already on disk (`_replay_verify_journal` in `src/bernstein/cli/commands/advanced_cmd.py`), which proves the journal was not edited after the fact and says nothing about whether the recorded steps are reachable under the coordination rules. The rest of the replay group — agent-view, export, publish, diff, debug — likewise freezes the recorded chain and re-executes nothing.

So the determinism property was enforced only by code structure (no sampling in the scheduler), not demonstrated by a check an operator can run on a finished run. An operator handed a journal with a doctored outcome had no command that would say "step 8 could not have happened".

## How

New module `src/bernstein/core/replay/rederive.py`.

`rederive_run(journal_path, sandbox=...)` splits every recorded row into two categories and treats them differently:

| Recorded fact | Treated as | Handling |
|---|---|---|
| plan graph (`plan.graph.full`), leaf outcome, agent id, model, cost | input | carried verbatim; coordination did not choose it |
| whether a task was claimable when it was claimed | decision | re-derived from the plan's dependency edges and the outcomes seen so far |
| whether an outcome belonged to a task that was running | decision | re-derived from the outstanding-claim set |
| the chain over the resulting sequence | decision | rebuilt by a fresh `EventJournal` in the sandbox, never copied |

Accepted steps are appended to a brand-new journal under a throwaway sandbox directory, so the head the command compares is computed from the inputs rather than read off the recorded chain. Exit 0 iff the re-derived timing-excluded head equals the recorded head; the timing envelope is excluded because the journal's own payload projection already drops it.

Two failure shapes, deliberately distinguished:

* **`underivable_step`** — a step the rules cannot produce. Reported with the step index *and* the rule that refused it (`dependency_not_completed`, `task_already_claimed`, `task_not_in_plan`, `outcome_for_unclaimed_task`).
* **`head_mismatch`** — every step was derivable but a payload differs. The first differing step is located with the existing pairwise divergence machinery (`diff_event_logs` in `core/replay/diff.py`) rather than a second comparator grown here.

Plus `plan_missing`, `journal_unreadable` and `journal_not_found` for runs that carry no input to re-derive from.

**The one decision the issue left open, and how it was resolved.** "Feed the recorded inputs back through the real tick loop in a sandbox" and "works offline with no adapter binaries installed" cannot both hold if the *literal* `Orchestrator._tick` is invoked: that path needs a task server, git worktrees, a cost tracker and adapter processes, none of which exist for a finished run being audited. Re-derivation therefore drives the coordination state machine the tick loop advances — the claim/outcome/dependency rules — rather than the orchestrator process that hosts it. What that leaves carried-through rather than re-derived is listed under Remaining and documented in `docs/operations/deterministic-replay.md`.

Re-derivation writes nothing outside the sandbox, which is a `tempfile.TemporaryDirectory` created by the CLI — auditing a run must not leave artifacts in the run directory being audited.

## Tests

Each test failed before the change: the core file failed at import (the module did not exist), the CLI file failed with exit code 2 (no such option).

Core — `tests/unit/core/replay/test_rederive.py`:

1. `test_untouched_run_rederives_to_the_recorded_timing_excluded_head` — **load-bearing.** This is the property the whole command exists for: an untouched recorded run re-derives to its own head. Without it the other eight only prove the command refuses things.
2. `test_rederived_head_is_independent_of_the_recorded_wall_clock` — rewriting every `ts` / `elapsed_s` leaves the re-derived head unchanged, so "matching head" means timing-excluded and not "identical file".
3. `test_flipping_a_recorded_outcome_names_the_first_underivable_step` — a dependency demoted from completed to verification-failed makes the dependent's claim underivable; the named step and rule are asserted, not just a different head.
4. `test_outcome_for_a_task_that_was_never_claimed_is_refused` — an outcome with no outstanding claim is not a reachable coordination step.
5. `test_claim_before_its_dependency_completed_is_refused` — the plan's dependency edge gates every recorded claim.
6. `test_edited_outcome_payload_diverges_at_the_named_step` — a payload edit that keeps the sequence derivable still moves the head, and the first differing step is named.
7. `test_run_without_a_recorded_plan_is_refused_by_name` — no recorded planning output is a named refusal, not a silent pass.
8. `test_rederivation_opens_no_socket_and_needs_no_executable_on_path` — with `PATH` emptied and `socket.socket` booby-trapped, re-derivation still succeeds. This is the offline acceptance criterion, tested rather than asserted in prose.
9. `test_sandbox_is_the_only_tree_the_rederivation_writes` — the recorded run directory is unchanged afterwards.

CLI — `tests/unit/test_replay_rederive_cli.py`:

10. `test_rederive_exits_zero_when_the_recorded_run_is_derivable`
11. `test_rederive_names_the_first_divergent_step_as_json_and_exits_nonzero` — asserts `reason_code`, `rule` and `step_index` on the JSON channel.
12. `test_rederive_leaves_no_sandbox_behind_and_does_not_touch_the_run_dir`
13. `test_rederive_reports_a_missing_journal_rather_than_a_traceback`

## Checklist

- [x] `uv run ruff check src/` passes (and `ruff format --check src/`)
- [x] `uv run pyright src/` — `rederive.py` reports 0 errors; `advanced_cmd.py` reports the same 147 pre-existing errors as `origin/main`, so this change adds none
- [x] `uv run python scripts/run_tests.py -x` passes for both new test files, plus the replay/CLI regression set that imports `advanced_cmd` (`test_replay_cmd`, `test_replay_verify_cli`, `test_replay_journal_cli`, `test_replay_debug_cli`, `test_replay_as_json_failure_paths`, `test_cli_decomposition`, `test_operator_surface_imports`)
- [x] New code has type hints

### Documentation duty

- [x] User-visible README section updated — N/A (README untouched; this is an operator verb documented under `docs/operations/`)
- [x] `docs/operations/<area>.md` updated — `docs/operations/deterministic-replay.md` gains a "Coordination re-derivation" section with the input/decision split and the refusal codes
- [x] `docs/api/` schema regenerated if a public surface changed — N/A (no HTTP or schema surface changed)
- [x] `uv run bernstein agents-md sync` run — produced no changes
- [x] Tests cover the documented behaviour

Part of #4213

## Remaining

- Agent-level batching and spawn grouping (`agent_spawned` payloads, role packing, `max_agents` admission) are carried through as recorded inputs rather than re-derived. Re-deriving them needs the spawner's grouping rules factored out of the orchestrator first.
- Resumed runs whose opening claims were reconciled from a previous run are not yet modelled. The plan gate is skipped while no graph event has been seen, so such runs pass rather than false-alarm, but they are not checked either.
- `plan.graph.full` is appended on normal ticks only (every sixth, and the first tick is always a fast tick), so a run that finished in fewer ticks recorded no planning output and re-derives to `plan_missing`. Closing that means widening what the orchestrator records, which this PR deliberately does not touch; the refusal is documented so it reads as a recording gap rather than a command fault.
- Multi-node runs remain out of scope, as the issue states.
