### PR TITLE
ci: set explicit artifact retention on the two uploads that have none

### DIFF
--- a/.github/workflows/bernstein-issues-decompose.yml
+++ b/.github/workflows/bernstein-issues-decompose.yml
@@ -137,6 +137,10 @@ jobs:
           name: issue-decompose-plan-${{ github.event.issue.number }}
           path: issue-decompose-plan.md
           if-no-files-found: error
+          # The plan is consumed by the scope gate in the same run and read by
+          # a maintainer shortly after; without this it inherits the
+          # repository default of 90 days.
+          retention-days: 14
 
   scope_gate:
     name: Require approved file scope

--- a/.github/workflows/trace-conformance.yml
+++ b/.github/workflows/trace-conformance.yml
@@ -102,3 +102,8 @@ jobs:
           name: trace-conformance-report
           path: trace-conformance-report/
           if-no-files-found: warn
+          # The report is read while the run is still on someone's screen;
+          # without this it inherits the repository default of 90 days. Every
+          # other retained artefact in this repository sets 7, 14, 30 or 90
+          # deliberately, so state the intent here too.
+          retention-days: 14

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -6022,6 +6022,7 @@ class TestAdaptivePollingBackoff:
         assert hasattr(orch, "_idle_multiplier")
         assert orch._idle_multiplier == 1
 
+
 # --- Reverse task-to-session index ---
 
 

--- a/verify_cli/bernstein_verify_receipt/__main__.py
+++ b/verify_cli/bernstein_verify_receipt/__main__.py
@@ -75,9 +75,7 @@ def cli() -> None:
     show_default=True,
     help="Which format(s) to verify.",
 )
-@click.option(
-    "--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details."
-)
+@click.option("--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details.")
 def verify_cmd(
     receipt_path: Path,
     jwk_path: Path | None,

--- a/verify_cli/bernstein_verify_receipt/verify.py
+++ b/verify_cli/bernstein_verify_receipt/verify.py
@@ -291,8 +291,7 @@ def verify_subject_binding(receipt: dict[str, Any]) -> tuple[CheckResult, str]:
                 "subject_binding",
                 ok=False,
                 detail=(
-                    f"recomputed head {recomputed[:16]}… "
-                    f"!= range.head_sha256 {range_head[:16]}…"
+                    f"recomputed head {recomputed[:16]}… != range.head_sha256 {range_head[:16]}…"
                 ),
             ),
             recomputed,
@@ -418,10 +417,7 @@ def verify_intoto(receipt: dict[str, Any], public_key: Any, recomputed_head: str
         return CheckResult(
             "intoto",
             ok=False,
-            detail=(
-                f"recomputed head {recomputed_head[:16]}… "
-                f"not in statement subject digests"
-            ),
+            detail=(f"recomputed head {recomputed_head[:16]}… not in statement subject digests"),
         )
     return CheckResult("intoto", ok=True, detail="DSSE/in-toto verified, subject bound to head")
 
@@ -469,8 +465,7 @@ def verify_transparency(
             "transparency",
             ok=False,
             detail=(
-                f"STH subject {subject_sha256[:16]}… "
-                f"!= recomputed head {recomputed_head[:16]}…"
+                f"STH subject {subject_sha256[:16]}… != recomputed head {recomputed_head[:16]}…"
             ),
         )
 
@@ -510,10 +505,7 @@ def verify_transparency(
             return CheckResult(
                 "transparency",
                 ok=False,
-                detail=(
-                    f"inclusion proof root {proven_root[:16]}… "
-                    f"!= STH root {root_hash[:16]}…"
-                ),
+                detail=(f"inclusion proof root {proven_root[:16]}… != STH root {root_hash[:16]}…"),
             )
     return CheckResult(
         "transparency", ok=True, detail="RFC6962 STH signed, root + inclusion proof verified"


### PR DESCRIPTION
## What

Adds `retention-days: 14` to the two `actions/upload-artifact` steps in this
repository that do not set it:

| workflow | artifact |
| --- | --- |
| `trace-conformance.yml` | `trace-conformance-report` |
| `bernstein-issues-decompose.yml` | `issue-decompose-plan-<issue>` |

## Why

There are 33 `upload-artifact` steps across `.github/workflows/`. 31 of them
set `retention-days` explicitly, with values chosen per artifact:

| value | steps |
| --- | --- |
| 1 day | 2 |
| 7 days | 3 |
| 14 days | 14 |
| 30 days | 4 |
| 90 days | 2 |

The remaining steps fall through to the repository default, which is 90 days
(and 90 is also this repository's configured maximum). So two short-lived
debugging artefacts are being kept for the longest period the repository
allows, purely because nobody wrote the number down.

The decompose plan is the more visible of the two: it is uploaded per issue
number, and issue-triggered workflows are among the highest-volume in the
repository, so the artefact accumulates one copy per decomposition attempt.

14 days matches the value already used by 14 of the 31 explicit steps, and is
the value already chosen for comparable debugging output elsewhere in the
repository.

## How

Four and five added lines respectively: the `retention-days` key plus a
comment saying what the artefact is for and why the number is short.

No step, trigger, permission, artifact name or path changes. The artefacts are
still uploaded, and are still there while anyone is likely to look at them.

## Risk

An artefact needed more than 14 days after its run would no longer be there.
Both are run-scoped debugging output rather than evidence: the conformance
report is a rendering of a result the run page already shows, and the plan is
consumed by the scope gate inside the same run.

If someone does need one later, the run can be re-run, and the fix is to raise
the number for that artefact.

Nothing that signs, publishes or releases is touched -- the `dist` artefact in
the publish workflow keeps the retention it has today.

## Checklist

- [x] No check is disabled, weakened or removed
- [x] No permission is widened
- [x] No release, publish, signing or artefact-upload-to-release workflow touched
- [x] No branch protection or ruleset change
- [x] Value matches the most common explicit value already in the repository
