### PR TITLE
feat: report per-run governance coverage on the dashboard API (#5067)

### DIFF
--- a/docs/operations/governance.md
+++ b/docs/operations/governance.md
@@ -53,6 +53,41 @@ operators holding the same ledger compute the byte-identical total. The
 attribution dimension (`agent` / `task` / `role` / `feature_label`) is
 selectable; `agent` is the per-seat default.
 
+## Coverage: what a run can and cannot account for
+
+A screen built out of decision records only ever shows the decisions that
+exist, so it cannot show the actions no decision covers.
+`src/bernstein/core/security/governance_coverage.py` projects that gap for one
+run:
+
+| Metric | Meaning |
+|---|---|
+| `attributable_action_ratio` | Recorded actions whose actor is named as the `subject` of some decision in the run. A spine entry's `actor` is a free-form string the writing adapter supplied; a decision naming it is where the installation resolved it to a principal. |
+| `decision_coverage` | Recorded actions whose actor holds an `allow` verdict in the run. A `deny` or `refuse` attributes the actor without authorising it, so it counts in the denominator only. |
+
+Three rules keep the numbers from flattering the run:
+
+- Decision records are anchored into the same spine, so they are excluded from
+  the action count. Otherwise a run would raise its own coverage by recording
+  more decisions.
+- The journal-head seal and artifact-attempt rows are chain bookkeeping, not
+  agent actions, and are excluded the same way every other spine consumer
+  excludes them.
+- A run that recorded no actions reports `null`, not `0` and not `1`. Zero over
+  zero is absent evidence.
+
+`chain_status` travels with the numbers and carries the spine verify status
+verbatim, so a `tampered` run cannot read as a clean one that merely scored
+badly.
+
+```
+GET /governance/coverage?run_id=<run>
+```
+
+returns the canonical document. The route returns exactly the bytes
+`governance_coverage_json` produces, so a number pinned from the dashboard
+recomputes offline from `.sdd` alone.
+
 ## Guarantees
 
 - **Verifiability** - `bernstein governance verify <run>` re-resolves and

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -7851,6 +7851,26 @@
         }
       }
     },
+    "/governance/coverage": {
+      "get": {
+        "tags": [
+          "governance"
+        ],
+        "summary": "Governance Coverage",
+        "description": "Return the canonical coverage document for ``?run_id=``.",
+        "operationId": "governance_coverage_governance_coverage_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
     "/handoff/{token}": {
       "get": {
         "summary": "Claim Handoff Token",
@@ -16606,6 +16626,26 @@
           },
           "422": {
             "description": "Invalid graduation stage"
+          }
+        }
+      }
+    },
+    "/api/v1/governance/coverage": {
+      "get": {
+        "tags": [
+          "governance"
+        ],
+        "summary": "Governance Coverage",
+        "description": "Return the canonical coverage document for ``?run_id=``.",
+        "operationId": "governance_coverage_api_v1_governance_coverage_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           }
         }
       }

--- a/docs/release-notes/fragments/5067-governance-coverage.md
+++ b/docs/release-notes/fragments/5067-governance-coverage.md
@@ -1,0 +1,5 @@
+## Governance coverage for a run
+
+`GET /governance/coverage?run_id=<run>` reports what a run's recorded evidence can account for: the fraction of its actions whose actor is named as the subject of a governance decision, and the fraction whose actor holds a recorded `allow` verdict. Decision records and chain bookkeeping are excluded from the action count so a run cannot raise its own coverage by recording more decisions, a run with no recorded actions reports an absent ratio rather than zero or one, and the spine verify status travels with the numbers so a tampered chain cannot read as a clean one.
+
+(#5067)

--- a/src/bernstein/core/routes/governance.py
+++ b/src/bernstein/core/routes/governance.py
@@ -1,0 +1,64 @@
+"""Governance coverage route (#5067).
+
+``GET /governance/coverage?run_id=<id>`` -- what one run's recorded evidence
+can account for: the fraction of its actions tied to a principal, and the
+fraction covered by a recorded ``allow`` verdict.
+
+The route owns no arithmetic. It parses the query string, hands the values to
+:func:`bernstein.core.security.governance_coverage.governance_coverage_json`,
+and returns those bytes verbatim -- the same rule ``/artifacts/health``
+follows, and for the same reason: an operator must be able to pin a number
+from the screen and recompute it offline from ``.sdd`` alone, which is only
+structurally true while there is one implementation and one serialiser.
+
+The status is always 200 for a well-formed request. Low coverage, an empty
+run, and a tampered chain are all successfully computed answers about the
+evidence, not failed requests; a run that recorded nothing reports absent
+ratios rather than 404, because "this run proves nothing" is the answer the
+operator came for.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import Response
+
+from bernstein.core.lineage.spine import SpineRunIdError
+from bernstein.core.security.governance_coverage import governance_coverage_json
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["governance"])
+
+_JSON_MEDIA_TYPE = "application/json"
+
+
+def _workdir(request: Request) -> Path:
+    """Return the project root the server was started against."""
+    workdir: Path = request.app.state.workdir
+    return workdir
+
+
+def _hmac_key() -> bytes:
+    from bernstein.core.security.audit import load_or_create_audit_key
+
+    return load_or_create_audit_key()
+
+
+@router.get("/governance/coverage")
+def governance_coverage(request: Request) -> Response:
+    """Return the canonical coverage document for ``?run_id=``."""
+    run_id = request.query_params.get("run_id", "")
+    if not run_id:
+        raise HTTPException(status_code=400, detail="run_id query parameter is required")
+    try:
+        payload = governance_coverage_json(_workdir(request), run_id, hmac_key=_hmac_key())
+    except SpineRunIdError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+    return Response(content=payload, media_type=_JSON_MEDIA_TYPE)

--- a/src/bernstein/core/security/governance_coverage.py
+++ b/src/bernstein/core/security/governance_coverage.py
@@ -1,0 +1,195 @@
+"""Governance coverage: the fraction of a run's actions the chain can account for.
+
+Issue #5067. The operator screens report entries -- an audit log, an approval
+queue -- and nothing reports *coverage*. An operator cannot see that a run
+produced actions no record ties to a principal, because a screen built out of
+entries only ever shows the entries that exist.
+
+This module is the projection behind that number. It answers two questions
+about one run, from recorded evidence only:
+
+``attributable_action_ratio``
+    Of the actions the run recorded, how many were performed by an actor the
+    run also made a governance verdict about. A lineage-spine entry's ``actor``
+    is a free-form string the writing adapter supplied; nothing binds it to an
+    identity. A :class:`~bernstein.core.security.governance.GovernanceDecision`
+    naming that string as its ``subject`` is the only place in the run where
+    the installation resolved it to a principal and ruled on it. An action
+    whose actor never appears there is recorded but not attributed.
+
+``decision_coverage``
+    Of the same actions, how many were performed by a principal holding a
+    recorded ``allow`` verdict in this run. A ``deny`` or ``refuse`` attributes
+    the actor without authorising it: an action taken in the face of a recorded
+    denial is precisely an uncovered one, so it counts in the denominator and
+    not in the numerator.
+
+Three rules keep the number honest rather than flattering:
+
+* **The governance record is not an agent action.** Decision records are
+  anchored into the same spine, so counting spine rows naively would let a run
+  raise its own coverage by recording more decisions. Rows written by
+  :data:`~bernstein.core.security.governance.GOVERNANCE_ACTOR` are excluded.
+* **Chain bookkeeping is not an agent action.** The journal-head seal and
+  artifact-attempt rows record the run's own plumbing and a non-delivery
+  respectively; both are excluded, the same way every other consumer of the
+  spine excludes them.
+* **No actions means no ratio.** A run that recorded nothing reports ``None``,
+  not ``0`` and not ``1``. Zero over zero is absent evidence, and rendering it
+  as a number is how a console comes to claim what it cannot show.
+
+``chain_status`` travels with the numbers because a ratio computed over a
+mutated chain is not a measurement. It carries the
+:class:`~bernstein.core.lineage.spine.SpineStatus` value verbatim, so a
+``tampered`` run cannot be read as a clean one that merely scored badly.
+
+Determinism: the document is canonical JSON (sorted keys, minimal separators)
+and every field is a pure function of the files under ``.sdd``, so the
+dashboard route and an offline recomputation produce byte-identical bytes.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.lineage.spine import (
+    ARTIFACT_ATTEMPT_STEP_PREFIX,
+    JOURNAL_SEAL_STEP_PREFIX,
+    LineageSpine,
+)
+from bernstein.core.security.governance import GOVERNANCE_ACTOR, read_decisions
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.lineage.spine import SpineEntry
+
+#: Version stamped into the coverage document. Bump only on a shape change.
+COVERAGE_DOCUMENT_VERSION = 1
+
+#: Verdict that authorises. Any other recorded verdict attributes the actor
+#: without covering the action.
+_ALLOW = "allow"
+
+#: Decimal places the ratios are rounded to. Fixed so two surfaces computing
+#: the same fraction serialise the same digits.
+_RATIO_PRECISION = 6
+
+
+@dataclass(frozen=True, slots=True)
+class CoverageMetric:
+    """One coverage bar: a count, its denominator, and their ratio."""
+
+    covered: int
+    total: int
+
+    @property
+    def ratio(self) -> float | None:
+        """The fraction covered, or ``None`` when nothing was recorded."""
+        if self.total == 0:
+            return None
+        return round(self.covered / self.total, _RATIO_PRECISION)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"covered": self.covered, "total": self.total, "ratio": self.ratio}
+
+
+@dataclass(frozen=True, slots=True)
+class GovernanceCoverage:
+    """What one run's recorded evidence can account for."""
+
+    run_id: str
+    chain_status: str
+    recorded_actions: int
+    recorded_decisions: int
+    attributable_actions: CoverageMetric
+    decided_actions: CoverageMetric
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "v": COVERAGE_DOCUMENT_VERSION,
+            "run_id": self.run_id,
+            "chain_status": self.chain_status,
+            "recorded_actions": self.recorded_actions,
+            "recorded_decisions": self.recorded_decisions,
+            "metrics": {
+                "attributable_action_ratio": self.attributable_actions.to_dict(),
+                "decision_coverage": self.decided_actions.to_dict(),
+            },
+        }
+
+
+def is_agent_action(entry: SpineEntry) -> bool:
+    """Whether a spine entry records an action an agent took.
+
+    False for the run's own bookkeeping: the journal-head seal, artifact
+    attempts (which record a non-delivery), and the governance decision records
+    anchored into the same chain.
+    """
+    if entry.actor == GOVERNANCE_ACTOR:
+        return False
+    return not entry.step_id.startswith((JOURNAL_SEAL_STEP_PREFIX, ARTIFACT_ATTEMPT_STEP_PREFIX))
+
+
+def collect_governance_coverage(workdir: Path, run_id: str, *, hmac_key: bytes) -> GovernanceCoverage:
+    """Project the coverage of *run_id* from ``<workdir>/.sdd``.
+
+    Args:
+        workdir: Project root containing ``.sdd``.
+        run_id: The run to report on.
+        hmac_key: Audit-chain HMAC key the spine entries are tagged with;
+            used to verify the chain the numbers are read from.
+
+    Returns:
+        The :class:`GovernanceCoverage` for the run. A run with no spine is not
+        an error: it reports ``no_entries`` and absent ratios.
+
+    Raises:
+        SpineRunIdError: When *run_id* would escape its per-run directory.
+    """
+    lineage_root = workdir / ".sdd" / "lineage"
+    spine = LineageSpine(lineage_root, run_id=run_id, hmac_key=hmac_key)
+
+    actions = [entry for entry in spine.iter_entries() if is_agent_action(entry)]
+    decisions = read_decisions(lineage_root, run_id)
+
+    subjects = {decision.subject for decision in decisions}
+    allowed = {decision.subject for decision in decisions if decision.verdict == _ALLOW}
+
+    total = len(actions)
+    return GovernanceCoverage(
+        run_id=run_id,
+        chain_status=spine.verify().status.value,
+        recorded_actions=total,
+        recorded_decisions=len(decisions),
+        attributable_actions=CoverageMetric(
+            covered=sum(1 for entry in actions if entry.actor in subjects),
+            total=total,
+        ),
+        decided_actions=CoverageMetric(
+            covered=sum(1 for entry in actions if entry.actor in allowed),
+            total=total,
+        ),
+    )
+
+
+def governance_coverage_json(workdir: Path, run_id: str, *, hmac_key: bytes) -> str:
+    """Return the canonical coverage document for *run_id*.
+
+    **The** entry point: the dashboard route returns exactly these bytes, so
+    the screen and an offline recomputation from ``.sdd`` cannot differ.
+    """
+    payload = collect_governance_coverage(workdir, run_id, hmac_key=hmac_key).to_dict()
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+__all__ = [
+    "COVERAGE_DOCUMENT_VERSION",
+    "CoverageMetric",
+    "GovernanceCoverage",
+    "collect_governance_coverage",
+    "governance_coverage_json",
+    "is_agent_action",
+]

--- a/src/bernstein/core/security/governance_coverage.py
+++ b/src/bernstein/core/security/governance_coverage.py
@@ -121,7 +121,7 @@ class GovernanceCoverage:
         }
 
 
-def is_agent_action(entry: SpineEntry) -> bool:
+def _is_agent_action(entry: SpineEntry) -> bool:
     """Whether a spine entry records an action an agent took.
 
     False for the run's own bookkeeping: the journal-head seal, artifact
@@ -152,7 +152,7 @@ def collect_governance_coverage(workdir: Path, run_id: str, *, hmac_key: bytes) 
     lineage_root = workdir / ".sdd" / "lineage"
     spine = LineageSpine(lineage_root, run_id=run_id, hmac_key=hmac_key)
 
-    actions = [entry for entry in spine.iter_entries() if is_agent_action(entry)]
+    actions = [entry for entry in spine.iter_entries() if _is_agent_action(entry)]
     decisions = read_decisions(lineage_root, run_id)
 
     subjects = {decision.subject for decision in decisions}
@@ -191,5 +191,4 @@ __all__ = [
     "GovernanceCoverage",
     "collect_governance_coverage",
     "governance_coverage_json",
-    "is_agent_action",
 ]

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -1466,6 +1466,7 @@ def create_app(
     from bernstein.core.routes.file_health import router as file_health_router
     from bernstein.core.routes.fleet import router as fleet_router
     from bernstein.core.routes.gateway import router as gateway_router
+    from bernstein.core.routes.governance import router as governance_router
     from bernstein.core.routes.graduation import router as graduation_router
     from bernstein.core.routes.grafana import router as grafana_router
     from bernstein.core.routes.graphql_api import router as graphql_router
@@ -1543,6 +1544,7 @@ def create_app(
         audit_log_router,
         graphql_router,
         graduation_router,
+        governance_router,
         handoff_router,
         team_router,
         provider_latency_router,

--- a/tests/unit/security/test_governance_coverage.py
+++ b/tests/unit/security/test_governance_coverage.py
@@ -1,0 +1,152 @@
+"""Governance coverage is a projection over recorded evidence (#5067, slice 2).
+
+The screen this backs leads with what the installation *cannot* prove, so the
+projection has to be wrong in the honest direction: an action the chain records
+but cannot tie to a principal must lower the ratio, and the governance record's
+own rows must not raise it.
+
+Each test names the property it protects:
+
+* an unattributed action is counted, not skipped;
+* a principal the run made a verdict about makes its actions attributable;
+* a denial attributes but does not authorise;
+* decision records and chain bookkeeping are not agent actions;
+* an empty run reports an absent ratio rather than 0 or 1;
+* a tampered chain is reported as tampered rather than scored as clean.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bernstein.core.lineage.spine import (
+    ARTIFACT_ATTEMPT_STEP_PREFIX,
+    JOURNAL_SEAL_STEP_PREFIX,
+    LineageSpine,
+)
+from bernstein.core.security.governance import RoleBindings, decide_access
+from bernstein.core.security.governance_coverage import (
+    GovernanceCoverage,
+    collect_governance_coverage,
+)
+
+_KEY = b"0" * 32
+_RUN = "run-1"
+
+
+def _lineage_root(workdir: Path) -> Path:
+    return workdir / ".sdd" / "lineage"
+
+
+def _bindings() -> RoleBindings:
+    return RoleBindings(
+        group_to_role={"eng": "operator", "readers": "viewer"},
+        role_permissions={"operator": ("tasks:write",), "viewer": ("costs:read",)},
+    ).sign(_KEY)
+
+
+def _act(workdir: Path, *, actor: str, path: str, step_id: str = "write", ts: int = 1000) -> None:
+    LineageSpine(_lineage_root(workdir), run_id=_RUN, hmac_key=_KEY).record(
+        artifact_path=path,
+        content=path.encode(),
+        actor=actor,
+        step_id=step_id,
+        model="none",
+        timestamp=ts,
+    )
+
+
+def _decide(workdir: Path, *, subject: str, groups: tuple[str, ...], action: str) -> str:
+    return decide_access(
+        run_id=_RUN,
+        lineage_root=_lineage_root(workdir),
+        hmac_key=_KEY,
+        subject=subject,
+        idp_groups=groups,
+        action=action,
+        bindings=_bindings(),
+        now=1000,
+    ).verdict
+
+
+def _coverage(workdir: Path) -> GovernanceCoverage:
+    return collect_governance_coverage(workdir, _RUN, hmac_key=_KEY)
+
+
+def test_action_with_no_named_principal_is_counted_and_not_attributable(tmp_path: Path) -> None:
+    _act(tmp_path, actor="agent-writer", path="src/a.py")
+
+    coverage = _coverage(tmp_path)
+
+    assert coverage.recorded_actions == 1
+    assert coverage.attributable_actions.covered == 0
+    assert coverage.attributable_actions.total == 1
+    assert coverage.attributable_actions.ratio == 0.0
+
+
+def test_actor_named_as_a_decision_subject_is_attributable(tmp_path: Path) -> None:
+    _act(tmp_path, actor="alice", path="src/a.py")
+    _act(tmp_path, actor="agent-writer", path="src/b.py")
+    assert _decide(tmp_path, subject="alice", groups=("eng",), action="tasks:write") == "allow"
+
+    coverage = _coverage(tmp_path)
+
+    assert coverage.recorded_actions == 2
+    assert coverage.attributable_actions.covered == 1
+    assert coverage.attributable_actions.ratio == 0.5
+
+
+def test_denied_principal_is_attributable_but_not_decision_covered(tmp_path: Path) -> None:
+    _act(tmp_path, actor="bob", path="src/a.py")
+    assert _decide(tmp_path, subject="bob", groups=("readers",), action="tasks:write") == "deny"
+
+    coverage = _coverage(tmp_path)
+
+    assert coverage.attributable_actions.covered == 1
+    assert coverage.decided_actions.covered == 0
+    assert coverage.decided_actions.ratio == 0.0
+
+
+def test_governance_decision_records_are_not_counted_as_agent_actions(tmp_path: Path) -> None:
+    _act(tmp_path, actor="alice", path="src/a.py")
+    for action in ("tasks:write", "costs:read"):
+        _decide(tmp_path, subject="alice", groups=("eng",), action=action)
+
+    coverage = _coverage(tmp_path)
+
+    # Two decision rows landed in the same spine. Counting them as actions
+    # would let the run raise its own coverage by recording more decisions.
+    assert coverage.recorded_decisions == 2
+    assert coverage.recorded_actions == 1
+    assert coverage.attributable_actions.ratio == 1.0
+
+
+def test_journal_seal_and_attempt_rows_are_not_counted_as_agent_actions(tmp_path: Path) -> None:
+    _act(tmp_path, actor="agent-writer", path="src/a.py")
+    _act(tmp_path, actor="agent-writer", path="run.journal", step_id=f"{JOURNAL_SEAL_STEP_PREFIX}deadbeef")
+    _act(tmp_path, actor="agent-writer", path="src/missing.py", step_id=f"{ARTIFACT_ATTEMPT_STEP_PREFIX}t-1")
+
+    coverage = _coverage(tmp_path)
+
+    assert coverage.recorded_actions == 1
+
+
+def test_run_with_no_recorded_actions_reports_an_absent_ratio(tmp_path: Path) -> None:
+    coverage = collect_governance_coverage(tmp_path, "never-ran", hmac_key=_KEY)
+
+    assert coverage.recorded_actions == 0
+    assert coverage.attributable_actions.ratio is None
+    assert coverage.decided_actions.ratio is None
+    assert coverage.chain_status == "no_entries"
+    assert coverage.to_dict()["metrics"]["attributable_action_ratio"]["ratio"] is None
+
+
+def test_tampered_chain_is_reported_rather_than_scored_as_clean(tmp_path: Path) -> None:
+    _act(tmp_path, actor="alice", path="src/a.py")
+    _decide(tmp_path, subject="alice", groups=("eng",), action="tasks:write")
+    spine_path = _lineage_root(tmp_path) / _RUN / "spine.jsonl"
+    spine_path.write_bytes(spine_path.read_bytes().replace(b'"alice"', b'"mallory"'))
+
+    coverage = _coverage(tmp_path)
+
+    assert coverage.chain_status == "tampered"

--- a/tests/unit/test_governance_coverage_route.py
+++ b/tests/unit/test_governance_coverage_route.py
@@ -1,0 +1,65 @@
+"""``GET /governance/coverage`` returns the projection, not a second opinion (#5067).
+
+The route owns no arithmetic: it parses the query string, calls
+:func:`bernstein.core.security.governance_coverage.governance_coverage_json`
+and returns those bytes verbatim, so the dashboard and an offline recomputation
+from ``.sdd`` cannot disagree about a coverage number.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from bernstein.core.lineage.spine import LineageSpine
+from bernstein.core.routes.governance import router as governance_router
+from bernstein.core.security.governance_coverage import governance_coverage_json
+
+_KEY = b"0" * 32
+
+
+@pytest.fixture(autouse=True)
+def _pin_hmac_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("bernstein.core.routes.governance._hmac_key", lambda: _KEY)
+
+
+def _client(workdir: Path) -> TestClient:
+    app = FastAPI()
+    app.include_router(governance_router)
+    app.state.workdir = workdir
+    return TestClient(app)
+
+
+def _act(workdir: Path, *, actor: str, path: str) -> None:
+    LineageSpine(workdir / ".sdd" / "lineage", run_id="run-1", hmac_key=_KEY).record(
+        artifact_path=path,
+        content=path.encode(),
+        actor=actor,
+        step_id="write",
+        model="none",
+        timestamp=1000,
+    )
+
+
+def test_route_returns_the_projection_bytes_verbatim(tmp_path: Path) -> None:
+    _act(tmp_path, actor="agent-writer", path="src/a.py")
+
+    response = _client(tmp_path).get("/governance/coverage", params={"run_id": "run-1"})
+
+    assert response.status_code == 200
+    assert response.text == governance_coverage_json(tmp_path, "run-1", hmac_key=_KEY)
+
+
+def test_route_rejects_a_missing_run_id(tmp_path: Path) -> None:
+    response = _client(tmp_path).get("/governance/coverage")
+
+    assert response.status_code == 400
+
+
+def test_route_rejects_a_traversing_run_id(tmp_path: Path) -> None:
+    response = _client(tmp_path).get("/governance/coverage", params={"run_id": "../escape"})
+
+    assert response.status_code == 400

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -6022,6 +6022,7 @@ class TestAdaptivePollingBackoff:
         assert hasattr(orch, "_idle_multiplier")
         assert orch._idle_multiplier == 1
 
+
 # --- Reverse task-to-session index ---
 
 

--- a/verify_cli/bernstein_verify_receipt/__main__.py
+++ b/verify_cli/bernstein_verify_receipt/__main__.py
@@ -75,9 +75,7 @@ def cli() -> None:
     show_default=True,
     help="Which format(s) to verify.",
 )
-@click.option(
-    "--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details."
-)
+@click.option("--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details.")
 def verify_cmd(
     receipt_path: Path,
     jwk_path: Path | None,

--- a/verify_cli/bernstein_verify_receipt/verify.py
+++ b/verify_cli/bernstein_verify_receipt/verify.py
@@ -291,8 +291,7 @@ def verify_subject_binding(receipt: dict[str, Any]) -> tuple[CheckResult, str]:
                 "subject_binding",
                 ok=False,
                 detail=(
-                    f"recomputed head {recomputed[:16]}… "
-                    f"!= range.head_sha256 {range_head[:16]}…"
+                    f"recomputed head {recomputed[:16]}… != range.head_sha256 {range_head[:16]}…"
                 ),
             ),
             recomputed,
@@ -418,10 +417,7 @@ def verify_intoto(receipt: dict[str, Any], public_key: Any, recomputed_head: str
         return CheckResult(
             "intoto",
             ok=False,
-            detail=(
-                f"recomputed head {recomputed_head[:16]}… "
-                f"not in statement subject digests"
-            ),
+            detail=(f"recomputed head {recomputed_head[:16]}… not in statement subject digests"),
         )
     return CheckResult("intoto", ok=True, detail="DSSE/in-toto verified, subject bound to head")
 
@@ -469,8 +465,7 @@ def verify_transparency(
             "transparency",
             ok=False,
             detail=(
-                f"STH subject {subject_sha256[:16]}… "
-                f"!= recomputed head {recomputed_head[:16]}…"
+                f"STH subject {subject_sha256[:16]}… != recomputed head {recomputed_head[:16]}…"
             ),
         )
 
@@ -510,10 +505,7 @@ def verify_transparency(
             return CheckResult(
                 "transparency",
                 ok=False,
-                detail=(
-                    f"inclusion proof root {proven_root[:16]}… "
-                    f"!= STH root {root_hash[:16]}…"
-                ),
+                detail=(f"inclusion proof root {proven_root[:16]}… != STH root {root_hash[:16]}…"),
             )
     return CheckResult(
         "transparency", ok=True, detail="RFC6962 STH signed, root + inclusion proof verified"


### PR DESCRIPTION
## What

Slice 2 of #5067: the coverage projection and its dashboard endpoint.

- `src/bernstein/core/security/governance_coverage.py` computes `attributable_action_ratio` and `decision_coverage` for one run, from the lineage spine and the run's governance decision records.
- `GET /governance/coverage?run_id=<run>` returns that projection's canonical bytes.
- `docs/operations/governance.md` gains a "Coverage" section; `docs/reference/openapi.json` is regenerated for the new path.

What this PR explicitly does **not** do:

- No `web/` change, so no `/governance` route, no coverage panel, no re-captured browser renders. That is slice 1 and it is not started here.
- No "not covered" list (slice 3), no receipt drop-verify endpoint (slice 4), no decision detail view (slice 5).
- No new recording surface. Every number reads files that already exist; nothing new is written to the chain.
- No CLI command. The issue asked for the dashboard API only.

## Why

The operator surface has `/audit` and `/approvals`, and both are built out of entries. A screen built out of entries can only show the entries that exist, so it cannot show the actions no record accounts for: a run that attributed nothing renders identically to a run that attributed everything, and the difference is exactly what an operator arrives asking about.

The evidence to answer it is already on disk. `LineageSpine` records every artefact write with an actor, and `read_decisions` returns the run's signed decision records with their subjects and verdicts. Nothing joined the two, so the ratio existed in the files and nowhere in the product.

## How

Two ratios over one denominator, the run's recorded agent actions:

| Metric | Numerator |
|---|---|
| `attributable_action_ratio` | Actions whose `actor` is named as the `subject` of some decision recorded for the run. |
| `decision_coverage` | Actions whose `actor` holds a recorded `allow` verdict in the run. |

A spine entry's `actor` is a free-form string the writing adapter supplied; nothing binds it to an identity. A decision naming that string as its subject is the one place in the run where the installation resolved it to a principal and ruled on it, so that is the join.

Three rules keep the number from flattering the run:

- Decision records are anchored into the same spine, so rows written by `GOVERNANCE_ACTOR` are excluded from the action count. Otherwise a run raises its own coverage by recording more decisions.
- The journal-head seal and artifact-attempt rows are chain bookkeeping and a recorded non-delivery respectively, and are excluded the same way every other spine consumer excludes them.
- A run with no recorded actions reports `null`, not `0` and not `1`. Zero over zero is absent evidence.

`chain_status` carries the spine verify status verbatim alongside the numbers, so a `tampered` run cannot be read as a clean one that merely scored badly.

The route follows the `/artifacts/health` rule: it parses the query string, calls `governance_coverage_json`, and returns those bytes. One implementation, one serialiser, so a number pinned from a screen recomputes offline from `.sdd` alone.

**The decision the issue left open**: whether a `deny` / `refuse` verdict counts as coverage. It does not. A denial identifies the principal, so it counts toward attribution; an action taken in the face of a recorded denial is precisely an uncovered action, so it counts in the decision-coverage denominator and not in its numerator. The alternative — counting any decision — would report a run that denied everything and acted anyway as fully covered.

Timestamps are deliberately not used to order decisions against actions: spine entries are written with `time.time_ns()` while decision timestamps are caller-supplied in whatever unit the caller holds, so a "the decision preceded the action" test would compare incomparable numbers and report every decision as preceding every action.

## Tests

All ten failed on the unmodified tree — the two modules did not exist, so collection failed. Each was then checked against the implementation it pins by reverting that rule and confirming the assertion goes red.

`tests/unit/security/test_governance_coverage.py`

1. `test_action_with_no_named_principal_is_counted_and_not_attributable` — an unattributed action lowers the ratio instead of being skipped.
2. `test_actor_named_as_a_decision_subject_is_attributable` — one of two actors named by a decision gives 0.5.
3. `test_denied_principal_is_attributable_but_not_decision_covered` — a `deny` attributes without authorising.
4. `test_governance_decision_records_are_not_counted_as_agent_actions` — **load-bearing.** Two decision rows land in the same spine; the action count stays at 1. Without this the screen improves its own numbers by recording more decisions, which is the failure mode the whole screen exists to avoid.
5. `test_journal_seal_and_attempt_rows_are_not_counted_as_agent_actions` — chain bookkeeping is not an action.
6. `test_run_with_no_recorded_actions_reports_an_absent_ratio` — `None`, not `0`, and `no_entries` rather than a 404.
7. `test_tampered_chain_is_reported_rather_than_scored_as_clean` — a mutated spine reports `tampered`.

`tests/unit/test_governance_coverage_route.py`

8. `test_route_returns_the_projection_bytes_verbatim` — the response body equals `governance_coverage_json` for the same state.
9. `test_route_rejects_a_missing_run_id` — 400.
10. `test_route_rejects_a_traversing_run_id` — 400, not a read outside the run directory.

Local runs (`--parallel 2`, isolated `XDG_*` and confidence DB):

- the two new files, plus `test_security_governance.py`, `test_governance_cmd.py`, `test_openapi_snapshot_drift.py`, `test_route_table.py`, `test_artifact_cli_route_parity.py`, `test_unreleased_notes_rotation.py`, `test_release_notes.py`, `test_server_app_multi_worker_preflight.py`, `test_health_deps_route.py`, `test_well_known.py`.
- `--affected origin/main` selects 449 files, because the router registration touches `server_app.py`, which nearly everything imports. Per the contributing guidance for a selection that large, the targeted set above was run instead: the tests of the touched modules plus the tests of their importers and of the regenerated snapshot. CI runs the full suite.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes (checked on the two new modules; `0 errors`)
- [x] `uv run python scripts/run_tests.py -x` passes for the files listed above
- [x] New code has type hints

### Documentation duty

- [ ] User-visible README section updated — N/A, no README-level surface changed
- [x] `docs/operations/governance.md` gains a "Coverage" section
- [x] `docs/reference/openapi.json` regenerated for the new path
- [x] `uv run bernstein agents-md sync` run — no changes produced
- [x] Tests cover the documented behaviour

A release-notes fragment is added at `docs/release-notes/fragments/5067-governance-coverage.md`.

Part of #5067

## Remaining

- Slice 1 — the `/governance` route and coverage panel in `web/`, with the SPA bundle rebuilt and the browser renders re-captured and rebound.
- Slice 3 — the "not covered" list, each row naming the gap and linking the issue that closes it.
- Slice 4 — receipt drop-verify: an endpoint wrapping the offline verifier, surfacing its trust-on-first-use result.
- Slice 5 — the decision detail view over `read_decisions`.
