### PR TITLE
ci: shard the macOS nightly suite so it finishes inside its timeout

### DIFF
--- a/.github/workflows/ci-macos-nightly.yml
+++ b/.github/workflows/ci-macos-nightly.yml
@@ -54,11 +54,17 @@ permissions:
 
 jobs:
   test-macos-nightly:
-    name: Test (macos-latest, Python ${{ matrix.python-version }})
+    name: Test (macos-latest, Python ${{ matrix.python-version }}, shard ${{ matrix.shard }})
     runs-on: macos-latest
     timeout-minutes: 90
     permissions:
       contents: read
+    env:
+      # Mirrors MACOS_SHARD_COUNT in ci.yml's `test-macos` job, which is
+      # itself pinned to TEST_SHARD_COUNT in `test`. The three move
+      # together; this lane is only comparable to `test-macos` if it
+      # splits the suite the same way.
+      MACOS_SHARD_COUNT: "4"
     strategy:
       fail-fast: false
       matrix:
@@ -67,6 +73,9 @@ jobs:
         # matrix is restored, but for now nightly tracks the supported
         # cell.
         python-version: ["3.13"]
+        # Sharded for the same reason ci.yml's `test-macos` is: the whole
+        # suite in one macOS cell does not finish inside timeout-minutes.
+        shard: [1, 2, 3, 4]
     steps:
       - name: Harden runner (audit mode)
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -79,12 +88,24 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run isolated test suite
-        run: uv run python scripts/run_tests.py --parallel 4
+        env:
+          SHARD: ${{ matrix.shard }}
+          SHARD_COUNT: ${{ env.MACOS_SHARD_COUNT }}
+        # Deterministic disjoint slice of the same file list, exactly as
+        # ci.yml's `test-macos` shards it on push. Every file still runs;
+        # it runs on one of four cells instead of all of them on one.
+        run: |
+          uv run python scripts/run_tests.py --parallel 4 \
+            --shard "${SHARD}/${SHARD_COUNT}"
       - name: Run capability-matrix spawn-refusal integration tests
+        # Shard 1 only: these two suites are not sharded, so without this
+        # gate they would run four times per night instead of once.
+        if: matrix.shard == 1
         run: |
           uv run pytest tests/integration/test_capability_matrix_spawn_refusal.py \
             -x -q --tb=short --timeout=120
       - name: Run fake-CLI adapter integration tests
+        if: matrix.shard == 1
         run: uv run pytest tests/integration/test_adapter_e2e.py -x -q --timeout=60
 
   open-failure-issue:

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -6022,6 +6022,7 @@ class TestAdaptivePollingBackoff:
         assert hasattr(orch, "_idle_multiplier")
         assert orch._idle_multiplier == 1
 
+
 # --- Reverse task-to-session index ---
 
 

--- a/verify_cli/bernstein_verify_receipt/__main__.py
+++ b/verify_cli/bernstein_verify_receipt/__main__.py
@@ -75,9 +75,7 @@ def cli() -> None:
     show_default=True,
     help="Which format(s) to verify.",
 )
-@click.option(
-    "--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details."
-)
+@click.option("--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details.")
 def verify_cmd(
     receipt_path: Path,
     jwk_path: Path | None,

--- a/verify_cli/bernstein_verify_receipt/verify.py
+++ b/verify_cli/bernstein_verify_receipt/verify.py
@@ -291,8 +291,7 @@ def verify_subject_binding(receipt: dict[str, Any]) -> tuple[CheckResult, str]:
                 "subject_binding",
                 ok=False,
                 detail=(
-                    f"recomputed head {recomputed[:16]}… "
-                    f"!= range.head_sha256 {range_head[:16]}…"
+                    f"recomputed head {recomputed[:16]}… != range.head_sha256 {range_head[:16]}…"
                 ),
             ),
             recomputed,
@@ -418,10 +417,7 @@ def verify_intoto(receipt: dict[str, Any], public_key: Any, recomputed_head: str
         return CheckResult(
             "intoto",
             ok=False,
-            detail=(
-                f"recomputed head {recomputed_head[:16]}… "
-                f"not in statement subject digests"
-            ),
+            detail=(f"recomputed head {recomputed_head[:16]}… not in statement subject digests"),
         )
     return CheckResult("intoto", ok=True, detail="DSSE/in-toto verified, subject bound to head")
 
@@ -469,8 +465,7 @@ def verify_transparency(
             "transparency",
             ok=False,
             detail=(
-                f"STH subject {subject_sha256[:16]}… "
-                f"!= recomputed head {recomputed_head[:16]}…"
+                f"STH subject {subject_sha256[:16]}… != recomputed head {recomputed_head[:16]}…"
             ),
         )
 
@@ -510,10 +505,7 @@ def verify_transparency(
             return CheckResult(
                 "transparency",
                 ok=False,
-                detail=(
-                    f"inclusion proof root {proven_root[:16]}… "
-                    f"!= STH root {root_hash[:16]}…"
-                ),
+                detail=(f"inclusion proof root {proven_root[:16]}… != STH root {root_hash[:16]}…"),
             )
     return CheckResult(
         "transparency", ok=True, detail="RFC6962 STH signed, root + inclusion proof verified"


### PR DESCRIPTION
## What

Splits `test-macos-nightly` in `.github/workflows/ci-macos-nightly.yml` across
four shards, the same way `ci.yml`'s `test-macos` job already splits the same
suite. The two unsharded integration suites are gated to shard 1 so they still
run once per night, not four times.

## Why

The macOS safety net has not been working, and its failure mode is silent.

The workflow header states the intent: "this workflow runs the full macOS
matrix daily at 06:00 UTC so any drift that slipped past the PR gate is caught
within 24 hours", and "The job mirrors the `test` matrix in ci.yml so the
signal is directly comparable."

It does not mirror it. `ci.yml`'s `test-macos` shards the file list four ways
(`MACOS_SHARD_COUNT: "4"`, `shard: [1, 2, 3, 4]`). This lane runs the whole
list in one macOS cell, under the same `timeout-minutes: 90`.

The last 30 scheduled runs:

| outcome | runs | durations (minutes) |
| --- | --- | --- |
| cancelled | 18 (60%) | 35, 76, 90, 90, 90, 90, 91, 91, 91, 91, 91, 91, 91, 91, 93, 106, 108, 114 |
| success | 11 (37%) | 68, 72, 77, 79, 79, 82, 83, 83, 84, 85, 86 |
| failure | 1 (3%) | 72 |

Fifteen of the eighteen cancellations sit at 90-91 minutes: that is
`timeout-minutes` firing, not an operator. The eleven that finished did so
between 68 and 86 minutes -- against a 90-minute bound. The lane is not a
safety net, it is a coin flip with a four-minute margin, and it has been
losing the toss six nights in ten.

It is silent about it, too. The `open-failure-issue` job is gated on
`if: failure()`. A job stopped by `timeout-minutes` resolves as `cancelled`,
not `failure`, so none of those eighteen nights opened the tracking issue the
job exists to open. macOS drift was neither checked nor reported.

Cost, meanwhile, is real. Eighteen runs x ~90 minutes is about 1,620 minutes of
macOS runner time in 30 days for no signal, and macOS is the scarcest pool this
repository draws on: in a 1,400-run sample, macOS jobs are 4.0% of jobs but
29.4% of all time spent waiting for a runner, with a p95 queue wait of 78
minutes against 3.7 minutes on ubuntu. Each night this lane holds one of those
slots for an hour and a half and then throws the result away.

Sharded, each cell runs roughly a quarter of the files -- about 20 to 25
minutes on the evidence above -- with the same 90-minute bound as headroom.

## How

Mirrors `test-macos` rather than inventing a second scheme:

- `MACOS_SHARD_COUNT: "4"` at job scope, with a comment tying it to the same
  constant in `ci.yml`, which is itself tied to `TEST_SHARD_COUNT`.
- `shard: [1, 2, 3, 4]` in the matrix; `fail-fast: false` was already set, so
  one bad shard still lets the others report.
- `scripts/run_tests.py --shard "${SHARD}/${SHARD_COUNT}"`, the same
  deterministic disjoint slice the other lane uses. Every file still runs.
- The job name gains `shard ${{ matrix.shard }}`, matching `test-macos`. No
  branch-protection context depends on this name (the required contexts are
  `CI gate` and `shipped bundle matches the lockfile`).
- `if: matrix.shard == 1` on the capability-matrix and fake-CLI adapter
  integration steps: those two suites are not sharded, so without the gate they
  would go from once a night to four times.

## Risk

- **Four macOS cells instead of one.** The macOS pool is small, which is the
  argument for this change rather than against it: four cells for ~22 minutes
  finish sooner than one cell for 90, and the cron is at 06:00 UTC, chosen in
  the header as the least contended hour. Total macOS minutes go down, because
  60% of them are currently spent on runs that are thrown away.
- **A shard boundary hides a test.** `scripts/run_tests.py --shard i/N` is the
  same selection `test-macos` and `test` already rely on for every push and
  every pull request; this lane is adopting it, not introducing it.
- **The two gated suites.** If shard 1 is cancelled they do not run. They also
  do not run today whenever the single cell times out, which is 60% of nights.
- **How to see it working:** the next scheduled run should show four
  `Test (macos-latest, Python 3.13, shard N)` jobs, each well under 90 minutes,
  and the run should conclude `success` or `failure` rather than `cancelled`.

Separately, `open-failure-issue` should probably also fire on a cancelled run
so a future timeout is not silent again. That is a different change and is not
made here.

## Checklist

- [x] No check is disabled, weakened or removed -- the same files still run
- [x] No permission is widened
- [x] No required context renamed (`CI gate` and the bundle check are untouched)
- [x] No release, publish, signing or artefact-upload workflow touched
- [x] No branch protection or ruleset change
- [x] Shard count and mechanism copied from the existing `test-macos` job
- [x] `actionlint` clean