### PR TITLE
feat: resolve a task's change set and add 'bernstein undo --dry-run' (#2919)

### DIFF
--- a/docs/operations/task-revert.md
+++ b/docs/operations/task-revert.md
@@ -1,0 +1,99 @@
+# Reverting a task's change (`bernstein undo --dry-run`)
+
+Audience: operators who need to undo one agent task's work and want to
+see exactly which files that covers before anything moves.
+
+## Why a task needs its own change set
+
+An agent task is normally one logical change spread over several files.
+Reverting it by hand — picking files, or reverting the merge commit —
+routinely misses part of the change or reverts unrelated work that
+landed nearby. To revert a task cleanly you first need a precise,
+reproducible answer to *what did this task change*.
+
+Two sources cannot supply that answer today:
+
+| Source | Why it cannot answer |
+|---|---|
+| Commit subjects | `bernstein undo` matches `task:<task_id>` against the last 50 subjects. Nothing writes that string — agent commits read `[WIP] <title>` and `feat: <summary>` — so the scan finds nothing for a real task. |
+| The lineage spine | A spine entry carries `artifact_path`, `content_hash`, `actor` and `step_id`, and **no task id**. Writes made by a CLI adapter's own subprocess never cross that boundary at all. |
+
+The task's worktree does know. Every task runs on its own
+`agent/<session_id>` branch, and the session-to-task binding is already
+recorded in `.sdd/runtime/pids/<session_id>.json`.
+
+## Resolving the change set
+
+`src/bernstein/core/worktrees/change_set.py` exposes
+`resolve_task_change_set(repo_root, task_id)`. It:
+
+1. finds the worktree whose PID record carries `task_id`, via
+   `classify_worktrees`;
+2. computes the merge base of `agent/<session_id>` and the integration
+   branch (`main`);
+3. diffs **three-dot** — from the merge base, not from where the
+   integration branch now stands — and returns each changed path with
+   its pre- and post-change blob hash.
+
+The three dots are load-bearing. A two-dot `main..agent/<sid>` diff
+reports every path that landed on `main` *after* the task forked as a
+deletion the task never made. A revert built on that set would restore
+files the task never removed and still report a clean run.
+
+Each entry is a `TaskChangePath`:
+
+| Field | Meaning |
+|---|---|
+| `path` | Repo-relative path, as git names it |
+| `change_type` | `added` / `modified` / `deleted` / `typechange` |
+| `pre_hash` | Blob before the task; `None` when the task added the path |
+| `post_hash` | Blob on the task branch; `None` when the task deleted it |
+
+Paths come back in git's path order, so two operators resolving the same
+task get the same set in the same order.
+
+## Refusals
+
+The resolver raises `TaskChangeSetUnresolved` rather than returning an
+empty set when it cannot tell. An empty set is a real answer — a task
+that touched no files — so the two must not look alike:
+
+| Situation | Behaviour |
+|---|---|
+| No worktree records the task | Refuse, naming the task id |
+| Several worktrees claim the task | Refuse, naming the sessions — the binding cannot be arbitrated |
+| Branch missing, or git fails / times out | Refuse, quoting git's error |
+
+## `bernstein undo --dry-run`
+
+```
+bernstein undo <task_id> --dry-run
+```
+
+Prints one line per changed path — kind, path, and abbreviated
+`pre -> post` blob — and exits. It never touches the working tree, the
+index, or `HEAD`: `git status --porcelain` is byte-identical before and
+after.
+
+```
+╭─ Change set for task-abc123 (agent/backend-abc123) ─╮
+│ added      docs/new.md      -        3e757656       │
+│ deleted    old/legacy.py    286c5f57 -              │
+│ modified   src/thing.py     3367afdb b66ba06d       │
+╰─────────────────────────────────────────────────────╯
+Dry run: nothing was reverted.
+```
+
+`--dry-run` requires a task id. `--all` names no single task, so it has
+no change set to print; combining the two is a usage error rather than
+an empty report that would read as "this session changed nothing".
+
+An unresolvable task id exits non-zero with the reason.
+
+## Not yet implemented
+
+The dry run reports the change set; it does not revert it. Without
+`--dry-run`, `bernstein undo` still uses the commit-subject scan
+described above. Still to come: the isolated restore of each path to its
+pre-task blob, detection of paths a later task has since changed, and a
+signed reversal receipt anchored in the audit chain.

--- a/docs/operations/task-revert.md
+++ b/docs/operations/task-revert.md
@@ -76,11 +76,11 @@ index, or `HEAD`: `git status --porcelain` is byte-identical before and
 after.
 
 ```
-╭─ Change set for task-abc123 (agent/backend-abc123) ─╮
-│ added      docs/new.md      -        3e757656       │
-│ deleted    old/legacy.py    286c5f57 -              │
-│ modified   src/thing.py     3367afdb b66ba06d       │
-╰─────────────────────────────────────────────────────╯
+╭────────── Change set for task-abc123 (agent/backend-abc123) ──────────╮
+│ added      docs/new.md  - -> 3e757656                                 │
+│ deleted    old/legacy.py  da9ee9d1 -> -                               │
+│ modified   src/thing.py  3367afdb -> b66ba06d                         │
+╰───────────────────────────────────────────────────────────────────────╯
 Dry run: nothing was reverted.
 ```
 

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -85,7 +85,7 @@ The "do work" commands. This is where most operators live.
 | `bernstein init-wizard` | Deprecated alias of `bernstein init --wizard`; removed in v4.0.0. | `cli/init_wizard_cmd.py` |
 | `bernstein dry-run` | Preview the plan without spawning. | `cli/commands/dry_run_cmd.py:203` |
 | `bernstein replay RUN_ID` | Replay a past run step-by-step. | `cli/commands/advanced_cmd.py:876` |
-| `bernstein undo` | Undo the last operation. | `cli/undo_cmd.py:15` |
+| `bernstein undo` | Undo the last operation. `--dry-run TASK_ID` prints the paths that task changed and exits without touching the tree ([task revert](../operations/task-revert.md)). | `cli/commands/undo_cmd.py:22` |
 | `bernstein checkpoint` | Save progress for later resume. | `cli/commands/checkpoint_cmd.py:49` |
 | `bernstein wrap-up` | End session with summary + learnings. | `cli/wrap_up_cmd.py` |
 | `bernstein fork --run ID --from-step N` | Rewind a run to journal step N and branch a new run from its content-addressed worktree snapshot. | `cli/commands/fork_cmd.py` |

--- a/docs/release-notes/fragments/2919-undo-dry-run.md
+++ b/docs/release-notes/fragments/2919-undo-dry-run.md
@@ -1,0 +1,3 @@
+## ``bernstein undo --dry-run`` prints a task's change set without touching the tree
+
+Added ``bernstein undo --dry-run`` to the ``undo`` command — running the flag on a worktree task prints the files that would be reverted and exits without modifying the working tree or any git state, letting operators audit a reversal before committing to it. (#2919)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -284,6 +284,7 @@ nav:
           - Recipes: operations/recipes.md
           - Worktrees: operations/worktrees.md
           - Snapshot undo: git/snapshot-undo.md
+          - Task revert: operations/task-revert.md
           - Session handoff: operations/session-handoff.md
           - Routine scenarios: routine-scenarios.md
           - Per-step routing: workflows/per-step-routing.md

--- a/src/bernstein/cli/commands/undo_cmd.py
+++ b/src/bernstein/cli/commands/undo_cmd.py
@@ -8,7 +8,14 @@ from pathlib import Path
 
 import click
 from rich.console import Console
+from rich.markup import escape
 from rich.panel import Panel
+
+from bernstein.core.worktrees.change_set import (
+    TaskChangeSet,
+    TaskChangeSetUnresolved,
+    resolve_task_change_set,
+)
 
 console = Console()
 
@@ -17,15 +24,25 @@ console = Console()
 @click.argument("task_id", required=False)
 @click.option("--all", "revert_all", is_flag=True, help="Revert all changes from the current session.")
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt.")
-def undo_cmd(task_id: str | None, revert_all: bool, yes: bool) -> None:
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Print the paths the task changed and exit without touching the tree.",
+)
+def undo_cmd(task_id: str | None, revert_all: bool, yes: bool, dry_run: bool) -> None:
     """Revert changes made by an agent.
 
     \b
-      bernstein undo task-123    # revert changes from a specific task
-      bernstein undo --all       # revert all changes in current session
+      bernstein undo task-123              # revert changes from a specific task
+      bernstein undo task-123 --dry-run    # show what that task changed, change nothing
+      bernstein undo --all                 # revert all changes in current session
     """
     if not task_id and not revert_all:
         console.print("[red]Error:[/red] Specify a task ID or use --all")
+        return
+
+    if dry_run:
+        _print_change_set(task_id)
         return
 
     commits_to_revert = _find_commits_to_revert(task_id, revert_all)
@@ -51,6 +68,50 @@ def undo_cmd(task_id: str | None, revert_all: bool, yes: bool) -> None:
         console.print(f"\n[green]✓[/green] Successfully reverted {success_count} commit(s).")
         _log_undo_audit(task_id, revert_all, success_count)
         _run_post_revert_tests()
+
+
+def _print_change_set(task_id: str | None) -> None:
+    """Print the set of paths ``task_id`` changed, without touching the tree.
+
+    The set comes from the task's own worktree branch (see
+    :func:`~bernstein.core.worktrees.change_set.resolve_task_change_set`),
+    not from the commit-subject scan the revert path still uses.
+
+    Raises:
+        click.UsageError: ``--all`` was given. A change set is a property
+            of one task; ``--all`` names none, so there is nothing to
+            print, and printing an empty report would read as "this
+            session changed nothing".
+        click.ClickException: The task's change set could not be resolved.
+    """
+    if task_id is None:
+        msg = "--dry-run needs a task ID: a change set belongs to one task, and --all names none"
+        raise click.UsageError(msg)
+    try:
+        change_set = resolve_task_change_set(Path.cwd(), task_id)
+    except TaskChangeSetUnresolved as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    console.print(
+        Panel(
+            _render_change_set(change_set),
+            title=f"Change set for {escape(task_id)} ({escape(change_set.branch)})",
+            border_style="cyan",
+        )
+    )
+    console.print("[dim]Dry run: nothing was reverted.[/dim]")
+
+
+def _render_change_set(change_set: TaskChangeSet) -> str:
+    """Render one line per changed path: kind, path, and pre -> post blob."""
+    if not change_set.paths:
+        return f"[dim]{escape(change_set.branch)} changed no files.[/dim]"
+    lines: list[str] = []
+    for entry in change_set.paths:
+        pre = entry.pre_hash[:8] if entry.pre_hash else "-"
+        post = entry.post_hash[:8] if entry.post_hash else "-"
+        lines.append(f"[yellow]{entry.change_type:<10}[/yellow] {escape(entry.path)}  [dim]{pre} -> {post}[/dim]")
+    return "\n".join(lines)
 
 
 def _find_commits_to_revert(task_id: str | None, revert_all: bool) -> list[tuple[str, str]]:

--- a/src/bernstein/core/worktrees/change_set.py
+++ b/src/bernstein/core/worktrees/change_set.py
@@ -1,0 +1,270 @@
+"""Resolve the exact set of paths one task changed.
+
+"Undo this task" needs a definition of *this task's change* that does not
+depend on guessing. Two obvious sources cannot supply one:
+
+* **Commit subjects.** ``bernstein undo`` matches ``task:<task_id>``
+  against recent subjects, but nothing in the tree writes that string -
+  agent commits read ``[WIP] <title>`` and ``feat: <summary>`` - so the
+  scan answers "nothing to undo" for every real task.
+* **The lineage spine.** A spine entry carries ``artifact_path``,
+  ``content_hash``, ``actor`` and ``step_id`` and no task id, and writes
+  performed by a CLI adapter's own subprocess never reach that boundary
+  at all.
+
+The per-task worktree does know. Every task runs on its own
+``agent/<session_id>`` branch, and the session-to-task binding is already
+recorded in ``.sdd/runtime/pids/<session_id>.json`` and surfaced by
+:func:`~bernstein.core.worktrees.classifier.classify_worktrees`. Diffing
+that branch against the integration branch **three-dot** - from where the
+task forked, not from where the integration branch now stands - yields
+exactly the paths the task itself changed.
+
+The three dots are load-bearing. Two-dot ``main..agent/<sid>`` reports
+every path that landed on ``main`` after the task forked as a *deletion*
+the task never made; a reversal built on that set would restore files the
+task never removed and still report a clean revert.
+
+This module is read-only. It resolves and returns the change set; it does
+not revert anything.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from bernstein.core.git.git_ops import GitResult, run_git
+from bernstein.core.worktrees.classifier import (
+    DEFAULT_INTEGRATION_BRANCH,
+    classify_worktrees,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+__all__ = [
+    "TaskChangePath",
+    "TaskChangeSet",
+    "TaskChangeSetUnresolved",
+    "resolve_task_change_set",
+]
+
+#: Seconds allowed for each read-only git call. Mirrors the budget
+#: ``spawner_merge._incoming_files`` gives the equivalent diff.
+_GIT_TIMEOUT_S = 30
+
+#: ``git diff --raw`` status letter to the word this module reports.
+_CHANGE_TYPES = {
+    "A": "added",
+    "M": "modified",
+    "D": "deleted",
+    "T": "typechange",
+}
+
+
+class TaskChangeSetUnresolved(RuntimeError):
+    """The set of paths a task changed could not be determined.
+
+    Raised rather than collapsed into an empty change set. An empty set is
+    a real answer - a task that touched no files - so returning one for a
+    task whose worktree cannot be found, or whose branch git could not
+    diff, would make "we could not look" indistinguishable from "there is
+    nothing there". A reversal driven by the second reading would report
+    success having reverted nothing.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class TaskChangePath:
+    """One path the task changed, with the blobs on either side of it.
+
+    Attributes:
+        path: Repo-relative path, exactly as git names it.
+        change_type: ``added`` / ``modified`` / ``deleted`` /
+            ``typechange``, or the lowercased git status letter for a
+            status this module does not name.
+        pre_hash: Blob hash the path held before the task, or ``None``
+            when the task added it.
+        post_hash: Blob hash the path holds on the task branch, or
+            ``None`` when the task deleted it.
+    """
+
+    path: str
+    change_type: str
+    pre_hash: str | None
+    post_hash: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class TaskChangeSet:
+    """Everything one task changed, resolved from its worktree branch.
+
+    Attributes:
+        task_id: Task the set belongs to.
+        session_id: Session that ran it - the worktree slug and the
+            ``agent/<session_id>`` branch suffix.
+        branch: Branch the task's commits live on.
+        integration_branch: Branch the task branch was diffed against.
+        merge_base: Commit the task forked from; the pre-change side of
+            every path below.
+        paths: The changed paths in git's path order.
+    """
+
+    task_id: str
+    session_id: str
+    branch: str
+    integration_branch: str
+    merge_base: str
+    paths: tuple[TaskChangePath, ...]
+
+
+def resolve_task_change_set(
+    repo_root: Path,
+    task_id: str,
+    *,
+    integration_branch: str = DEFAULT_INTEGRATION_BRANCH,
+) -> TaskChangeSet:
+    """Return the set of paths ``task_id`` changed, with blob hashes.
+
+    Args:
+        repo_root: Absolute repository root.
+        task_id: Task whose change set to resolve.
+        integration_branch: Branch the task branch is diffed against.
+            Defaults to :data:`DEFAULT_INTEGRATION_BRANCH`.
+
+    Returns:
+        A :class:`TaskChangeSet`; ``paths`` is empty only when the task's
+        branch genuinely changed nothing.
+
+    Raises:
+        TaskChangeSetUnresolved: No worktree records this task, more than
+            one does, or git could not diff the task's branch.
+    """
+    session_id = _session_for_task(repo_root, task_id)
+    branch = f"agent/{session_id}"
+    merge_base = _merge_base(repo_root, integration_branch, branch, task_id=task_id)
+    paths = _diff_raw(repo_root, merge_base, branch, task_id=task_id)
+    return TaskChangeSet(
+        task_id=task_id,
+        session_id=session_id,
+        branch=branch,
+        integration_branch=integration_branch,
+        merge_base=merge_base,
+        paths=paths,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _session_for_task(repo_root: Path, task_id: str) -> str:
+    """Return the session id whose worktree carries ``task_id``.
+
+    Raises:
+        TaskChangeSetUnresolved: Zero or several worktrees claim the task.
+            Two worktrees for one task is a binding we cannot arbitrate,
+            and picking either would attribute one session's files to the
+            other's reversal.
+    """
+    matches = [row for row in classify_worktrees(repo_root) if row.task_id == task_id]
+    if not matches:
+        msg = f"no worktree under {repo_root}/.sdd records task {task_id!r}; its change set cannot be resolved"
+        raise TaskChangeSetUnresolved(msg)
+    if len(matches) > 1:
+        sessions = ", ".join(sorted(row.session_id for row in matches))
+        msg = f"task {task_id!r} is claimed by several worktrees ({sessions}); refusing to guess"
+        raise TaskChangeSetUnresolved(msg)
+    return matches[0].session_id
+
+
+def _merge_base(repo_root: Path, integration_branch: str, branch: str, *, task_id: str) -> str:
+    """Return the commit ``branch`` forked from ``integration_branch``."""
+    result = _git(repo_root, ["merge-base", integration_branch, branch], task_id=task_id)
+    base = result.stdout.strip()
+    if not base:
+        msg = (
+            f"task {task_id!r}: {branch} and {integration_branch} share no merge base, "
+            "so what the task changed cannot be separated from what it inherited"
+        )
+        raise TaskChangeSetUnresolved(msg)
+    return base
+
+
+def _diff_raw(
+    repo_root: Path,
+    merge_base: str,
+    branch: str,
+    *,
+    task_id: str,
+) -> tuple[TaskChangePath, ...]:
+    """Return the changed paths between ``merge_base`` and ``branch``.
+
+    ``--no-renames`` because rename detection reports only a rename's
+    destination, and a reversal has to restore the source path too.
+    ``--abbrev=64`` asks for more hexdigits than any hash git uses, which
+    git clamps to the full object name - so the hashes are never
+    abbreviated prefixes that could collide.
+    """
+    result = _git(
+        repo_root,
+        ["diff", "--raw", "--no-renames", "-z", "--abbrev=64", f"{merge_base}..{branch}"],
+        task_id=task_id,
+    )
+    fields = result.stdout.split("\0")
+    paths: list[TaskChangePath] = []
+    index = 0
+    while index < len(fields):
+        meta = fields[index]
+        if not meta:
+            index += 1
+            continue
+        if index + 1 >= len(fields):
+            msg = f"task {task_id!r}: git diff --raw record {meta!r} has no path"
+            raise TaskChangeSetUnresolved(msg)
+        paths.append(_parse_record(meta, fields[index + 1], task_id=task_id))
+        index += 2
+    return tuple(paths)
+
+
+def _parse_record(meta: str, path: str, *, task_id: str) -> TaskChangePath:
+    """Parse one ``:<mode> <mode> <sha> <sha> <status>`` raw-diff record."""
+    parts = meta.lstrip(":").split(" ")
+    if len(parts) != 5 or not meta.startswith(":"):
+        msg = f"task {task_id!r}: unparsable git diff --raw record {meta!r}"
+        raise TaskChangeSetUnresolved(msg)
+    _pre_mode, _post_mode, pre_sha, post_sha, status = parts
+    return TaskChangePath(
+        path=path,
+        change_type=_CHANGE_TYPES.get(status, status.lower()),
+        pre_hash=_blob_or_none(pre_sha),
+        post_hash=_blob_or_none(post_sha),
+    )
+
+
+def _blob_or_none(sha: str) -> str | None:
+    """Return ``sha``, or ``None`` for git's all-zero "no blob" sentinel."""
+    if not sha or sha.strip("0") == "":
+        return None
+    return sha
+
+
+def _git(repo_root: Path, args: list[str], *, task_id: str) -> GitResult:
+    """Run a read-only git command, raising on failure or timeout.
+
+    Every git call here answers a question the caller then treats as
+    fact, so a non-zero exit must not degrade to an empty answer.
+    """
+    try:
+        result = run_git(args, repo_root, timeout=_GIT_TIMEOUT_S)
+    except (OSError, subprocess.SubprocessError) as exc:
+        msg = f"task {task_id!r}: git {' '.join(args)} did not complete ({exc})"
+        raise TaskChangeSetUnresolved(msg) from exc
+    if result.returncode != 0:
+        detail = result.stderr.strip() or f"exit {result.returncode}"
+        msg = f"task {task_id!r}: git {' '.join(args)} failed ({detail})"
+        raise TaskChangeSetUnresolved(msg)
+    return result

--- a/src/bernstein/core/worktrees/change_set.py
+++ b/src/bernstein/core/worktrees/change_set.py
@@ -35,7 +35,7 @@ import subprocess
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from bernstein.core.git.git_ops import GitResult, run_git
+from bernstein.core.git.git_basic import GitResult, run_git
 from bernstein.core.worktrees.classifier import (
     DEFAULT_INTEGRATION_BRANCH,
     classify_worktrees,

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -6022,6 +6022,7 @@ class TestAdaptivePollingBackoff:
         assert hasattr(orch, "_idle_multiplier")
         assert orch._idle_multiplier == 1
 
+
 # --- Reverse task-to-session index ---
 
 

--- a/tests/unit/test_task_change_set.py
+++ b/tests/unit/test_task_change_set.py
@@ -1,0 +1,247 @@
+"""What did one task change? Resolved from the task's worktree branch.
+
+``bernstein undo`` today finds commits by matching ``task:<task_id>``
+against the last 50 commit subjects. Nothing in the tree writes that
+string - the agent commit prompts emit ``[WIP] <title>`` and
+``feat: <summary>`` - so the subject scan answers "nothing to undo" for
+every real task. The lineage spine cannot answer either: a spine entry
+carries ``artifact_path``/``content_hash``/``actor``/``step_id`` and no
+task id, and CLI-adapter subprocess writes never cross that boundary.
+
+The task's own worktree branch does know. These tests build a real repo
+with a real linked worktree and pin the resolver against it:
+
+1. the resolved set is exactly the paths the task's branch changed,
+2. every path carries its pre- and post-change blob hash,
+3. a path changed only on the integration branch is absent,
+4. an unknown task id is refused rather than answered with an empty set,
+5. ``bernstein undo --dry-run`` prints that set and leaves the tree
+   byte-identical,
+6. ``--dry-run`` without a task id is refused.
+
+Test 3 is the load-bearing one: every later conflict check compares the
+task's set against what other work touched, so an integration-only path
+leaking into the set would make the reversal revert work the task never
+did. The two-dot spec ``main..agent/<sid>`` reports exactly that path as
+a deletion; only the three-dot spec excludes it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.undo_cmd import undo_cmd
+from bernstein.core.worktrees.change_set import (
+    TaskChangeSetUnresolved,
+    resolve_task_change_set,
+)
+
+SESSION_ID = "backend-abc123"
+TASK_ID = "task-abc123"
+
+# ---------------------------------------------------------------------------
+# Real-git fixture
+# ---------------------------------------------------------------------------
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run git in *cwd* with a deterministic identity."""
+    return subprocess.run(
+        [
+            "git",
+            "-C",
+            str(cwd),
+            "-c",
+            "user.email=test@bernstein",
+            "-c",
+            "user.name=test",
+            "-c",
+            "commit.gpgsign=false",
+            *args,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _blob(cwd: Path, rev: str, path: str) -> str:
+    """Return the blob sha of *path* at *rev*."""
+    return _git(cwd, "rev-parse", f"{rev}:{path}").stdout.strip()
+
+
+@pytest.fixture()
+def task_repo(tmp_path: Path) -> Path:
+    """A repo whose task worktree changed three files, main a fourth.
+
+    Layout after this fixture:
+
+    * ``main``: seed commit (``seed.txt``, ``mod.txt``, ``del.txt``) plus a
+      later commit adding ``integ.txt`` - work the task never touched.
+    * ``agent/<session>``: branched off the seed commit; adds
+      ``added.txt``, modifies ``mod.txt``, deletes ``del.txt``.
+    * ``.sdd/runtime/pids/<session>.json``: the record that binds the
+      session to :data:`TASK_ID`.
+
+    The task's commit subject is deliberately ``feat: add feature`` - the
+    shape agents actually produce, carrying no ``task:<id>`` marker.
+    """
+    subprocess.run(["git", "init", "-q", "-b", "main", str(tmp_path)], check=True)
+    (tmp_path / "seed.txt").write_text("seed\n")
+    (tmp_path / "mod.txt").write_text("old\n")
+    (tmp_path / "del.txt").write_text("gone\n")
+    _git(tmp_path, "add", "seed.txt", "mod.txt", "del.txt")
+    _git(tmp_path, "commit", "-q", "-m", "seed")
+
+    worktrees = tmp_path / ".sdd" / "runtime" / "worktrees"
+    worktrees.mkdir(parents=True, exist_ok=True)
+    wt = worktrees / SESSION_ID
+    _git(tmp_path, "worktree", "add", "-q", "-b", f"agent/{SESSION_ID}", str(wt), "main")
+
+    (wt / "added.txt").write_text("new\n")
+    (wt / "mod.txt").write_text("new content\n")
+    (wt / "del.txt").unlink()
+    _git(wt, "add", "-A", "added.txt", "mod.txt", "del.txt")
+    _git(wt, "commit", "-q", "-m", "feat: add feature")
+
+    # Work that landed on the integration branch after the task forked.
+    (tmp_path / "integ.txt").write_text("other\n")
+    _git(tmp_path, "add", "integ.txt")
+    _git(tmp_path, "commit", "-q", "-m", "chore: unrelated main work")
+
+    pids = tmp_path / ".sdd" / "runtime" / "pids"
+    pids.mkdir(parents=True, exist_ok=True)
+    (pids / f"{SESSION_ID}.json").write_text(
+        json.dumps({"task_id": TASK_ID, "worker_pid": os.getpid()}),
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# 1-4: change-set resolution
+# ---------------------------------------------------------------------------
+
+
+def test_change_set_names_exactly_the_paths_the_task_changed(task_repo: Path) -> None:
+    """The resolved set is the task's three paths, in path order.
+
+    The task's commit subject carries no ``task:<id>`` marker, so a
+    resolver built on commit subjects would return nothing here.
+    """
+    subjects = _git(task_repo, "log", "--pretty=format:%s", f"agent/{SESSION_ID}").stdout
+    assert f"task:{TASK_ID}" not in subjects, "fixture must not hand the resolver a subject marker"
+
+    change_set = resolve_task_change_set(task_repo, TASK_ID)
+
+    assert change_set.task_id == TASK_ID
+    assert change_set.session_id == SESSION_ID
+    assert change_set.branch == f"agent/{SESSION_ID}"
+    assert [p.path for p in change_set.paths] == ["added.txt", "del.txt", "mod.txt"]
+    assert [p.change_type for p in change_set.paths] == ["added", "deleted", "modified"]
+
+
+def test_change_set_records_pre_and_post_blob_hashes_for_each_path(task_repo: Path) -> None:
+    """Each path carries the blob it came from and the blob it became.
+
+    An added path has no pre-image and a deleted path no post-image; both
+    are ``None`` rather than git's all-zero sentinel, so a caller cannot
+    mistake "no such blob" for a real content hash.
+    """
+    change_set = resolve_task_change_set(task_repo, TASK_ID)
+    by_path = {p.path: p for p in change_set.paths}
+    base = change_set.merge_base
+    branch = f"agent/{SESSION_ID}"
+
+    assert by_path["added.txt"].pre_hash is None
+    assert by_path["added.txt"].post_hash == _blob(task_repo, branch, "added.txt")
+
+    assert by_path["mod.txt"].pre_hash == _blob(task_repo, base, "mod.txt")
+    assert by_path["mod.txt"].post_hash == _blob(task_repo, branch, "mod.txt")
+    assert by_path["mod.txt"].pre_hash != by_path["mod.txt"].post_hash
+
+    assert by_path["del.txt"].pre_hash == _blob(task_repo, base, "del.txt")
+    assert by_path["del.txt"].post_hash is None
+
+
+def test_integration_only_path_is_absent_from_the_change_set(task_repo: Path) -> None:
+    """A path changed only on ``main`` is not part of the task's set.
+
+    Load-bearing: ``integ.txt`` exists on the integration branch and not
+    on the task branch. Diffed two-dot it shows up as a deletion the task
+    never made, and a reversal built on that set would restore a file the
+    task never removed while reporting a clean revert.
+    """
+    two_dot = _git(task_repo, "diff", "--name-only", "--no-renames", f"main..agent/{SESSION_ID}").stdout.split()
+    assert "integ.txt" in two_dot, "fixture must reproduce the two-dot trap"
+
+    change_set = resolve_task_change_set(task_repo, TASK_ID)
+
+    assert "integ.txt" not in [p.path for p in change_set.paths]
+
+
+def test_unknown_task_id_is_refused_not_answered_with_an_empty_set(task_repo: Path) -> None:
+    """No worktree for the task means "cannot tell", not "changed nothing".
+
+    An empty set is a task that touched no files; a task we cannot find is
+    not that, and returning one for the other would let a reversal report
+    success having reverted nothing.
+    """
+    with pytest.raises(TaskChangeSetUnresolved) as excinfo:
+        resolve_task_change_set(task_repo, "task-that-never-ran")
+
+    assert "task-that-never-ran" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# 5-6: the CLI dry run
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_prints_the_change_set_and_leaves_the_tree_byte_identical(
+    task_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--dry-run`` reports the set and mutates nothing.
+
+    ``git status --porcelain`` must come back byte-for-byte the same, and
+    the printed report must name the task's paths and not the
+    integration-only one.
+    """
+    monkeypatch.chdir(task_repo)
+    before = _git(task_repo, "status", "--porcelain").stdout
+
+    result = CliRunner().invoke(undo_cmd, [TASK_ID, "--dry-run"])
+
+    after = _git(task_repo, "status", "--porcelain").stdout
+    assert after == before, "dry run touched the working tree"
+    assert result.exit_code == 0, result.output
+    for path in ("added.txt", "del.txt", "mod.txt"):
+        assert path in result.output
+    assert "integ.txt" not in result.output
+    # HEAD must be untouched too - no revert commit was created.
+    assert _git(task_repo, "log", "--pretty=format:%s", "-n", "1").stdout == "chore: unrelated main work"
+
+
+def test_dry_run_without_a_task_id_is_refused(
+    task_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--all --dry-run`` fails loudly: a change set is per task.
+
+    ``--all`` names no single task, so there is no recorded change set to
+    print. Refusing with a non-zero exit keeps that from reading as "this
+    session changed nothing".
+    """
+    monkeypatch.chdir(task_repo)
+
+    result = CliRunner().invoke(undo_cmd, ["--all", "--dry-run"])
+
+    assert result.exit_code != 0
+    assert "--dry-run" in result.output

--- a/verify_cli/bernstein_verify_receipt/__main__.py
+++ b/verify_cli/bernstein_verify_receipt/__main__.py
@@ -75,9 +75,7 @@ def cli() -> None:
     show_default=True,
     help="Which format(s) to verify.",
 )
-@click.option(
-    "--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details."
-)
+@click.option("--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details.")
 def verify_cmd(
     receipt_path: Path,
     jwk_path: Path | None,

--- a/verify_cli/bernstein_verify_receipt/verify.py
+++ b/verify_cli/bernstein_verify_receipt/verify.py
@@ -291,8 +291,7 @@ def verify_subject_binding(receipt: dict[str, Any]) -> tuple[CheckResult, str]:
                 "subject_binding",
                 ok=False,
                 detail=(
-                    f"recomputed head {recomputed[:16]}… "
-                    f"!= range.head_sha256 {range_head[:16]}…"
+                    f"recomputed head {recomputed[:16]}… != range.head_sha256 {range_head[:16]}…"
                 ),
             ),
             recomputed,
@@ -418,10 +417,7 @@ def verify_intoto(receipt: dict[str, Any], public_key: Any, recomputed_head: str
         return CheckResult(
             "intoto",
             ok=False,
-            detail=(
-                f"recomputed head {recomputed_head[:16]}… "
-                f"not in statement subject digests"
-            ),
+            detail=(f"recomputed head {recomputed_head[:16]}… not in statement subject digests"),
         )
     return CheckResult("intoto", ok=True, detail="DSSE/in-toto verified, subject bound to head")
 
@@ -469,8 +465,7 @@ def verify_transparency(
             "transparency",
             ok=False,
             detail=(
-                f"STH subject {subject_sha256[:16]}… "
-                f"!= recomputed head {recomputed_head[:16]}…"
+                f"STH subject {subject_sha256[:16]}… != recomputed head {recomputed_head[:16]}…"
             ),
         )
 
@@ -510,10 +505,7 @@ def verify_transparency(
             return CheckResult(
                 "transparency",
                 ok=False,
-                detail=(
-                    f"inclusion proof root {proven_root[:16]}… "
-                    f"!= STH root {root_hash[:16]}…"
-                ),
+                detail=(f"inclusion proof root {proven_root[:16]}… != STH root {root_hash[:16]}…"),
             )
     return CheckResult(
         "transparency", ok=True, detail="RFC6962 STH signed, root + inclusion proof verified"


### PR DESCRIPTION
## What

Resolves, read-only, the exact set of paths one task changed, and surfaces it as `bernstein undo <task_id> --dry-run`.

New module `src/bernstein/core/worktrees/change_set.py`:

- `resolve_task_change_set(repo_root, task_id) -> TaskChangeSet`
- `TaskChangePath` — one path with its `change_type` and its pre-/post-change blob hash
- `TaskChangeSetUnresolved` — raised when the set cannot be determined

New flag on `bernstein undo`: `--dry-run` prints that set and returns before any git write.

**This PR does not** revert anything. `_find_commits_to_revert` and `_execute_reverts` are untouched, and `bernstein undo` without `--dry-run` behaves exactly as before. No fresh-worktree restore, no later-task conflict detection, no signed reversal receipt, no `bernstein task revert` command.

## Why

Reverting an agent's work needs a precise, reproducible answer to *what did this task change*. An agent task is one logical change spread over several files, so reverting it by picking files or reverting a merge routinely misses part of the change or reverts unrelated work that landed nearby.

Neither existing source can supply that answer:

| Source | Why it cannot answer |
|---|---|
| Commit subjects | `_find_commits_to_revert` (`src/bernstein/cli/commands/undo_cmd.py`) matches `task:<task_id>` across the last 50 subjects. Nothing in the tree writes that string — the agent commit prompts emit `[WIP] <title>` (`core/agents/spawner_core.py:589`) and `feat: <summary>` (`:1110`). The scan finds nothing for a real task. |
| Lineage spine | A `LineageSpine` entry (`core/lineage/spine.py`) carries `artifact_path`, `content_hash`, `actor`, `step_id`, `model`, `timestamp` — and no task id. `record_artifact_write`'s own docstring notes that CLI-adapter subprocess file writes never cross that boundary. |

The per-task worktree does know. Each task runs on its own `agent/<session_id>` branch, and the session-to-task binding is already recorded in `.sdd/runtime/pids/<session_id>.json` and surfaced by `classify_worktrees`.

## How

1. `classify_worktrees(repo_root)` maps `task_id` to `session_id`; the branch is `agent/<session_id>`.
2. `git merge-base main agent/<session_id>` fixes where the task forked.
3. `git diff --raw --no-renames -z --abbrev=64 <merge_base>..<branch>` yields the changed paths in git path order, each with its pre- and post-change blob hash. `--no-renames` because rename detection reports only a rename's destination and a reversal has to restore the source path too. `--abbrev=64` asks for more hexdigits than any hash git uses, which git clamps to the full object name, so the hashes are never abbreviated prefixes.
4. Git's all-zero blob sentinel becomes `None`, so an added path's missing pre-image cannot be mistaken for a content hash.
5. `--dry-run` renders that set and returns before `_find_commits_to_revert` is reached.

**Three dots, not two.** `main..agent/<sid>` reports every path that landed on `main` after the task forked as a deletion the task never made. Diffing from the merge base excludes it. Test 3 pins exactly this.

**Refusals, not empty answers.** A task with no worktree, a task claimed by two worktrees, a missing branch, and a failed or timed-out git call all raise `TaskChangeSetUnresolved`. An empty set is a real answer — a task that touched no files — so "we could not look" must not be returned in its shape. This mirrors `IncomingChangeUnreadable` in `core/agents/spawner_merge.py`.

`undo_cmd` is imported eagerly by `cli/main.py`, so the new import is kept cheap: `change_set` pulls only `classifier` (stdlib only) and `git_basic`, not the `git_ops` facade, which would drag `git_pr` and the GitHub module onto every CLI startup. Importing `change_set` costs 0.05s and loads neither.

**Open decision, decided here.** The issue left `--dry-run`'s relationship to `--all` open. `--dry-run` now *requires* a task id, and `--all --dry-run` is a `click.UsageError`. A change set is a property of one task; `--all` names none, so the alternative would be an empty report that reads as "this session changed nothing" — the failure mode the refusals above exist to prevent. An unresolvable task id likewise exits non-zero with the reason rather than printing an empty panel.

## Tests

`tests/unit/test_task_change_set.py` — a real repo with a real linked worktree: the task branch adds `added.txt`, modifies `mod.txt`, deletes `del.txt`; `main` separately gains `integ.txt`. The task's commit subject is `feat: add feature`, carrying no `task:<id>` marker, so a subject-based resolver would return nothing here.

All six failed before the change (`ModuleNotFoundError: No module named 'bernstein.core.worktrees.change_set'` at import; the two CLI tests additionally had no `--dry-run` flag to invoke).

1. `test_change_set_names_exactly_the_paths_the_task_changed` — the set is the task's three paths, in path order, with the right change kinds; asserts first that the fixture hands the resolver no subject marker.
2. `test_change_set_records_pre_and_post_blob_hashes_for_each_path` — hashes match `git rev-parse <rev>:<path>`; an added path's `pre_hash` and a deleted path's `post_hash` are `None`.
3. **Load-bearing:** `test_integration_only_path_is_absent_from_the_change_set` — asserts the two-dot trap reproduces (`integ.txt` appears in `main..agent/<sid>`), then that the resolved set excludes it. Every later conflict check compares this set against what other work touched, so an integration-only path leaking in would make a reversal restore a file the task never removed and still report a clean run.
4. `test_unknown_task_id_is_refused_not_answered_with_an_empty_set` — raises, naming the task id.
5. `test_dry_run_prints_the_change_set_and_leaves_the_tree_byte_identical` — `git status --porcelain` byte-identical before and after, HEAD unmoved, the three paths printed and `integ.txt` not.
6. `test_dry_run_without_a_task_id_is_refused` — `--all --dry-run` exits non-zero.

Also run green: `tests/unit/cli/test_undo_cmd.py` (existing undo behaviour unchanged) and `tests/unit/test_worktree_classifier.py`.

## Checklist

- [x] `uv run ruff check src/` — clean
- [x] `uv run ruff format --check src/` — clean
- [x] `uv run pyright src/bernstein/core/worktrees/change_set.py src/bernstein/cli/commands/undo_cmd.py` — no new errors; `mypy` clean on both
- [x] `uv run python scripts/run_tests.py -x tests/unit/test_task_change_set.py tests/unit/cli/test_undo_cmd.py tests/unit/test_worktree_classifier.py` — 20 passed
- [x] `uv run python scripts/run_tests.py tests/unit/cli/ tests/unit/test_task_change_set.py tests/unit/test_worktree_classifier.py tests/unit/test_worktrees_cmd.py tests/unit/test_tui_worktree_status.py tests/unit/test_cli_command_registration.py tests/unit/scripts/test_run_tests_affected_gate.py tests/unit/test_sonar_s3358_nested_ternary.py` — 61 of 62 files pass. `tests/unit/cli/test_run_banner.py` fails with a subprocess `TimeoutError` on this machine, and fails identically on an unmodified `origin/main` checkout — environmental, not from this change. The full `--affected origin/main` set is 1533 files (`cli/main.py` imports `undo_cmd` eagerly, so the reverse-dependency closure is nearly the whole suite); it did not finish locally, so CI runs it.
- [x] Type hints on every new function and dataclass field
- [x] User-visible behaviour: `docs/reference/cli-reference.md` row for `bernstein undo` updated (its source path was stale too)
- [x] Operator workflow: new `docs/operations/task-revert.md`, wired into `mkdocs.yml` nav
- [ ] N/A — `docs/api/`: no public API schema changed
- [x] Architecture / new module: `uv run bernstein agents-md sync` run, produced no changes
- [ ] N/A — no new test layer; this lands in `tests/unit/`

Part of #2919

## Remaining

- Reversal in a fresh worktree: restore each path to its recorded pre-task blob and verify the resulting diff is the inverse of the change set.
- Later-task conflict detection: a path changed since by a different task blocks that path and names the blocking task, the rest revert — no silent partial revert.
- Signed reversal receipt binding `{reverted_task_id, reverted_change_set_hash, pre_task_content_hashes, revert_commit}`, anchored in the audit chain and verifiable offline, plus its tamper test.
- The `bernstein task revert <task_id>` command surface.
