### PR TITLE
feat: portable authority envelope schema and standalone verifier (#5055)

### DIFF
--- a/docs/interop/authority-envelope.md
+++ b/docs/interop/authority-envelope.md
@@ -1,0 +1,114 @@
+# Authority envelope
+
+An **authority envelope** is a single file that records who acted, under which
+delegated authority, which policy decision allowed it, what evidence ties that
+decision to an artefact, and — stated in the file itself — what the envelope
+does *not* cover.
+
+It exists so that evidence about authority can be checked somewhere other than
+the install that produced it: by a gateway, another agent runtime, a policy
+engine, or an auditor's own tooling.
+
+Two artefacts define it today:
+
+| Artefact | Path |
+|---|---|
+| Schema (v1) | `schemas/authority-envelope-v1.json` |
+| Standalone verifier | `verify_cli/bernstein_verify_envelope/` |
+| Golden vectors | `tests/fixtures/authority-envelope-vectors/` |
+
+There is no producer yet. This page describes the format and the verifier; an
+envelope is written by hand or by the vector builder until a producer lands.
+
+## Verifying one
+
+```bash
+pip install bernstein-verify-envelope
+bernstein-verify-envelope verify ./authority-envelope.json --verbose
+```
+
+Exit codes: `0` verified, `1` a check failed, `2` bad arguments. The verifier
+depends on `cryptography` and `click` and nothing else — in particular it never
+imports `bernstein` and never opens a socket, which is asserted by a test that
+runs it in a subprocess where importing `bernstein` raises.
+
+## Shape
+
+```
+schema_version    pinned to 1.0.0
+envelope_type     https://bernstein.run/attestations/authority-envelope/v1
+principal         the acting identity, plus the key material to check it
+grants            the authority it acted under, root first, each link attenuating
+decisions         one record per authorization, each naming a versioned policy
+evidence          artefact hashes tying decisions to what happened
+coverage          what this envelope does NOT cover, stated in the envelope
+section_digests   per-section hashes, so a failure names the section that moved
+signature         detached EdDSA JWS over the canonical bytes of everything above
+```
+
+Nothing in the envelope references a run identifier or a lineage root, so it can
+carry activity Bernstein did not schedule.
+
+### Canonical form
+
+RFC 8785 JCS. The signature is a detached compact JWS (RFC 7515 Appendix F)
+whose signing input is `BASE64URL(JCS(header)) || "." || BASE64URL(JCS(body))`,
+where the body is every top-level member except `signature`, and the protected
+header is `{"alg": "EdDSA", "typ": "application/vnd.bernstein.authority-envelope+jws", "kid": …}`.
+
+The verifier re-implements JCS locally rather than importing it. The committed
+golden vector is what proves the two implementations agree; sharing the code
+would prove nothing about an independent reader.
+
+## What a passing envelope proves
+
+- **The identifier is bound to the key.** `principal.id_binding` recomputes over
+  the principal id and its JWK, so an identifier cannot be re-pointed at other
+  key material.
+- **The grant chain attenuates.** Each link's hash chains to its parent's, its
+  scope is a subset of the parent's, its expiry is no later, its issuer is the
+  parent's subject, and the last link's subject is the acting principal.
+  Rewriting an ancestor invalidates every descendant.
+- **Each decision follows from the authority it cites.** The decision's
+  `inputs_hash` recomputes from its own recorded policy inputs *and* the grant
+  hash, so an edited input or a swapped grant is detected. An `allow` for an
+  action outside the cited link's scope is rejected, as is a decision timestamped
+  after that link expired.
+- **Evidence attaches to something.** Every artefact hash names a decision the
+  envelope carries.
+- **The gaps are declared.** The verifier re-derives which decisions carry
+  evidence and which do not, and rejects a `coverage` section that does not name
+  every gap. An envelope with no `coverage` section at all is refused rather than
+  read as complete.
+- **Nothing was edited after signing.** The detached JWS covers the whole body,
+  and the per-section digests localise a mutation to the section it landed in.
+
+## What it does not prove
+
+- **That the signing key is trusted.** An envelope verified against the key it
+  carries is trust-on-first-use, and is reported as such. Pinning an external key
+  is not implemented yet, so today an attacker who can replace the whole file can
+  also replace the key it carries. Compare the key out of band until pinning
+  lands.
+- **That the grants were unrevoked** when they were used. The envelope carries
+  expiries, not revocation state.
+- **That the artefacts exist or say what they are claimed to say.** Evidence
+  entries are hashes; matching them against real artefacts is the reader's step.
+- **That the acting principal was who it claimed to be.** The envelope binds an
+  identifier to a key; it does not prove possession of that key at the time of
+  the action.
+- **Anything outside its own `coverage`.** A partial envelope names its gaps and
+  the verifier enforces that they are named — the gaps remain gaps.
+
+## Golden vectors
+
+`tests/fixtures/authority-envelope-vectors/` holds a deliberately partial
+envelope (two decisions, one of them uncovered) and a tampered copy. Both are
+committed rather than minted at test time, so a change to the canonical form or
+a hash preimage fails CI instead of silently invalidating an envelope already
+handed to a reader. The builder is deterministic; re-mint it only when the
+format itself changes:
+
+```bash
+uv run python tests/fixtures/authority-envelope-vectors/_build_authority_envelope_vectors.py
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -508,6 +508,7 @@ nav:
           - ACP server and client roles: interop/acp.md
           - A2A signed agent cards: architecture/a2a.md
           - A2A capability cards & lineage interop: interop/a2a.md
+          - Authority envelope: interop/authority-envelope.md
           - Eventing v2 (unified feed): events/grammar.md
           - .well-known manifest: protocols/well-known-manifest.md
           - SPIFFE workload identity: reference/spiffe-workload-identity.md

--- a/schemas/authority-envelope-v1.json
+++ b/schemas/authority-envelope-v1.json
@@ -1,0 +1,286 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://bernstein.alexchernysh.com/schemas/authority-envelope-v1.json",
+  "title": "Bernstein Authority Envelope (v1)",
+  "description": "A portable, self-describing record of who acted, under which delegated authority, and which policy decision allowed it. The envelope is not run-scoped: nothing in it references a run identifier or a lineage root, so activity Bernstein did not schedule can be carried in the same shape. Canonical form is RFC 8785 JCS; the signature is a detached EdDSA JWS (RFC 7515 Appendix F) over the JCS bytes of the envelope body, where the body is every top-level member except `signature`. Every hash the envelope carries is recomputable from material the envelope itself records: `principal.id_binding` binds the principal identifier to its key, each `grants[].grant_hash` chains to its parent, each `decisions[].inputs_hash` covers the decision's policy inputs and the grant it cites, and `section_digests` lets a verifier name which section diverged rather than reporting only a broken signature. A signature says who asserted the envelope; the recomputation says the assertion follows from its own inputs.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "envelope_type",
+    "principal",
+    "grants",
+    "decisions",
+    "evidence",
+    "coverage",
+    "section_digests",
+    "signature"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": ["1.0.0"],
+      "description": "Pinned envelope schema version."
+    },
+    "envelope_type": {
+      "type": "string",
+      "const": "https://bernstein.run/attestations/authority-envelope/v1",
+      "description": "URL identifying the envelope type."
+    },
+    "principal": {
+      "type": "object",
+      "description": "The acting identity, as a reference plus the material needed to check it. The principal key is the identity that acted; it is not necessarily the key that signed this envelope.",
+      "required": ["id", "key", "id_binding"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable identifier for the acting principal."
+        },
+        "key_id": {
+          "type": "string",
+          "description": "Optional key identifier for the principal key."
+        },
+        "key": {
+          "$ref": "#/definitions/ed25519_jwk",
+          "description": "The principal's Ed25519 public key (RFC 8037 OKP JWK)."
+        },
+        "id_binding": {
+          "$ref": "#/definitions/sha256_hex",
+          "description": "sha256 over the JCS bytes of {\"v\": schema_version, \"id\": principal.id, \"key\": principal.key}. A verifier recomputes it, so an identifier cannot be re-pointed at a different key without detection."
+        }
+      }
+    },
+    "grants": {
+      "type": "array",
+      "minItems": 1,
+      "description": "The authority under which the principal acted, ordered root first. Each link attenuates the previous one: its scope is a subset, its expiry is no later, and its issuer is the previous link's subject. The last link's subject is the principal.",
+      "items": {
+        "type": "object",
+        "required": [
+          "grant_id",
+          "parent",
+          "issuer",
+          "subject",
+          "scope",
+          "not_after",
+          "grant_hash"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "grant_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Identifier for this link, unique within the envelope."
+          },
+          "parent": {
+            "type": ["string", "null"],
+            "description": "grant_id of the preceding link; null on the root link only."
+          },
+          "issuer": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Identity that issued this link."
+          },
+          "subject": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Identity this link was issued to."
+          },
+          "scope": {
+            "type": "array",
+            "uniqueItems": true,
+            "description": "Actions this link authorises, sorted ascending so the canonical form is stable.",
+            "items": {"type": "string", "minLength": 1}
+          },
+          "not_after": {
+            "$ref": "#/definitions/rfc3339_utc",
+            "description": "Expiry of this link. Must be no later than the parent's."
+          },
+          "grant_hash": {
+            "$ref": "#/definitions/sha256_hex",
+            "description": "sha256 over the JCS bytes of {\"v\": schema_version, \"grant_id\", \"issuer\", \"subject\", \"scope\", \"not_after\", \"parent_hash\"}, where parent_hash is the empty string on the root link and the parent's grant_hash otherwise. Chaining the hashes means a rewritten ancestor invalidates every descendant."
+          }
+        }
+      }
+    },
+    "decisions": {
+      "type": "array",
+      "minItems": 1,
+      "description": "One record per authorization, each naming the versioned policy that produced it and the grant link it drew authority from.",
+      "items": {
+        "type": "object",
+        "required": [
+          "decision_id",
+          "grant",
+          "subject",
+          "action",
+          "resource",
+          "verdict",
+          "policy",
+          "inputs",
+          "inputs_hash",
+          "timestamp"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "decision_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Identifier for this decision, unique within the envelope."
+          },
+          "grant": {
+            "type": "string",
+            "minLength": 1,
+            "description": "grant_id of the link this decision drew authority from."
+          },
+          "subject": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The identity the decision is about; must equal the cited link's subject."
+          },
+          "action": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The requested action."
+          },
+          "resource": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The resource the action was requested against."
+          },
+          "verdict": {
+            "type": "string",
+            "enum": ["allow", "deny"],
+            "description": "The outcome. An `allow` whose action is outside the cited link's scope does not follow from the recorded authority and is rejected."
+          },
+          "policy": {
+            "type": "object",
+            "required": ["id", "version"],
+            "additionalProperties": false,
+            "description": "The versioned policy that produced the verdict.",
+            "properties": {
+              "id": {"type": "string", "minLength": 1},
+              "version": {"type": "string", "minLength": 1}
+            }
+          },
+          "inputs": {
+            "type": "object",
+            "description": "The policy inputs the verdict was computed from -- policy material only, never secrets. Opaque to the schema and covered verbatim by inputs_hash."
+          },
+          "inputs_hash": {
+            "$ref": "#/definitions/sha256_hex",
+            "description": "sha256 over the JCS bytes of {\"v\": schema_version, \"subject\", \"action\", \"resource\", \"policy\", \"inputs\", \"grant_hash\"} where grant_hash is the cited link's grant_hash. Recomputing it detects an edited input and ties the decision to one exact grant chain."
+          },
+          "timestamp": {
+            "$ref": "#/definitions/rfc3339_utc",
+            "description": "When the decision was taken. Must be no later than the cited link's not_after."
+          }
+        }
+      }
+    },
+    "evidence": {
+      "type": "array",
+      "description": "Hashes tying decisions to what actually happened. Every entry names a decision the envelope carries; a decision with no entry is a gap and must be declared in coverage.uncovered.",
+      "items": {
+        "type": "object",
+        "required": ["decision", "name", "digest"],
+        "additionalProperties": false,
+        "properties": {
+          "decision": {"type": "string", "minLength": 1},
+          "name": {"type": "string", "minLength": 1},
+          "digest": {
+            "type": "object",
+            "required": ["sha256"],
+            "additionalProperties": false,
+            "properties": {"sha256": {"$ref": "#/definitions/sha256_hex"}}
+          }
+        }
+      }
+    },
+    "coverage": {
+      "type": "object",
+      "description": "What this envelope does and does not cover, stated in the envelope. A verifier refuses an envelope that omits this member rather than reading silence as full coverage.",
+      "required": ["covered", "uncovered", "statement"],
+      "additionalProperties": false,
+      "properties": {
+        "covered": {
+          "type": "array",
+          "uniqueItems": true,
+          "description": "decision_ids that carry at least one evidence entry. Recomputed from evidence; a mismatch is rejected.",
+          "items": {"type": "string", "minLength": 1}
+        },
+        "uncovered": {
+          "type": "array",
+          "uniqueItems": true,
+          "description": "Every decision with no evidence entry, named explicitly with the reason it is missing.",
+          "items": {
+            "type": "object",
+            "required": ["decision_id", "action", "reason"],
+            "additionalProperties": false,
+            "properties": {
+              "decision_id": {"type": "string", "minLength": 1},
+              "action": {"type": "string", "minLength": 1},
+              "reason": {"type": "string", "minLength": 1}
+            }
+          }
+        },
+        "statement": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Plain-language statement of the envelope's limits, for a reader who will not run the verifier."
+        }
+      }
+    },
+    "section_digests": {
+      "type": "object",
+      "description": "sha256 over the JCS bytes of each named section, so a verifier can report which section diverged instead of only that the signature failed.",
+      "required": ["principal", "grants", "decisions", "evidence", "coverage"],
+      "additionalProperties": false,
+      "properties": {
+        "principal": {"$ref": "#/definitions/sha256_hex"},
+        "grants": {"$ref": "#/definitions/sha256_hex"},
+        "decisions": {"$ref": "#/definitions/sha256_hex"},
+        "evidence": {"$ref": "#/definitions/sha256_hex"},
+        "coverage": {"$ref": "#/definitions/sha256_hex"}
+      }
+    },
+    "signature": {
+      "type": "object",
+      "description": "Detached EdDSA JWS over the JCS bytes of the envelope body (every top-level member except this one). The embedded key is a hint: an external verifier may pin its own.",
+      "required": ["alg", "kid", "public_key_jwk", "jws"],
+      "additionalProperties": false,
+      "properties": {
+        "alg": {"type": "string", "const": "EdDSA"},
+        "kid": {"type": "string", "minLength": 1},
+        "public_key_jwk": {"$ref": "#/definitions/ed25519_jwk"},
+        "jws": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_-]+\\.\\.[A-Za-z0-9_-]+$",
+          "description": "Compact detached JWS: BASE64URL(JCS(protected header)) || '..' || BASE64URL(signature). The protected header is {\"alg\": \"EdDSA\", \"typ\": \"application/vnd.bernstein.authority-envelope+jws\", \"kid\": signature.kid} and the signing input is BASE64URL(JCS(header)) || '.' || BASE64URL(JCS(body))."
+        }
+      }
+    }
+  },
+  "definitions": {
+    "sha256_hex": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "rfc3339_utc": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+    },
+    "ed25519_jwk": {
+      "type": "object",
+      "required": ["kty", "crv", "x"],
+      "additionalProperties": false,
+      "properties": {
+        "kty": {"type": "string", "const": "OKP"},
+        "crv": {"type": "string", "const": "Ed25519"},
+        "x": {"type": "string", "pattern": "^[A-Za-z0-9_-]{43}$"}
+      }
+    }
+  }
+}

--- a/tests/fixtures/authority-envelope-vectors/README.md
+++ b/tests/fixtures/authority-envelope-vectors/README.md
@@ -1,0 +1,38 @@
+# Authority-envelope golden vectors
+
+Committed test vectors for `schemas/authority-envelope-v1.json` and the
+standalone verifier in `verify_cli/bernstein_verify_envelope/`.
+
+| File | What it is |
+|---|---|
+| `valid-authority-envelope.json` | A deliberately **partial** envelope: two authorization decisions, one of which carries no evidence and is therefore named in `coverage.uncovered`. Verifies clean. |
+| `tampered-authority-envelope.json` | The same envelope with `decisions[1].verdict` flipped to `deny`. Must be rejected, and the rejection must name the `decisions` section. |
+| `_build_authority_envelope_vectors.py` | Re-mints both files. Run by hand, never by the test suite. |
+
+## Why the vectors are committed
+
+The vectors are the target the verifier is judged against. Minting them inside
+the test would move both sides of the comparison at once: a verifier that
+stopped checking `inputs_hash` and a builder that stopped computing it would
+still agree with each other. Because the bytes are committed, a change to the
+canonical form, a hash preimage, or the JWS signing input fails CI instead of
+silently invalidating an envelope already handed to an auditor.
+
+The builder is fully deterministic — fixed timestamps, seeded Ed25519 keys — so
+re-minting an unchanged format reproduces the files byte for byte. Re-mint only
+when the envelope format itself changed:
+
+```bash
+uv run python tests/fixtures/authority-envelope-vectors/_build_authority_envelope_vectors.py
+```
+
+Review the resulting diff as new evidence rather than as a formatting change.
+
+## Keys
+
+Both keys are seeded from constants in the builder and exist only for these
+vectors. They are not operator keys and must never be trusted for anything else.
+
+- Principal key: seed `b"p" * 32`.
+- Attestor (signing) key: seed `b"a" * 32`. The envelope carries its public half
+  as a hint; a verifier is expected to pin its own key out of band.

--- a/tests/fixtures/authority-envelope-vectors/_build_authority_envelope_vectors.py
+++ b/tests/fixtures/authority-envelope-vectors/_build_authority_envelope_vectors.py
@@ -69,9 +69,7 @@ def _jwk(private_key: Ed25519PrivateKey) -> dict[str, str]:
     """RFC 8037 OKP JWK for the public half of *private_key*."""
     from cryptography.hazmat.primitives import serialization
 
-    raw = private_key.public_key().public_bytes(
-        serialization.Encoding.Raw, serialization.PublicFormat.Raw
-    )
+    raw = private_key.public_key().public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
     return {"kty": "OKP", "crv": "Ed25519", "x": _b64url(raw)}
 
 
@@ -156,9 +154,7 @@ def build_envelope() -> dict[str, Any]:
         "id": REVIEWER,
         "key_id": "principal-reviewer-7",
         "key": principal_jwk,
-        "id_binding": _sha256_jcs(
-            {"v": SCHEMA_VERSION, "id": REVIEWER, "key": principal_jwk}
-        ),
+        "id_binding": _sha256_jcs({"v": SCHEMA_VERSION, "id": REVIEWER, "key": principal_jwk}),
     }
 
     root = _grant(
@@ -242,8 +238,7 @@ def build_envelope() -> dict[str, Any]:
         "coverage": coverage,
     }
     body["section_digests"] = {
-        name: _sha256_jcs(body[name])
-        for name in ("principal", "grants", "decisions", "evidence", "coverage")
+        name: _sha256_jcs(body[name]) for name in ("principal", "grants", "decisions", "evidence", "coverage")
     }
 
     kid = "authority-envelope-vector-key"

--- a/tests/fixtures/authority-envelope-vectors/_build_authority_envelope_vectors.py
+++ b/tests/fixtures/authority-envelope-vectors/_build_authority_envelope_vectors.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Re-mint the authority-envelope golden vectors in this directory (issue #5055).
+
+Run by hand from a source checkout, never by the test suite::
+
+    uv run python tests/fixtures/authority-envelope-vectors/_build_authority_envelope_vectors.py
+
+It builds one deliberately partial envelope -- two authorization decisions, one
+of which carries no evidence and is therefore declared in ``coverage.uncovered``
+-- signs it with the deterministic Ed25519 key pinned below, and writes a second
+copy with one decision mutated.
+
+Why the vectors are committed rather than generated at test time
+----------------------------------------------------------------
+The vector is the target the standalone verifier is judged against. Minting it
+inside the test would move both sides of the comparison at once: a verifier that
+stopped checking ``inputs_hash`` and a builder that stopped computing it would
+still agree. Committing the bytes means a change to the canonical form, the hash
+preimages, or the JWS signing input fails CI instead of silently invalidating an
+envelope already handed to an auditor.
+
+Everything here is deterministic, so a re-mint with an unchanged format produces
+byte-identical files: the timestamps are fixed constants and the signing key is
+seeded. Re-mint only when the envelope format itself changes, and review the
+diff as new evidence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+# The production side of the canonicalisation. The standalone verifier
+# re-implements RFC 8785 locally; the golden vector is what proves the two
+# implementations agree.
+from bernstein.core.security.agent_card_signer import _b64url, canonicalize_jcs
+
+OUT_DIR = Path(__file__).resolve().parent
+
+SCHEMA_VERSION = "1.0.0"
+ENVELOPE_TYPE = "https://bernstein.run/attestations/authority-envelope/v1"
+JWS_TYP = "application/vnd.bernstein.authority-envelope+jws"
+
+_PRINCIPAL_SEED = b"p" * 32
+_ATTESTOR_SEED = b"a" * 32
+
+OPERATOR = "urn:bernstein:principal:operator:alex"
+ORCHESTRATOR = "urn:bernstein:principal:agent:orchestrator-1"
+REVIEWER = "urn:bernstein:principal:agent:reviewer-7"
+
+BINDINGS_HASH = hashlib.sha256(b"role-bindings/v3").hexdigest()
+ARTEFACT_DIGEST = hashlib.sha256(b"lineage/step-0007.json").hexdigest()
+
+
+def _sha256_jcs(value: Any) -> str:
+    """Content hash over the RFC 8785 canonical bytes of *value*."""
+    return hashlib.sha256(canonicalize_jcs(value)).hexdigest()
+
+
+def _jwk(private_key: Ed25519PrivateKey) -> dict[str, str]:
+    """RFC 8037 OKP JWK for the public half of *private_key*."""
+    from cryptography.hazmat.primitives import serialization
+
+    raw = private_key.public_key().public_bytes(
+        serialization.Encoding.Raw, serialization.PublicFormat.Raw
+    )
+    return {"kty": "OKP", "crv": "Ed25519", "x": _b64url(raw)}
+
+
+def _grant(
+    *,
+    grant_id: str,
+    parent_hash: str,
+    parent: str | None,
+    issuer: str,
+    subject: str,
+    scope: list[str],
+    not_after: str,
+) -> dict[str, Any]:
+    """Build one grant-chain link with its chained hash filled in."""
+    scope = sorted(scope)
+    grant_hash = _sha256_jcs(
+        {
+            "v": SCHEMA_VERSION,
+            "grant_id": grant_id,
+            "issuer": issuer,
+            "subject": subject,
+            "scope": scope,
+            "not_after": not_after,
+            "parent_hash": parent_hash,
+        }
+    )
+    return {
+        "grant_id": grant_id,
+        "parent": parent,
+        "issuer": issuer,
+        "subject": subject,
+        "scope": scope,
+        "not_after": not_after,
+        "grant_hash": grant_hash,
+    }
+
+
+def _decision(
+    *,
+    decision_id: str,
+    grant: dict[str, Any],
+    action: str,
+    resource: str,
+    verdict: str,
+    policy: dict[str, str],
+    inputs: dict[str, Any],
+    timestamp: str,
+) -> dict[str, Any]:
+    """Build one decision record with its recomputable input hash filled in."""
+    inputs_hash = _sha256_jcs(
+        {
+            "v": SCHEMA_VERSION,
+            "subject": grant["subject"],
+            "action": action,
+            "resource": resource,
+            "policy": policy,
+            "inputs": inputs,
+            "grant_hash": grant["grant_hash"],
+        }
+    )
+    return {
+        "decision_id": decision_id,
+        "grant": grant["grant_id"],
+        "subject": grant["subject"],
+        "action": action,
+        "resource": resource,
+        "verdict": verdict,
+        "policy": policy,
+        "inputs": inputs,
+        "inputs_hash": inputs_hash,
+        "timestamp": timestamp,
+    }
+
+
+def build_envelope() -> dict[str, Any]:
+    """Build and sign the deliberately-partial golden envelope."""
+    principal_key = Ed25519PrivateKey.from_private_bytes(_PRINCIPAL_SEED)
+    attestor_key = Ed25519PrivateKey.from_private_bytes(_ATTESTOR_SEED)
+
+    principal_jwk = _jwk(principal_key)
+    principal = {
+        "id": REVIEWER,
+        "key_id": "principal-reviewer-7",
+        "key": principal_jwk,
+        "id_binding": _sha256_jcs(
+            {"v": SCHEMA_VERSION, "id": REVIEWER, "key": principal_jwk}
+        ),
+    }
+
+    root = _grant(
+        grant_id="g-root",
+        parent=None,
+        parent_hash="",
+        issuer=OPERATOR,
+        subject=ORCHESTRATOR,
+        scope=["repo.read", "repo.write", "task.close", "task.read"],
+        not_after="2030-01-01T00:00:00Z",
+    )
+    hop = _grant(
+        grant_id="g-hop1",
+        parent=root["grant_id"],
+        parent_hash=root["grant_hash"],
+        issuer=ORCHESTRATOR,
+        subject=REVIEWER,
+        scope=["repo.read", "task.close"],
+        not_after="2027-01-01T00:00:00Z",
+    )
+    grants = [root, hop]
+
+    policy = {"id": "policy:role-bindings", "version": "3"}
+    inputs = {"role": "reviewer", "bindings_hash": BINDINGS_HASH}
+    decisions = [
+        _decision(
+            decision_id="d-1",
+            grant=hop,
+            action="repo.read",
+            resource="urn:bernstein:repo:bernstein",
+            verdict="allow",
+            policy=policy,
+            inputs=inputs,
+            timestamp="2026-05-04T09:15:00Z",
+        ),
+        _decision(
+            decision_id="d-2",
+            grant=hop,
+            action="task.close",
+            resource="urn:bernstein:task:T-4180",
+            verdict="allow",
+            policy=policy,
+            inputs=inputs,
+            timestamp="2026-05-04T09:17:30Z",
+        ),
+    ]
+
+    evidence = [
+        {
+            "decision": "d-1",
+            "name": "lineage/step-0007.json",
+            "digest": {"sha256": ARTEFACT_DIGEST},
+        }
+    ]
+
+    coverage = {
+        "covered": ["d-1"],
+        "uncovered": [
+            {
+                "decision_id": "d-2",
+                "action": "task.close",
+                "reason": "the artefact this decision authorised was not exported with the envelope",
+            }
+        ],
+        "statement": (
+            "Covers 1 of 2 authorization decisions with an artefact hash. The envelope proves "
+            "the recorded grant chain attenuates, that each decision follows from the link it "
+            "cites, and that the covered decision names an artefact digest. It does not prove "
+            "the artefact was produced, that the signing key is trusted, or that the grants "
+            "were unrevoked."
+        ),
+    }
+
+    body: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "envelope_type": ENVELOPE_TYPE,
+        "principal": principal,
+        "grants": grants,
+        "decisions": decisions,
+        "evidence": evidence,
+        "coverage": coverage,
+    }
+    body["section_digests"] = {
+        name: _sha256_jcs(body[name])
+        for name in ("principal", "grants", "decisions", "evidence", "coverage")
+    }
+
+    kid = "authority-envelope-vector-key"
+    header = {"alg": "EdDSA", "typ": JWS_TYP, "kid": kid}
+    header_b64 = _b64url(canonicalize_jcs(header))
+    body_b64 = _b64url(canonicalize_jcs(body))
+    signature = attestor_key.sign(f"{header_b64}.{body_b64}".encode("ascii"))
+
+    envelope = dict(body)
+    envelope["signature"] = {
+        "alg": "EdDSA",
+        "kid": kid,
+        "public_key_jwk": _jwk(attestor_key),
+        "jws": f"{header_b64}..{_b64url(signature)}",
+    }
+    return envelope
+
+
+def main() -> None:
+    """Write the valid and tampered vectors."""
+    envelope = build_envelope()
+
+    valid_path = OUT_DIR / "valid-authority-envelope.json"
+    valid_bytes = json.dumps(envelope, indent=2, sort_keys=True).encode("utf-8") + b"\n"
+    valid_path.write_bytes(valid_bytes)
+    print(f"Wrote valid envelope:    {valid_path}  ({len(valid_bytes)} bytes)")
+
+    tampered = json.loads(valid_bytes)
+    original = tampered["decisions"][1]["verdict"]
+    tampered["decisions"][1]["verdict"] = "deny"
+    print(f"Tampering decisions[1].verdict: {original!r} -> 'deny'")
+    tampered_path = OUT_DIR / "tampered-authority-envelope.json"
+    tampered_bytes = json.dumps(tampered, indent=2, sort_keys=True).encode("utf-8") + b"\n"
+    tampered_path.write_bytes(tampered_bytes)
+    print(f"Wrote tampered envelope: {tampered_path}  ({len(tampered_bytes)} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/authority-envelope-vectors/tampered-authority-envelope.json
+++ b/tests/fixtures/authority-envelope-vectors/tampered-authority-envelope.json
@@ -1,0 +1,119 @@
+{
+  "coverage": {
+    "covered": [
+      "d-1"
+    ],
+    "statement": "Covers 1 of 2 authorization decisions with an artefact hash. The envelope proves the recorded grant chain attenuates, that each decision follows from the link it cites, and that the covered decision names an artefact digest. It does not prove the artefact was produced, that the signing key is trusted, or that the grants were unrevoked.",
+    "uncovered": [
+      {
+        "action": "task.close",
+        "decision_id": "d-2",
+        "reason": "the artefact this decision authorised was not exported with the envelope"
+      }
+    ]
+  },
+  "decisions": [
+    {
+      "action": "repo.read",
+      "decision_id": "d-1",
+      "grant": "g-hop1",
+      "inputs": {
+        "bindings_hash": "d6873cb83477572bd8ac89499e22d205b04092593080796bdeb9b1c2bd5a7def",
+        "role": "reviewer"
+      },
+      "inputs_hash": "f0bbd033aa4c959bfc63b9a872b241f7cf8507626f77e2afbb2cd09da2bc620d",
+      "policy": {
+        "id": "policy:role-bindings",
+        "version": "3"
+      },
+      "resource": "urn:bernstein:repo:bernstein",
+      "subject": "urn:bernstein:principal:agent:reviewer-7",
+      "timestamp": "2026-05-04T09:15:00Z",
+      "verdict": "allow"
+    },
+    {
+      "action": "task.close",
+      "decision_id": "d-2",
+      "grant": "g-hop1",
+      "inputs": {
+        "bindings_hash": "d6873cb83477572bd8ac89499e22d205b04092593080796bdeb9b1c2bd5a7def",
+        "role": "reviewer"
+      },
+      "inputs_hash": "0548f96f96ae836f24b80c640fd49a3f88f25bc90ffb5360d7dd594fbfabe5fc",
+      "policy": {
+        "id": "policy:role-bindings",
+        "version": "3"
+      },
+      "resource": "urn:bernstein:task:T-4180",
+      "subject": "urn:bernstein:principal:agent:reviewer-7",
+      "timestamp": "2026-05-04T09:17:30Z",
+      "verdict": "deny"
+    }
+  ],
+  "envelope_type": "https://bernstein.run/attestations/authority-envelope/v1",
+  "evidence": [
+    {
+      "decision": "d-1",
+      "digest": {
+        "sha256": "6d22d8a4602b66464654d2a54a32bcdf4eb40620cd69134b200fe255358ab61b"
+      },
+      "name": "lineage/step-0007.json"
+    }
+  ],
+  "grants": [
+    {
+      "grant_hash": "6e9a085b00236d970d42bc41c11c9ecb7c4c2935d0632a77d8a4aabb77712985",
+      "grant_id": "g-root",
+      "issuer": "urn:bernstein:principal:operator:alex",
+      "not_after": "2030-01-01T00:00:00Z",
+      "parent": null,
+      "scope": [
+        "repo.read",
+        "repo.write",
+        "task.close",
+        "task.read"
+      ],
+      "subject": "urn:bernstein:principal:agent:orchestrator-1"
+    },
+    {
+      "grant_hash": "2bf5caa9d5b03e6013934fade85411312f6c99eb41de9d504e85b20618c4a2c2",
+      "grant_id": "g-hop1",
+      "issuer": "urn:bernstein:principal:agent:orchestrator-1",
+      "not_after": "2027-01-01T00:00:00Z",
+      "parent": "g-root",
+      "scope": [
+        "repo.read",
+        "task.close"
+      ],
+      "subject": "urn:bernstein:principal:agent:reviewer-7"
+    }
+  ],
+  "principal": {
+    "id": "urn:bernstein:principal:agent:reviewer-7",
+    "id_binding": "b012e1bece83f2909ead1a16f5a7d1516ec98b6461ed62088f10041b63bee23c",
+    "key": {
+      "crv": "Ed25519",
+      "kty": "OKP",
+      "x": "GSBMjDuoW6BZzRiskBe9AqGNpdEMaPt3mjS-Q-8Gd5E"
+    },
+    "key_id": "principal-reviewer-7"
+  },
+  "schema_version": "1.0.0",
+  "section_digests": {
+    "coverage": "55fe772424c4736c0d3d0c75f1fb6b7820b696892c527834527dfa1801f07fd8",
+    "decisions": "4e7a7f5eb526a5715e36a26f48be85fda4508343c5752b5a4fa0742bceb5e4b9",
+    "evidence": "ca0722167d9d1746b990f0b1d055a1446142b8b90a4ebad1142b95c1e589a097",
+    "grants": "8761d0fe98a26355251e5a8545128d301a44d19671cfeb3e51b0c4235b11a697",
+    "principal": "663a602a23692b85cac222960101847c7b4a269aaeca4f7f2e6cae012d19faed"
+  },
+  "signature": {
+    "alg": "EdDSA",
+    "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImF1dGhvcml0eS1lbnZlbG9wZS12ZWN0b3Ita2V5IiwidHlwIjoiYXBwbGljYXRpb24vdm5kLmJlcm5zdGVpbi5hdXRob3JpdHktZW52ZWxvcGUrandzIn0..cWuKN_msozOxUI63GNm_BbfUc7IdO8dO9OgIbsiDEqWfEFvPA723Ou-lK4PknDIZuJIyGG78lSCsIPGE7U1wAQ",
+    "kid": "authority-envelope-vector-key",
+    "public_key_jwk": {
+      "crv": "Ed25519",
+      "kty": "OKP",
+      "x": "rwaj4ykXFOTzVsGcmxXNGVHsbmZiqne-B1R_KJODNB0"
+    }
+  }
+}

--- a/tests/fixtures/authority-envelope-vectors/valid-authority-envelope.json
+++ b/tests/fixtures/authority-envelope-vectors/valid-authority-envelope.json
@@ -1,0 +1,119 @@
+{
+  "coverage": {
+    "covered": [
+      "d-1"
+    ],
+    "statement": "Covers 1 of 2 authorization decisions with an artefact hash. The envelope proves the recorded grant chain attenuates, that each decision follows from the link it cites, and that the covered decision names an artefact digest. It does not prove the artefact was produced, that the signing key is trusted, or that the grants were unrevoked.",
+    "uncovered": [
+      {
+        "action": "task.close",
+        "decision_id": "d-2",
+        "reason": "the artefact this decision authorised was not exported with the envelope"
+      }
+    ]
+  },
+  "decisions": [
+    {
+      "action": "repo.read",
+      "decision_id": "d-1",
+      "grant": "g-hop1",
+      "inputs": {
+        "bindings_hash": "d6873cb83477572bd8ac89499e22d205b04092593080796bdeb9b1c2bd5a7def",
+        "role": "reviewer"
+      },
+      "inputs_hash": "f0bbd033aa4c959bfc63b9a872b241f7cf8507626f77e2afbb2cd09da2bc620d",
+      "policy": {
+        "id": "policy:role-bindings",
+        "version": "3"
+      },
+      "resource": "urn:bernstein:repo:bernstein",
+      "subject": "urn:bernstein:principal:agent:reviewer-7",
+      "timestamp": "2026-05-04T09:15:00Z",
+      "verdict": "allow"
+    },
+    {
+      "action": "task.close",
+      "decision_id": "d-2",
+      "grant": "g-hop1",
+      "inputs": {
+        "bindings_hash": "d6873cb83477572bd8ac89499e22d205b04092593080796bdeb9b1c2bd5a7def",
+        "role": "reviewer"
+      },
+      "inputs_hash": "0548f96f96ae836f24b80c640fd49a3f88f25bc90ffb5360d7dd594fbfabe5fc",
+      "policy": {
+        "id": "policy:role-bindings",
+        "version": "3"
+      },
+      "resource": "urn:bernstein:task:T-4180",
+      "subject": "urn:bernstein:principal:agent:reviewer-7",
+      "timestamp": "2026-05-04T09:17:30Z",
+      "verdict": "allow"
+    }
+  ],
+  "envelope_type": "https://bernstein.run/attestations/authority-envelope/v1",
+  "evidence": [
+    {
+      "decision": "d-1",
+      "digest": {
+        "sha256": "6d22d8a4602b66464654d2a54a32bcdf4eb40620cd69134b200fe255358ab61b"
+      },
+      "name": "lineage/step-0007.json"
+    }
+  ],
+  "grants": [
+    {
+      "grant_hash": "6e9a085b00236d970d42bc41c11c9ecb7c4c2935d0632a77d8a4aabb77712985",
+      "grant_id": "g-root",
+      "issuer": "urn:bernstein:principal:operator:alex",
+      "not_after": "2030-01-01T00:00:00Z",
+      "parent": null,
+      "scope": [
+        "repo.read",
+        "repo.write",
+        "task.close",
+        "task.read"
+      ],
+      "subject": "urn:bernstein:principal:agent:orchestrator-1"
+    },
+    {
+      "grant_hash": "2bf5caa9d5b03e6013934fade85411312f6c99eb41de9d504e85b20618c4a2c2",
+      "grant_id": "g-hop1",
+      "issuer": "urn:bernstein:principal:agent:orchestrator-1",
+      "not_after": "2027-01-01T00:00:00Z",
+      "parent": "g-root",
+      "scope": [
+        "repo.read",
+        "task.close"
+      ],
+      "subject": "urn:bernstein:principal:agent:reviewer-7"
+    }
+  ],
+  "principal": {
+    "id": "urn:bernstein:principal:agent:reviewer-7",
+    "id_binding": "b012e1bece83f2909ead1a16f5a7d1516ec98b6461ed62088f10041b63bee23c",
+    "key": {
+      "crv": "Ed25519",
+      "kty": "OKP",
+      "x": "GSBMjDuoW6BZzRiskBe9AqGNpdEMaPt3mjS-Q-8Gd5E"
+    },
+    "key_id": "principal-reviewer-7"
+  },
+  "schema_version": "1.0.0",
+  "section_digests": {
+    "coverage": "55fe772424c4736c0d3d0c75f1fb6b7820b696892c527834527dfa1801f07fd8",
+    "decisions": "4e7a7f5eb526a5715e36a26f48be85fda4508343c5752b5a4fa0742bceb5e4b9",
+    "evidence": "ca0722167d9d1746b990f0b1d055a1446142b8b90a4ebad1142b95c1e589a097",
+    "grants": "8761d0fe98a26355251e5a8545128d301a44d19671cfeb3e51b0c4235b11a697",
+    "principal": "663a602a23692b85cac222960101847c7b4a269aaeca4f7f2e6cae012d19faed"
+  },
+  "signature": {
+    "alg": "EdDSA",
+    "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImF1dGhvcml0eS1lbnZlbG9wZS12ZWN0b3Ita2V5IiwidHlwIjoiYXBwbGljYXRpb24vdm5kLmJlcm5zdGVpbi5hdXRob3JpdHktZW52ZWxvcGUrandzIn0..cWuKN_msozOxUI63GNm_BbfUc7IdO8dO9OgIbsiDEqWfEFvPA723Ou-lK4PknDIZuJIyGG78lSCsIPGE7U1wAQ",
+    "kid": "authority-envelope-vector-key",
+    "public_key_jwk": {
+      "crv": "Ed25519",
+      "kty": "OKP",
+      "x": "rwaj4ykXFOTzVsGcmxXNGVHsbmZiqne-B1R_KJODNB0"
+    }
+  }
+}

--- a/tests/unit/test_authority_envelope_verifier.py
+++ b/tests/unit/test_authority_envelope_verifier.py
@@ -58,12 +58,15 @@ sys.meta_path.insert(0, _BernsteinBlocker())
 '''
 
 # Runs the verifier's ``__main__`` under that blocker.
-_ISOLATED_RUNNER = _BLOCKER_PRELUDE + """
+_ISOLATED_RUNNER = (
+    _BLOCKER_PRELUDE
+    + """
 import runpy
 
 sys.argv = ["bernstein-verify-envelope", *sys.argv[1:]]
 runpy.run_module("bernstein_verify_envelope", run_name="__main__")
 """
+)
 
 
 @pytest.fixture(scope="module")
@@ -157,9 +160,7 @@ def test_verifier_package_imports_neither_bernstein_nor_the_network() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_one_byte_mutation_in_decisions_names_the_decisions_section(
-    isolated_runner: Path, tmp_path: Path
-) -> None:
+def test_one_byte_mutation_in_decisions_names_the_decisions_section(isolated_runner: Path, tmp_path: Path) -> None:
     """Flipping one character of a decision verdict is reported against ``decisions``."""
     path = _mutate(
         tmp_path,
@@ -173,9 +174,7 @@ def test_one_byte_mutation_in_decisions_names_the_decisions_section(
     assert "[FAIL] signature" in proc.stdout
 
 
-def test_one_byte_mutation_in_grants_names_the_grants_section(
-    isolated_runner: Path, tmp_path: Path
-) -> None:
+def test_one_byte_mutation_in_grants_names_the_grants_section(isolated_runner: Path, tmp_path: Path) -> None:
     """The section named is the one that changed, not a hard-coded first section."""
     path = _mutate(
         tmp_path,
@@ -200,9 +199,7 @@ def test_committed_tampered_vector_is_rejected(isolated_runner: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_envelope_without_a_coverage_section_is_refused(
-    isolated_runner: Path, tmp_path: Path
-) -> None:
+def test_envelope_without_a_coverage_section_is_refused(isolated_runner: Path, tmp_path: Path) -> None:
     """Silence about scope is refused outright, not treated as full coverage."""
     path = _mutate(tmp_path, lambda doc: doc.pop("coverage"), "no-coverage.json")
     proc = _run_verifier(isolated_runner, path)
@@ -211,9 +208,7 @@ def test_envelope_without_a_coverage_section_is_refused(
     assert "missing" in proc.stdout
 
 
-def test_coverage_that_hides_an_uncovered_decision_is_refused(
-    isolated_runner: Path, tmp_path: Path
-) -> None:
+def test_coverage_that_hides_an_uncovered_decision_is_refused(isolated_runner: Path, tmp_path: Path) -> None:
     """A decision carrying no evidence must be named in ``coverage.uncovered``."""
 
     def _hide(doc: dict[str, Any]) -> None:
@@ -237,9 +232,7 @@ def test_coverage_names_the_gap_on_the_passing_vector(isolated_runner: Path) -> 
 # ---------------------------------------------------------------------------
 
 
-def test_grant_chain_that_widens_scope_is_rejected(
-    isolated_runner: Path, tmp_path: Path
-) -> None:
+def test_grant_chain_that_widens_scope_is_rejected(isolated_runner: Path, tmp_path: Path) -> None:
     """A child grant may only narrow its parent's scope."""
 
     def _widen(doc: dict[str, Any]) -> None:
@@ -253,9 +246,7 @@ def test_grant_chain_that_widens_scope_is_rejected(
     assert "repo.admin" in proc.stdout
 
 
-def test_allow_verdict_outside_the_referenced_grant_scope_is_rejected(
-    isolated_runner: Path, tmp_path: Path
-) -> None:
+def test_allow_verdict_outside_the_referenced_grant_scope_is_rejected(isolated_runner: Path, tmp_path: Path) -> None:
     """An ``allow`` must follow from the grant it names, not merely be signed."""
 
     def _overreach(doc: dict[str, Any]) -> None:
@@ -265,11 +256,11 @@ def test_allow_verdict_outside_the_referenced_grant_scope_is_rejected(
     proc = _run_verifier(isolated_runner, path)
     assert proc.returncode == 1
     assert "[FAIL] decisions" in proc.stdout
+    assert "outside the scope" in proc.stdout
+    assert "repo.delete" in proc.stdout
 
 
-def test_decision_inputs_hash_is_recomputed_not_trusted(
-    isolated_runner: Path, tmp_path: Path
-) -> None:
+def test_decision_inputs_hash_is_recomputed_not_trusted(isolated_runner: Path, tmp_path: Path) -> None:
     """Editing a decision's recorded inputs breaks its recomputed input hash."""
 
     def _edit_inputs(doc: dict[str, Any]) -> None:
@@ -282,9 +273,7 @@ def test_decision_inputs_hash_is_recomputed_not_trusted(
     assert "inputs_hash" in proc.stdout
 
 
-def test_decision_taken_after_its_grant_expired_is_rejected(
-    isolated_runner: Path, tmp_path: Path
-) -> None:
+def test_decision_taken_after_its_grant_expired_is_rejected(isolated_runner: Path, tmp_path: Path) -> None:
     """Every decision must fall inside the validity window of the grant it cites."""
 
     def _late(doc: dict[str, Any]) -> None:
@@ -296,9 +285,7 @@ def test_decision_taken_after_its_grant_expired_is_rejected(
     assert "[FAIL] decisions" in proc.stdout
 
 
-def test_evidence_referencing_an_unknown_decision_is_rejected(
-    isolated_runner: Path, tmp_path: Path
-) -> None:
+def test_evidence_referencing_an_unknown_decision_is_rejected(isolated_runner: Path, tmp_path: Path) -> None:
     """Evidence must attach to a decision the envelope actually carries."""
 
     def _dangle(doc: dict[str, Any]) -> None:
@@ -310,9 +297,7 @@ def test_evidence_referencing_an_unknown_decision_is_rejected(
     assert "[FAIL] evidence" in proc.stdout
 
 
-def test_principal_id_rebound_to_another_key_is_rejected(
-    isolated_runner: Path, tmp_path: Path
-) -> None:
+def test_principal_id_rebound_to_another_key_is_rejected(isolated_runner: Path, tmp_path: Path) -> None:
     """The principal's identifier is bound to its key material by a recomputed hash."""
 
     def _swap_key(doc: dict[str, Any]) -> None:

--- a/tests/unit/test_authority_envelope_verifier.py
+++ b/tests/unit/test_authority_envelope_verifier.py
@@ -1,0 +1,349 @@
+"""Conformance tests for the portable authority envelope (#5055, slices E1-E2).
+
+The envelope exists so that evidence about *authority* -- who acted, under
+which grant, and which policy decision allowed it -- can be checked somewhere
+other than the Bernstein install that produced it. Two properties carry that
+promise and every test below pins one of them:
+
+1. **Independence.** ``verify_cli/bernstein_verify_envelope`` validates the
+   committed golden vector in a subprocess where ``import bernstein`` raises,
+   with no network reachable. If the verifier ever grows a ``bernstein.*``
+   import, the subprocess dies with ``ImportError`` and the test fails.
+2. **Recomputation.** A signature proves who said it; the verifier re-derives
+   the grant-chain hashes, the decision input hashes and the coverage
+   statement from the envelope's own recorded inputs, so a widened scope or a
+   silently-dropped decision fails even when the signature is intact.
+
+The vectors under ``tests/fixtures/authority-envelope-vectors/`` are committed,
+not minted at test time -- see the README there.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VERIFY_CLI_ROOT = REPO_ROOT / "verify_cli"
+PACKAGE_DIR = VERIFY_CLI_ROOT / "bernstein_verify_envelope"
+SCHEMA_PATH = REPO_ROOT / "schemas" / "authority-envelope-v1.json"
+VECTOR_DIR = REPO_ROOT / "tests" / "fixtures" / "authority-envelope-vectors"
+VALID_VECTOR = VECTOR_DIR / "valid-authority-envelope.json"
+TAMPERED_VECTOR = VECTOR_DIR / "tampered-authority-envelope.json"
+
+# Makes ``bernstein`` unimportable, so the subprocess is a real, hostile-to-us
+# environment rather than a promise.
+_BLOCKER_PRELUDE = '''
+import sys
+
+
+class _BernsteinBlocker:
+    """Meta-path finder that refuses every ``bernstein`` import."""
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "bernstein" or fullname.startswith("bernstein."):
+            raise ImportError(f"blocked import of {fullname} (verifier independence probe)")
+        return None
+
+
+sys.meta_path.insert(0, _BernsteinBlocker())
+'''
+
+# Runs the verifier's ``__main__`` under that blocker.
+_ISOLATED_RUNNER = _BLOCKER_PRELUDE + """
+import runpy
+
+sys.argv = ["bernstein-verify-envelope", *sys.argv[1:]]
+runpy.run_module("bernstein_verify_envelope", run_name="__main__")
+"""
+
+
+@pytest.fixture(scope="module")
+def isolated_runner(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Path to the runner script that blocks ``bernstein`` then starts the CLI."""
+    runner = tmp_path_factory.mktemp("envelope-runner") / "run_isolated.py"
+    runner.write_text(_ISOLATED_RUNNER, encoding="utf-8")
+    return runner
+
+
+def _run_verifier(runner: Path, envelope: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    """Run the standalone verifier over *envelope* with ``bernstein`` blocked."""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(VERIFY_CLI_ROOT)
+    return subprocess.run(
+        [sys.executable, str(runner), "verify", str(envelope), *extra],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+def _load_valid() -> dict[str, Any]:
+    return json.loads(VALID_VECTOR.read_text(encoding="utf-8"))
+
+
+def _write(tmp_path: Path, doc: dict[str, Any], name: str = "envelope.json") -> Path:
+    out = tmp_path / name
+    out.write_text(json.dumps(doc, sort_keys=True, separators=(",", ":")), encoding="utf-8")
+    return out
+
+
+def _mutate(tmp_path: Path, edit: Callable[[dict[str, Any]], None], name: str) -> Path:
+    doc = _load_valid()
+    edit(doc)
+    return _write(tmp_path, doc, name)
+
+
+# ---------------------------------------------------------------------------
+# 1-3. Independence: no bernstein, no network, golden vector passes
+# ---------------------------------------------------------------------------
+
+
+def test_golden_vector_verifies_in_a_subprocess_without_bernstein(isolated_runner: Path) -> None:
+    """The committed vector verifies where ``import bernstein`` raises."""
+    proc = _run_verifier(isolated_runner, VALID_VECTOR)
+    assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    assert "OVERALL: PASS" in proc.stdout
+    assert "ImportError" not in proc.stderr
+    for section in ("principal", "grants", "decisions", "evidence", "coverage", "signature"):
+        assert f"[PASS] {section}" in proc.stdout
+
+
+def test_the_independence_probe_actually_blocks_bernstein() -> None:
+    """The blocker used by test 1 is real: importing bernstein under it fails.
+
+    Without this, test 1 could pass merely because nothing tried to import
+    ``bernstein`` in a process where it was importable all along.
+    """
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(VERIFY_CLI_ROOT)
+    blocked = subprocess.run(
+        [sys.executable, "-c", _BLOCKER_PRELUDE + "\nimport bernstein\n"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert blocked.returncode != 0
+    assert "blocked import of bernstein" in blocked.stderr
+
+
+def test_verifier_package_imports_neither_bernstein_nor_the_network() -> None:
+    """The verifier source names no ``bernstein`` module and no network client."""
+    sources = sorted(PACKAGE_DIR.glob("*.py"))
+    assert sources, f"no verifier sources under {PACKAGE_DIR}"
+    forbidden = ("bernstein.", "httpx", "requests", "urllib", "socket", "aiohttp")
+    for path in sources:
+        text = path.read_text(encoding="utf-8")
+        for line in text.splitlines():
+            stripped = line.strip()
+            if not (stripped.startswith("import ") or stripped.startswith("from ")):
+                continue
+            for token in forbidden:
+                assert token not in stripped, f"{path.name}: forbidden import {stripped!r}"
+
+
+# ---------------------------------------------------------------------------
+# 4-5. A one-byte mutation fails, and the failure names the section
+# ---------------------------------------------------------------------------
+
+
+def test_one_byte_mutation_in_decisions_names_the_decisions_section(
+    isolated_runner: Path, tmp_path: Path
+) -> None:
+    """Flipping one character of a decision verdict is reported against ``decisions``."""
+    path = _mutate(
+        tmp_path,
+        lambda doc: doc["decisions"][0].__setitem__("verdict", "deny"),
+        "mutated-decisions.json",
+    )
+    proc = _run_verifier(isolated_runner, path)
+    assert proc.returncode == 1
+    assert "OVERALL: FAIL" in proc.stdout
+    assert "[FAIL] section:decisions" in proc.stdout
+    assert "[FAIL] signature" in proc.stdout
+
+
+def test_one_byte_mutation_in_grants_names_the_grants_section(
+    isolated_runner: Path, tmp_path: Path
+) -> None:
+    """The section named is the one that changed, not a hard-coded first section."""
+    path = _mutate(
+        tmp_path,
+        lambda doc: doc["grants"][-1].__setitem__("not_after", "2999-01-01T00:00:00Z"),
+        "mutated-grants.json",
+    )
+    proc = _run_verifier(isolated_runner, path)
+    assert proc.returncode == 1
+    assert "[FAIL] section:grants" in proc.stdout
+    assert "[FAIL] section:decisions" not in proc.stdout
+
+
+def test_committed_tampered_vector_is_rejected(isolated_runner: Path) -> None:
+    """The committed negative vector stays rejected as the format evolves."""
+    proc = _run_verifier(isolated_runner, TAMPERED_VECTOR)
+    assert proc.returncode == 1
+    assert "OVERALL: FAIL" in proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# 6-7. Coverage is a field, not an omission
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_without_a_coverage_section_is_refused(
+    isolated_runner: Path, tmp_path: Path
+) -> None:
+    """Silence about scope is refused outright, not treated as full coverage."""
+    path = _mutate(tmp_path, lambda doc: doc.pop("coverage"), "no-coverage.json")
+    proc = _run_verifier(isolated_runner, path)
+    assert proc.returncode == 1
+    assert "[FAIL] coverage" in proc.stdout
+    assert "missing" in proc.stdout
+
+
+def test_coverage_that_hides_an_uncovered_decision_is_refused(
+    isolated_runner: Path, tmp_path: Path
+) -> None:
+    """A decision carrying no evidence must be named in ``coverage.uncovered``."""
+
+    def _hide(doc: dict[str, Any]) -> None:
+        doc["coverage"]["uncovered"] = []
+
+    path = _mutate(tmp_path, _hide, "hidden-gap.json")
+    proc = _run_verifier(isolated_runner, path)
+    assert proc.returncode == 1
+    assert "[FAIL] coverage" in proc.stdout
+
+
+def test_coverage_names_the_gap_on_the_passing_vector(isolated_runner: Path) -> None:
+    """The golden vector is deliberately partial and reports its own gap."""
+    proc = _run_verifier(isolated_runner, VALID_VECTOR, "--verbose")
+    assert proc.returncode == 0
+    assert "uncovered" in proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# 8-10. Recomputation: the verifier re-derives, it does not trust
+# ---------------------------------------------------------------------------
+
+
+def test_grant_chain_that_widens_scope_is_rejected(
+    isolated_runner: Path, tmp_path: Path
+) -> None:
+    """A child grant may only narrow its parent's scope."""
+
+    def _widen(doc: dict[str, Any]) -> None:
+        child = doc["grants"][-1]
+        child["scope"] = sorted({*child["scope"], "repo.admin"})
+
+    path = _mutate(tmp_path, _widen, "widened.json")
+    proc = _run_verifier(isolated_runner, path)
+    assert proc.returncode == 1
+    assert "[FAIL] grants" in proc.stdout
+    assert "repo.admin" in proc.stdout
+
+
+def test_allow_verdict_outside_the_referenced_grant_scope_is_rejected(
+    isolated_runner: Path, tmp_path: Path
+) -> None:
+    """An ``allow`` must follow from the grant it names, not merely be signed."""
+
+    def _overreach(doc: dict[str, Any]) -> None:
+        doc["decisions"][0]["action"] = "repo.delete"
+
+    path = _mutate(tmp_path, _overreach, "overreach.json")
+    proc = _run_verifier(isolated_runner, path)
+    assert proc.returncode == 1
+    assert "[FAIL] decisions" in proc.stdout
+
+
+def test_decision_inputs_hash_is_recomputed_not_trusted(
+    isolated_runner: Path, tmp_path: Path
+) -> None:
+    """Editing a decision's recorded inputs breaks its recomputed input hash."""
+
+    def _edit_inputs(doc: dict[str, Any]) -> None:
+        doc["decisions"][0]["inputs"]["role"] = "admin"
+
+    path = _mutate(tmp_path, _edit_inputs, "edited-inputs.json")
+    proc = _run_verifier(isolated_runner, path)
+    assert proc.returncode == 1
+    assert "[FAIL] decisions" in proc.stdout
+    assert "inputs_hash" in proc.stdout
+
+
+def test_decision_taken_after_its_grant_expired_is_rejected(
+    isolated_runner: Path, tmp_path: Path
+) -> None:
+    """Every decision must fall inside the validity window of the grant it cites."""
+
+    def _late(doc: dict[str, Any]) -> None:
+        doc["decisions"][0]["timestamp"] = "2999-01-01T00:00:00Z"
+
+    path = _mutate(tmp_path, _late, "late-decision.json")
+    proc = _run_verifier(isolated_runner, path)
+    assert proc.returncode == 1
+    assert "[FAIL] decisions" in proc.stdout
+
+
+def test_evidence_referencing_an_unknown_decision_is_rejected(
+    isolated_runner: Path, tmp_path: Path
+) -> None:
+    """Evidence must attach to a decision the envelope actually carries."""
+
+    def _dangle(doc: dict[str, Any]) -> None:
+        doc["evidence"][0]["decision"] = "d-does-not-exist"
+
+    path = _mutate(tmp_path, _dangle, "dangling-evidence.json")
+    proc = _run_verifier(isolated_runner, path)
+    assert proc.returncode == 1
+    assert "[FAIL] evidence" in proc.stdout
+
+
+def test_principal_id_rebound_to_another_key_is_rejected(
+    isolated_runner: Path, tmp_path: Path
+) -> None:
+    """The principal's identifier is bound to its key material by a recomputed hash."""
+
+    def _swap_key(doc: dict[str, Any]) -> None:
+        doc["principal"]["key"]["x"] = "A" + doc["principal"]["key"]["x"][1:]
+
+    path = _mutate(tmp_path, _swap_key, "rebound-principal.json")
+    proc = _run_verifier(isolated_runner, path)
+    assert proc.returncode == 1
+    assert "[FAIL] principal" in proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# 11-12. The schema is the contract the vector is checked against
+# ---------------------------------------------------------------------------
+
+
+def test_schema_accepts_the_golden_vector() -> None:
+    """The committed vector validates against the committed JSON Schema."""
+    import jsonschema
+
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=_load_valid(), schema=schema)
+
+
+def test_schema_requires_the_coverage_section() -> None:
+    """Coverage is required by the schema, not only by the verifier."""
+    import jsonschema
+
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    assert "coverage" in schema["required"]
+    doc = copy.deepcopy(_load_valid())
+    doc.pop("coverage")
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=doc, schema=schema)

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -6022,6 +6022,7 @@ class TestAdaptivePollingBackoff:
         assert hasattr(orch, "_idle_multiplier")
         assert orch._idle_multiplier == 1
 
+
 # --- Reverse task-to-session index ---
 
 

--- a/verify_cli/bernstein_verify_envelope/README.md
+++ b/verify_cli/bernstein_verify_envelope/README.md
@@ -1,0 +1,55 @@
+# bernstein-verify-envelope
+
+Standalone verifier for a **Bernstein authority envelope**: a single file that
+records who acted, under which delegated authority, which policy decision
+allowed it, what evidence ties the decision to an artefact, and — stated in the
+file itself — what the envelope does *not* cover.
+
+The point of the envelope is that it means something outside the install that
+produced it. This verifier is the proof: it imports only `cryptography` and
+`click`, never `bernstein`, and never opens a socket.
+
+```bash
+pip install bernstein-verify-envelope
+bernstein-verify-envelope verify ./authority-envelope.json --verbose
+```
+
+Exit codes: `0` verified, `1` a check failed, `2` bad arguments.
+
+## What it checks
+
+| Check | What it proves |
+|---|---|
+| `envelope_type` | The file declares the schema version and type this verifier implements. |
+| `coverage` (gate) | The envelope states what it does not cover. An envelope with no `coverage` section is refused outright — silence is not read as full coverage. |
+| `signature` | The detached EdDSA JWS verifies over the RFC 8785 canonical bytes of the envelope body. |
+| `section:<name>` | Each section's recorded digest recomputes, so a failure names the section that moved rather than only reporting a broken signature. |
+| `principal` | The principal identifier is bound to its key material by a recomputed hash. |
+| `grants` | The chain hashes recompute and every link attenuates: subset scope, no later expiry, issuer equal to the previous subject, terminating at the principal. |
+| `decisions` | Each decision's input hash recomputes from its own recorded inputs and the grant it cites; an `allow` outside that grant's scope, or a decision taken after the grant expired, is rejected. |
+| `evidence` | Every artefact hash attaches to a decision the envelope carries. |
+| `coverage` | The coverage statement recomputes: the decisions carrying evidence and the gaps are both re-derived from the envelope, so a hidden gap fails. |
+
+## What a passing envelope does *not* prove
+
+- **That the key is trusted.** Verifying against the key the envelope carries is
+  trust-on-first-use, and is reported as such. Pinning a key out of band is not
+  implemented yet.
+- **That the grants were unrevoked** at the time they were used. The envelope
+  carries expiries, not revocation state.
+- **That the artefacts exist.** Evidence entries are hashes; matching them to
+  real artefacts is the auditor's step.
+- **Anything outside its `coverage`.** A partial envelope names its own gaps and
+  the verifier enforces that they are named — but the gaps remain gaps.
+
+## Canonical form
+
+RFC 8785 JCS, re-implemented in `verify.py` rather than imported, so agreement
+with the producer is demonstrated by the committed golden vector instead of
+assumed by sharing code. The signature is a detached compact JWS (RFC 7515
+Appendix F) whose signing input is
+`BASE64URL(JCS(header)) || "." || BASE64URL(JCS(body))`, where the body is every
+top-level member except `signature`.
+
+The schema is `schemas/authority-envelope-v1.json`; the vectors are under
+`tests/fixtures/authority-envelope-vectors/`.

--- a/verify_cli/bernstein_verify_envelope/__init__.py
+++ b/verify_cli/bernstein_verify_envelope/__init__.py
@@ -1,0 +1,14 @@
+"""Standalone authority-envelope verifier for Bernstein.
+
+Validates a portable authority envelope -- principal, grant chain, policy
+decisions, evidence hashes, coverage statement and signature -- with only
+``cryptography`` and ``click`` as dependencies. Provides the CLI entry point
+``bernstein-verify-envelope``.
+
+This package MUST NOT import from bernstein.* at runtime, and MUST NOT open a
+network connection.
+"""
+
+from __future__ import annotations
+
+__version__ = "1.0.0"

--- a/verify_cli/bernstein_verify_envelope/__main__.py
+++ b/verify_cli/bernstein_verify_envelope/__main__.py
@@ -1,0 +1,60 @@
+"""bernstein-verify-envelope CLI entry point.
+
+Usage::
+
+    bernstein-verify-envelope verify <envelope_path> [--verbose]
+
+Output convention (matching ``bernstein-verify-receipt``):
+  - Human summary on stdout (one PASS/FAIL line per check, then OVERALL).
+  - Structured JSON on stderr for machine consumers.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+
+from bernstein_verify_envelope.verify import VerifyResult, run_verify
+
+
+def _emit(result: VerifyResult, kind: str) -> int:
+    """Write a human summary to stdout and JSON to stderr; return the exit code."""
+    if result.ok:
+        click.echo(f"PASS  {kind}: {result.stats}")
+    else:
+        click.echo(f"FAIL  {kind}: {len(result.errors)} error(s)")
+        for err in result.errors[:10]:
+            click.echo(f"  - {err}")
+        if len(result.errors) > 10:
+            click.echo(f"  ... and {len(result.errors) - 10} more")
+    click.echo(
+        json.dumps({"ok": result.ok, "kind": kind, "stats": result.stats, "errors": result.errors}),
+        err=True,
+    )
+    return 0 if result.ok else 1
+
+
+@click.group()
+@click.version_option(package_name="bernstein-verify-envelope")
+def cli() -> None:
+    """Standalone auditor CLI for Bernstein authority envelopes.
+
+    Verifies envelopes with cryptography + click only - no bernstein package
+    installation required. Works offline (air-gap).
+    """
+
+
+@cli.command("verify")
+@click.argument("envelope_path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option("--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details.")
+def verify_cmd(envelope_path: Path, verbose: bool) -> None:
+    """Verify an authority envelope using the standalone verifier."""
+    result = run_verify(envelope_path=envelope_path, verbose=verbose, stream=sys.stdout)
+    sys.exit(_emit(result, kind="verify"))
+
+
+if __name__ == "__main__":
+    cli()

--- a/verify_cli/bernstein_verify_envelope/pyproject.toml
+++ b/verify_cli/bernstein_verify_envelope/pyproject.toml
@@ -1,0 +1,58 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "bernstein-verify-envelope"
+version = "1.0.0"
+description = "Standalone auditor CLI for Bernstein authority envelopes. Verifies the principal binding, grant chain, policy decisions, evidence hashes and coverage statement without importing bernstein.*"
+readme = "README.md"
+requires-python = ">=3.12"
+license = "Apache-2.0"
+authors = [{ name = "Alex Chernysh", email = "alex@alexchernysh.com" }]
+keywords = [
+    "audit",
+    "authority",
+    "delegation",
+    "compliance",
+    "ed25519",
+    "jws",
+    "jcs",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "Intended Audience :: Legal Industry",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Security",
+    "Typing :: Typed",
+]
+# Hard rule: this wheel is auditor-grade. Two deps only.
+# - cryptography: Ed25519 signature verification (RFC 8037).
+# - click: argument parsing for the CLI entry-point.
+# Anything else must be vendored or re-implemented locally so the
+# air-gapped laptop install stays a single `pip install bernstein-verify-envelope`.
+dependencies = [
+    "cryptography>=50.0.0",
+    "click>=8.1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "ruff>=0.6",
+]
+
+[project.scripts]
+bernstein-verify-envelope = "bernstein_verify_envelope.__main__:cli"
+
+[tool.hatch.build.targets.wheel]
+packages = ["bernstein_verify_envelope"]

--- a/verify_cli/bernstein_verify_envelope/verify.py
+++ b/verify_cli/bernstein_verify_envelope/verify.py
@@ -1,0 +1,737 @@
+"""Standalone verification of a Bernstein authority envelope.
+
+This module is the heart of ``bernstein-verify-envelope``. It MUST NOT import
+anything from ``bernstein.*``, and it MUST NOT open a socket. Every primitive
+is re-implemented here:
+
+  * RFC 8785 JCS canonical JSON (object names sorted as UTF-16 code units).
+  * Detached compact JWS (RFC 7515 Appendix F) with EdDSA.
+  * Ed25519 JWK -> public key (RFC 8037).
+  * The envelope's own hash preimages: the principal id binding, the chained
+    grant hashes, the decision input hashes, and the per-section digests.
+
+Nothing here trusts a recorded hash. Each one is recomputed from material the
+envelope itself carries, so a widened grant scope, an edited policy input or a
+silently-dropped decision fails even when the signature is intact. The
+signature says who asserted the envelope; the recomputation says the assertion
+follows from its own inputs.
+
+The envelope's embedded key is a hint, not a trust anchor: an envelope that
+verifies against the key it carries is reported as trust-on-first-use.
+
+Air-gap guarantee: no network calls. Only stdlib + ``cryptography``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import IO, Any
+
+# Wire-format constants. These MUST match schemas/authority-envelope-v1.json.
+SCHEMA_VERSION = "1.0.0"
+ENVELOPE_TYPE = "https://bernstein.run/attestations/authority-envelope/v1"
+JWS_TYP = "application/vnd.bernstein.authority-envelope+jws"
+JWS_ALG = "EdDSA"
+SECTION_NAMES = ("principal", "grants", "decisions", "evidence", "coverage")
+_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CheckResult:
+    """Outcome of a single verification check."""
+
+    name: str
+    ok: bool
+    detail: str = ""
+
+
+@dataclass
+class VerifyResult:
+    """Aggregate outcome across every check that ran."""
+
+    checks: list[CheckResult] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        """True iff every check that ran reported success."""
+        return all(c.ok for c in self.checks)
+
+    @property
+    def errors(self) -> list[str]:
+        """``name: detail`` for every failing check."""
+        return [f"{c.name}: {c.detail}" for c in self.checks if not c.ok]
+
+    @property
+    def stats(self) -> str:
+        """Human-readable summary: count of passed vs total checks."""
+        n_ok = sum(1 for c in self.checks if c.ok)
+        return f"{n_ok}/{len(self.checks)} checks passed"
+
+
+# ---------------------------------------------------------------------------
+# RFC 8785 JCS
+# ---------------------------------------------------------------------------
+
+
+def _utf16_code_units(name: str) -> bytes:
+    """Return *name* as big-endian UTF-16 code units for RFC 8785 ordering."""
+    return name.encode("utf-16-be", errors="surrogatepass")
+
+
+def _sorted_by_code_units(value: Any) -> Any:
+    """Rebuild *value* with every object's names in RFC 8785 order."""
+    if isinstance(value, dict):
+        named = sorted(value.items(), key=lambda pair: _utf16_code_units(str(pair[0])))
+        return {name: _sorted_by_code_units(item) for name, item in named}
+    if isinstance(value, (list, tuple)):
+        return [_sorted_by_code_units(item) for item in value]
+    return value
+
+
+def canonicalize_jcs(value: Any) -> bytes:
+    """Return the RFC 8785 canonical JSON encoding of *value* as UTF-8 bytes."""
+    return json.dumps(
+        _sorted_by_code_units(value),
+        sort_keys=False,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sha256_jcs(value: Any) -> str:
+    """Content hash over the canonical bytes of *value*."""
+    return hashlib.sha256(canonicalize_jcs(value)).hexdigest()
+
+
+def _b64url(data: bytes) -> str:
+    """Base64-url-encode without padding (RFC 7515 §2)."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(data: str) -> bytes:
+    """Base64-url-decode, restoring padding."""
+    return base64.urlsafe_b64decode(data + ("=" * (-len(data) % 4)))
+
+
+def _public_key_from_jwk(jwk: Any) -> Any:
+    """Convert an OKP/Ed25519 JWK into an Ed25519PublicKey (RFC 8037)."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+    if not isinstance(jwk, dict) or jwk.get("kty") != "OKP" or jwk.get("crv") != "Ed25519":
+        raise ValueError(f"expected kty=OKP, crv=Ed25519; got {jwk!r}")
+    x = jwk.get("x")
+    if not isinstance(x, str):
+        raise ValueError("JWK 'x' missing or not a string")
+    raw = _b64url_decode(x)
+    if len(raw) != 32:
+        raise ValueError(f"Ed25519 public key must be 32 bytes (got {len(raw)})")
+    return Ed25519PublicKey.from_public_bytes(raw)
+
+
+def _parse_timestamp(value: Any, what: str) -> datetime:
+    """Parse an RFC 3339 UTC timestamp, raising ValueError with context."""
+    if not isinstance(value, str):
+        raise ValueError(f"{what} is not a string")
+    try:
+        return datetime.strptime(value, _TIMESTAMP_FORMAT)
+    except ValueError as exc:
+        raise ValueError(f"{what} {value!r} is not RFC 3339 UTC (YYYY-MM-DDThh:mm:ssZ)") from exc
+
+
+# ---------------------------------------------------------------------------
+# Section verifiers
+# ---------------------------------------------------------------------------
+
+
+def verify_envelope_type(envelope: dict[str, Any]) -> CheckResult:
+    """The envelope must declare the version and type this verifier implements."""
+    version = envelope.get("schema_version")
+    kind = envelope.get("envelope_type")
+    if version != SCHEMA_VERSION:
+        return CheckResult(
+            "envelope_type", ok=False, detail=f"unsupported schema_version {version!r}"
+        )
+    if kind != ENVELOPE_TYPE:
+        return CheckResult("envelope_type", ok=False, detail=f"unexpected envelope_type {kind!r}")
+    return CheckResult("envelope_type", ok=True, detail=f"{ENVELOPE_TYPE} v{SCHEMA_VERSION}")
+
+
+def verify_coverage_present(envelope: dict[str, Any]) -> CheckResult:
+    """Refuse an envelope that says nothing about what it does not cover.
+
+    Silence about a gap reads as full coverage to anyone who does not run the
+    verifier, so an omitted section is a refusal rather than a warning.
+    """
+    coverage = envelope.get("coverage")
+    if not isinstance(coverage, dict):
+        return CheckResult(
+            "coverage",
+            ok=False,
+            detail=(
+                "coverage section is missing; an envelope must state what it does not cover, "
+                "and silence is not read as full coverage"
+            ),
+        )
+    for member in ("covered", "uncovered", "statement"):
+        if member not in coverage:
+            return CheckResult(
+                "coverage",
+                ok=False,
+                detail=f"coverage.{member} is missing from the coverage section",
+            )
+    return CheckResult("coverage", ok=True)
+
+
+def verify_signature(envelope: dict[str, Any]) -> tuple[CheckResult, str]:
+    """Verify the detached EdDSA JWS over the JCS bytes of the envelope body.
+
+    Returns ``(check, note)`` where the note records how the verifying key was
+    obtained. The embedded key is a hint, so a successful verification against
+    it is reported as trust-on-first-use.
+    """
+    from cryptography.exceptions import InvalidSignature
+
+    block = envelope.get("signature")
+    if not isinstance(block, dict):
+        return CheckResult("signature", ok=False, detail="signature section missing"), ""
+    if block.get("alg") != JWS_ALG:
+        return CheckResult("signature", ok=False, detail=f"unexpected alg {block.get('alg')!r}"), ""
+
+    jws = block.get("jws")
+    if not isinstance(jws, str) or jws.count(".") != 2:
+        return CheckResult("signature", ok=False, detail="jws is not a compact JWS"), ""
+    header_b64, payload_b64, sig_b64 = jws.split(".")
+    if payload_b64:
+        # Not a detached signature -- refuse rather than verify a payload that
+        # is not the envelope body.
+        return CheckResult("signature", ok=False, detail="jws is not detached"), ""
+
+    try:
+        header = json.loads(_b64url_decode(header_b64))
+    except (ValueError, json.JSONDecodeError) as exc:
+        return CheckResult(
+            "signature", ok=False, detail=f"protected header decode failed: {exc}"
+        ), ""
+    if not isinstance(header, dict):
+        return CheckResult("signature", ok=False, detail="protected header is not an object"), ""
+    if header.get("alg") != JWS_ALG or header.get("typ") != JWS_TYP:
+        return (
+            CheckResult(
+                "signature",
+                ok=False,
+                detail=(
+                    "protected header alg/typ mismatch: "
+                    f"{header.get('alg')!r}/{header.get('typ')!r}"
+                ),
+            ),
+            "",
+        )
+    if header.get("kid") != block.get("kid"):
+        return (
+            CheckResult(
+                "signature", ok=False, detail="protected header kid differs from signature.kid"
+            ),
+            "",
+        )
+
+    try:
+        public_key = _public_key_from_jwk(block.get("public_key_jwk"))
+    except ValueError as exc:
+        return CheckResult("signature", ok=False, detail=f"embedded key unusable: {exc}"), ""
+
+    body = {key: value for key, value in envelope.items() if key != "signature"}
+    signing_input = f"{header_b64}.{_b64url(canonicalize_jcs(body))}".encode("ascii")
+    try:
+        public_key.verify(_b64url_decode(sig_b64), signing_input)
+    except InvalidSignature:
+        return (
+            CheckResult(
+                "signature",
+                ok=False,
+                detail="detached JWS does not verify over the canonical envelope body",
+            ),
+            "",
+        )
+    except ValueError as exc:
+        return CheckResult("signature", ok=False, detail=f"signature decode failed: {exc}"), ""
+
+    note = "trust-on-first-use (verified against the key the envelope carries)"
+    return CheckResult("signature", ok=True, detail=note), note
+
+
+def verify_section_digests(envelope: dict[str, Any]) -> list[CheckResult]:
+    """Recompute each section digest so a failure names the section that moved."""
+    digests = envelope.get("section_digests")
+    if not isinstance(digests, dict):
+        return [CheckResult("section_digests", ok=False, detail="section_digests missing")]
+
+    checks: list[CheckResult] = []
+    for name in SECTION_NAMES:
+        recorded = digests.get(name)
+        if name not in envelope:
+            checks.append(CheckResult(f"section:{name}", ok=False, detail="section missing"))
+            continue
+        recomputed = _sha256_jcs(envelope[name])
+        if recorded != recomputed:
+            checks.append(
+                CheckResult(
+                    f"section:{name}",
+                    ok=False,
+                    detail=(
+                        f"recomputed digest {recomputed[:16]}... != recorded "
+                        f"{str(recorded)[:16]}... (the {name} section was modified)"
+                    ),
+                )
+            )
+        else:
+            checks.append(CheckResult(f"section:{name}", ok=True, detail=f"{recomputed[:16]}..."))
+    return checks
+
+
+def verify_principal(envelope: dict[str, Any]) -> CheckResult:
+    """Recompute the binding between the principal identifier and its key."""
+    principal = envelope.get("principal")
+    if not isinstance(principal, dict):
+        return CheckResult("principal", ok=False, detail="principal section missing")
+
+    principal_id = principal.get("id")
+    key = principal.get("key")
+    if not isinstance(principal_id, str) or not principal_id:
+        return CheckResult("principal", ok=False, detail="principal.id missing")
+    try:
+        _public_key_from_jwk(key)
+    except ValueError as exc:
+        return CheckResult("principal", ok=False, detail=f"principal.key unusable: {exc}")
+
+    recomputed = _sha256_jcs({"v": SCHEMA_VERSION, "id": principal_id, "key": key})
+    recorded = principal.get("id_binding")
+    if recorded != recomputed:
+        return CheckResult(
+            "principal",
+            ok=False,
+            detail=(
+                f"recomputed id_binding {recomputed[:16]}... != recorded "
+                f"{str(recorded)[:16]}... (the identifier was re-pointed at other key material)"
+            ),
+        )
+    return CheckResult("principal", ok=True, detail=f"{principal_id} bound to its key")
+
+
+def _grant_hash(grant: dict[str, Any], parent_hash: str) -> str:
+    """Recompute one grant link's chained hash."""
+    return _sha256_jcs(
+        {
+            "v": SCHEMA_VERSION,
+            "grant_id": grant.get("grant_id"),
+            "issuer": grant.get("issuer"),
+            "subject": grant.get("subject"),
+            "scope": grant.get("scope"),
+            "not_after": grant.get("not_after"),
+            "parent_hash": parent_hash,
+        }
+    )
+
+
+def verify_grants(envelope: dict[str, Any]) -> CheckResult:
+    """Recompute the grant chain: chained hashes, attenuation, and terminus."""
+    grants = envelope.get("grants")
+    if not isinstance(grants, list) or not grants:
+        return CheckResult("grants", ok=False, detail="grants section missing or empty")
+
+    seen: set[str] = set()
+    parent_hash = ""
+    previous: dict[str, Any] | None = None
+    for index, grant in enumerate(grants):
+        if not isinstance(grant, dict):
+            return CheckResult("grants", ok=False, detail=f"grants[{index}] is not an object")
+        grant_id = str(grant.get("grant_id", ""))
+        if not grant_id or grant_id in seen:
+            return CheckResult(
+                "grants", ok=False, detail=f"grants[{index}] has a missing or duplicate grant_id"
+            )
+        seen.add(grant_id)
+
+        scope = grant.get("scope")
+        if not isinstance(scope, list) or scope != sorted(set(scope)):
+            return CheckResult(
+                "grants", ok=False, detail=f"grant {grant_id} scope is not a sorted, unique list"
+            )
+
+        try:
+            not_after = _parse_timestamp(grant.get("not_after"), f"grant {grant_id} not_after")
+        except ValueError as exc:
+            return CheckResult("grants", ok=False, detail=str(exc))
+
+        if previous is None:
+            if grant.get("parent") is not None:
+                return CheckResult(
+                    "grants", ok=False, detail=f"root grant {grant_id} must have parent null"
+                )
+        else:
+            if grant.get("parent") != previous.get("grant_id"):
+                return CheckResult(
+                    "grants",
+                    ok=False,
+                    detail=(
+                        f"grant {grant_id} parent {grant.get('parent')!r} is not the preceding link"
+                    ),
+                )
+            if grant.get("issuer") != previous.get("subject"):
+                return CheckResult(
+                    "grants",
+                    ok=False,
+                    detail=(
+                        f"grant {grant_id} issuer {grant.get('issuer')!r} is not the subject of "
+                        f"grant {previous.get('grant_id')!r}"
+                    ),
+                )
+            widened = sorted(set(scope) - set(previous.get("scope") or []))
+            if widened:
+                return CheckResult(
+                    "grants",
+                    ok=False,
+                    detail=(
+                        f"grant {grant_id} widens its parent's scope with {widened}; "
+                        "each link may only attenuate"
+                    ),
+                )
+            parent_not_after = _parse_timestamp(
+                previous.get("not_after"), f"grant {previous.get('grant_id')} not_after"
+            )
+            if not_after > parent_not_after:
+                return CheckResult(
+                    "grants",
+                    ok=False,
+                    detail=(
+                        f"grant {grant_id} expires at {grant.get('not_after')}, later than its "
+                        f"parent at {previous.get('not_after')}"
+                    ),
+                )
+
+        recomputed = _grant_hash(grant, parent_hash)
+        if grant.get("grant_hash") != recomputed:
+            return CheckResult(
+                "grants",
+                ok=False,
+                detail=(
+                    f"grant {grant_id} recomputed hash {recomputed[:16]}... != recorded "
+                    f"{str(grant.get('grant_hash'))[:16]}..."
+                ),
+            )
+        parent_hash = recomputed
+        previous = grant
+
+    principal_id = (envelope.get("principal") or {}).get("id")
+    if previous is not None and previous.get("subject") != principal_id:
+        return CheckResult(
+            "grants",
+            ok=False,
+            detail=(
+                f"the chain ends at {previous.get('subject')!r}, which is not the acting "
+                f"principal {principal_id!r}"
+            ),
+        )
+    return CheckResult("grants", ok=True, detail=f"{len(grants)} link(s), each attenuating")
+
+
+def verify_decisions(envelope: dict[str, Any]) -> CheckResult:
+    """Recompute every decision from its own inputs and the grant it cites."""
+    decisions = envelope.get("decisions")
+    if not isinstance(decisions, list) or not decisions:
+        return CheckResult("decisions", ok=False, detail="decisions section missing or empty")
+
+    grants_by_id: dict[str, dict[str, Any]] = {
+        str(g.get("grant_id")): g for g in (envelope.get("grants") or []) if isinstance(g, dict)
+    }
+
+    seen: set[str] = set()
+    for index, decision in enumerate(decisions):
+        if not isinstance(decision, dict):
+            return CheckResult("decisions", ok=False, detail=f"decisions[{index}] is not an object")
+        decision_id = str(decision.get("decision_id", ""))
+        if not decision_id or decision_id in seen:
+            return CheckResult(
+                "decisions",
+                ok=False,
+                detail=f"decisions[{index}] has a missing or duplicate decision_id",
+            )
+        seen.add(decision_id)
+
+        grant = grants_by_id.get(str(decision.get("grant")))
+        if grant is None:
+            return CheckResult(
+                "decisions",
+                ok=False,
+                detail=(
+                    f"decision {decision_id} cites grant {decision.get('grant')!r}, "
+                    "which is not in the chain"
+                ),
+            )
+        if decision.get("subject") != grant.get("subject"):
+            return CheckResult(
+                "decisions",
+                ok=False,
+                detail=(
+                    f"decision {decision_id} subject {decision.get('subject')!r} is not "
+                    "the subject "
+                    f"of grant {grant.get('grant_id')!r}"
+                ),
+            )
+
+        # The substantive violations are reported before the integrity hash, so
+        # an overreaching decision is named as overreach rather than as a hash
+        # mismatch it also happens to cause.
+        verdict = decision.get("verdict")
+        if verdict not in ("allow", "deny"):
+            return CheckResult(
+                "decisions", ok=False, detail=f"decision {decision_id} has verdict {verdict!r}"
+            )
+        scope = grant.get("scope") or []
+        if verdict == "allow" and decision.get("action") not in scope:
+            return CheckResult(
+                "decisions",
+                ok=False,
+                detail=(
+                    f"decision {decision_id} allows {decision.get('action')!r}, which is outside "
+                    f"the scope of grant {grant.get('grant_id')!r}"
+                ),
+            )
+
+        recomputed = _sha256_jcs(
+            {
+                "v": SCHEMA_VERSION,
+                "subject": decision.get("subject"),
+                "action": decision.get("action"),
+                "resource": decision.get("resource"),
+                "policy": decision.get("policy"),
+                "inputs": decision.get("inputs"),
+                "grant_hash": grant.get("grant_hash"),
+            }
+        )
+        if decision.get("inputs_hash") != recomputed:
+            return CheckResult(
+                "decisions",
+                ok=False,
+                detail=(
+                    f"decision {decision_id} recomputed inputs_hash {recomputed[:16]}... != "
+                    f"recorded {str(decision.get('inputs_hash'))[:16]}..."
+                ),
+            )
+
+        try:
+            taken = _parse_timestamp(decision.get("timestamp"), f"decision {decision_id} timestamp")
+            not_after = _parse_timestamp(
+                grant.get("not_after"), f"grant {grant.get('grant_id')} not_after"
+            )
+        except ValueError as exc:
+            return CheckResult("decisions", ok=False, detail=str(exc))
+        if taken > not_after:
+            return CheckResult(
+                "decisions",
+                ok=False,
+                detail=(
+                    f"decision {decision_id} was taken at {decision.get('timestamp')}, after "
+                    f"grant {grant.get('grant_id')} expired at {grant.get('not_after')}"
+                ),
+            )
+
+    return CheckResult("decisions", ok=True, detail=f"{len(decisions)} decision(s) recomputed")
+
+
+def verify_evidence(envelope: dict[str, Any]) -> CheckResult:
+    """Every evidence entry must attach to a decision the envelope carries."""
+    evidence = envelope.get("evidence")
+    if not isinstance(evidence, list):
+        return CheckResult("evidence", ok=False, detail="evidence section missing or not a list")
+
+    decision_ids = {
+        str(d.get("decision_id")) for d in (envelope.get("decisions") or []) if isinstance(d, dict)
+    }
+    for index, entry in enumerate(evidence):
+        if not isinstance(entry, dict):
+            return CheckResult("evidence", ok=False, detail=f"evidence[{index}] is not an object")
+        target = str(entry.get("decision", ""))
+        if target not in decision_ids:
+            return CheckResult(
+                "evidence",
+                ok=False,
+                detail=(
+                    f"evidence[{index}] names decision {target!r}, which the envelope "
+                    "does not carry"
+                ),
+            )
+        digest = (entry.get("digest") or {}).get("sha256")
+        if not isinstance(digest, str) or len(digest) != 64:
+            return CheckResult(
+                "evidence",
+                ok=False,
+                detail=f"evidence[{index}] digest.sha256 is not a sha256 hex digest",
+            )
+    return CheckResult("evidence", ok=True, detail=f"{len(evidence)} artefact hash(es)")
+
+
+def verify_coverage(envelope: dict[str, Any]) -> CheckResult:
+    """Recompute the coverage statement from the decisions and the evidence."""
+    coverage = envelope.get("coverage") or {}
+    decisions = [d for d in (envelope.get("decisions") or []) if isinstance(d, dict)]
+    decision_ids = {str(d.get("decision_id")) for d in decisions}
+    actions = {str(d.get("decision_id")): d.get("action") for d in decisions}
+
+    with_evidence = {
+        str(e.get("decision"))
+        for e in (envelope.get("evidence") or [])
+        if isinstance(e, dict) and str(e.get("decision")) in decision_ids
+    }
+    declared_covered = set(coverage.get("covered") or [])
+    if declared_covered != with_evidence:
+        return CheckResult(
+            "coverage",
+            ok=False,
+            detail=(
+                f"coverage.covered names {sorted(declared_covered)} but the decisions carrying "
+                f"evidence are {sorted(with_evidence)}"
+            ),
+        )
+
+    gaps = decision_ids - with_evidence
+    uncovered = coverage.get("uncovered")
+    if not isinstance(uncovered, list):
+        return CheckResult("coverage", ok=False, detail="coverage.uncovered is not a list")
+    declared_gaps: dict[str, Any] = {}
+    for index, entry in enumerate(uncovered):
+        if not isinstance(entry, dict):
+            return CheckResult(
+                "coverage", ok=False, detail=f"coverage.uncovered[{index}] is not an object"
+            )
+        declared_gaps[str(entry.get("decision_id", ""))] = entry
+    if set(declared_gaps) != gaps:
+        return CheckResult(
+            "coverage",
+            ok=False,
+            detail=(
+                f"coverage.uncovered names {sorted(declared_gaps)} but the decisions with no "
+                f"evidence are {sorted(gaps)}; a gap the envelope does not state is a refusal"
+            ),
+        )
+    for decision_id, entry in declared_gaps.items():
+        if entry.get("action") != actions.get(decision_id):
+            return CheckResult(
+                "coverage",
+                ok=False,
+                detail=(
+                    f"coverage.uncovered entry for {decision_id} names action "
+                    f"{entry.get('action')!r}, not the decision's {actions.get(decision_id)!r}"
+                ),
+            )
+        if not str(entry.get("reason", "")).strip():
+            return CheckResult(
+                "coverage",
+                ok=False,
+                detail=f"coverage.uncovered entry for {decision_id} states no reason",
+            )
+
+    if not str(coverage.get("statement", "")).strip():
+        return CheckResult("coverage", ok=False, detail="coverage.statement is empty")
+
+    return CheckResult(
+        "coverage",
+        ok=True,
+        detail=(
+            f"{len(with_evidence)}/{len(decision_ids)} decisions carry evidence; "
+            f"uncovered: {sorted(gaps)}"
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def _print_check(check: CheckResult, *, verbose: bool, stream: IO[str]) -> None:
+    """Emit one PASS/FAIL line to the output stream."""
+    status = "PASS" if check.ok else "FAIL"
+    line = f"[{status}] {check.name}"
+    if check.detail and (not check.ok or verbose):
+        line += f" - {check.detail}"
+    print(line, file=stream)
+
+
+def run_verify(*, envelope_path: Path, verbose: bool, stream: IO[str]) -> VerifyResult:
+    """Run every check over the envelope at *envelope_path*."""
+    result = VerifyResult()
+
+    def record(check: CheckResult) -> None:
+        result.checks.append(check)
+        _print_check(check, verbose=verbose, stream=stream)
+
+    try:
+        envelope = json.loads(Path(envelope_path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        record(CheckResult("envelope_load", ok=False, detail=str(exc)))
+        print("OVERALL: FAIL", file=stream)
+        return result
+    if not isinstance(envelope, dict):
+        record(CheckResult("envelope_load", ok=False, detail="envelope is not a JSON object"))
+        print("OVERALL: FAIL", file=stream)
+        return result
+
+    record(verify_envelope_type(envelope))
+
+    # Coverage presence is a gate, not a check among others: an envelope that
+    # is silent about its gaps is refused before anything else is reported.
+    presence = verify_coverage_present(envelope)
+    if not presence.ok:
+        record(presence)
+        print("OVERALL: FAIL", file=stream)
+        return result
+
+    signature_check, _note = verify_signature(envelope)
+    record(signature_check)
+    for check in verify_section_digests(envelope):
+        record(check)
+    record(verify_principal(envelope))
+    record(verify_grants(envelope))
+    record(verify_decisions(envelope))
+    record(verify_evidence(envelope))
+    record(verify_coverage(envelope))
+
+    print(f"OVERALL: {'PASS' if result.ok else 'FAIL'}", file=stream)
+    return result
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the argparse CLI used when this module is run directly."""
+    parser = argparse.ArgumentParser(
+        description="Verify a Bernstein authority envelope without importing the bernstein package."
+    )
+    parser.add_argument("--envelope", required=True, type=Path, help="Path to the envelope JSON.")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Print PASS-line details.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns 0 pass, 1 fail, 2 bad args."""
+    args = _build_parser().parse_args(argv)
+    if not args.envelope.is_file():
+        print(f"ERROR: not a file: {args.envelope}", file=sys.stderr)
+        return 2
+    result = run_verify(envelope_path=args.envelope, verbose=args.verbose, stream=sys.stdout)
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/verify_cli/bernstein_verify_receipt/__main__.py
+++ b/verify_cli/bernstein_verify_receipt/__main__.py
@@ -75,9 +75,7 @@ def cli() -> None:
     show_default=True,
     help="Which format(s) to verify.",
 )
-@click.option(
-    "--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details."
-)
+@click.option("--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details.")
 def verify_cmd(
     receipt_path: Path,
     jwk_path: Path | None,

--- a/verify_cli/bernstein_verify_receipt/verify.py
+++ b/verify_cli/bernstein_verify_receipt/verify.py
@@ -291,8 +291,7 @@ def verify_subject_binding(receipt: dict[str, Any]) -> tuple[CheckResult, str]:
                 "subject_binding",
                 ok=False,
                 detail=(
-                    f"recomputed head {recomputed[:16]}… "
-                    f"!= range.head_sha256 {range_head[:16]}…"
+                    f"recomputed head {recomputed[:16]}… != range.head_sha256 {range_head[:16]}…"
                 ),
             ),
             recomputed,
@@ -418,10 +417,7 @@ def verify_intoto(receipt: dict[str, Any], public_key: Any, recomputed_head: str
         return CheckResult(
             "intoto",
             ok=False,
-            detail=(
-                f"recomputed head {recomputed_head[:16]}… "
-                f"not in statement subject digests"
-            ),
+            detail=(f"recomputed head {recomputed_head[:16]}… not in statement subject digests"),
         )
     return CheckResult("intoto", ok=True, detail="DSSE/in-toto verified, subject bound to head")
 
@@ -469,8 +465,7 @@ def verify_transparency(
             "transparency",
             ok=False,
             detail=(
-                f"STH subject {subject_sha256[:16]}… "
-                f"!= recomputed head {recomputed_head[:16]}…"
+                f"STH subject {subject_sha256[:16]}… != recomputed head {recomputed_head[:16]}…"
             ),
         )
 
@@ -510,10 +505,7 @@ def verify_transparency(
             return CheckResult(
                 "transparency",
                 ok=False,
-                detail=(
-                    f"inclusion proof root {proven_root[:16]}… "
-                    f"!= STH root {root_hash[:16]}…"
-                ),
+                detail=(f"inclusion proof root {proven_root[:16]}… != STH root {root_hash[:16]}…"),
             )
     return CheckResult(
         "transparency", ok=True, detail="RFC6962 STH signed, root + inclusion proof verified"


### PR DESCRIPTION
## What

Adds the first two slices of the portable authority envelope: a versioned schema with a canonical serialization and committed golden vectors (E1), and a standalone verifier that validates them without the `bernstein` package (E2).

**In scope**

- `schemas/authority-envelope-v1.json` — sections `principal`, `grants`, `decisions`, `evidence`, `coverage`, `section_digests`, `signature`, with the hash preimages written out so an independent implementer can reproduce them.
- `tests/fixtures/authority-envelope-vectors/` — one deliberately partial envelope, one tampered copy, and a deterministic builder.
- `verify_cli/bernstein_verify_envelope/` — the verifier, its CLI, and its wheel metadata.
- `docs/interop/authority-envelope.md` — what an envelope proves and, at greater length, what it does not.

**Explicitly not in scope**

- No producer. Nothing under `src/bernstein/` changes, and no existing decision record is rewritten to emit an envelope. That is E3.
- No external key pinning (`--jwk` / `--public-key`). An envelope verified against the key it carries is reported as trust-on-first-use, and the documentation says so plainly. That is E5.
- No revocation checking, no wall-clock expiry check. The verifier compares a decision's timestamp against the grant it cites, which is clock-free and keeps the golden vector valid forever; whether a grant was revoked is not something the envelope carries.

### Decision this PR made

The issue left the canonical form open (`cbor2`/JCS). **JCS (RFC 8785), no CBOR.** Reasons: the envelope's sections are JSON-native and are read by humans as often as by verifiers; the repository's existing authority machinery already signs JCS bytes with a detached EdDSA JWS (`core/interop/a2a_card.py`, `core/security/agent_card_signer.py`), so the shape is one an existing reader already knows; and dropping CBOR keeps the auditor wheel at two dependencies (`cryptography`, `click`) instead of three. The audit-receipt verifier needs `cbor2` because COSE_Sign1 is a CBOR format — nothing here is.

## Why

Everything the repository records about authority is shaped for its own consumption. `GovernanceDecision` (`src/bernstein/core/security/governance.py:217`) is anchored to a run spine and stored under `lineage_root/<run_id>/`, so it cannot exist outside a run we scheduled. The run receipt (`src/bernstein/core/replay/run_receipt.py:216`) has the right shape — self-describing, verifiable offline — but carries no principal, no grant chain, and no policy decision reference. The compliance pack (`verify_cli/bernstein_verify/verify.py:455`) reads its signing keys out of the same zip, so the bundle certifies itself.

The result an operator hits: the evidence only means something on the install that produced it. Handing it to a gateway, another agent runtime, a policy engine, or an auditor's own tooling requires re-implementing internals first.

The schema is also the thing the neighbouring work needs in order to agree on a target, which is why it lands before any producer.

## How

The envelope is one JSON object. `section_digests` and `signature` are what make it checkable:

- The signature is a detached compact JWS (RFC 7515 Appendix F, `alg=EdDSA`) whose signing input is `BASE64URL(JCS(header)) || "." || BASE64URL(JCS(body))`, where the body is every top-level member except `signature` — the same construction `_sign_card_body` already uses for capability cards.
- `section_digests` records a sha256 over the canonical bytes of each section. Without it a mutation anywhere reports only "the signature failed"; with it the verifier names the section that moved.

Every other hash exists so the verifier can re-derive rather than trust, in the idiom `_access_inputs_hash` (`src/bernstein/core/security/governance.py:383`) already establishes for role decisions:

- `principal.id_binding` recomputes over the principal id and its JWK.
- `grants[].grant_hash` chains to the parent's, so rewriting an ancestor invalidates every descendant. Attenuation is checked structurally: subset scope, no later expiry, issuer equal to the previous subject, chain terminating at the principal.
- `decisions[].inputs_hash` covers the decision's own policy inputs *and* the cited grant's hash. An `allow` for an action outside that grant's scope is rejected, as is a decision timestamped after the grant expired.
- `coverage` is re-derived: the verifier computes which decisions carry evidence and which do not, and rejects a coverage section that does not name every gap. An envelope with no coverage section is refused outright rather than read as complete.

The verifier re-implements JCS locally instead of importing `canonicalize_jcs`. Sharing the code would prove the two sides agree with themselves; the committed golden vector proves an independent reader agrees with the producer.

## Tests

`tests/unit/test_authority_envelope_verifier.py`. Every one of these failed on the unmodified tree — the first run reported `ImportError: No module named bernstein_verify_envelope` — and each was written before the code it pins.

1. `test_golden_vector_verifies_in_a_subprocess_without_bernstein` — **load-bearing.** Runs the verifier in a real subprocess where a meta-path finder makes `import bernstein` raise, and asserts every section passes. If the verifier ever grows a `bernstein.*` import, this dies with `ImportError`.
2. `test_the_independence_probe_actually_blocks_bernstein` — proves the blocker in test 1 is real, so test 1 cannot pass merely because nothing tried the import.
3. `test_verifier_package_imports_neither_bernstein_nor_the_network` — no `bernstein.`, `httpx`, `requests`, `urllib`, `socket` or `aiohttp` on any import line.
4. `test_one_byte_mutation_in_decisions_names_the_decisions_section` — **load-bearing.** One flipped verdict fails, and the report names `section:decisions`, not just the signature.
5. `test_one_byte_mutation_in_grants_names_the_grants_section` — the section named is the one that changed, not a hard-coded first section.
6. `test_committed_tampered_vector_is_rejected` — the committed negative vector stays rejected.
7. `test_envelope_without_a_coverage_section_is_refused` — silence about scope is a refusal.
8. `test_coverage_that_hides_an_uncovered_decision_is_refused` — a decision with no evidence must be named in `coverage.uncovered`.
9. `test_coverage_names_the_gap_on_the_passing_vector` — the passing vector is partial and reports its own gap.
10. `test_grant_chain_that_widens_scope_is_rejected` — a child link may only narrow.
11. `test_allow_verdict_outside_the_referenced_grant_scope_is_rejected` — an `allow` must follow from the grant it cites, not merely be signed.
12. `test_decision_inputs_hash_is_recomputed_not_trusted` — editing recorded inputs breaks the recomputed hash.
13. `test_decision_taken_after_its_grant_expired_is_rejected` — decisions fall inside the cited link's window.
14. `test_evidence_referencing_an_unknown_decision_is_rejected` — evidence attaches to a decision the envelope carries.
15. `test_principal_id_rebound_to_another_key_is_rejected` — the identifier is bound to its key material.
16. `test_schema_accepts_the_golden_vector` — the vector validates against the committed schema.
17. `test_schema_requires_the_coverage_section` — coverage is required by the schema, not only by the verifier.

Local runs (17 passed):

```
uv run python scripts/run_tests.py --parallel 2 tests/unit/test_authority_envelope_verifier.py \
    tests/unit/test_distribution_manifests.py tests/unit/test_co_change_neighbours.py
```

`--affected origin/main` selects several hundred files here, so per the contributor guidance the run above covers the modules touched plus their readers instead: nothing under `src/` changes, the new verifier package is imported only by the new test file, and `mkdocs.yml` is read only by `tests/unit/test_tui_render_freshness.py`, which was also run. That file has one failure — `test_the_committed_render_matches_what_the_dashboard_draws` — which reproduces unchanged on `origin/main` in this environment and is unrelated to this branch. CI runs the full suite.

## Checklist

- [x] `uv run ruff check src/` passes — unchanged by this PR (no files under `src/` are touched); the two `UP042` findings it reports here are pre-existing on `origin/main` with this ruff version. `ruff check` and `ruff format --check` are clean on every file this PR adds.
- [x] `uv run pyright src/` passes — unchanged; `[tool.pyright] include = ["src"]`, and `verify_cli/` is outside that scope exactly as the existing standalone verifiers are.
- [x] `uv run python scripts/run_tests.py -x` — see the scoped runs above.
- [x] New code has type hints

### Documentation duty

- [x] User-visible README section updated — N/A (no README change; the new page is `docs/interop/authority-envelope.md`, linked from the MkDocs nav).
- [x] `docs/operations/<area>.md` updated — N/A (no operator surface changes; there is no producer in this slice).
- [x] `docs/api/` schema regenerated if a public surface changed — N/A (no public API change).
- [x] `uv run bernstein agents-md sync` — N/A (no module under `src/bernstein/` added or changed).
- [x] Tests cover the documented behaviour — the "what it does not prove" list in the docs matches the checks the verifier runs and the ones it deliberately does not.

Part of #5055

## Remaining

- **E3** — a producer for the run-scoped case, built from the existing `GovernanceDecision` and run-receipt fields.
- **E4** — a coverage statement emitted by that producer. The schema section and the verifier's refusal of an unstated gap land here; what remains is a producer that computes coverage from a real run rather than a hand-built vector.
- **E5** — external key pinning (`--jwk` / `--public-key`) and a test that an envelope re-signed with a different key is rejected when pinned and reported as trust-on-first-use when not. The verifier already reports trust-on-first-use; it cannot yet be given a pin.
