### PR TITLE
ci: recapture the web UI renders on runners when the SPA bundle moves

### DIFF
--- a/.github/workflows/webui-render-recapture.yml
+++ b/.github/workflows/webui-render-recapture.yml
@@ -1,0 +1,192 @@
+name: Web UI render recapture
+
+# A dependency bump that rebuilds the shipped SPA turns three checks red for
+# one cause, and the fix needs a browser the author may not have.
+#
+# The chain, from this repository's own history:
+#
+#   1. `spa-bundle-freshness.yml` requires the committed bundle under
+#      `src/bernstein/gui/static/` to match a rebuild from
+#      `web/package-lock.json`. A frontend dependency bump therefore has to
+#      carry the rebuilt bundle.
+#   2. The rebuilt bundle has new content-hashed asset filenames, so the
+#      digest in `docs/assets/webui-renders.json` no longer matches.
+#   3. That fails `bind_webui_renders.py`, which fails the "Operator-surface
+#      render freshness" step of `Repo hygiene`, and independently fails
+#      `tests/unit/test_webui_render_binding.py` in whichever `test` shard
+#      that file lands in, and therefore the aggregate `CI gate`.
+#
+# Four pull-request runs in the 30 days to 2026-09-01 ended this way, on
+# `renovate/tanstack-query-monorepo` and `renovate/vite-8.x-lockfile`. The
+# failing shard was 2, 3 and 4 on different occasions, so the same defect
+# does not cluster in per-job failure statistics and reads as three unrelated
+# shard failures.
+#
+# Clearing it means re-running `scripts/capture_webui_renders.py`, which
+# boots `bernstein gui serve` and drives headless Chromium over ten screens.
+# An automation-authored pull request cannot do that, and a human has to
+# install Playwright locally to do it for them. Two commits on `main` in that
+# same window (#4552, #4027) exist only to carry that catch-up work.
+#
+# This lane does the capture on a runner and publishes the result as an
+# artifact. It deliberately does NOT commit anything and does NOT rebind
+# without recapturing:
+#
+#   * the guarantee `bind_webui_renders.py` holds is that nobody shipped a UI
+#     change while leaving the published screenshots behind. Rebinding
+#     without capturing would assert that the committed screenshots show the
+#     new bundle when nobody looked, which is the one thing the gate exists
+#     to prevent;
+#   * so `Repo hygiene` and the binding test still fail, exactly as today.
+#     What changes is the cost of clearing them: download an artifact and
+#     commit it, instead of reproducing a browser capture locally.
+#
+# The job never fails. It holds no write permission, and it is not a required
+# context, so nothing it does can gate a merge.
+
+on:
+  pull_request:
+    paths:
+      - 'web/**'
+      - 'src/bernstein/gui/static/**'
+      - 'docs/assets/webui-renders.json'
+      - 'scripts/capture_webui_renders.py'
+      - 'scripts/bind_webui_renders.py'
+      # Listed so a change to this lane exercises itself on its own pull
+      # request rather than first proving itself on somebody else's.
+      - '.github/workflows/webui-render-recapture.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: webui-render-recapture-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+# Read-only, deliberately. This lane publishes an artifact; it does not push
+# to the pull request branch.
+permissions:
+  contents: read
+
+jobs:
+  recapture:
+    name: Recapture the web UI renders
+    runs-on: ubuntu-latest
+    # The whole job, not just the capture step: `npm ci`, a Chromium download
+    # and a booted server all have their own ways to fail, and none of them is
+    # a statement about the pull request. A breakage here is reported in the
+    # job summary rather than as a red check.
+    continue-on-error: true
+    # Chromium download plus ten captures against a booted server. Observed
+    # cost of the parts that already run in CI (npm ci + npm run build) is
+    # under a minute; the browser is the rest.
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7 # zizmor: ignore[cache-poisoning]
+        with:
+          node-version: '24'
+
+      - name: Set up uv
+        uses: ./.github/actions/bootstrap
+        with:
+          python-version: '3.13'
+
+      - name: Install web dependencies
+        working-directory: web
+        run: npm ci
+
+      - name: Rebuild the shipped bundle
+        # Same two commands the required `shipped bundle matches the lockfile`
+        # lane runs. On a pull request that already carries the rebuilt bundle
+        # this is a no-op; on one that does not, it produces the bundle the
+        # renders have to be captured against either way.
+        working-directory: web
+        run: npm run build
+
+      - name: Install the project
+        run: uv sync
+
+      - name: Install Chromium for Playwright
+        run: uv run --with playwright python -m playwright install --with-deps chromium
+
+      - name: Recapture the renders
+        id: capture
+        # Never redden the pull request. A browser capture has more ways to
+        # fail than the thing it is helping with, and this lane is a
+        # convenience, not a gate: if it breaks, the author is exactly where
+        # they are today.
+        continue-on-error: true
+        env:
+          # The script builds a throwaway git repository for the seeded
+          # screens; give it an identity so `git commit` there cannot prompt.
+          GIT_AUTHOR_NAME: bernstein-ci
+          GIT_AUTHOR_EMAIL: ci@bernstein.invalid
+          GIT_COMMITTER_NAME: bernstein-ci
+          GIT_COMMITTER_EMAIL: ci@bernstein.invalid
+        run: |
+          set -euo pipefail
+          uv run --with playwright python scripts/capture_webui_renders.py
+          uv run python scripts/bind_webui_renders.py --update
+
+      - name: Report what changed
+        id: diff
+        if: always()
+        run: |
+          set -euo pipefail
+          CHANGED="$(git status --porcelain --untracked-files=all -- docs/assets)"
+          if [ -z "$CHANGED" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "### Web UI renders"
+              echo
+              if [ "${CAPTURE_OUTCOME}" = "success" ]; then
+                echo "Recapture produced no change: the committed renders and"
+                echo "binding already match the bundle this branch builds."
+              else
+                echo "The recapture step did not complete, so there is nothing"
+                echo "to publish. See the step log above."
+              fi
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Web UI renders are out of date"
+            echo
+            echo "This branch changes the shipped SPA bundle, so the committed"
+            echo "screenshots under \`docs/assets/\` no longer bind to it."
+            echo
+            echo "Recaptured them on this runner. Download the"
+            echo "\`webui-renders-recaptured\` artifact from this run, unpack it"
+            echo "over \`docs/assets/\`, and commit. That clears the render"
+            echo "freshness step of \`Repo hygiene\`, the binding test, and the"
+            echo "\`CI gate\` roll-up together."
+            echo
+            echo "Files:"
+            echo
+            echo '```'
+            echo "${CHANGED}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          CAPTURE_OUTCOME: ${{ steps.capture.outcome }}
+
+      - name: Upload the recaptured renders
+        if: always() && steps.diff.outputs.changed == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: webui-renders-recaptured
+          path: |
+            docs/assets/webui-*.png
+            docs/assets/webui-renders.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -77,6 +77,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/trunk-health-slo.yml | Trunk Health SLO | schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "trunk-health-slo"} | 1 |
 | .github/workflows/typecheck-ts.yml | TypeScript typecheck | merge_group, pull_request, push | {"cancel-in-progress": "true", "group": "typecheck-ts-${{ github.event.pull_request.number \|\| github.ref }}"} | 1 |
 | .github/workflows/volunteer-verify.yml | Volunteer receipt verification check run | pull_request_target | {"cancel-in-progress": "true", "group": "volunteer-verify-${{ github.event.pull_request.number }}"} | 1 |
+| .github/workflows/webui-render-recapture.yml | Web UI render recapture | pull_request, workflow_dispatch | {"cancel-in-progress": "true", "group": "webui-render-recapture-${{ github.event.pull_request.number \|\| github.ref }}"} | 1 |
 | .github/workflows/zizmor.yml | zizmor (workflow static analysis) | pull_request, push, schedule, workflow_dispatch | {"cancel-in-progress": "${{ github.event_name == 'pull_request' }}", "group": "zizmor-${{ github.ref }}"} | 1 |
 
 ## Check Emitters
@@ -149,6 +150,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/trunk-health-slo.yml | compute: Compute trunk red-rate and toggle the andon marker |
 | .github/workflows/typecheck-ts.yml | typecheck: typecheck (${{ matrix.package }}) |
 | .github/workflows/volunteer-verify.yml | verify: Verify volunteer receipt |
+| .github/workflows/webui-render-recapture.yml | recapture: Recapture the web UI renders |
 | .github/workflows/zizmor.yml | zizmor: zizmor static analysis |
 
 ## Permissions And Secrets
@@ -221,6 +223,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/trunk-health-slo.yml | compute: {"actions": "read", "issues": "write"} | - |
 | .github/workflows/typecheck-ts.yml | workflow: {"contents": "read"}<br>typecheck: {"contents": "read"} | - |
 | .github/workflows/volunteer-verify.yml | verify: {"checks": "write", "contents": "read", "pull-requests": "read"} | GITHUB_TOKEN |
+| .github/workflows/webui-render-recapture.yml | workflow: {"contents": "read"}<br>recapture: {"contents": "read"} | - |
 | .github/workflows/zizmor.yml | workflow: {"contents": "read"}<br>zizmor: {"actions": "read", "contents": "read", "security-events": "write"} | - |
 
 ## Cross-Workflow Calls
@@ -254,3 +257,4 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/soc2-evidence-weekly.yml | pack: upload soc2-evidence-${{ github.run_id }} |
 | .github/workflows/static-analysis-extended.yml | perflint: upload perflint-sarif<br>refurb: upload refurb-sarif<br>semgrep: upload semgrep-sarif<br>trivy-fs: upload trivy-fs-sarif<br>trivy-iac: upload trivy-iac-sarif<br>vulture: upload vulture-sarif |
 | .github/workflows/trace-conformance.yml | trace-tests: upload trace-conformance-report |
+| .github/workflows/webui-render-recapture.yml | recapture: upload webui-renders-recaptured |

--- a/tests/unit/test_merge_queue_gate_coverage_yaml.py
+++ b/tests/unit/test_merge_queue_gate_coverage_yaml.py
@@ -84,6 +84,12 @@ ADVISORY_BY_DECISION = {
         "pre-merge autosync). Its own header already records that none of these is a "
         "required check."
     ),
+    "webui-render-recapture.yml": (
+        "Recaptures the web UI renders on a runner and uploads them as a review artifact when a "
+        "web/** change moves the SPA bundle. It is evidence for the reviewer, not a gate: the check "
+        "that has to fail when the bundle is stale is the required bundle-freshness lane, and this "
+        "lane deliberately never blocks a pull request (#5157)."
+    ),
     "trufflehog.yml": ("Secret scanning. Advisory as configured today; nothing about #4028 changed it."),
     "pr-observability-summary.yml": (
         "Posts a summary on the pull request behind a `deep-review` label. It reports, it "

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -6022,6 +6022,7 @@ class TestAdaptivePollingBackoff:
         assert hasattr(orch, "_idle_multiplier")
         assert orch._idle_multiplier == 1
 
+
 # --- Reverse task-to-session index ---
 
 

--- a/verify_cli/bernstein_verify_receipt/__main__.py
+++ b/verify_cli/bernstein_verify_receipt/__main__.py
@@ -75,9 +75,7 @@ def cli() -> None:
     show_default=True,
     help="Which format(s) to verify.",
 )
-@click.option(
-    "--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details."
-)
+@click.option("--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details.")
 def verify_cmd(
     receipt_path: Path,
     jwk_path: Path | None,

--- a/verify_cli/bernstein_verify_receipt/verify.py
+++ b/verify_cli/bernstein_verify_receipt/verify.py
@@ -291,8 +291,7 @@ def verify_subject_binding(receipt: dict[str, Any]) -> tuple[CheckResult, str]:
                 "subject_binding",
                 ok=False,
                 detail=(
-                    f"recomputed head {recomputed[:16]}… "
-                    f"!= range.head_sha256 {range_head[:16]}…"
+                    f"recomputed head {recomputed[:16]}… != range.head_sha256 {range_head[:16]}…"
                 ),
             ),
             recomputed,
@@ -418,10 +417,7 @@ def verify_intoto(receipt: dict[str, Any], public_key: Any, recomputed_head: str
         return CheckResult(
             "intoto",
             ok=False,
-            detail=(
-                f"recomputed head {recomputed_head[:16]}… "
-                f"not in statement subject digests"
-            ),
+            detail=(f"recomputed head {recomputed_head[:16]}… not in statement subject digests"),
         )
     return CheckResult("intoto", ok=True, detail="DSSE/in-toto verified, subject bound to head")
 
@@ -469,8 +465,7 @@ def verify_transparency(
             "transparency",
             ok=False,
             detail=(
-                f"STH subject {subject_sha256[:16]}… "
-                f"!= recomputed head {recomputed_head[:16]}…"
+                f"STH subject {subject_sha256[:16]}… != recomputed head {recomputed_head[:16]}…"
             ),
         )
 
@@ -510,10 +505,7 @@ def verify_transparency(
             return CheckResult(
                 "transparency",
                 ok=False,
-                detail=(
-                    f"inclusion proof root {proven_root[:16]}… "
-                    f"!= STH root {root_hash[:16]}…"
-                ),
+                detail=(f"inclusion proof root {proven_root[:16]}… != STH root {root_hash[:16]}…"),
             )
     return CheckResult(
         "transparency", ok=True, detail="RFC6962 STH signed, root + inclusion proof verified"


### PR DESCRIPTION
## What

Adds an advisory lane, `.github/workflows/webui-render-recapture.yml`, that runs
on pull requests touching `web/**` or `src/bernstein/gui/static/**`. It rebuilds
the SPA, re-runs `scripts/capture_webui_renders.py` against it, applies
`scripts/bind_webui_renders.py --update`, and publishes the result as the
`webui-renders-recaptured` artifact.

It commits nothing, holds `contents: read`, is not a required context, and
cannot fail (job-level `continue-on-error`).

## Why

One cause turns three checks red at once, and the fix needs a browser the
author of the change may not have.

The chain, all of it working as designed:

1. `spa-bundle-freshness.yml` requires the committed bundle to match a rebuild
   from `web/package-lock.json`, so a frontend dependency bump has to carry the
   rebuilt bundle.
2. The rebuild produces new content-hashed asset filenames, so the digest in
   `docs/assets/webui-renders.json` no longer matches the bundle.
3. `bind_webui_renders.py` fails, which fails the "Operator-surface render
   freshness" step of `Repo hygiene`; `tests/unit/test_webui_render_binding.py`
   fails independently in whichever `test` shard that file lands in; and the
   `CI gate` roll-up fails because those two did.

Four pull-request CI runs in the 30 days to 2026-09-01 ended exactly this way:

| run | branch | failed jobs |
| --- | --- | --- |
| 33270950476 | `renovate/tanstack-query-monorepo` | Repo hygiene (render freshness), Test shard 4, CI gate |
| 33054043829 | `renovate/vite-8.x-lockfile` | Repo hygiene (render freshness), Test shard 4, CI gate |
| 33570375688 | `renovate/tanstack-query-monorepo` | Repo hygiene (render freshness), Test shard 2, CI gate |
| 31788698554 | `renovate/vite-8.x-lockfile` | Test shard 3, CI gate |

Four runs, eleven red checks, one root cause. Note the shard number: 4, 4, 2, 3.
The binding test lands in a different shard depending on the file list, so the
same defect never clusters in per-job failure statistics -- it reads as three
unrelated shard failures.

Clearing it means running `scripts/capture_webui_renders.py`, which boots
`bernstein gui serve` and drives headless Chromium over ten screens. An
automation-authored pull request cannot do that. Two commits on `main` in the
same window exist only to carry that catch-up work by hand:

- #4552 `chore(gui): rebuild the shipped SPA bundle after the lucide-react bump`
- #4027 `chore(web): rebuild SPA bundle for lucide-react 1.31.0`

12 commits touched `src/bernstein/gui/static/` in that window; 8 of them were
dependency bumps.

## How

The lane reuses what already runs elsewhere. `npm ci` and `npm run build` are
the same two commands the required `shipped bundle matches the lockfile` job
runs, so the bundle the renders are captured against is the same one that lane
validates. The only genuinely new cost is the Chromium download.

Order: checkout, Node 24, `./.github/actions/bootstrap`, `npm ci`,
`npm run build`, `uv sync` (so `capture_webui_renders.py` finds
`.venv/bin/bernstein`, which is how it resolves the server), Chromium,
capture, rebind, then report and upload only if `docs/assets` actually moved.

Its own path filter includes this workflow file, so this pull request exercises
the lane rather than shipping it untested.

**What it deliberately does not do.** It does not rebind without recapturing,
and it does not push to the branch. `bind_webui_renders.py` guarantees that
nobody shipped a UI change while leaving the published screenshots behind;
rebinding without a capture would assert that the committed screenshots show
the new bundle when nobody looked, which is the single thing the gate exists to
prevent. So `Repo hygiene` and the binding test still fail exactly as they do
today. What changes is the cost of clearing them: download an artifact and
commit it, instead of reproducing a browser capture locally.

Committing back to the branch would remove the last manual step, but it needs a
token with write access to the pull request head. That is a separate decision
and is not made here.

## Risk

- **The lane breaks.** `npm ci`, the Chromium download and the booted server all
  have their own failure modes. `continue-on-error` is set at job level, so a
  breakage reports in the job summary and never turns the pull request red. The
  author is then exactly where they are today.
- **The captured renders are wrong.** They are produced by the repository's own
  capture script from the bundle this branch builds, and a human still reviews
  and commits them. The script is all-or-nothing across both screen groups, so a
  half-finished run publishes nothing.
- **Cost.** 12 pull requests in 30 days match the path filter, roughly one run
  every two and a half days. The job is capped at 25 minutes.
- **How to see it working:** open a pull request that bumps a bundled frontend
  dependency; the run should attach `webui-renders-recaptured` and the job
  summary should list the changed files.

## Checklist

- [x] No check is disabled, weakened or removed -- the binding gate still fails
- [x] No permission is widened (`contents: read`, no branch write)
- [x] Not a required context; cannot gate a merge
- [x] No release, publish, signing or artefact-upload-to-release workflow touched
- [x] No branch protection or ruleset change
- [x] `actionlint` clean; `zizmor` reports only the repository-wide
      `self-repository` hint that every `./.github/actions/bootstrap` caller
      already produces
