### PR TITLE
ci: report workflow registrations that no longer have a file on main

### DIFF
--- a/.github/workflows/detached-workflow-canary.yml
+++ b/.github/workflows/detached-workflow-canary.yml
@@ -1,0 +1,127 @@
+name: Detached workflow canary
+
+# A workflow file deleted from `main` keeps running, and keeps failing.
+#
+# GitHub registers a workflow the first time it runs and keeps that
+# registration after the file is deleted. `pull_request` runs execute the
+# workflow file from the pull request's merge ref, so any branch opened before
+# the deletion still carries the file and still runs it. The registration stays
+# `active`, the runs still spend runner slots, and their failures still show up
+# on the pull request - for a lane the repository decided to remove.
+#
+# This happened here. `.github/workflows/review-bot-ack.yml` was removed in
+# #3780. It then ran 2125 more times between 2026-08-03 and 2026-08-23, 13.0%
+# of them failing and 52.5% cancelled, entirely from branches predating the
+# removal. Nothing in the repository could see it: the file was gone, so no
+# in-tree check could name it, and the runs looked like an ordinary lane
+# failing. `.github/workflows/main-red-guard.yml` is in the same state today -
+# deleted from `main`, registration still `active`.
+#
+# So this checks the one thing an in-tree check cannot: what the repository is
+# actually running, against what it actually contains.
+#
+# Advisory on purpose. The finding is "somebody should disable a registration",
+# which is a repository-settings action a workflow should not take by itself,
+# and a red weekly job would be a worse signal than a summary that names the
+# workflow and the command.
+
+on:
+  schedule:
+    # Weekly, offset from the other Monday audits so they do not contend.
+    - cron: "43 8 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: detached-workflow-canary-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  canary:
+    name: Detached workflow canary
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Advisory: the action this reports is a settings change a human makes.
+    continue-on-error: true
+    permissions:
+      contents: read
+      # Read-only listing of workflow registrations and their recent runs.
+      actions: read
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Compare registered workflows with the committed ones
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          # Only registrations that actually ran recently are interesting. A
+          # registration with no recent runs is inert; one that is still
+          # producing runs is spending slots on a lane that no longer exists.
+          LOOKBACK_DAYS: "30"
+        run: |
+          set -euo pipefail
+
+          since="$(date -u -d "-${LOOKBACK_DAYS} days" +%Y-%m-%dT%H:%M:%SZ)"
+          detached=""
+
+          # `dynamic/...` paths are GitHub-managed workflows (Dependabot,
+          # code scanning, Pages). They have no file in any repository and
+          # are not what this looks for.
+          while IFS=$'\t' read -r id state wf_path; do
+            case "${wf_path}" in
+              dynamic/*) continue ;;
+            esac
+            [ "${state}" = "active" ] || continue
+            [ -f "${wf_path}" ] && continue
+
+            recent="$(gh api "repos/${GH_REPO}/actions/workflows/${id}/runs?per_page=100&created=>=${since}" \
+              --jq '.total_count' 2>/dev/null || echo 0)"
+            [ "${recent}" -gt 0 ] || continue
+
+            detached="${detached}| \`${wf_path}\` | ${id} | ${recent} |"$'\n'
+          done < <(gh api --paginate "repos/${GH_REPO}/actions/workflows" \
+                     --jq '.workflows[] | [.id, .state, .path] | @tsv')
+
+          if [ -z "${detached}" ]; then
+            {
+              echo "### Detached workflow canary"
+              echo
+              echo "Every active workflow registration that ran in the last"
+              echo "${LOOKBACK_DAYS} days has a file on this ref."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          {
+            echo "### Detached workflows are still running"
+            echo
+            echo "These workflow registrations are \`active\` and produced runs"
+            echo "in the last ${LOOKBACK_DAYS} days, but have no file on this"
+            echo "ref. They are running from branches that predate their"
+            echo "deletion, spending runner slots and reporting results for"
+            echo "lanes this repository removed."
+            echo
+            echo "| path | workflow id | runs in the last ${LOOKBACK_DAYS} days |"
+            echo "| --- | --- | --- |"
+            printf '%s' "${detached}"
+            echo
+            echo "To stop one, disable its registration:"
+            echo
+            echo '```'
+            echo "gh api -X PUT repos/${GH_REPO}/actions/workflows/<id>/disable"
+            echo '```'
+            echo
+            echo "Disabling is reversible (\`/enable\`) and does not touch any"
+            echo "workflow file."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "::warning::detached workflow registrations are still producing runs; see the job summary"

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -6022,6 +6022,7 @@ class TestAdaptivePollingBackoff:
         assert hasattr(orch, "_idle_multiplier")
         assert orch._idle_multiplier == 1
 
+
 # --- Reverse task-to-session index ---
 
 

--- a/verify_cli/bernstein_verify_receipt/__main__.py
+++ b/verify_cli/bernstein_verify_receipt/__main__.py
@@ -75,9 +75,7 @@ def cli() -> None:
     show_default=True,
     help="Which format(s) to verify.",
 )
-@click.option(
-    "--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details."
-)
+@click.option("--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details.")
 def verify_cmd(
     receipt_path: Path,
     jwk_path: Path | None,

--- a/verify_cli/bernstein_verify_receipt/verify.py
+++ b/verify_cli/bernstein_verify_receipt/verify.py
@@ -291,8 +291,7 @@ def verify_subject_binding(receipt: dict[str, Any]) -> tuple[CheckResult, str]:
                 "subject_binding",
                 ok=False,
                 detail=(
-                    f"recomputed head {recomputed[:16]}… "
-                    f"!= range.head_sha256 {range_head[:16]}…"
+                    f"recomputed head {recomputed[:16]}… != range.head_sha256 {range_head[:16]}…"
                 ),
             ),
             recomputed,
@@ -418,10 +417,7 @@ def verify_intoto(receipt: dict[str, Any], public_key: Any, recomputed_head: str
         return CheckResult(
             "intoto",
             ok=False,
-            detail=(
-                f"recomputed head {recomputed_head[:16]}… "
-                f"not in statement subject digests"
-            ),
+            detail=(f"recomputed head {recomputed_head[:16]}… not in statement subject digests"),
         )
     return CheckResult("intoto", ok=True, detail="DSSE/in-toto verified, subject bound to head")
 
@@ -469,8 +465,7 @@ def verify_transparency(
             "transparency",
             ok=False,
             detail=(
-                f"STH subject {subject_sha256[:16]}… "
-                f"!= recomputed head {recomputed_head[:16]}…"
+                f"STH subject {subject_sha256[:16]}… != recomputed head {recomputed_head[:16]}…"
             ),
         )
 
@@ -510,10 +505,7 @@ def verify_transparency(
             return CheckResult(
                 "transparency",
                 ok=False,
-                detail=(
-                    f"inclusion proof root {proven_root[:16]}… "
-                    f"!= STH root {root_hash[:16]}…"
-                ),
+                detail=(f"inclusion proof root {proven_root[:16]}… != STH root {root_hash[:16]}…"),
             )
     return CheckResult(
         "transparency", ok=True, detail="RFC6962 STH signed, root + inclusion proof verified"


### PR DESCRIPTION
## What

Adds `.github/workflows/detached-workflow-canary.yml`: a weekly, advisory job
that lists workflow registrations which are `active`, produced runs in the last
30 days, and have no file on the checked-out ref. It writes a job summary and a
`::warning::`. It changes nothing and never fails.

## Why

A workflow file deleted from `main` keeps running, and keeps failing, and
nothing in the repository can see it.

GitHub registers a workflow the first time it runs and keeps the registration
after the file is deleted. `pull_request` runs execute the workflow file from
the pull request's merge ref, so every branch opened before the deletion still
carries the file and still runs it.

`.github/workflows/review-bot-ack.yml` was removed in #3780. Over the 30 days
to 2026-09-01 it ran anyway:

| metric | value |
| --- | --- |
| runs in the window | 2,125 |
| of which failed | 276 (13.0%) |
| of which cancelled | 1,116 (52.5%) |
| distinct branches driving them | 12+ (`fix/2980-mypy-orchestration` 71, `fix/tenant-id-validation` 67, `agy/3140-fold-subcommands` 63, ...) |
| last run | 2026-08-23 |

For scale: 2,125 runs is 4.6% of the 45,767 workflow runs in that window, from
a lane the repository had already decided to remove. Its 13.0% failure rate was
landing on unrelated pull requests. The two companion registrations
(`review-bot-ack-publish.yml`, `review-bot-sweep.yml`) reached the `deleted`
state on their own and stopped; this one did not.

Nothing in-tree could catch it. Every existing guard reasons about files that
are present -- `required-check-canary` over `CI gate` emitters,
`ci-topology-heal` over the topology report, `branch-protection-audit` over
protection settings. A file that is gone is invisible to all of them. The only
place the evidence exists is the list of registrations, which is API state, not
tree state.

It is not over. `.github/workflows/main-red-guard.yml` is in the same
condition today: absent from `main`, registration still `active`. It is quiet
only because no current branch happens to carry it.

## How

One job. Lists registrations via `gh api --paginate`, skips the
GitHub-managed `dynamic/...` entries, skips anything not `active`, skips
anything whose path exists in the checkout, and then asks each survivor for its
run count in the last 30 days. Only registrations that are both detached and
still producing runs are reported.

The summary names the workflow, its id, its recent run count, and the
`gh api -X PUT .../disable` command that stops it.

Weekly cron at 08:43 Monday, offset from the other Monday audits so they do not
contend for slots. Roughly 4 runs a month, under a minute each.

## Risk

- **Advisory only.** `continue-on-error` is set at job level, and the finding is
  a repository-settings action a human takes. A workflow that disabled
  registrations by itself would be a worse thing than the problem.
- **False positives.** A registration first seen on a branch whose file has not
  merged yet would be listed. The `active` + recent-runs filters narrow it, but
  the summary is a prompt to look, not a verdict.
- **Permissions.** New workflow, `contents: read` plus `actions: read`. No
  existing grant is changed, and read-only listing is the minimum the check
  needs.
- **How to see it working:** run it from the Actions tab; today it should list
  `.github/workflows/main-red-guard.yml` only if that registration has produced
  runs in the last 30 days, and otherwise report a clean result.

## Checklist

- [x] No check is disabled, weakened or removed
- [x] No existing permission is widened
- [x] Not a required context; cannot gate a merge
- [x] No release, publish, signing or artefact-upload workflow touched
- [x] No branch protection or ruleset change
- [x] `actionlint` clean; `zizmor` reports no findings