### PR TITLE
feat: anchor audit checkpoints outside the local filesystem (#5036)

### DIFF
--- a/docs/release-notes/fragments/5147-anchor-audit-checkpoints.md
+++ b/docs/release-notes/fragments/5147-anchor-audit-checkpoints.md
@@ -1,0 +1,11 @@
+## Anchor audit checkpoints outside the local filesystem
+
+Adds optional external anchoring of audit checkpoints using RFC 3161 TimeStampTokens, enabling verification that local audit history hasn’t been truncated or tampered. New CLI commands:
+
+- `bernstein audit anchor --print-request` – prints a SHA-256 digest and an `openssl ts -query` command for TSA preparation
+- `bernstein audit anchor --rfc3161-token <file>` – records an RFC 3161 token alongside an audit checkpoint
+- `bernstein audit anchor --rfc3161-tsa-url <url>` – stores a TSA URL reference
+
+`bernstein doctor` also surfaces anchoring posture with a new "Audit anchoring" row.
+
+(#5147)

--- a/docs/security/audit-log.md
+++ b/docs/security/audit-log.md
@@ -413,10 +413,73 @@ scope, stated honestly: the checkpoint gate makes a shrink
 non-launderable by the seal job and detectable by every verify run
 against the local directory. an actor with write access to **both**
 the chain segments and the checkpoints file can still rewind both to
-a mutually consistent earlier state; catching that requires retention
-outside the writer's filesystem (an independent co-signer over
-checkpoints), which is planned as a follow-up and tracked on the
-issue tracker.
+a mutually consistent earlier state; catching that needs retention
+outside the writer's filesystem, which is what external anchors are.
+
+### External anchors: retention outside this machine
+
+everything the checkpoint gate compares against is material we hold.
+an actor who controls the audit directory holds all of it, so they
+can roll all of it back together and every local check passes. an
+**anchor** is the part they cannot reproduce: an RFC 3161 timestamp
+token, issued by a TSA, over `sha256(canonical checkpoint payload)`.
+the checkpoint payload already pins the origin, the record count and
+the per-segment leaves, so timestamping it timestamps the claim about
+how long the history was - and a TSA will not issue a token dated
+earlier.
+
+anchoring is optional, off by default, and bernstein never contacts a
+TSA. the operator makes the request and hands back the response:
+
+```bash
+# 1. what to timestamp
+bernstein audit anchor --print-request
+
+# 2. ask your TSA (any RFC 3161 endpoint)
+openssl ts -query -digest <digest> -sha256 -cert -no_nonce -out req.tsq
+curl -sS -H 'Content-Type: application/timestamp-query' \
+     --data-binary @req.tsq <tsa-url> -o resp.tsr
+
+# 3. record it beside the checkpoint
+bernstein audit anchor --rfc3161-token resp.tsr --rfc3161-tsa-url <tsa-url>
+```
+
+anchors live in `.sdd/audit/checkpoints/anchors.jsonl`, append-only
+and fsynced, beside `checkpoints.jsonl` and never inside it: a
+checkpoint payload carries no timestamps by design, and folding a
+token into it would break the byte-determinism of the checkpoints
+file. the record copies the anchored `origin`, `entry_count` and
+`checkpoint_root` out of the checkpoint, so deleting the checkpoints
+file does not delete the number the anchor was pinning.
+
+`bernstein audit verify` then runs an **external anchors** pillar:
+
+- the token must parse and its `messageImprint` must cover the
+  checkpoint payload the anchor names. this needs nothing from the
+  operator, so it always runs.
+- pass `--rfc3161-trusted-tsa-bundle <roots.pem>` to also authenticate
+  the issuing TSA. without it the token is bound to the checkpoint but
+  the signer is not identified - verify says so in its output.
+- a local history shorter than the newest anchored record count, a
+  different chain origin, or an anchored checkpoint that is no longer
+  on record are all **contradictions**, and each exits non-zero naming
+  the anchor.
+
+an anchor contradiction is **not** clearable with `audit ack-tear`.
+an acknowledgement records that an operator looked at local damage;
+it cannot withdraw a signature a third party made. restore the
+missing history, or treat the anchored range as unaccounted for.
+
+keep a copy of `anchors.jsonl` off the machine that writes it. an
+anchor deleted together with the history it contradicts protects
+nothing - which is why `bernstein doctor` reports the anchoring state
+(`never anchored` / `anchored at N entries, last at T`) rather than
+letting an unanchored install look as strong as an anchored one.
+
+still open, and deliberately not shipped here: a witness
+co-signature protocol between two installs, and operator-supplied
+external sinks (object lock, append-only bucket) for checkpoint
+retention.
 
 ## Replaying a log
 

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -12,6 +12,7 @@ Commands:
   bernstein audit seal               Compute and store a Merkle root.
   bernstein audit seal --anchor-git  Also create a git tag.
   bernstein audit ack-tear           Acknowledge recorded tear evidence.
+  bernstein audit anchor             Anchor a checkpoint with an RFC 3161 token.
   bernstein audit verify             Verify HMAC chain, Merkle tree, checkpoint.
   bernstein audit verify --hmac-only Verify HMAC chain only.
   bernstein audit verify --merkle-only  Verify Merkle tree only.
@@ -46,6 +47,10 @@ from bernstein.cli.helpers import console
 
 if TYPE_CHECKING:
     from datetime import date
+
+    from cryptography.x509 import Certificate
+
+    from bernstein.core.persistence.checkpoint_anchor import CheckpointAnchor
 
 AUDIT_DIR = Path(".sdd/audit")
 MERKLE_DIR = AUDIT_DIR / "merkle"
@@ -253,7 +258,25 @@ def seal_cmd(anchor_git: bool, allow_broken_chain: bool) -> None:
     type=click.Path(dir_okay=False, exists=True, resolve_path=True),
     help="Original trigger body to re-digest against a trigger receipt.",
 )
-def verify_cmd(merkle_only: bool, hmac_only: bool, receipt_path: str | None, payload_path: str | None) -> None:
+@click.option(
+    "--rfc3161-trusted-tsa-bundle",
+    "rfc3161_trust_bundle",
+    default=None,
+    type=click.Path(dir_okay=False, exists=True, resolve_path=True),
+    help=(
+        "Path to a PEM/DER X.509 trust bundle (operator-supplied TSA roots). "
+        "Enables TSA chain validation of recorded checkpoint anchors. Without "
+        "it, an anchor's token is still bound to the checkpoint it covers, but "
+        "the issuing TSA is not authenticated."
+    ),
+)
+def verify_cmd(
+    merkle_only: bool,
+    hmac_only: bool,
+    receipt_path: str | None,
+    payload_path: str | None,
+    rfc3161_trust_bundle: str | None,
+) -> None:
     """Verify audit log integrity (HMAC chain per RFC 2104 + Merkle tree).
 
     \b
@@ -267,6 +290,10 @@ def verify_cmd(merkle_only: bool, hmac_only: bool, receipt_path: str | None, pay
       bernstein audit verify --receipt r.json --payload body.json
                                           Also re-digest the original trigger
                                           body against the receipt
+      bernstein audit verify --rfc3161-trusted-tsa-bundle roots.pem
+                                          Also authenticate the TSA that
+                                          signed each recorded checkpoint
+                                          anchor
 
     Exits non-zero on any chain break, missing record, or HMAC mismatch.
     Run from cron and fail the run on non-zero exit (cite: docs/security/audit-log.md).
@@ -302,6 +329,16 @@ def verify_cmd(merkle_only: bool, hmac_only: bool, receipt_path: str | None, pay
     # invoking either narrow form must still go red when history shrinks.
     if not _verify_checkpoints():
         failed_pillars.append("Checkpoints")
+
+    # External anchors are the pillar the operator cannot satisfy from inside:
+    # a checkpoint proves the history did not shrink relative to material we
+    # hold, and an actor who holds all of it can roll all of it back together.
+    # A TSA token over a checkpoint payload is a statement someone else signed
+    # about how long the history was, so a rollback below the newest anchored
+    # entry count contradicts it. Runs regardless of --hmac-only / --merkle-only
+    # for the same reason the checkpoint pillar does.
+    if not _verify_anchors(rfc3161_trust_bundle):
+        failed_pillars.append("External Anchors")
 
     # Evidence bundles are a third integrity pillar: a tampered evidence file
     # must fail verify exactly like a tampered chain entry (#2362). This runs
@@ -1013,6 +1050,144 @@ def _verify_checkpoints() -> bool:
     return False
 
 
+def _known_checkpoint_roots() -> set[str] | None:
+    """Return the roots of the checkpoints on record, or ``None`` when unreadable.
+
+    ``None`` means "cannot tell" (no audit key, or a damaged checkpoints
+    file), not "none recorded": an anchor whose checkpoint is genuinely gone
+    must not be confused with one we simply could not look up.
+    """
+    from bernstein.core.persistence.chain_checkpoint import (
+        CheckpointFileError,
+        load_checkpoints,
+    )
+    from bernstein.core.security.audit import AuditKeyMissingError, load_audit_key
+
+    try:
+        key = load_audit_key()
+    except AuditKeyMissingError:
+        return None
+    try:
+        state = load_checkpoints(AUDIT_DIR, key)
+    except CheckpointFileError:
+        return None
+    return {str(cp.get("root_hash", "")) for cp in state.checkpoints}
+
+
+def _load_anchor_trust(trust_bundle: str | None) -> tuple[list[Certificate] | None, bool]:
+    """Load operator TSA trust anchors; ``(certs, ok)``."""
+    if not trust_bundle:
+        return None, True
+    from bernstein.core.security.rfc3161_verifier import load_trusted_tsa_certs
+
+    try:
+        return load_trusted_tsa_certs(Path(trust_bundle)), True
+    except (OSError, ValueError) as exc:
+        console.print(f"[red]TSA trust bundle load failed: {exc}[/red]")
+        return None, False
+
+
+def _verify_anchors(trust_bundle: str | None = None) -> bool:
+    """Verify recorded external anchors against the local audit history.
+
+    Three ways to fail, all loud: the anchors file itself does not read, an
+    anchor's token does not hold up (unparsable, or covering other bytes, or -
+    when the operator supplied trust anchors - issued by a TSA they do not
+    trust), or the local history contradicts what an anchor recorded.
+
+    An install with no anchors passes and says so. Anchoring is optional, and
+    an air-gapped install must be able to run without a TSA; what it must not
+    do is stay quiet about being unanchored.
+    """
+    from bernstein.core.persistence.checkpoint_anchor import (
+        AnchorFileError,
+        anchor_gen_time,
+        check_anchor_contradictions,
+        load_anchors,
+        newest_anchor,
+        verify_anchor_token,
+    )
+
+    console.print()
+    try:
+        anchors = load_anchors(AUDIT_DIR)
+    except AnchorFileError as exc:
+        console.print(
+            Panel("[bold red]External Anchor Verification FAILED[/bold red]", border_style="red", expand=False)
+        )
+        for err in exc.errors:
+            console.print(f"  [red]![/red] {err}")
+        return False
+
+    if not anchors:
+        console.print(
+            "[yellow]Audit history is not externally anchored[/yellow] "
+            "[dim](no RFC 3161 anchor recorded; a rollback of the chain and the "
+            "checkpoints together would leave nothing to contradict it).[/dim]"
+        )
+        console.print("[dim]To anchor: bernstein audit anchor --print-request[/dim]")
+        return True
+
+    trusted, ok = _load_anchor_trust(trust_bundle)
+    if not ok:
+        return False
+
+    token_errors: list[tuple[CheckpointAnchor, list[str]]] = []
+    for anchor in anchors:
+        errors = verify_anchor_token(anchor, trusted_tsa_certs=trusted)
+        if errors:
+            token_errors.append((anchor, errors))
+    if token_errors:
+        console.print(
+            Panel("[bold red]External Anchor Verification FAILED[/bold red]", border_style="red", expand=False)
+        )
+        for anchor, errors in token_errors:
+            console.print(f"  [red]![/red] anchor: {anchor.describe()}")
+            for err in errors:
+                console.print(f"    [red]-[/red] {err}")
+        return False
+
+    conflicts = check_anchor_contradictions(
+        AUDIT_DIR,
+        anchors,
+        checkpoint_roots=_known_checkpoint_roots(),
+    )
+    if conflicts:
+        console.print(Panel("[bold red]External Anchor Contradiction[/bold red]", border_style="red", expand=False))
+        for anchor in anchors:
+            console.print(f"  [red]![/red] anchor: {anchor.describe()}")
+        for conflict in conflicts:
+            console.print(f"  [red]![/red] {conflict.detail}")
+        console.print(
+            "  [dim]The local audit history contradicts a statement signed outside this\n"
+            "  machine. This is not clearable with 'bernstein audit ack-tear': an\n"
+            "  acknowledgement records that an operator looked at local damage, and it\n"
+            "  cannot withdraw a third party's signature. Restore the missing history,\n"
+            "  or treat the anchored range as unaccounted for.[/dim]"
+        )
+        return False
+
+    newest = newest_anchor(anchors)
+    console.print(
+        Panel("[bold green]External Anchor Verification Passed[/bold green]", border_style="green", expand=False)
+    )
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("Key", style="dim", no_wrap=True, min_width=14)
+    table.add_column("Value")
+    table.add_row("Anchors", str(len(anchors)))
+    if newest is not None:
+        table.add_row("Anchored entries", str(newest.entry_count))
+        table.add_row("Anchored root", newest.checkpoint_root)
+        gen_time = anchor_gen_time(newest)
+        table.add_row("Anchored at", gen_time.isoformat() if gen_time else "-")
+        if newest.tsa_url:
+            table.add_row("TSA", newest.tsa_url)
+    if not trusted:
+        table.add_row("Note", "TSA identity unverified (pass --rfc3161-trusted-tsa-bundle)")
+    console.print(table)
+    return True
+
+
 def _os_user() -> str:
     """Best-effort OS user name, for acknowledgement records."""
     import getpass
@@ -1101,6 +1276,129 @@ def ack_tear_cmd(segment: str, offset: int, reason: str, actor: str | None) -> N
             details,
         )
     console.print(f"[green]Acknowledged[/green] tear in {segment} at byte {offset}.")
+
+
+@audit_group.command("anchor")
+@click.option(
+    "--print-request",
+    "print_request",
+    is_flag=True,
+    default=False,
+    help="Print the digest to timestamp (and the openssl invocation), then exit.",
+)
+@click.option(
+    "--rfc3161-token",
+    "rfc3161_token",
+    default=None,
+    type=click.Path(dir_okay=False, exists=True, resolve_path=True),
+    help="Path to the TSA response: raw DER (.tsr) or the base64 form 'audit export' takes.",
+)
+@click.option(
+    "--rfc3161-tsa-url",
+    "rfc3161_tsa_url",
+    default="",
+    help="URL of the TSA that issued the token (recorded for the operator, informational).",
+)
+def anchor_cmd(print_request: bool, rfc3161_token: str | None, rfc3161_tsa_url: str) -> None:
+    """Anchor the newest checkpoint with an RFC 3161 timestamp token.
+
+    \b
+      bernstein audit anchor --print-request
+                                          Print sha256(checkpoint payload) and
+                                          the openssl command that requests a
+                                          token over it
+      bernstein audit anchor --rfc3161-token resp.tsr
+                                          Record the TSA's response beside the
+                                          checkpoint
+
+    A checkpoint proves the audit history did not shrink relative to material
+    on this disk. An actor who can rewrite the chain can rewrite that material
+    too. The timestamp token is the part they cannot produce: a TSA will not
+    issue one dated earlier, so a history shorter than the newest anchored
+    entry count contradicts a signature made outside this machine, and
+    'bernstein audit verify' exits non-zero saying so.
+
+    Bernstein never contacts the TSA. The operator makes the request and
+    supplies the response, the same contract as
+    'bernstein audit export --rfc3161-token'; an air-gapped install simply
+    runs without an anchor, and 'bernstein doctor' reports that it is
+    unanchored.
+    """
+    from bernstein.core.persistence.chain_checkpoint import (
+        CheckpointFileError,
+        load_checkpoints,
+    )
+    from bernstein.core.persistence.checkpoint_anchor import (
+        anchors_path,
+        checkpoint_digest,
+        record_anchor,
+    )
+    from bernstein.core.security.audit import AuditKeyMissingError, load_audit_key
+
+    if not AUDIT_DIR.is_dir():
+        raise click.ClickException(f"audit directory not found: {AUDIT_DIR}")
+    if print_request == bool(rfc3161_token):
+        raise click.ClickException("pass exactly one of --print-request or --rfc3161-token")
+
+    try:
+        key = load_audit_key()
+    except AuditKeyMissingError as exc:
+        raise click.ClickException(f"{exc} (checkpoints are signed with the audit key)") from None
+    try:
+        checkpoint = load_checkpoints(AUDIT_DIR, key).last
+    except CheckpointFileError as exc:
+        raise click.ClickException(str(exc)) from None
+    if checkpoint is None:
+        raise click.ClickException("no checkpoint recorded yet; run 'bernstein audit seal' first")
+
+    digest = checkpoint_digest(checkpoint).hex()
+    if print_request:
+        console.print(f"[bold]Checkpoint payload digest (sha256):[/bold] {digest}")
+        console.print(f"[dim]Pinned entries:[/dim] {checkpoint.get('entry_count', '-')}")
+        console.print(f"[dim]Checkpoint root:[/dim] {checkpoint.get('root_hash', '')}")
+        console.print()
+        console.print("[dim]Request a token over exactly that digest, then record the response:[/dim]")
+        console.print(f"  openssl ts -query -digest {digest} -sha256 -cert -no_nonce -out req.tsq")
+        console.print("  curl -sS -H 'Content-Type: application/timestamp-query' \\")
+        console.print("       --data-binary @req.tsq <your-tsa-url> -o resp.tsr")
+        console.print("  bernstein audit anchor --rfc3161-token resp.tsr --rfc3161-tsa-url <your-tsa-url>")
+        return
+
+    token_path = Path(str(rfc3161_token))
+    raw = token_path.read_bytes()
+    token_bytes = _decode_tsa_response(raw)
+    try:
+        anchor = record_anchor(AUDIT_DIR, checkpoint, token_bytes, tsa_url=rfc3161_tsa_url)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from None
+
+    console.print(f"[green]Anchored[/green] {anchor.describe()}")
+    console.print(f"[dim]Recorded in {anchors_path(AUDIT_DIR)}[/dim]")
+    console.print(
+        "[dim]Keep a copy of that file off this machine: an anchor deleted with the "
+        "history it contradicts protects nothing.[/dim]"
+    )
+
+
+def _decode_tsa_response(raw: bytes) -> bytes:
+    """Return DER token bytes from a TSA response file.
+
+    Accepts both shapes operators actually hold: the raw DER ``.tsr`` that
+    ``openssl ts -reply`` and TSA HTTP endpoints emit, and the base64 text
+    form that ``bernstein audit export --rfc3161-token`` already takes. DER
+    always starts with a SEQUENCE tag, which base64 text never does, so the
+    two are told apart without guessing.
+    """
+    import base64
+    import binascii
+
+    if raw[:1] == b"\x30":
+        return raw
+    try:
+        return base64.b64decode(raw.decode("ascii").strip(), validate=True)
+    except (UnicodeDecodeError, binascii.Error, ValueError) as exc:
+        msg = f"token file is neither DER nor base64: {exc}"
+        raise click.ClickException(msg) from None
 
 
 def _verify_merkle_tree() -> bool:

--- a/src/bernstein/cli/commands/doctor_cmd.py
+++ b/src/bernstein/cli/commands/doctor_cmd.py
@@ -906,6 +906,53 @@ def check_eval_gate_min_n_advisory(workdir: Path | None = None) -> dict[str, Any
     }
 
 
+def check_audit_anchoring(workdir: Path | None = None) -> dict[str, Any]:
+    """Report whether the audit history is anchored outside this machine (#5036).
+
+    The Merkle seal and the signed checkpoint are both computed from material
+    on this disk with this install's key, so an actor who controls the audit
+    directory can roll all of it back together and every local verification
+    still passes. An RFC 3161 token over a checkpoint is the part they cannot
+    reproduce. The failure this check exists for is not the missing anchor -
+    it is an operator believing the seal is stronger than it is, so an
+    unanchored install says so plainly instead of staying silent.
+    """
+    from bernstein.core.persistence.checkpoint_anchor import anchoring_state
+
+    root = workdir if workdir is not None else Path.cwd()
+    audit_dir = root / ".sdd" / "audit"
+    name = "Audit anchoring"
+    fix = (
+        "Anchor the newest checkpoint: bernstein audit anchor --print-request, "
+        "then bernstein audit anchor --rfc3161-token <tsa response>"
+    )
+    if not audit_dir.is_dir():
+        return {"name": name, "status": _CHECK_PASS, "detail": "no audit log yet", "fix": ""}
+
+    state = anchoring_state(audit_dir)
+    if state.errors:
+        return {
+            "name": name,
+            "status": _CHECK_FAIL,
+            "detail": f"anchor record unusable: {state.errors[0]}",
+            "fix": "Investigate .sdd/audit/checkpoints/anchors.jsonl before trusting the seal",
+        }
+    if not state.anchored:
+        return {
+            "name": name,
+            "status": _CHECK_WARN,
+            "detail": "audit history has never been externally anchored",
+            "fix": fix,
+        }
+    when = state.newest_gen_time.isoformat() if state.newest_gen_time else "unknown time"
+    return {
+        "name": name,
+        "status": _CHECK_PASS,
+        "detail": f"anchored at {state.newest_entry_count} entries, last at {when}",
+        "fix": "",
+    }
+
+
 def run_all_checks() -> list[dict[str, Any]]:
     """Run all health checks and return results."""
     checks: list[dict[str, Any]] = []
@@ -916,6 +963,7 @@ def run_all_checks() -> list[dict[str, Any]]:
     checks.extend((check_price_table_advisory(), check_knob_matrix_advisory()))
     checks.extend(check_skill_revocations())
     checks.append(check_eval_gate_min_n_advisory())
+    checks.append(check_audit_anchoring())
     checks.extend(check_api_keys())
     checks.extend(
         (

--- a/src/bernstein/cli/commands/status_cmd.py
+++ b/src/bernstein/cli/commands/status_cmd.py
@@ -746,6 +746,22 @@ def _doctor_check_eval_gate_power(checks: list[dict[str, Any]], workdir: Path) -
     _add_check(checks, advisory["name"], True, detail, fix)
 
 
+def _doctor_check_audit_anchoring(checks: list[dict[str, Any]], workdir: Path) -> None:
+    """Surface whether the audit history is anchored outside this machine (#5036).
+
+    A never-anchored install is a WARN row that still passes the run - anchoring
+    is optional and an air-gapped install cannot do it at all. A contradicted or
+    unreadable anchor fails: something signed outside this machine disagrees
+    with the local history, which no local decision can settle.
+    """
+    from bernstein.cli.commands.doctor_cmd import check_audit_anchoring
+
+    row = check_audit_anchoring(workdir)
+    status = row["status"]
+    detail = f"WARNING: {row['detail']}" if status == "WARN" else row["detail"]
+    _add_check(checks, row["name"], status != "FAIL", detail, row["fix"])
+
+
 def _doctor_check_otel_export(checks: list[dict[str, Any]]) -> None:
     """Surface the live OTLP export advisory (#2526, Phase 4).
 
@@ -1222,6 +1238,7 @@ def doctor(as_json: bool, auto_fix: bool) -> None:
     _doctor_check_schedule_supervisor(checks, workdir)
     _doctor_check_eval_gate_power(checks, workdir)
     _doctor_check_otel_export(checks)
+    _doctor_check_audit_anchoring(checks, workdir)
 
     if auto_fix:
         _doctor_auto_fix(checks, stale_pid_paths, workdir, fixed, manual_needed)

--- a/src/bernstein/core/persistence/chain_checkpoint.py
+++ b/src/bernstein/core/persistence/chain_checkpoint.py
@@ -47,8 +47,11 @@ produce byte-identical checkpoint files.
 Residual (documented, not hidden): an actor with write access to both the
 chain segments and the checkpoints file can truncate both to a mutually
 consistent earlier state. Detecting that requires retention outside the
-local filesystem (a witness co-signature over checkpoints), which is a
-follow-up, not part of this module.
+local filesystem, which lives in
+:mod:`bernstein.core.persistence.checkpoint_anchor`: an optional RFC 3161
+token over a checkpoint's canonical bytes, so a history shorter than the
+newest anchored entry count contradicts a signature made off this machine.
+A witness co-signature between two installs is still a follow-up.
 """
 
 from __future__ import annotations

--- a/src/bernstein/core/persistence/checkpoint_anchor.py
+++ b/src/bernstein/core/persistence/checkpoint_anchor.py
@@ -1,0 +1,603 @@
+"""External anchors over audit checkpoints: retention that outlives the disk.
+
+:mod:`bernstein.core.persistence.chain_checkpoint` makes an audit-history
+shrink sticky, but only against material we hold ourselves. Its own module
+docstring names the residual: an actor with write access to both the chain
+segments and the checkpoints file can truncate both to a mutually consistent
+earlier state, and every local verification still passes, because from inside
+nothing remembers that a longer history existed.
+
+An anchor is that memory. It is a statement a third party signed about the
+size of our history at a point in time:
+
+* An RFC 3161 ``TimeStampToken`` whose ``messageImprint`` covers
+  ``sha256(canonical(checkpoint payload))``. The checkpoint payload already
+  pins ``origin``, ``entry_count``, ``root_hash`` and the per-file leaves, so
+  timestamping it timestamps the *claim about the size of history*, not an
+  unstructured blob of bytes.
+* The claim itself, copied out of the checkpoint into the anchor record:
+  ``origin``, ``entry_count``, ``checkpoint_root``. A rollback that deletes the
+  checkpoints file therefore does not delete the number it was pinning.
+
+Verification asks a question the operator cannot answer for themselves: does
+the local history contradict something a TSA signed? A history shorter than
+the newest anchored ``entry_count``, a different chain origin, or a missing
+anchored checkpoint are all contradictions, and none of them can be produced
+by rolling the local state back - a TSA will not issue a token dated earlier.
+
+Storage discipline
+------------------
+Anchors live in ``<audit_dir>/checkpoints/anchors.jsonl``, beside the
+checkpoints file and outside ``merkle/``. Append-only, one JSON object per
+line, fsynced. A crash-torn trailing fragment is skipped, exactly as in the
+checkpoints file: the pin regresses to the last complete anchor, which can
+only make it older, never stronger.
+
+The token is stored *beside* the checkpoint and never inside it. Checkpoint
+payloads carry no timestamps by design, so that two byte-identical audit
+directories sealed with the same key produce byte-identical checkpoint files;
+folding a TSA token (which carries ``genTime``) into the payload would destroy
+that. Nothing in this module writes to ``checkpoints.jsonl``.
+
+The anchor record is not HMAC-signed. The audit key is a local secret, and an
+actor who can rewrite the chain has it; a local signature over an anchor would
+add nothing an attacker could not forge. The token is the signature, and the
+signer is outside the machine.
+
+Offline tolerance: anchoring is optional and Bernstein never contacts a TSA.
+The operator obtains the token themselves (``bernstein audit anchor
+--print-request`` emits the digest for ``openssl ts -query -digest``), exactly
+as they already do for ``bernstein audit export --rfc3161-token``. An
+air-gapped install runs with no anchors at all - and ``bernstein doctor`` says
+so, rather than implying the seal is stronger than it is.
+
+Not covered here: witness co-signature between two installs, and operator-
+supplied external sinks for checkpoint retention. Both are follow-ups.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+from bernstein.core.persistence.chain_checkpoint import (
+    CHECKPOINTS_SUBDIR,
+    CheckpointConflict,
+    chain_snapshot,
+    compute_origin,
+    count_entries,
+)
+
+if TYPE_CHECKING:
+    from datetime import datetime
+    from pathlib import Path
+
+    from cryptography import x509
+
+#: Schema version for anchor records.
+ANCHOR_VERSION = 1
+
+#: File name of the append-only anchor log, beside ``checkpoints.jsonl``.
+ANCHORS_FILE = "anchors.jsonl"
+
+#: The only anchor kind this module writes today.
+ANCHOR_KIND_RFC3161 = "rfc3161"
+
+#: Conflict kinds raised by :func:`check_anchor_contradictions`. None of them
+#: appear in :attr:`CheckpointConflict.ACKABLE_KINDS`: an anchor is a statement
+#: by a third party, and a local acknowledgement cannot un-sign it.
+ANCHOR_CONFLICT_KINDS = (
+    "anchor_entry_count",
+    "anchor_origin",
+    "anchor_checkpoint_missing",
+)
+
+
+class AnchorFileError(RuntimeError):
+    """Raised when the anchors file itself fails validation.
+
+    A committed line that does not parse, lacks the fields an anchor is made
+    of, or carries an unreadable token means the append-only discipline was
+    violated. The verifier must not guess which anchors to trust, and must not
+    treat a damaged anchor as an absent one.
+    """
+
+    def __init__(self, errors: list[str]) -> None:
+        self.errors = errors
+        head = "; ".join(errors[:3])
+        super().__init__(f"Audit anchor file failed validation: {head}")
+
+
+@dataclass(frozen=True)
+class CheckpointAnchor:
+    """One externally-signed statement about the size of the audit history.
+
+    Attributes:
+        kind: Anchor mechanism; ``rfc3161`` today.
+        origin: Chain origin the anchored checkpoint pinned.
+        entry_count: Number of canonical records the checkpoint pinned.
+        checkpoint_root: ``root_hash`` of the anchored checkpoint.
+        payload_sha256: Hex SHA-256 of the checkpoint's canonical payload -
+            the digest the TSA timestamped.
+        token_b64: Base64 DER ``TimeStampToken`` / ``TimeStampResp``.
+        tsa_url: Informational URL of the issuing TSA (may be empty).
+        line_no: 1-based line in the anchors file, for error messages.
+    """
+
+    kind: str
+    origin: str
+    entry_count: int
+    checkpoint_root: str
+    payload_sha256: str
+    token_b64: str
+    tsa_url: str
+    line_no: int = 0
+
+    def token_bytes(self) -> bytes:
+        """Return the decoded DER token.
+
+        Raises:
+            ValueError: When ``token_b64`` is not valid base64.
+        """
+        try:
+            return base64.b64decode(self.token_b64, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            msg = f"anchor token is not valid base64: {exc}"
+            raise ValueError(msg) from exc
+
+    def describe(self) -> str:
+        """Return a one-line identification of the anchor for operator output."""
+        where = f" from {self.tsa_url}" if self.tsa_url else ""
+        return (
+            f"{self.kind} anchor over checkpoint root {self.checkpoint_root[:16]}… ({self.entry_count} entries){where}"
+        )
+
+
+@dataclass(frozen=True)
+class AnchoringState:
+    """Anchoring posture of one audit directory, for operator surfaces.
+
+    Attributes:
+        anchored: ``True`` when at least one usable anchor is on record.
+        anchor_count: Number of anchors recorded.
+        newest_entry_count: Highest anchored entry count (``0`` when none).
+        newest_gen_time: ``genTime`` of the token behind the newest anchor,
+            or ``None`` when unavailable (no anchor, or an unreadable token).
+        errors: Anchor-file or token problems observed while reading.
+    """
+
+    anchored: bool
+    anchor_count: int
+    newest_entry_count: int
+    newest_gen_time: datetime | None
+    errors: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Paths + canonical digest
+# ---------------------------------------------------------------------------
+
+
+def anchors_path(audit_dir: Path) -> Path:
+    """Return the append-only anchors file path for *audit_dir*."""
+    return audit_dir / CHECKPOINTS_SUBDIR / ANCHORS_FILE
+
+
+def _canonical(payload: dict[str, Any]) -> bytes:
+    """Serialise *payload* exactly as ``chain_checkpoint`` signs it."""
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+
+
+def checkpoint_digest(checkpoint: dict[str, Any]) -> bytes:
+    """Return the SHA-256 of a checkpoint payload's canonical bytes.
+
+    This is the digest a TSA timestamps. It is a pure function of the
+    checkpoint payload, so an operator can recompute it offline from the
+    checkpoints file and confirm which statement a token covers.
+    """
+    return hashlib.sha256(_canonical(checkpoint)).digest()
+
+
+# ---------------------------------------------------------------------------
+# Load
+# ---------------------------------------------------------------------------
+
+
+def _parse_anchor(doc: dict[str, Any], line_no: int) -> CheckpointAnchor:
+    """Build an anchor from one parsed line.
+
+    Raises:
+        ValueError: When a required field is missing or ill-typed.
+    """
+    if doc.get("version") != ANCHOR_VERSION:
+        msg = f"unsupported anchor version {doc.get('version')!r}"
+        raise ValueError(msg)
+    kind = str(doc.get("kind", ""))
+    if kind != ANCHOR_KIND_RFC3161:
+        msg = f"unsupported anchor kind {kind!r}"
+        raise ValueError(msg)
+    for field in ("origin", "checkpoint_root", "payload_sha256", "token_b64"):
+        if not isinstance(doc.get(field), str) or not doc[field]:
+            msg = f"missing or empty {field}"
+            raise ValueError(msg)
+    entry_count = doc.get("entry_count")
+    if not isinstance(entry_count, int) or isinstance(entry_count, bool) or entry_count < 0:
+        msg = f"entry_count must be a non-negative integer, got {entry_count!r}"
+        raise ValueError(msg)
+    return CheckpointAnchor(
+        kind=kind,
+        origin=str(doc["origin"]),
+        entry_count=entry_count,
+        checkpoint_root=str(doc["checkpoint_root"]),
+        payload_sha256=str(doc["payload_sha256"]),
+        token_b64=str(doc["token_b64"]),
+        tsa_url=str(doc.get("tsa_url", "")),
+        line_no=line_no,
+    )
+
+
+def load_anchors(audit_dir: Path) -> list[CheckpointAnchor]:
+    """Read and validate the anchors file.
+
+    A torn trailing fragment (a crash-interrupted append) is skipped. Every
+    committed line must parse into a well-formed anchor; anything else raises,
+    because an anchor that cannot be read is not the same as an anchor that
+    was never taken.
+
+    Args:
+        audit_dir: The audit directory.
+
+    Returns:
+        Anchors in file order (empty when nothing is anchored).
+
+    Raises:
+        AnchorFileError: On any committed-line validation failure.
+    """
+    path = anchors_path(audit_dir)
+    try:
+        raw = path.read_bytes()
+    except FileNotFoundError:
+        return []
+    except OSError as exc:
+        raise AnchorFileError([f"unreadable anchors file: {exc}"]) from exc
+    if not raw:
+        return []
+
+    lines = raw.split(b"\n")
+    if lines and lines[-1] == b"":
+        lines.pop()
+
+    anchors: list[CheckpointAnchor] = []
+    errors: list[str] = []
+    last_index = len(lines) - 1
+    for line_no, line in enumerate(lines):
+        is_last = line_no == last_index
+        try:
+            doc = json.loads(line)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            if is_last and not raw.endswith(b"\n"):
+                # Crash-interrupted append: ignore the fragment.
+                break
+            errors.append(f"{ANCHORS_FILE}:{line_no + 1}: unparsable committed line")
+            break
+        if not isinstance(doc, dict):
+            errors.append(f"{ANCHORS_FILE}:{line_no + 1}: not a JSON object")
+            break
+        try:
+            anchors.append(_parse_anchor(cast("dict[str, Any]", doc), line_no + 1))
+        except ValueError as exc:
+            errors.append(f"{ANCHORS_FILE}:{line_no + 1}: {exc}")
+            break
+
+    if errors:
+        raise AnchorFileError(errors)
+    return anchors
+
+
+def newest_anchor(anchors: list[CheckpointAnchor]) -> CheckpointAnchor | None:
+    """Return the anchor claiming the largest history, or ``None``.
+
+    File order is append order, but the strongest statement is the one over
+    the most entries: that is the count a rollback has to contradict.
+    """
+    if not anchors:
+        return None
+    return max(anchors, key=lambda anchor: anchor.entry_count)
+
+
+# ---------------------------------------------------------------------------
+# Record
+# ---------------------------------------------------------------------------
+
+
+def record_anchor(
+    audit_dir: Path,
+    checkpoint: dict[str, Any],
+    token_bytes: bytes,
+    *,
+    tsa_url: str = "",
+) -> CheckpointAnchor:
+    """Append an RFC 3161 anchor over *checkpoint*.
+
+    The token must already cover ``sha256(canonical(checkpoint))``: an anchor
+    filed against a checkpoint the TSA never saw would be a claim with no
+    signer behind it, so the imprint is checked before anything is written.
+    Trust-chain validation is a separate, operator-configured step (it needs
+    the operator's TSA roots); binding the token to the bytes it covers does
+    not, and must happen here.
+
+    Args:
+        audit_dir: The audit directory.
+        checkpoint: A checkpoint payload from ``chain_checkpoint``.
+        token_bytes: DER ``TimeStampToken`` or ``TimeStampResp``.
+        tsa_url: Informational URL of the issuing TSA.
+
+    Returns:
+        The recorded anchor.
+
+    Raises:
+        ValueError: When the token does not parse or its messageImprint
+            covers something other than this checkpoint.
+        OSError: When the anchors file cannot be written.
+    """
+    from bernstein.core.security.rfc3161_verifier import read_token_imprint
+
+    digest = checkpoint_digest(checkpoint)
+    imprint = read_token_imprint(token_bytes)
+    if imprint.hashed_message != digest:
+        msg = (
+            "messageImprint mismatch: the token covers a different payload than "
+            f"checkpoint root {str(checkpoint.get('root_hash', ''))[:16]}… "
+            f"(expected sha256 {digest.hex()})"
+        )
+        raise ValueError(msg)
+
+    anchor = CheckpointAnchor(
+        kind=ANCHOR_KIND_RFC3161,
+        origin=str(checkpoint.get("origin", "")),
+        entry_count=int(checkpoint.get("entry_count", 0) or 0),
+        checkpoint_root=str(checkpoint.get("root_hash", "")),
+        payload_sha256=digest.hex(),
+        token_b64=base64.b64encode(token_bytes).decode("ascii"),
+        tsa_url=tsa_url,
+    )
+    doc = {
+        "version": ANCHOR_VERSION,
+        "kind": anchor.kind,
+        "origin": anchor.origin,
+        "entry_count": anchor.entry_count,
+        "checkpoint_root": anchor.checkpoint_root,
+        "payload_sha256": anchor.payload_sha256,
+        "token_b64": anchor.token_b64,
+        "tsa_url": anchor.tsa_url,
+    }
+    path = anchors_path(audit_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(doc, sort_keys=True, separators=(",", ":")).encode() + b"\n"
+    # Append + fsync: an anchor that is still in the page cache when the next
+    # crash arrives cannot contradict anything afterwards.
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    try:
+        os.write(fd, line)
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    return anchor
+
+
+# ---------------------------------------------------------------------------
+# Token verification
+# ---------------------------------------------------------------------------
+
+
+def verify_anchor_token(
+    anchor: CheckpointAnchor,
+    *,
+    trusted_tsa_certs: list[x509.Certificate] | None = None,
+) -> list[str]:
+    """Return the problems with *anchor*'s token; empty when it holds up.
+
+    Two layers, because they answer different questions and need different
+    inputs:
+
+    1. Binding - the token parses and its ``messageImprint`` equals the
+       ``payload_sha256`` the anchor claims. Needs nothing from the operator,
+       so it always runs: a token that covers other bytes never passes as an
+       anchor of this history.
+    2. Identity - the TSA certificate chain walks to an operator-supplied
+       trust anchor. Runs only when *trusted_tsa_certs* is supplied, mirroring
+       ``audit verify-multitenant --rfc3161-trusted-tsa-bundle``: without a
+       pinned root there is no policy to check against, and the OS trust store
+       is deliberately not consulted.
+
+    Args:
+        anchor: The anchor to check.
+        trusted_tsa_certs: Operator-supplied TSA trust anchors, or ``None``.
+
+    Returns:
+        Human-readable error strings.
+    """
+    from bernstein.core.security.rfc3161_verifier import (
+        read_token_imprint,
+        verify_rfc3161_token,
+    )
+
+    try:
+        token = anchor.token_bytes()
+    except ValueError as exc:
+        return [str(exc)]
+    try:
+        expected = bytes.fromhex(anchor.payload_sha256)
+    except ValueError as exc:
+        return [f"anchor payload_sha256 is not valid hex: {exc}"]
+
+    try:
+        imprint = read_token_imprint(token)
+    except ValueError as exc:
+        return [f"token: {exc}"]
+    if imprint.hashed_message != expected:
+        return ["token messageImprint does not cover the anchored checkpoint payload"]
+
+    if not trusted_tsa_certs:
+        return []
+    result = verify_rfc3161_token(token, expected, trusted_tsa_certs)
+    if not result.ok:
+        return [f"token chain: {err}" for err in result.errors]
+    return []
+
+
+def anchor_gen_time(anchor: CheckpointAnchor) -> datetime | None:
+    """Return the TSA ``genTime`` behind *anchor*, or ``None`` when unreadable."""
+    from bernstein.core.security.rfc3161_verifier import read_token_imprint
+
+    try:
+        return read_token_imprint(anchor.token_bytes()).gen_time
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Contradiction
+# ---------------------------------------------------------------------------
+
+
+def check_anchor_contradictions(
+    audit_dir: Path,
+    anchors: list[CheckpointAnchor],
+    *,
+    segments: list[tuple[str, bytes]] | None = None,
+    checkpoint_roots: set[str] | None = None,
+) -> list[CheckpointConflict]:
+    """Return the ways the local history contradicts *anchors*.
+
+    Reported as :class:`CheckpointConflict` values so the CLI renders an
+    anchor contradiction in the same shape as a checkpoint divergence. Their
+    kinds are deliberately outside
+    :attr:`CheckpointConflict.ACKABLE_KINDS`: ``bernstein audit ack-tear``
+    records that an operator looked at local damage, and a local record cannot
+    withdraw a signature a third party made.
+
+    Args:
+        audit_dir: The audit directory.
+        anchors: Anchors as returned by :func:`load_anchors`.
+        segments: An existing :func:`chain_snapshot` to reuse.
+        checkpoint_roots: Roots of the checkpoints currently on record. When
+            supplied, an anchored checkpoint that is no longer there is itself
+            a contradiction - that is exactly the "truncate the chain and the
+            checkpoints together" case. Omit when the audit key is
+            unavailable, since checkpoints cannot be read without it.
+
+    Returns:
+        Conflicts, empty when the local history is consistent with every
+        anchor.
+    """
+    newest = newest_anchor(anchors)
+    if newest is None:
+        return []
+
+    snapshot = segments if segments is not None else chain_snapshot(audit_dir)
+    conflicts: list[CheckpointConflict] = []
+
+    current_count = count_entries(audit_dir, segments=snapshot)
+    if current_count < newest.entry_count:
+        conflicts.append(
+            CheckpointConflict(
+                kind="anchor_entry_count",
+                segment="",
+                offset=0,
+                detail=(f"chain holds {current_count} records; the anchor records that {newest.entry_count} existed"),
+            ),
+        )
+
+    origin = compute_origin(audit_dir, segments=snapshot)
+    if origin is not None and newest.origin and origin != newest.origin:
+        conflicts.append(
+            CheckpointConflict(
+                kind="anchor_origin",
+                segment="",
+                offset=0,
+                detail=(f"chain origin {origin[:16]}… does not match the anchored origin {newest.origin[:16]}…"),
+            ),
+        )
+
+    if checkpoint_roots is not None:
+        for anchor in anchors:
+            if anchor.checkpoint_root in checkpoint_roots:
+                continue
+            conflicts.append(
+                CheckpointConflict(
+                    kind="anchor_checkpoint_missing",
+                    segment="",
+                    offset=0,
+                    detail=(
+                        f"anchored checkpoint root {anchor.checkpoint_root[:16]}… is no "
+                        "longer on record (the checkpoints file was truncated or replaced)"
+                    ),
+                ),
+            )
+    return conflicts
+
+
+# ---------------------------------------------------------------------------
+# Operator posture
+# ---------------------------------------------------------------------------
+
+
+def anchoring_state(audit_dir: Path) -> AnchoringState:
+    """Return the anchoring posture of *audit_dir* for operator surfaces.
+
+    Never raises: a damaged anchors file is reported through ``errors`` so
+    ``bernstein doctor`` can say what it found instead of crashing.
+    """
+    try:
+        anchors = load_anchors(audit_dir)
+    except AnchorFileError as exc:
+        return AnchoringState(
+            anchored=False,
+            anchor_count=0,
+            newest_entry_count=0,
+            newest_gen_time=None,
+            errors=list(exc.errors),
+        )
+    newest = newest_anchor(anchors)
+    if newest is None:
+        return AnchoringState(
+            anchored=False,
+            anchor_count=0,
+            newest_entry_count=0,
+            newest_gen_time=None,
+            errors=[],
+        )
+    errors = verify_anchor_token(newest)
+    return AnchoringState(
+        anchored=not errors,
+        anchor_count=len(anchors),
+        newest_entry_count=newest.entry_count,
+        newest_gen_time=anchor_gen_time(newest),
+        errors=errors,
+    )
+
+
+__all__ = [
+    "ANCHORS_FILE",
+    "ANCHOR_CONFLICT_KINDS",
+    "ANCHOR_KIND_RFC3161",
+    "ANCHOR_VERSION",
+    "AnchorFileError",
+    "AnchoringState",
+    "CheckpointAnchor",
+    "anchor_gen_time",
+    "anchoring_state",
+    "anchors_path",
+    "check_anchor_contradictions",
+    "checkpoint_digest",
+    "load_anchors",
+    "newest_anchor",
+    "record_anchor",
+    "verify_anchor_token",
+]

--- a/src/bernstein/core/security/rfc3161_verifier.py
+++ b/src/bernstein/core/security/rfc3161_verifier.py
@@ -605,6 +605,66 @@ def _walk_chain(
     verifier.verify(signing_cert, intermediates)
 
 
+@dataclass(frozen=True, slots=True)
+class RFC3161Imprint:
+    """What a token *claims*, recovered without any trust decision.
+
+    Parsing is not verifying: this says which digest the token covers and
+    when the TSA says it did so, but nothing about who signed it. Callers
+    that need an identity must still run :func:`verify_rfc3161_token` with
+    operator-supplied trust anchors. The split exists because binding a
+    token to the bytes it covers is useful on its own - an offline install
+    with no trust bundle can still refuse a token issued over something
+    else.
+
+    Attributes:
+        hash_algorithm: ``sha256`` / ``sha384`` / ``sha512``.
+        hashed_message: Raw ``messageImprint.hashedMessage`` bytes.
+        gen_time: ``TSTInfo.genTime``, or ``None`` when absent.
+    """
+
+    hash_algorithm: str
+    hashed_message: bytes
+    gen_time: datetime | None
+
+
+def read_token_imprint(token_bytes: bytes) -> RFC3161Imprint:
+    """Return the messageImprint and genTime *token_bytes* carries.
+
+    Args:
+        token_bytes: A bare ``TimeStampToken`` or a full ``TimeStampResp``.
+
+    Returns:
+        The parsed :class:`RFC3161Imprint`.
+
+    Raises:
+        ValueError: When the token does not parse, the messageImprint is
+            malformed, or its hash algorithm is not one we accept as
+            strong enough to anchor an audit history.
+    """
+    _signed_data, tst_info, _certs, _signer_info = _parse_token(token_bytes)
+    try:
+        imprint = tst_info["message_imprint"]
+        hash_oid = imprint["hash_algorithm"]["algorithm"].dotted
+        hashed_message = bytes(imprint["hashed_message"].native)
+    except (KeyError, AttributeError, ValueError, TypeError) as exc:
+        raise ValueError(f"messageImprint: {exc}") from exc
+    hash_name = str(_HASH_OID_TO_NAME.get(hash_oid, hash_oid))
+    if hash_oid not in _ACCEPTED_HASH_OIDS:
+        raise ValueError(
+            f"messageImprint uses unsupported or weak hash algorithm: {hash_name}",
+        )
+    try:
+        gen_time = cast("datetime | None", tst_info["gen_time"].native)
+    except (KeyError, AttributeError):
+        gen_time = None
+    return RFC3161Imprint(
+        hash_algorithm=hash_name,
+        hashed_message=hashed_message,
+        gen_time=gen_time,
+    )
+
+
 def hash_payload_for_tsa(payload: bytes, *, algorithm: str = "sha256") -> bytes:
     """Hash *payload* with the requested algorithm for messageImprint compare.
 
@@ -630,8 +690,10 @@ def hash_payload_for_tsa(payload: bytes, *, algorithm: str = "sha256") -> bytes:
 
 
 __all__ = [
+    "RFC3161Imprint",
     "RFC3161Verification",
     "hash_payload_for_tsa",
     "load_trusted_tsa_certs",
+    "read_token_imprint",
     "verify_rfc3161_token",
 ]

--- a/tests/unit/test_checkpoint_anchor.py
+++ b/tests/unit/test_checkpoint_anchor.py
@@ -1,0 +1,491 @@
+"""External RFC 3161 anchors over audit checkpoints (#5036).
+
+``chain_checkpoint`` makes an audit-history shrink sticky only against
+material we hold ourselves: an actor with write access to both the chain
+segments and the checkpoints file can truncate both to a mutually
+consistent earlier state and every local verification still passes. These
+tests pin the behaviour of the anchor that closes that residual - a
+timestamp token a third party signed over a checkpoint's canonical bytes,
+stored beside the checkpoint and never inside it.
+
+The tests mint their own TimeStampTokens from a throwaway CA so the
+messageImprint can cover a checkpoint produced in the test. No network
+call is made, here or in the product code.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from click.testing import CliRunner
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+from bernstein.cli.commands.audit_cmd import audit_group
+from bernstein.core.persistence.chain_checkpoint import (
+    checkpoints_path,
+    count_entries,
+    load_checkpoints,
+    record_checkpoint,
+)
+from bernstein.core.persistence.checkpoint_anchor import (
+    AnchorFileError,
+    anchoring_state,
+    anchors_path,
+    check_anchor_contradictions,
+    checkpoint_digest,
+    load_anchors,
+    record_anchor,
+)
+from bernstein.core.persistence.merkle import compute_seal
+from bernstein.core.security.audit import AuditLog
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_KEY = b"anchor-substrate-test-key-0123456"
+
+
+# ---------------------------------------------------------------------------
+# A throwaway TSA: mints real RFC 3161 tokens over arbitrary digests.
+# ---------------------------------------------------------------------------
+
+
+class _TestTSA:
+    """Self-contained TSA: a root CA plus a time-stamping leaf.
+
+    Real ASN.1, real RSA signatures, real trust chain - the product
+    verifier is exercised end-to-end. Only the trust anchor is local.
+    """
+
+    def __init__(self) -> None:
+        self.ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        now = datetime.now(UTC)
+        ca_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Bernstein Test TSA Root")])
+        self.ca_cert = (
+            x509.CertificateBuilder()
+            .subject_name(ca_name)
+            .issuer_name(ca_name)
+            .public_key(self.ca_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now - timedelta(days=1))
+            .not_valid_after(now + timedelta(days=1))
+            .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+            .add_extension(x509.SubjectKeyIdentifier.from_public_key(self.ca_key.public_key()), critical=False)
+            .sign(self.ca_key, hashes.SHA256())
+        )
+        self.leaf_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        self.leaf_cert = (
+            x509.CertificateBuilder()
+            .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Bernstein Test TSA")]))
+            .issuer_name(self.ca_cert.subject)
+            .public_key(self.leaf_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now - timedelta(days=1))
+            .not_valid_after(now + timedelta(days=1))
+            .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+            .add_extension(x509.ExtendedKeyUsage([ExtendedKeyUsageOID.TIME_STAMPING]), critical=True)
+            .add_extension(x509.SubjectKeyIdentifier.from_public_key(self.leaf_key.public_key()), critical=False)
+            .sign(self.ca_key, hashes.SHA256())
+        )
+
+    def token(self, digest: bytes) -> bytes:
+        """Return a DER TimeStampToken whose messageImprint covers *digest*."""
+        from asn1crypto import cms, tsp
+        from asn1crypto import x509 as asn1_x509
+
+        tst = tsp.TSTInfo(
+            {
+                "version": "v1",
+                "policy": "1.3.6.1.4.1.99999.1",
+                "message_imprint": {
+                    "hash_algorithm": {"algorithm": "sha256"},
+                    "hashed_message": digest,
+                },
+                "serial_number": 1,
+                "gen_time": datetime.now(UTC),
+            },
+        )
+        tst_bytes = tst.dump()
+        signed_attrs = cms.CMSAttributes(
+            [
+                cms.CMSAttribute({"type": "content_type", "values": ["tst_info"]}),
+                cms.CMSAttribute({"type": "message_digest", "values": [hashlib.sha256(tst_bytes).digest()]}),
+            ],
+        )
+        signature = self.leaf_key.sign(signed_attrs.dump(), padding.PKCS1v15(), hashes.SHA256())
+        signer_info = cms.SignerInfo(
+            {
+                "version": "v1",
+                "sid": cms.SignerIdentifier(
+                    {
+                        "issuer_and_serial_number": cms.IssuerAndSerialNumber(
+                            {
+                                "issuer": asn1_x509.Name.load(self.leaf_cert.issuer.public_bytes()),
+                                "serial_number": self.leaf_cert.serial_number,
+                            },
+                        ),
+                    },
+                ),
+                "digest_algorithm": {"algorithm": "sha256"},
+                "signed_attrs": signed_attrs,
+                "signature_algorithm": {"algorithm": "rsassa_pkcs1v15"},
+                "signature": signature,
+            },
+        )
+        signed_data = cms.SignedData(
+            {
+                "version": "v3",
+                "digest_algorithms": [{"algorithm": "sha256"}],
+                "encap_content_info": {
+                    "content_type": "tst_info",
+                    "content": cms.ParsableOctetString(tst_bytes),
+                },
+                "certificates": [
+                    asn1_x509.Certificate.load(self.leaf_cert.public_bytes(serialization.Encoding.DER)),
+                    asn1_x509.Certificate.load(self.ca_cert.public_bytes(serialization.Encoding.DER)),
+                ],
+                "signer_infos": [signer_info],
+            },
+        )
+        return cms.ContentInfo({"content_type": "signed_data", "content": signed_data}).dump()
+
+    def trust_bundle(self, path: Path) -> Path:
+        path.write_bytes(self.ca_cert.public_bytes(serialization.Encoding.PEM))
+        return path
+
+
+@pytest.fixture(scope="module")
+def tsa() -> _TestTSA:
+    return _TestTSA()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed(tmp_path: Path, count: int = 6) -> Path:
+    audit_dir = tmp_path / ".sdd" / "audit"
+    log = AuditLog(audit_dir, key=_KEY)
+    for i in range(count):
+        log.log("test.event", "tester", "task", f"t-{i}", {"i": i})
+    return audit_dir
+
+
+def _seal_and_pin(audit_dir: Path) -> dict[str, Any]:
+    _tree, seal = compute_seal(audit_dir, key=_KEY)
+    return record_checkpoint(audit_dir, seal, key=_KEY)
+
+
+def _truncate_history(audit_dir: Path, keep: int) -> None:
+    """Drop all but the first *keep* records from the live segment.
+
+    The chain stays HMAC-intact (a prefix of a chain is a valid chain), so
+    only a pin outside the truncated material can notice.
+    """
+    segment = next(iter(sorted(audit_dir.glob("*.jsonl"))))
+    lines = segment.read_bytes().split(b"\n")
+    body = [line for line in lines if line.strip()]
+    segment.write_bytes(b"".join(line + b"\n" for line in body[:keep]))
+
+
+def _cli_seal(audit_dir: Path) -> dict[str, Any]:
+    """Seal through the CLI (writes the seal file) and return the new checkpoint."""
+    result = CliRunner().invoke(audit_group, ["seal"])
+    assert result.exit_code == 0, result.output
+    checkpoint = load_checkpoints(audit_dir, _KEY).last
+    assert checkpoint is not None
+    return checkpoint
+
+
+@pytest.fixture()
+def cli_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A project root with a seeded audit chain and the key on disk."""
+    key_file = tmp_path / "audit.key"
+    key_file.write_bytes(_KEY)
+    key_file.chmod(0o600)
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(key_file))
+    monkeypatch.setenv("COLUMNS", "200")
+    _seed(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# 1. Anchoring a checkpoint
+# ---------------------------------------------------------------------------
+
+
+def test_checkpoint_can_be_anchored_with_an_rfc3161_token(tmp_path: Path, tsa: _TestTSA) -> None:
+    """A token over the checkpoint's canonical bytes is recorded beside it."""
+    audit_dir = _seed(tmp_path)
+    checkpoint = _seal_and_pin(audit_dir)
+
+    token = tsa.token(checkpoint_digest(checkpoint))
+    anchor = record_anchor(audit_dir, checkpoint, token, tsa_url="https://tsa.example/tsr")
+
+    assert anchor.entry_count == checkpoint["entry_count"]
+    assert anchor.checkpoint_root == checkpoint["root_hash"]
+    assert anchor.payload_sha256 == checkpoint_digest(checkpoint).hex()
+    assert anchor.tsa_url == "https://tsa.example/tsr"
+
+    stored = load_anchors(audit_dir)
+    assert [a.payload_sha256 for a in stored] == [anchor.payload_sha256]
+    assert anchors_path(audit_dir).exists()
+
+
+def test_anchor_refuses_a_token_that_covers_other_bytes(tmp_path: Path, tsa: _TestTSA) -> None:
+    """A token for some other payload cannot be filed against this checkpoint."""
+    audit_dir = _seed(tmp_path)
+    checkpoint = _seal_and_pin(audit_dir)
+
+    with pytest.raises(ValueError, match="messageImprint"):
+        record_anchor(audit_dir, checkpoint, tsa.token(hashlib.sha256(b"other").digest()))
+    assert not anchors_path(audit_dir).exists()
+
+
+# ---------------------------------------------------------------------------
+# 2. Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_anchored_checkpoint_payload_is_still_byte_identical_without_the_token(
+    tmp_path: Path,
+    tsa: _TestTSA,
+) -> None:
+    """The token lives beside the checkpoint, never inside its canonical bytes."""
+    audit_dir = _seed(tmp_path)
+    checkpoint = _seal_and_pin(audit_dir)
+    before = checkpoints_path(audit_dir).read_bytes()
+    entries_before = count_entries(audit_dir)
+
+    record_anchor(audit_dir, checkpoint, tsa.token(checkpoint_digest(checkpoint)))
+
+    assert checkpoints_path(audit_dir).read_bytes() == before
+    assert load_checkpoints(audit_dir, _KEY).last == checkpoint
+    assert checkpoint_digest(checkpoint) == hashlib.sha256(_payload_bytes(before)).digest()
+    # The anchors file must not be mistaken for a chain segment.
+    assert count_entries(audit_dir) == entries_before
+
+    # A later checkpoint is unaffected by the anchor beside its predecessor.
+    AuditLog(audit_dir, key=_KEY).log("test.event", "tester", "task", "extra", {})
+    second = _seal_and_pin(audit_dir)
+    assert set(second) == set(checkpoint)
+    assert not any(key.startswith("anchor") for key in second)
+
+
+def _payload_bytes(raw: bytes) -> bytes:
+    """Canonical bytes of the last checkpoint payload in a checkpoints file."""
+    doc = json.loads(raw.splitlines()[-1])
+    return json.dumps(doc["payload"], sort_keys=True, separators=(",", ":")).encode()
+
+
+# ---------------------------------------------------------------------------
+# 3. Contradiction - the load-bearing property
+# ---------------------------------------------------------------------------
+
+
+def test_verification_fails_when_history_is_shorter_than_the_newest_anchor(
+    cli_workspace: Path,
+    tsa: _TestTSA,
+) -> None:
+    """A rollback of chain AND checkpoints still contradicts the outside anchor."""
+    audit_dir = cli_workspace / ".sdd" / "audit"
+    checkpoint = _cli_seal(audit_dir)
+    record_anchor(audit_dir, checkpoint, tsa.token(checkpoint_digest(checkpoint)))
+
+    runner = CliRunner()
+    assert runner.invoke(audit_group, ["verify"]).exit_code == 0
+
+    # The full local rollback: history shrinks and the pin that would have
+    # noticed is deleted with it.
+    _truncate_history(audit_dir, keep=2)
+    checkpoints_path(audit_dir).unlink()
+
+    result = runner.invoke(audit_group, ["verify"])
+    assert result.exit_code == 1, result.output
+    assert "External Anchors" in result.output
+
+
+def test_verification_names_the_contradicted_anchor_in_its_error(
+    cli_workspace: Path,
+    tsa: _TestTSA,
+) -> None:
+    """The failure names the anchor: its entry count, root, and TSA."""
+    audit_dir = cli_workspace / ".sdd" / "audit"
+    checkpoint = _cli_seal(audit_dir)
+    record_anchor(
+        audit_dir,
+        checkpoint,
+        tsa.token(checkpoint_digest(checkpoint)),
+        tsa_url="https://tsa.example/tsr",
+    )
+    _truncate_history(audit_dir, keep=2)
+    checkpoints_path(audit_dir).unlink()
+
+    result = CliRunner().invoke(audit_group, ["verify"])
+    assert result.exit_code == 1, result.output
+    assert str(checkpoint["entry_count"]) in result.output
+    assert str(checkpoint["root_hash"])[:16] in result.output
+    assert "https://tsa.example/tsr" in result.output
+
+
+def test_anchor_contradiction_is_not_clearable_by_acknowledgement(
+    cli_workspace: Path,
+    tsa: _TestTSA,
+) -> None:
+    """An external statement cannot be waived by a local acknowledgement."""
+    from bernstein.core.persistence.chain_checkpoint import CheckpointConflict
+
+    audit_dir = cli_workspace / ".sdd" / "audit"
+    checkpoint = _cli_seal(audit_dir)
+    record_anchor(audit_dir, checkpoint, tsa.token(checkpoint_digest(checkpoint)))
+    _truncate_history(audit_dir, keep=2)
+
+    conflicts = check_anchor_contradictions(audit_dir, load_anchors(audit_dir))
+    assert conflicts
+    assert all(c.kind not in CheckpointConflict.ACKABLE_KINDS for c in conflicts)
+
+
+# ---------------------------------------------------------------------------
+# 5 + 6. Doctor and the air-gapped install
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_reports_never_anchored_on_a_fresh_install(cli_workspace: Path) -> None:
+    """An unanchored install says so rather than implying a stronger seal."""
+    from bernstein.cli.commands.doctor_cmd import check_audit_anchoring
+    from bernstein.cli.commands.status_cmd import _doctor_check_audit_anchoring
+
+    row = check_audit_anchoring(cli_workspace)
+    assert row["name"] == "Audit anchoring"
+    assert row["status"] == "WARN"
+    assert "never" in row["detail"].lower()
+    assert "bernstein audit anchor" in row["fix"]
+
+    # The row reaches the report `bernstein doctor` actually prints.
+    rendered: list[dict[str, Any]] = []
+    _doctor_check_audit_anchoring(rendered, cli_workspace)
+    assert [c["name"] for c in rendered] == ["Audit anchoring"]
+    assert rendered[0]["ok"] is True
+    assert rendered[0]["detail"].startswith("WARNING: ")
+
+
+def test_airgapped_install_runs_without_a_tsa_and_says_it_is_unanchored(cli_workspace: Path) -> None:
+    """No TSA, no anchors: verify still passes and names the missing anchor."""
+    audit_dir = cli_workspace / ".sdd" / "audit"
+    _cli_seal(audit_dir)
+
+    result = CliRunner().invoke(audit_group, ["verify"])
+    assert result.exit_code == 0, result.output
+    assert "not externally anchored" in result.output.lower()
+
+    state = anchoring_state(audit_dir)
+    assert state.anchored is False
+    assert state.newest_gen_time is None
+
+
+# ---------------------------------------------------------------------------
+# 7. A token that cannot be checked must not pass
+# ---------------------------------------------------------------------------
+
+
+def test_missing_or_invalid_token_does_not_silently_pass_verification(
+    cli_workspace: Path,
+    tsa: _TestTSA,
+) -> None:
+    """A corrupt, absent, or untrusted token fails the pillar loudly."""
+    audit_dir = cli_workspace / ".sdd" / "audit"
+    checkpoint = _cli_seal(audit_dir)
+    record_anchor(audit_dir, checkpoint, tsa.token(checkpoint_digest(checkpoint)))
+
+    runner = CliRunner()
+    assert runner.invoke(audit_group, ["verify"]).exit_code == 0
+
+    path = anchors_path(audit_dir)
+    good = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+
+    # (a) The token bytes are replaced with something that is not a token.
+    corrupt = {**good, "token_b64": base64.b64encode(b"not a timestamp token").decode("ascii")}
+    path.write_text(json.dumps(corrupt, sort_keys=True) + "\n", encoding="utf-8")
+    assert runner.invoke(audit_group, ["verify"]).exit_code == 1
+
+    # (b) The token is gone entirely; the claim about history remains.
+    missing = {k: v for k, v in good.items() if k != "token_b64"}
+    path.write_text(json.dumps(missing, sort_keys=True) + "\n", encoding="utf-8")
+    with pytest.raises(AnchorFileError):
+        load_anchors(audit_dir)
+    assert runner.invoke(audit_group, ["verify"]).exit_code == 1
+
+
+def test_trust_bundle_rejects_a_token_from_an_unknown_tsa(
+    cli_workspace: Path,
+    tsa: _TestTSA,
+    tmp_path: Path,
+) -> None:
+    """With operator trust anchors supplied, a foreign TSA fails the chain walk."""
+    audit_dir = cli_workspace / ".sdd" / "audit"
+    checkpoint = _cli_seal(audit_dir)
+    record_anchor(audit_dir, checkpoint, tsa.token(checkpoint_digest(checkpoint)))
+
+    runner = CliRunner()
+    trusted = tsa.trust_bundle(tmp_path / "trusted.pem")
+    ok = runner.invoke(audit_group, ["verify", "--rfc3161-trusted-tsa-bundle", str(trusted)])
+    assert ok.exit_code == 0, ok.output
+
+    other = _TestTSA().trust_bundle(tmp_path / "other.pem")
+    bad = runner.invoke(audit_group, ["verify", "--rfc3161-trusted-tsa-bundle", str(other)])
+    assert bad.exit_code == 1, bad.output
+
+
+def test_anchor_command_round_trips_a_der_tsa_response(
+    cli_workspace: Path,
+    tsa: _TestTSA,
+    tmp_path: Path,
+) -> None:
+    """The operator flow: print the digest, hand back the TSA response, verify."""
+    audit_dir = cli_workspace / ".sdd" / "audit"
+    checkpoint = _cli_seal(audit_dir)
+    runner = CliRunner()
+
+    request = runner.invoke(audit_group, ["anchor", "--print-request"])
+    assert request.exit_code == 0, request.output
+    digest = checkpoint_digest(checkpoint).hex()
+    assert digest in request.output.replace("\n", "")
+
+    # openssl hands the operator raw DER, not the base64 form 'export' takes.
+    token_file = tmp_path / "resp.tsr"
+    token_file.write_bytes(tsa.token(checkpoint_digest(checkpoint)))
+    recorded = runner.invoke(
+        audit_group,
+        ["anchor", "--rfc3161-token", str(token_file), "--rfc3161-tsa-url", "https://tsa.example/tsr"],
+    )
+    assert recorded.exit_code == 0, recorded.output
+
+    stored = load_anchors(audit_dir)
+    assert [a.entry_count for a in stored] == [checkpoint["entry_count"]]
+    assert runner.invoke(audit_group, ["verify"]).exit_code == 0
+
+
+def test_anchor_command_refuses_a_token_for_another_checkpoint(
+    cli_workspace: Path,
+    tsa: _TestTSA,
+    tmp_path: Path,
+) -> None:
+    """Nothing is filed when the TSA never saw this checkpoint."""
+    audit_dir = cli_workspace / ".sdd" / "audit"
+    _cli_seal(audit_dir)
+    token_file = tmp_path / "resp.tsr"
+    token_file.write_bytes(tsa.token(hashlib.sha256(b"some other statement").digest()))
+
+    result = CliRunner().invoke(audit_group, ["anchor", "--rfc3161-token", str(token_file)])
+    assert result.exit_code != 0
+    assert not anchors_path(audit_dir).exists()

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -6022,6 +6022,7 @@ class TestAdaptivePollingBackoff:
         assert hasattr(orch, "_idle_multiplier")
         assert orch._idle_multiplier == 1
 
+
 # --- Reverse task-to-session index ---
 
 

--- a/verify_cli/bernstein_verify_receipt/__main__.py
+++ b/verify_cli/bernstein_verify_receipt/__main__.py
@@ -75,9 +75,7 @@ def cli() -> None:
     show_default=True,
     help="Which format(s) to verify.",
 )
-@click.option(
-    "--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details."
-)
+@click.option("--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details.")
 def verify_cmd(
     receipt_path: Path,
     jwk_path: Path | None,

--- a/verify_cli/bernstein_verify_receipt/verify.py
+++ b/verify_cli/bernstein_verify_receipt/verify.py
@@ -291,8 +291,7 @@ def verify_subject_binding(receipt: dict[str, Any]) -> tuple[CheckResult, str]:
                 "subject_binding",
                 ok=False,
                 detail=(
-                    f"recomputed head {recomputed[:16]}… "
-                    f"!= range.head_sha256 {range_head[:16]}…"
+                    f"recomputed head {recomputed[:16]}… != range.head_sha256 {range_head[:16]}…"
                 ),
             ),
             recomputed,
@@ -418,10 +417,7 @@ def verify_intoto(receipt: dict[str, Any], public_key: Any, recomputed_head: str
         return CheckResult(
             "intoto",
             ok=False,
-            detail=(
-                f"recomputed head {recomputed_head[:16]}… "
-                f"not in statement subject digests"
-            ),
+            detail=(f"recomputed head {recomputed_head[:16]}… not in statement subject digests"),
         )
     return CheckResult("intoto", ok=True, detail="DSSE/in-toto verified, subject bound to head")
 
@@ -469,8 +465,7 @@ def verify_transparency(
             "transparency",
             ok=False,
             detail=(
-                f"STH subject {subject_sha256[:16]}… "
-                f"!= recomputed head {recomputed_head[:16]}…"
+                f"STH subject {subject_sha256[:16]}… != recomputed head {recomputed_head[:16]}…"
             ),
         )
 
@@ -510,10 +505,7 @@ def verify_transparency(
             return CheckResult(
                 "transparency",
                 ok=False,
-                detail=(
-                    f"inclusion proof root {proven_root[:16]}… "
-                    f"!= STH root {root_hash[:16]}…"
-                ),
+                detail=(f"inclusion proof root {proven_root[:16]}… != STH root {root_hash[:16]}…"),
             )
     return CheckResult(
         "transparency", ok=True, detail="RFC6962 STH signed, root + inclusion proof verified"


### PR DESCRIPTION
## What

Slices 1-3 of #5036: an optional external anchor over an audit checkpoint, a
verification failure when the local history contradicts one, and an anchoring
line in `bernstein doctor`.

- `bernstein audit anchor --print-request` emits `sha256(canonical checkpoint
  payload)` and the `openssl ts -query` invocation that requests a token over
  it; `bernstein audit anchor --rfc3161-token <file>` records the operator's
  TSA response beside the checkpoint in an append-only
  `.sdd/audit/checkpoints/anchors.jsonl`.
- `bernstein audit verify` gains an **External Anchors** pillar. Every recorded
  token must parse and its `messageImprint` must cover the checkpoint the
  anchor names; `--rfc3161-trusted-tsa-bundle <roots.pem>` additionally
  authenticates the issuing TSA. A history shorter than the newest anchored
  entry count, a different chain origin, or an anchored checkpoint that is no
  longer on record each exit non-zero naming the anchor.
- `bernstein doctor` reports `never anchored` / `anchored at N entries, last at
  T`, so an unanchored install stops looking as strong as an anchored one.

Explicitly **not** in this PR:

- No TSA client. Bernstein makes no network call; the operator requests the
  token and hands back the response, the same contract `bernstein audit export
  --rfc3161-token` already has.
- No change to checkpoint payload canonical bytes. Anchors live beside the
  checkpoints file, never inside it, so the checkpoints file stays
  byte-deterministic (test 2 protects this).
- No witness co-signature protocol (slice 4) and no operator-supplied external
  sink (slice 5).
- No new failure mode for existing local damage: `ack-tear` is unchanged.

## Why

`src/bernstein/core/persistence/chain_checkpoint.py` states its own residual in
its module docstring: an actor with write access to both the chain segments and
the checkpoints file can truncate both to a mutually consistent earlier state.
Everything the checkpoint gate compares against - the chain, the Merkle seal,
the checkpoint pin - is computed from material on the same disk with the same
key, so an actor who controls the audit directory can roll all of it back
together and every local verification still passes.

That cannot be solved from inside, and the operator-facing half of the problem
is worse than the missing anchor itself: nothing today tells an operator that
their seal has this limit, so `audit verify` printing PASSED reads as a stronger
statement than it is.

An RFC 3161 token over a checkpoint's canonical bytes is the part a local
rollback cannot reproduce - a TSA will not issue a token dated earlier. Because
the checkpoint payload already pins the origin, the record count and the
per-segment leaves, timestamping it timestamps the claim about how long the
history was, not an unstructured blob.

## How

- `core/security/rfc3161_verifier.py` gains `read_token_imprint()`, which
  returns a token's `messageImprint` and `genTime` without making a trust
  decision. `verify_rfc3161_token()` refuses to say anything without operator
  trust anchors, and binding a token to the bytes it covers does not need them.
  No new ASN.1 or TSA code: it reuses the existing `_parse_token`.
- New `core/persistence/checkpoint_anchor.py` holds the anchor record (kind,
  origin, entry_count, checkpoint_root, payload_sha256, token, tsa_url), the
  append-only load/record path with the same torn-tail discipline as
  `checkpoints.jsonl`, token verification in two layers (binding always,
  identity only with a trust bundle), the contradiction check, and the posture
  summary `doctor` renders. The record carries no HMAC: the audit key is a
  local secret an attacker who can rewrite the chain already has, so the token
  is the only signature worth having here.
- Contradictions are reported as `CheckpointConflict` values so the CLI renders
  them in the same shape as a checkpoint divergence.
- `cli/commands/audit_cmd.py` adds the `anchor` command and the
  `_verify_anchors` pillar, which runs regardless of `--hmac-only` /
  `--merkle-only` for the same reason the checkpoint pillar does.
- `doctor_cmd.check_audit_anchoring()` plus the `status_cmd` wrapper that puts
  the row in the report `bernstein doctor` actually prints. A never-anchored
  install warns without failing the run (anchoring is optional and an air-gapped
  install cannot do it); an unreadable anchor record fails.

### The decision the issue left open

The issue describes the contradiction as "the same shape as the existing tear
conflict, which already exits non-zero and holds until `bernstein audit
ack-tear`". It keeps the shape - structured conflicts, the same renderer,
non-zero exit, no self-clearing - but an anchor contradiction is **not**
acknowledgeable. Its conflict kinds are deliberately outside
`CheckpointConflict.ACKABLE_KINDS`, alongside the existing `origin` and `root`
kinds, which are already unacknowledgeable for the same reason.

An acknowledgement is a local record that an operator looked at local damage. It
cannot withdraw a signature a third party made, and if a local record could
clear the contradiction, the anchor would be decorative: the actor who rewound
the history is exactly the actor who can write the acknowledgement. The remedy
is to restore the history or to treat the anchored range as unaccounted for, and
the CLI says so where it would otherwise print the `ack-tear` invocation.

## Tests

`tests/unit/test_checkpoint_anchor.py`. The tests mint their own
TimeStampTokens from a throwaway CA so the `messageImprint` can cover a
checkpoint produced in the test; the product's real ASN.1 parse, CMS signature
check and certificate-chain walk all run, offline. Every one of these failed on
the unmodified tree.

1. `test_checkpoint_can_be_anchored_with_an_rfc3161_token` - a token over the
   checkpoint's canonical bytes is recorded and reloads intact.
2. `test_anchor_refuses_a_token_that_covers_other_bytes` - a token for some
   other payload cannot be filed, and nothing is written.
3. `test_anchored_checkpoint_payload_is_still_byte_identical_without_the_token`
   - anchoring does not touch `checkpoints.jsonl`, the digest is a pure function
   of the payload, the anchors file is not counted as a chain segment, and the
   next checkpoint carries no anchor material.
4. **`test_verification_fails_when_history_is_shorter_than_the_newest_anchor`**
   - the load-bearing one. The full local rollback: the chain is truncated to a
   still-HMAC-valid prefix *and* the checkpoints file is deleted, which is
   exactly the residual the module documents. `audit verify` exits 1 naming the
   External Anchors pillar.
5. `test_verification_names_the_contradicted_anchor_in_its_error` - the failure
   carries the anchored entry count, the anchored root and the TSA URL.
6. `test_anchor_contradiction_is_not_clearable_by_acknowledgement` - pins the
   decision above: no anchor conflict kind is in `ACKABLE_KINDS`.
7. `test_doctor_reports_never_anchored_on_a_fresh_install` - the check and the
   row that reaches the rendered doctor report.
8. `test_airgapped_install_runs_without_a_tsa_and_says_it_is_unanchored` -
   verify exits 0 with no anchors and states the history is not externally
   anchored.
9. `test_missing_or_invalid_token_does_not_silently_pass_verification` - a token
   replaced with non-token bytes fails verification; an anchor line with the
   token removed fails to load and fails verification.
10. `test_trust_bundle_rejects_a_token_from_an_unknown_tsa` - with trust anchors
    supplied, the right roots pass and a foreign root fails.
11. `test_anchor_command_round_trips_a_der_tsa_response` - the operator flow end
    to end, including the raw DER `.tsr` shape openssl actually produces.
12. `test_anchor_command_refuses_a_token_for_another_checkpoint` - the CLI files
    nothing when the TSA never saw this checkpoint.

Tests 4, 5, 8, 9 and 10 were re-run with the pillar unwired to confirm they fail
for the stated reason and not incidentally.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` - the changed files report the same diagnostic count
      as `origin/main` (114 pre-existing in `audit_cmd.py`, 4 in
      `doctor_cmd.py`); the two new/edited modules report none
- [x] `uv run python scripts/run_tests.py -x` - ran the new file plus every test
      file that imports a changed module
- [x] New code has type hints

### Documentation duty

- [ ] User-visible README section updated - N/A
- [x] `docs/security/audit-log.md` updated: the "scope, stated honestly"
      paragraph now points at the anchor, and a new "External anchors" section
      documents the workflow, the storage discipline, the verify pillar and why
      a contradiction is not acknowledgeable
- [ ] `docs/api/` schema regenerated - N/A, no schema changed
- [x] `uv run bernstein agents-md sync` run; no files changed
- [x] Tests cover the documented behaviour

Part of #5036

## Remaining

- Slice 4: witness co-signature protocol between two installs, so a checkpoint
  carries the set of witnesses that saw it. The issue calls this a design
  conversation of its own.
- Slice 5: operator-supplied external sink (object-lock bucket, git remote) for
  checkpoint and anchor retention, so the anchor file itself is not deletable by
  the process it constrains. Today the CLI tells the operator to keep a copy off
  the machine; it does not do it for them.
