### PR TITLE
feat: derive a content-addressed context manifest from a task's declared paths (#3366)

### DIFF
--- a/docs/operations/context-policy.md
+++ b/docs/operations/context-policy.md
@@ -96,6 +96,43 @@ bernstein context verify --run-id <run_id>
 If the current context policy differs from what was used during the run, the
 verify command reports the diverging fields.
 
+## Declared context manifest
+
+`bernstein context manifest <task-id>` derives the **context manifest** for a
+task: the ordered set of files the task declares as its own (`owned_files`),
+each content-addressed by the SHA-256 of its bytes.
+
+```bash
+# Human-readable listing
+bernstein context manifest <task_id>
+
+# Machine-readable, for diffing two runs
+bernstein context manifest <task_id> --json
+```
+
+The manifest digest is a function of the declared path set and the bytes behind
+it, not of the order the tree was walked in or of how a path was spelled:
+`./src/a.py` and `src/a.py` are one entry, and deriving twice over an unchanged
+tree yields the same digest.
+
+A declared path the deriver cannot resolve to bytes is **not** dropped. It keeps
+its position in the list and records `unmanifested` with a reason code, so
+absence is explicit:
+
+| Reason | Meaning |
+|--------|---------|
+| `missing` | The path names nothing on disk. |
+| `not_a_file` | The path resolves to a directory or another non-regular file. |
+| `unreadable` | The file exists but its bytes could not be read. |
+| `outside_root` | The path resolves outside the repository root; its bytes are never read. |
+| `invalid_path` | The path is not a usable repository-relative path (empty, a NUL byte, the root itself, or too long). |
+
+Exit codes: `0` = derived, `1` = no such task. Unmanifested entries are
+reported, not treated as a failure.
+
+The digest is not yet anchored in the run record or on the run receipt, so this
+command reads the working tree rather than the chain.
+
 ## Related topics
 
 - [Context receipt schema](../reference/context-receipt.md) — The exact structure

--- a/docs/release-notes/fragments/3366-context-manifest-derivation.md
+++ b/docs/release-notes/fragments/3366-context-manifest-derivation.md
@@ -1,0 +1,13 @@
+## `bernstein context manifest` content-addresses a task's declared context
+
+A new `bernstein context manifest <task-id>` subcommand (plus `--workdir` and
+`--json`) derives the **context manifest** for a task: the ordered, deduplicated
+set of files the task declares as its own, each addressed by the SHA-256 of its
+bytes, with a manifest digest over the whole list. The digest is a function of
+the declared path set and the bytes behind it — deriving twice over an unchanged
+tree is byte-identical, and a single changed byte moves the digest and names the
+entry that moved. A declared path the deriver cannot resolve keeps its position
+and records `unmanifested` with a reason code (`missing`, `not_a_file`,
+`unreadable`, `outside_root`, `invalid_path`) rather than silently disappearing;
+a path that escapes the repository root is refused before its bytes are read
+(#3366).

--- a/src/bernstein/cli/commands/context_cmd.py
+++ b/src/bernstein/cli/commands/context_cmd.py
@@ -6,24 +6,35 @@ envelope remaining, dependency state, and the audit chain head at spawn (plus
 the intent capsule hash when one exists). Its hash is recorded in the spawn
 record, the run journal, and the audit chain::
 
-    bernstein context show   <task-id>
-    bernstein context verify <task-id>
+    bernstein context show     <task-id>
+    bernstein context verify   <task-id>
+    bernstein context manifest <task-id>
 
 ``show`` prints the operator projection of the capsule. ``verify`` recomputes
 the capsule offline from the on-disk bytes and checks its hash against the
 ``context.capsule`` audit-chain entry and the ``context.capsule_recorded``
 journal event at the recorded chain position; a tampered capsule, a reordered
 journal, or a mock-layer fixture fails.
+
+``manifest`` derives the content-addressed context manifest for a task's
+declared path set (#3366): every declared file addressed by the hash of its
+bytes, and every path that does not resolve recorded ``unmanifested`` with its
+reason code. Nothing anchors the digest in a run record yet, so the command is
+a read of the working tree, not of the chain.
 """
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 
 from bernstein.cli.helpers import console
+
+if TYPE_CHECKING:
+    from bernstein.core.tasks.models import Task
 
 
 def _load_hmac_key() -> bytes:
@@ -34,6 +45,19 @@ def _load_hmac_key() -> bytes:
 
 def _sdd_dir(workdir: Path) -> Path:
     return workdir / ".sdd"
+
+
+def _load_task(workdir: Path, task_id: str) -> Task | None:
+    """Return the persisted task for *task_id*, or None when there is no such task."""
+    from bernstein.core.tasks.task_store import TaskStore
+
+    sdd_dir = _sdd_dir(workdir)
+    store = TaskStore(
+        jsonl_path=sdd_dir / "runtime" / "tasks.jsonl",
+        archive_path=sdd_dir / "archive" / "tasks.jsonl",
+    )
+    store.replay_jsonl()
+    return store.get_task(task_id)
 
 
 def _chain(workdir: Path):
@@ -47,8 +71,9 @@ def context_group() -> None:
     """Show and verify chain-anchored worker context capsules.
 
     \b
-      bernstein context show   <task-id>
-      bernstein context verify <task-id>
+      bernstein context show     <task-id>
+      bernstein context verify   <task-id>
+      bernstein context manifest <task-id>
     """
 
 
@@ -151,6 +176,63 @@ def context_verify_cmd(task_id: str, workdir: str, as_json: bool) -> None:
     else:
         console.print(f"[red]MISMATCH[/red] -- {result.reason}")
     raise SystemExit(2)
+
+
+@context_group.command("manifest")
+@click.argument("task_id")
+@click.option(
+    "--workdir",
+    "-w",
+    type=click.Path(file_okay=False, exists=True),
+    default=".",
+    show_default=True,
+    help="Project root containing .sdd/; declared paths resolve under it.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit machine-readable JSON.")
+def context_manifest_cmd(task_id: str, workdir: str, as_json: bool) -> None:
+    """Derive the content-addressed context manifest for a task.
+
+    Each declared path on the task (``owned_files``) is content-addressed by the
+    hash of its bytes; a path that does not resolve keeps its position and
+    records ``unmanifested`` with a reason code, so absence is explicit.
+
+    Exit codes: 0 = derived, 1 = no such task.
+    """
+    from bernstein.core.agents.context_manifest import derive_context_manifest
+
+    root = Path(workdir).resolve()
+    task = _load_task(root, task_id)
+    if task is None:
+        console.print(f"[yellow]NO TASK[/yellow] -- no task {task_id} under {root / '.sdd'}")
+        raise SystemExit(1)
+
+    manifest = derive_context_manifest(repo_root=root, declared_paths=task.owned_files)
+    if as_json:
+        payload = {
+            "task_id": task_id,
+            "manifest_digest": manifest.manifest_digest(),
+            "entry_count": len(manifest.entries),
+            "unmanifested_count": len(manifest.unmanifested),
+            **manifest.to_dict(),
+        }
+        console.print_json(json.dumps(payload))
+        return
+
+    console.print()
+    console.print("[bold]Context manifest[/bold]")
+    console.print(f"  task_id          {task_id}")
+    console.print(f"  manifest_digest  {manifest.manifest_digest()}")
+    console.print(f"  entries          {len(manifest.entries)}")
+    console.print(f"  unmanifested     {len(manifest.unmanifested)}")
+    if not manifest.entries:
+        console.print("  [yellow](the task declares no paths -- nothing was manifested)[/yellow]")
+        return
+    console.print()
+    for index, entry in enumerate(manifest.entries):
+        if entry.unmanifested:
+            console.print(f"  {index:>3}  [yellow]unmanifested[/yellow] ({entry.reason})  {entry.path}")
+        else:
+            console.print(f"  {index:>3}  {entry.digest}  {entry.path}")
 
 
 __all__ = ["context_group"]

--- a/src/bernstein/core/agents/context_manifest.py
+++ b/src/bernstein/core/agents/context_manifest.py
@@ -1,0 +1,331 @@
+"""Content-addressed manifest of the files a task declares as its context.
+
+Issue #3366. The run journal already records what an agent *did*; what it was
+*shown* is left implicit. When two runs of the same task diverge, replay can
+prove the tool calls differed but cannot attribute the divergence to context
+drift, because the context set was never an artifact.
+
+This module derives that artifact. :func:`derive_context_manifest` reads a
+task's declared path set -- ``Task.owned_files`` -- and returns an ordered,
+deduplicated :class:`ContextManifest`: every resolvable file content-addressed
+as ``sha256:<hex>`` of its bytes, and every path that does not resolve recorded
+as an ``unmanifested`` entry carrying a reason code and still occupying its
+position in the list. Absence is explicit, never silent, and the entry count
+never shrinks below the number of distinct declared paths.
+
+The manifest digest follows the canonical-JSON discipline already in the tree
+(``ContextCapsule.canonical_bytes``): the digest is a function of the declared
+path set and the bytes behind it, not of the order the filesystem was walked in
+or of how a path happened to be spelled. Two derivations over the same tree are
+byte-identical; a single byte changed in one declared file moves the digest, and
+:func:`first_manifest_divergence` names the entry that moved and both hashes.
+
+Containment is not advisory here. A declared path is externally influenced (it
+arrives on a task from the API, the CLI, or an issue body), so every path goes
+through :func:`~bernstein.core.security.path_containment.contained_subpath`
+before it is opened. A path that escapes the repository root is recorded as
+``outside_root`` and its bytes are never read.
+
+This module is pure: it reads files and returns a value. Nothing anchors the
+digest in a run record or on a receipt yet, so no adapter behaviour depends on
+it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import posixpath
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.security.path_containment import (
+    PathContainmentError,
+    PathTooLongError,
+    contained_subpath,
+    validate_relative_path,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+__all__ = [
+    "CONTEXT_MANIFEST_VERSION",
+    "REASON_CODES",
+    "REASON_INVALID_PATH",
+    "REASON_MISSING",
+    "REASON_NOT_A_FILE",
+    "REASON_OUTSIDE_ROOT",
+    "REASON_UNREADABLE",
+    "ContextManifest",
+    "ContextManifestEntry",
+    "ManifestDivergence",
+    "derive_context_manifest",
+    "first_manifest_divergence",
+]
+
+#: Wire-format version stamped into every manifest preimage.
+CONTEXT_MANIFEST_VERSION = 1
+
+#: The declared path names nothing on disk.
+REASON_MISSING = "missing"
+
+#: The declared path resolves to a directory or another non-regular file.
+REASON_NOT_A_FILE = "not_a_file"
+
+#: The declared path resolves to a regular file whose bytes could not be read.
+REASON_UNREADABLE = "unreadable"
+
+#: The declared path resolves outside the repository root (traversal, an
+#: absolute path, or an ordinary-looking component that is a symlink out of the
+#: tree). The bytes behind such a path are never read.
+REASON_OUTSIDE_ROOT = "outside_root"
+
+#: The declared path is not a usable repository-relative path at all: empty,
+#: carrying a NUL byte, naming the root itself, or too long for the filesystem.
+REASON_INVALID_PATH = "invalid_path"
+
+#: Every reason code a deriver can record. Closed set: a reader that does not
+#: recognise a code is reading a manifest from a newer version.
+REASON_CODES = frozenset(
+    {
+        REASON_MISSING,
+        REASON_NOT_A_FILE,
+        REASON_UNREADABLE,
+        REASON_OUTSIDE_ROOT,
+        REASON_INVALID_PATH,
+    }
+)
+
+#: Read granularity for content addressing. A declared file can be large; the
+#: digest must not require holding it in memory.
+_CHUNK_BYTES = 1 << 20
+
+#: Normalised spellings that name the repository root rather than a file in it.
+_ROOT_SPELLINGS = frozenset({"", "."})
+
+
+@dataclass(frozen=True, slots=True)
+class ContextManifestEntry:
+    """One declared path, either content-addressed or explicitly unmanifested.
+
+    Frozen + slots so the byte form is canonical.
+
+    Attributes:
+        path: The declared path in normalised repository-relative POSIX form.
+            Normalisation is what makes the digest a function of the file set
+            rather than of the spelling: ``./src/a.py`` and ``src/a.py`` are one
+            entry.
+        digest: ``sha256:<hex>`` of the file's bytes, or the empty string when
+            the entry is unmanifested.
+        unmanifested: True when the deriver could not resolve the path to bytes.
+        reason: A member of :data:`REASON_CODES` when *unmanifested*, otherwise
+            the empty string.
+    """
+
+    path: str
+    digest: str
+    unmanifested: bool
+    reason: str
+
+    def to_canonical_dict(self) -> dict[str, Any]:
+        """Return the JCS-canonical mapping for this entry."""
+        return {
+            "path": self.path,
+            "digest": self.digest,
+            "unmanifested": self.unmanifested,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ContextManifest:
+    """The ordered, content-addressed set of files a task declares as context.
+
+    Attributes:
+        v: Wire-format version.
+        entries: Entries in declared order, deduplicated on the normalised path.
+    """
+
+    v: int
+    entries: tuple[ContextManifestEntry, ...]
+
+    def to_canonical_dict(self) -> dict[str, Any]:
+        """Return the JCS-canonical mapping (sorted keys, lists not tuples)."""
+        return {
+            "v": self.v,
+            "entries": [entry.to_canonical_dict() for entry in self.entries],
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        """Alias for on-disk storage."""
+        return self.to_canonical_dict()
+
+    def canonical_bytes(self) -> bytes:
+        """RFC 8785-style canonical bytes of the manifest."""
+        return json.dumps(
+            self.to_canonical_dict(),
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+            allow_nan=False,
+        ).encode("utf-8")
+
+    def manifest_digest(self) -> str:
+        """``sha256:`` content hash of the canonical manifest bytes."""
+        return "sha256:" + hashlib.sha256(self.canonical_bytes()).hexdigest()
+
+    @property
+    def unmanifested(self) -> tuple[ContextManifestEntry, ...]:
+        """The entries the deriver could not resolve, in declared order."""
+        return tuple(entry for entry in self.entries if entry.unmanifested)
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestDivergence:
+    """The first position at which two manifests disagree.
+
+    Attributes:
+        index: Zero-based position of the first differing entry.
+        path: The declared path at that position, taken from whichever side has
+            an entry there.
+        left: The entry on the left-hand manifest, or None when that manifest is
+            shorter.
+        right: The entry on the right-hand manifest, or None when that manifest
+            is shorter.
+    """
+
+    index: int
+    path: str
+    left: ContextManifestEntry | None
+    right: ContextManifestEntry | None
+
+
+def _normalise_declared(raw: str) -> str:
+    """Fold a declared path to repository-relative POSIX form.
+
+    Both separators are folded, not just this platform's: a task is written on
+    one host and derived on another, so ``src\\a.py`` has to normalise the same
+    way everywhere.
+
+    Args:
+        raw: The declared path exactly as it appears on the task.
+
+    Returns:
+        The normalised path, or *raw* unchanged when it carries a shape
+        (emptiness, a NUL byte) that the containment barrier must see verbatim
+        in order to reject it.
+    """
+    if not raw or "\x00" in raw:
+        return raw
+    return posixpath.normpath(raw.replace("\\", "/"))
+
+
+def _resolve(repo_root: Path, declared: str) -> tuple[Path | None, str]:
+    """Resolve one normalised declared path under *repo_root*.
+
+    Args:
+        repo_root: The repository root the path must stay inside.
+        declared: The normalised declared path.
+
+    Returns:
+        ``(path, "")`` when the path resolves to a readable regular file inside
+        the root, otherwise ``(None, reason)`` with a member of
+        :data:`REASON_CODES`.
+    """
+    if declared in _ROOT_SPELLINGS:
+        return None, REASON_INVALID_PATH
+    try:
+        validate_relative_path(declared, label="declared path")
+    except PathContainmentError:
+        return None, REASON_INVALID_PATH
+    try:
+        resolved = contained_subpath(repo_root, declared, label="declared path")
+    except PathTooLongError:
+        # A capacity failure, not an escape: the path is contained, it simply
+        # cannot name a file on this filesystem.
+        return None, REASON_INVALID_PATH
+    except PathContainmentError:
+        return None, REASON_OUTSIDE_ROOT
+    if not resolved.exists():
+        return None, REASON_MISSING
+    if not resolved.is_file():
+        return None, REASON_NOT_A_FILE
+    return resolved, ""
+
+
+def _digest_file(path: Path) -> str | None:
+    """Return ``sha256:<hex>`` of *path*'s bytes, or None when unreadable."""
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            while chunk := handle.read(_CHUNK_BYTES):
+                digest.update(chunk)
+    except OSError:
+        return None
+    return "sha256:" + digest.hexdigest()
+
+
+def _entry_for(repo_root: Path, declared: str) -> ContextManifestEntry:
+    """Build the manifest entry for one normalised declared path."""
+    resolved, reason = _resolve(repo_root, declared)
+    if resolved is None:
+        return ContextManifestEntry(path=declared, digest="", unmanifested=True, reason=reason)
+    digest = _digest_file(resolved)
+    if digest is None:
+        return ContextManifestEntry(path=declared, digest="", unmanifested=True, reason=REASON_UNREADABLE)
+    return ContextManifestEntry(path=declared, digest=digest, unmanifested=False, reason="")
+
+
+def derive_context_manifest(*, repo_root: Path | str, declared_paths: Sequence[str] | Iterable[str]) -> ContextManifest:
+    """Derive the content-addressed context manifest for a task's declared paths.
+
+    Args:
+        repo_root: The repository root every declared path is resolved under.
+            Trusted by configuration; the declared paths are not.
+        declared_paths: The task's declared path set, in declared order --
+            ``Task.owned_files`` at the call site.
+
+    Returns:
+        A :class:`ContextManifest` whose entries follow the declared order with
+        duplicate spellings of the same path collapsed to one entry. Every
+        declared path produces exactly one entry: a resolvable file is
+        content-addressed, and anything else is recorded ``unmanifested`` with
+        its reason code rather than dropped.
+    """
+    root = Path(repo_root)
+    seen: set[str] = set()
+    entries: list[ContextManifestEntry] = []
+    for raw in declared_paths:
+        declared = _normalise_declared(raw)
+        if declared in seen:
+            continue
+        seen.add(declared)
+        entries.append(_entry_for(root, declared))
+    return ContextManifest(v=CONTEXT_MANIFEST_VERSION, entries=tuple(entries))
+
+
+def first_manifest_divergence(left: ContextManifest, right: ContextManifest) -> ManifestDivergence | None:
+    """Return the first position at which two manifests disagree.
+
+    Positional, not set-based: the declared order is part of what the manifest
+    asserts, so a reordered context set diverges at the first moved entry rather
+    than comparing equal.
+
+    Args:
+        left: One manifest.
+        right: The manifest to compare it against.
+
+    Returns:
+        The first :class:`ManifestDivergence`, or None when the two manifests
+        carry identical entries in identical order.
+    """
+    for index in range(max(len(left.entries), len(right.entries))):
+        lhs = left.entries[index] if index < len(left.entries) else None
+        rhs = right.entries[index] if index < len(right.entries) else None
+        if lhs == rhs:
+            continue
+        path = lhs.path if lhs is not None else (rhs.path if rhs is not None else "")
+        return ManifestDivergence(index=index, path=path, left=lhs, right=rhs)
+    return None

--- a/tests/unit/test_context_cmd.py
+++ b/tests/unit/test_context_cmd.py
@@ -1,13 +1,18 @@
-"""CLI tests for ``bernstein context show|verify`` (#2545).
+"""CLI tests for ``bernstein context show|verify|manifest`` (#2545, #3366).
 
 ``verify`` recomputes the capsule offline from the on-disk bytes and checks its
 hash against the ``context.capsule`` audit-chain entry and the
 ``context.capsule_recorded`` journal event. A real capsule verifies; a
 mock-layer fixture fails with a mock diagnostic.
+
+``manifest`` derives the content-addressed context manifest from the task's
+declared path set, so an operator can see what the agent would be shown --
+including the entries the deriver could not resolve.
 """
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -91,3 +96,64 @@ def test_context_verify_mock_fails(project: Path) -> None:
     result = runner.invoke(context_group, ["verify", "task-mock", "--workdir", str(project)])
     assert result.exit_code == 2
     assert "MOCK" in result.output
+
+
+def _write_task(project: Path, task_id: str, owned_files: list[str]) -> None:
+    """Persist a task with *owned_files* into the store the CLI replays."""
+    from bernstein.core.tasks.models import Task
+
+    task = Task(
+        id=task_id,
+        title="manifest fixture",
+        description="declares a path set",
+        role="backend",
+        owned_files=owned_files,
+    )
+    tasks_path = project / ".sdd" / "runtime" / "tasks.jsonl"
+    tasks_path.parent.mkdir(parents=True, exist_ok=True)
+    with tasks_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(task.to_dict()) + "\n")
+
+
+def test_context_manifest_addresses_declared_files_and_names_unmanifested_entries(project: Path) -> None:
+    (project / "src").mkdir(parents=True, exist_ok=True)
+    (project / "src" / "a.py").write_text("alpha\n", encoding="utf-8")
+    _write_task(project, "task-manifest", ["src/a.py", "src/gone.py"])
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["manifest", "task-manifest", "--workdir", str(project)])
+
+    assert result.exit_code == 0, result.output
+    assert "Context manifest" in result.output
+    assert "sha256:" in result.output
+    assert "unmanifested" in result.output
+    assert "missing" in result.output
+    assert "src/gone.py" in result.output
+
+
+def test_context_manifest_json_carries_the_digest_and_every_entry(project: Path) -> None:
+    (project / "src").mkdir(parents=True, exist_ok=True)
+    (project / "src" / "a.py").write_text("alpha\n", encoding="utf-8")
+    _write_task(project, "task-manifest-json", ["src/a.py", "src/gone.py"])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        context_group,
+        ["manifest", "task-manifest-json", "--workdir", str(project), "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["manifest_digest"].startswith("sha256:")
+    assert payload["entry_count"] == 2
+    assert payload["unmanifested_count"] == 1
+    assert [entry["path"] for entry in payload["entries"]] == ["src/a.py", "src/gone.py"]
+    assert payload["entries"][1]["reason"] == "missing"
+
+
+def test_context_manifest_exits_nonzero_for_an_unknown_task(project: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["manifest", "no-such-task", "--workdir", str(project)])
+
+    assert result.exit_code == 1
+    assert "NO TASK" in result.output

--- a/tests/unit/test_context_manifest.py
+++ b/tests/unit/test_context_manifest.py
@@ -1,0 +1,165 @@
+"""Derivation of the content-addressed context manifest (#3366).
+
+What the agent was shown is an artifact here, not an implicit per-adapter
+decision. These tests pin the two properties that make the artifact worth
+anchoring later: the digest is a function of the declared path set and the bytes
+behind it (never of the walk or the spelling), and a path the deriver cannot
+resolve is recorded ``unmanifested`` with a reason code instead of vanishing.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.agents.context_manifest import (
+    CONTEXT_MANIFEST_VERSION,
+    REASON_CODES,
+    REASON_INVALID_PATH,
+    REASON_MISSING,
+    REASON_NOT_A_FILE,
+    REASON_OUTSIDE_ROOT,
+    REASON_UNREADABLE,
+    derive_context_manifest,
+    first_manifest_divergence,
+)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A small tree with two declared files and one directory."""
+    root = tmp_path / "repo"
+    (root / "src" / "pkg").mkdir(parents=True)
+    (root / "src" / "pkg" / "a.py").write_text("alpha\n", encoding="utf-8")
+    (root / "src" / "pkg" / "b.py").write_text("bravo\n", encoding="utf-8")
+    return root
+
+
+def test_manifest_digest_is_a_function_of_the_bytes_not_the_walk(repo: Path) -> None:
+    """Two derivations over the same tree produce byte-identical manifests."""
+    declared = ["src/pkg/a.py", "src/pkg/b.py"]
+
+    first = derive_context_manifest(repo_root=repo, declared_paths=declared)
+    second = derive_context_manifest(repo_root=repo, declared_paths=declared)
+
+    assert first.v == CONTEXT_MANIFEST_VERSION
+    assert first.canonical_bytes() == second.canonical_bytes()
+    assert first.manifest_digest() == second.manifest_digest()
+    assert first.manifest_digest().startswith("sha256:")
+    assert [entry.digest for entry in first.entries] == [entry.digest for entry in second.entries]
+    assert first_manifest_divergence(first, second) is None
+
+
+def test_single_byte_edit_changes_the_digest_and_names_the_first_differing_entry(repo: Path) -> None:
+    """A one-byte edit to a declared file moves the digest and is named."""
+    declared = ["src/pkg/a.py", "src/pkg/b.py"]
+    before = derive_context_manifest(repo_root=repo, declared_paths=declared)
+
+    (repo / "src" / "pkg" / "b.py").write_text("bravA\n", encoding="utf-8")
+    after = derive_context_manifest(repo_root=repo, declared_paths=declared)
+
+    assert after.manifest_digest() != before.manifest_digest()
+    divergence = first_manifest_divergence(before, after)
+    assert divergence is not None
+    assert divergence.index == 1
+    assert divergence.path == "src/pkg/b.py"
+    assert divergence.left is not None
+    assert divergence.right is not None
+    assert divergence.left.digest != divergence.right.digest
+
+
+def test_missing_path_is_unmanifested_and_does_not_shrink_the_entry_count(repo: Path) -> None:
+    """An unresolvable path keeps its position and records why."""
+    declared = ["src/pkg/a.py", "src/pkg/gone.py", "src/pkg/b.py"]
+
+    manifest = derive_context_manifest(repo_root=repo, declared_paths=declared)
+
+    assert len(manifest.entries) == len(declared)
+    middle = manifest.entries[1]
+    assert middle.path == "src/pkg/gone.py"
+    assert middle.unmanifested is True
+    assert middle.reason == REASON_MISSING
+    assert middle.reason in REASON_CODES
+    assert middle.digest == ""
+    assert manifest.unmanifested == (middle,)
+    # The entries around it still carry bytes.
+    assert manifest.entries[0].digest.startswith("sha256:")
+    assert manifest.entries[2].digest.startswith("sha256:")
+
+
+def test_directory_and_unreadable_entries_carry_distinct_reason_codes(repo: Path) -> None:
+    """A directory and a file that cannot be opened are told apart."""
+    locked = repo / "src" / "pkg" / "locked.py"
+    locked.write_text("secret\n", encoding="utf-8")
+    locked.chmod(stat.S_IWUSR)
+    if os.access(locked, os.R_OK):  # pragma: no cover - root ignores the mode bits
+        pytest.skip("this process can read a mode-0200 file; the unreadable case is unobservable")
+
+    try:
+        manifest = derive_context_manifest(repo_root=repo, declared_paths=["src/pkg", "src/pkg/locked.py"])
+    finally:
+        locked.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+    assert manifest.entries[0].reason == REASON_NOT_A_FILE
+    assert manifest.entries[1].reason == REASON_UNREADABLE
+    assert all(entry.unmanifested for entry in manifest.entries)
+    assert all(entry.digest == "" for entry in manifest.entries)
+
+
+def test_path_escaping_the_repo_root_is_unmanifested_and_its_bytes_are_never_read(repo: Path, tmp_path: Path) -> None:
+    """A declared path that leaves the root is refused, not content-addressed."""
+    outside = tmp_path / "outside.txt"
+    outside.write_text("not the agent's to see\n", encoding="utf-8")
+
+    manifest = derive_context_manifest(
+        repo_root=repo,
+        declared_paths=["../outside.txt", "/etc/hostname", ""],
+    )
+
+    assert [entry.reason for entry in manifest.entries] == [
+        REASON_INVALID_PATH,
+        REASON_INVALID_PATH,
+        REASON_INVALID_PATH,
+    ]
+    assert all(entry.unmanifested for entry in manifest.entries)
+    body = manifest.canonical_bytes().decode("utf-8")
+    assert "not the agent's to see" not in body
+    assert "sha256:" not in body
+
+
+def test_symlinked_entry_pointing_out_of_the_root_is_unmanifested(repo: Path, tmp_path: Path) -> None:
+    """An ordinary-looking component that leaves the tree is refused."""
+    outside = tmp_path / "outside.txt"
+    outside.write_text("not the agent's to see\n", encoding="utf-8")
+    (repo / "src" / "pkg" / "link.py").symlink_to(outside)
+
+    manifest = derive_context_manifest(repo_root=repo, declared_paths=["src/pkg/link.py"])
+
+    assert manifest.entries[0].unmanifested is True
+    assert manifest.entries[0].reason == REASON_OUTSIDE_ROOT
+    assert manifest.entries[0].digest == ""
+
+
+def test_declared_order_is_preserved_and_duplicate_paths_collapse_to_one_entry(repo: Path) -> None:
+    """The manifest is the declared order, deduplicated -- not a sorted walk."""
+    manifest = derive_context_manifest(
+        repo_root=repo,
+        declared_paths=["src/pkg/b.py", "src/pkg/a.py", "src/pkg/b.py"],
+    )
+
+    assert [entry.path for entry in manifest.entries] == ["src/pkg/b.py", "src/pkg/a.py"]
+
+
+def test_digest_is_independent_of_how_the_same_path_was_spelled(repo: Path) -> None:
+    """Spelling a path differently is not a different context set."""
+    plain = derive_context_manifest(repo_root=repo, declared_paths=["src/pkg/a.py"])
+    dotted = derive_context_manifest(repo_root=repo, declared_paths=["./src/pkg/a.py"])
+    windows = derive_context_manifest(repo_root=repo, declared_paths=["src\\pkg\\a.py"])
+    redundant = derive_context_manifest(repo_root=repo, declared_paths=["src/pkg/a.py", "./src/pkg/a.py"])
+
+    assert dotted.manifest_digest() == plain.manifest_digest()
+    assert windows.manifest_digest() == plain.manifest_digest()
+    assert redundant.manifest_digest() == plain.manifest_digest()

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -6022,6 +6022,7 @@ class TestAdaptivePollingBackoff:
         assert hasattr(orch, "_idle_multiplier")
         assert orch._idle_multiplier == 1
 
+
 # --- Reverse task-to-session index ---
 
 

--- a/verify_cli/bernstein_verify_receipt/__main__.py
+++ b/verify_cli/bernstein_verify_receipt/__main__.py
@@ -75,9 +75,7 @@ def cli() -> None:
     show_default=True,
     help="Which format(s) to verify.",
 )
-@click.option(
-    "--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details."
-)
+@click.option("--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details.")
 def verify_cmd(
     receipt_path: Path,
     jwk_path: Path | None,

--- a/verify_cli/bernstein_verify_receipt/verify.py
+++ b/verify_cli/bernstein_verify_receipt/verify.py
@@ -291,8 +291,7 @@ def verify_subject_binding(receipt: dict[str, Any]) -> tuple[CheckResult, str]:
                 "subject_binding",
                 ok=False,
                 detail=(
-                    f"recomputed head {recomputed[:16]}… "
-                    f"!= range.head_sha256 {range_head[:16]}…"
+                    f"recomputed head {recomputed[:16]}… != range.head_sha256 {range_head[:16]}…"
                 ),
             ),
             recomputed,
@@ -418,10 +417,7 @@ def verify_intoto(receipt: dict[str, Any], public_key: Any, recomputed_head: str
         return CheckResult(
             "intoto",
             ok=False,
-            detail=(
-                f"recomputed head {recomputed_head[:16]}… "
-                f"not in statement subject digests"
-            ),
+            detail=(f"recomputed head {recomputed_head[:16]}… not in statement subject digests"),
         )
     return CheckResult("intoto", ok=True, detail="DSSE/in-toto verified, subject bound to head")
 
@@ -469,8 +465,7 @@ def verify_transparency(
             "transparency",
             ok=False,
             detail=(
-                f"STH subject {subject_sha256[:16]}… "
-                f"!= recomputed head {recomputed_head[:16]}…"
+                f"STH subject {subject_sha256[:16]}… != recomputed head {recomputed_head[:16]}…"
             ),
         )
 
@@ -510,10 +505,7 @@ def verify_transparency(
             return CheckResult(
                 "transparency",
                 ok=False,
-                detail=(
-                    f"inclusion proof root {proven_root[:16]}… "
-                    f"!= STH root {root_hash[:16]}…"
-                ),
+                detail=(f"inclusion proof root {proven_root[:16]}… != STH root {root_hash[:16]}…"),
             )
     return CheckResult(
         "transparency", ok=True, detail="RFC6962 STH signed, root + inclusion proof verified"


### PR DESCRIPTION
## What

Step 1 of #3366: makes a task's declared context set an artifact instead of an
implicit per-adapter decision.

- New pure module `src/bernstein/core/agents/context_manifest.py` with
  `derive_context_manifest(*, repo_root, declared_paths)`. It reads a task's
  declared path set — `Task.owned_files` — and returns entries in declared
  order, deduplicated, each resolvable file addressed as `sha256:<hex>` of its
  bytes, with a manifest digest over the whole list.
- A path that does not resolve keeps its position and records `unmanifested`
  with a reason code (`missing`, `not_a_file`, `unreadable`, `outside_root`,
  `invalid_path`). The entry count never shrinks below the number of distinct
  declared paths.
- `first_manifest_divergence(left, right)` names the first entry two manifests
  disagree on, with both sides' hashes.
- New `bernstein context manifest <task-id>` on the existing `context` group,
  next to `show` and `verify`, with `--workdir` and `--json`.

**Explicitly not in this PR** — each named as out of scope by the issue's own
step-1 boundary:

- Anchoring the manifest digest in the run record or exposing it on the receipt.
  `build_context_capsule` / `seal_and_bind` are the natural anchor point but
  have no production call site on `main` today, so wiring a digest into a live
  run is its own piece of work.
- Replay's manifest-first divergence check. The comparison primitive is here;
  nothing in the replay path calls it yet.
- Symbol-range entries — those need the code graph from #3237, which is open.
- Any adapter change. Nothing reads the manifest during a run, so no adapter
  behaviour can move.

## Why

When two runs of the same task diverge, the journal can prove the tool calls
differed but not why. One input is systematically unrecorded: which files, at
which content, reached the prompt. That is decided per-adapter and per-run and
left implicit, so a divergence cannot be attributed to context drift — the
context set was never an artifact anyone could compare.

`bernstein context show` and `verify` already answer "what was this worker
given" for identity, params, budget envelope and chain head. The file set the
task declares is the one part of that answer with no representation at all.
This gives it one, in the same currency the rest of the record uses: content
addresses under the canonical-JSON discipline `ContextCapsule` already follows.

## How

- Entries carry `path`, `digest`, `unmanifested`, `reason`. The manifest
  canonicalises with the same `json.dumps(sort_keys=True, separators=(",", ":"),
  ensure_ascii=False, allow_nan=False)` form as
  `ContextCapsule.canonical_bytes`, so the digest is a function of the declared
  path set and the bytes behind it, never of the order the tree was walked in.
- Files are hashed in 1 MiB chunks, so a large declared file is not held in
  memory to be addressed.
- Containment is applied before any file is opened, not after. A declared path
  is externally influenced — it arrives on a task from the API, the CLI, or an
  issue body — so it goes through `validate_relative_path` and then
  `contained_subpath`. A path that escapes the root, including an
  ordinary-looking component that is a symlink out of the tree, is recorded
  `outside_root` and its bytes are never read.
- `PathTooLongError` is separated from its parent deliberately: it is a capacity
  failure, not an escape, so it records `invalid_path` rather than
  `outside_root`.
- The CLI loads the persisted task with the same `TaskStore(jsonl_path=...,
  archive_path=...)` + `replay_jsonl()` idiom `maintenance_cmd.py` uses, derives
  over `--workdir`, and prints the digest, the entry count, the unmanifested
  count, and every entry. Exit 1 when there is no such task; unmanifested
  entries are reported, not treated as a failure.

**Two decisions the issue left open, and why they were settled this way:**

1. **`contained_subpath`, not `contained_path`.** The issue points at
   `contained_path`, but that helper validates each argument as a *single*
   opaque path segment, while `owned_files` entries are multi-component relative
   paths (`src/pkg/mod.py`). `contained_subpath` is the multi-component
   counterpart in the same module and applies both halves of the same barrier.
   Using `contained_path` would have made every declared path report as invalid.

2. **The dedup key is the normalised path, and the entry carries that form.**
   Declared paths are folded to repository-relative POSIX form
   (`posixpath.normpath` over separator-normalised input) before dedup. Without
   this, `src/a.py` and `./src/a.py` are two entries with the same hash and two
   different manifest digests — the digest would be a function of how someone
   spelled the path, which defeats the whole point of comparing two runs.
   Backslashes are folded too, since a task is written on one host and derived
   on another. A normalised path that names the root itself (`""`, `"."`) is
   recorded `invalid_path` rather than silently dropped.

## Tests

Each test is named for the property it protects, and each failed before the
change: the module tests failed at collection (`bernstein.core.agents.context_manifest`
did not exist) and the three CLI tests failed with exit code 2 (`context` had no
`manifest` subcommand).

`tests/unit/test_context_manifest.py`:

1. `test_manifest_digest_is_a_function_of_the_bytes_not_the_walk` —
   **load-bearing.** Two derivations over the same tree produce byte-identical
   canonical bytes and the same digest. Everything later in #3366 rests on this:
   without it, anchoring the digest in a run record records noise, and comparing
   two manifests proves nothing.
2. `test_single_byte_edit_changes_the_digest_and_names_the_first_differing_entry`
   — a one-byte edit to one declared file moves the digest, and the divergence
   is reported at the right index with both hashes.
3. `test_missing_path_is_unmanifested_and_does_not_shrink_the_entry_count` — an
   unresolvable path keeps its position, records `missing`, and the entries
   around it still carry bytes.
4. `test_directory_and_unreadable_entries_carry_distinct_reason_codes` — a
   directory reports `not_a_file` and a mode-0200 file reports `unreadable`;
   they are not collapsed into one "could not read" case.
5. `test_path_escaping_the_repo_root_is_unmanifested_and_its_bytes_are_never_read`
   — `../outside.txt`, an absolute path and an empty string are refused, and the
   outside file's contents appear nowhere in the canonical bytes.
6. `test_symlinked_entry_pointing_out_of_the_root_is_unmanifested` — the case
   the string check alone cannot catch: an ordinary-looking component that is a
   symlink out of the tree reports `outside_root`.
7. `test_declared_order_is_preserved_and_duplicate_paths_collapse_to_one_entry` —
   the manifest is the declared order deduplicated, not a sorted walk.
8. `test_digest_is_independent_of_how_the_same_path_was_spelled` — pins decision
   2 above: `./src/pkg/a.py`, `src\pkg\a.py`, and a redundant re-declaration all
   digest identically to `src/pkg/a.py`.

`tests/unit/test_context_cmd.py`:

9. `test_context_manifest_addresses_declared_files_and_names_unmanifested_entries`
   — the operator surface shows both a hash and an unmanifested entry with its
   reason.
10. `test_context_manifest_json_carries_the_digest_and_every_entry` — the
    machine-readable form carries the digest, the counts, and every entry in
    declared order.
11. `test_context_manifest_exits_nonzero_for_an_unknown_task` — an unknown task
    id exits 1 rather than printing an empty manifest.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes (run over the changed files)
- [x] `uv run python scripts/run_tests.py -x` passes for the new and changed
      test files
- [x] New code has type hints

### Documentation duty

- [ ] User-visible README section updated — **N/A**: this adds a subcommand to an
      existing group the README does not enumerate.
- [x] `docs/operations/<area>.md` updated — new "Declared context manifest"
      section in `docs/operations/context-policy.md` with the reason-code table
      and the exit codes.
- [ ] `docs/api/` schema regenerated — **N/A**: no HTTP or MCP surface changed.
- [x] `uv run bernstein agents-md sync` run — produced no diff; the new module
      lives under an already-mapped package.
- [x] Tests cover the documented behaviour: every reason code in the new table
      is asserted by tests 3-6.

Also adds `docs/release-notes/fragments/3366-context-manifest-derivation.md`.

Part of #3366

## Remaining

- Anchor the manifest digest in the run record and expose it on the receipt, so
  a third party can verify what the agent was shown offline. Needs a production
  call site for `build_context_capsule` / `seal_and_bind` first — there is none
  on `main` today.
- Replay: manifest comparison as the first divergence check, naming the first
  differing entry before any step is re-driven. `first_manifest_divergence` is
  the primitive; the replay wiring is not done.
- Symbol-range entries, once the code graph from #3237 lands.
- Surface `unmanifested` entries in the run summary — this PR surfaces them only
  on the `context manifest` command.
