### PR TITLE
feat: propagate data sensitivity forward over the lineage closure (#5042)

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -10,3 +10,7 @@ holds the page to that — an entry naming an issue or PR a tagged release page
 already documents fails the build. An entry that cites released work as context
 rather than as its own attribution is exempted by hand there, with the reason.
 
+
+## Lineage
+
+- Lineage entries carry an additive optional `sensitivity` classification, and the effective sensitivity of an artefact is the maximum class over its lineage closure — so a summary of a confidential document is confidential. Absence fails closed to the highest class, and the verdict names the closure member that raised the level and the path through the graph that reaches it. An entry without the field canonicalises byte-identically to the pre-change schema, so every historical signature and HMAC is untouched (#5042).

--- a/src/bernstein/core/lineage/entry.py
+++ b/src/bernstein/core/lineage/entry.py
@@ -54,6 +54,15 @@ ARTEFACT_KINDS: frozenset[str] = frozenset(
 #: :mod:`bernstein.core.lineage.provenance`.
 TRUST_CLASSES: frozenset[str] = frozenset({"operator", "workspace", "first_party", "third_party", "public"})
 
+#: Data-sensitivity classes recordable on an entry (issue #5042). The mirror of
+#: :data:`TRUST_CLASSES` on the opposite axis: ``trust_class`` says how much we
+#: trust an input, ``sensitivity`` says how sensitive it is. ``None`` on an
+#: entry means "no classification recorded" and is dropped from the canonical
+#: form so pre-feature entries keep byte-identical wire bytes. The sensitivity
+#: projection treats absence as the *highest* class (fail closed high) -- see
+#: :mod:`bernstein.core.lineage.sensitivity`.
+SENSITIVITY_CLASSES: frozenset[str] = frozenset({"public", "internal", "confidential", "restricted"})
+
 #: Shape of a bare hex SHA-256, used to validate recorded attachment digests.
 _HEX64: re.Pattern[str] = re.compile(r"\A[0-9a-f]{64}\Z")
 
@@ -136,6 +145,13 @@ class LineageEntry:
     # bytes so every historical entry keeps its exact wire form, signature and
     # HMAC. When not None must be a valid ModelRef instance.
     model_ref: ModelRef | None = None
+    # Additive, optional (issue #5042), dropped when ``None`` on the same rule
+    # as ``trust_class``. The operator's data classification of this artefact.
+    # Deliberately a second field beside ``trust_class`` rather than a widening
+    # of it: trust and sensitivity are opposite axes and propagate in opposite
+    # directions (minimum over the closure vs maximum over it). When not None
+    # must be one of SENSITIVITY_CLASSES.
+    sensitivity: str | None = None
 
     def __post_init__(self) -> None:
         if self.v != LINEAGE_ENTRY_VERSION:
@@ -159,6 +175,8 @@ class LineageEntry:
                     raise ValueError(f"attachment digest must be 64 lower-case hex chars, got {d!r}")
         if self.model_ref is not None and not isinstance(self.model_ref, ModelRef):
             raise ValueError(f"model_ref must be a ModelRef instance, got {type(self.model_ref).__name__}")
+        if self.sensitivity is not None and self.sensitivity not in SENSITIVITY_CLASSES:
+            raise ValueError(f"unknown sensitivity: {self.sensitivity!r}")
 
 
 def _canonical_body(entry: LineageEntry) -> dict[str, object]:
@@ -181,6 +199,8 @@ def _canonical_body(entry: LineageEntry) -> dict[str, object]:
         body.pop("attachment_digests", None)
     if body.get("model_ref") is None:
         body.pop("model_ref", None)
+    if body.get("sensitivity") is None:
+        body.pop("sensitivity", None)
     return body
 
 

--- a/src/bernstein/core/lineage/sensitivity.py
+++ b/src/bernstein/core/lineage/sensitivity.py
@@ -1,0 +1,252 @@
+"""Data sensitivity with lineage-propagated classification (issue #5042).
+
+:mod:`bernstein.core.lineage.provenance` propagates *trust* inward: the
+effective trust of an artefact is the **minimum** ``trust_class`` over its
+lineage closure, fail-closed to the lowest class. This module is that file
+mirrored on the opposite axis, with the propagation rule inverted.
+
+An operator classifies a source; the classification is recorded inside the
+signed, HMAC-chained lineage entry as ``sensitivity``. The *effective*
+sensitivity of any artefact is the **maximum** sensitivity class over its
+lineage closure -- a deterministic projection of the signed graph, recomputable
+offline by any verifier holding the log. An agent that reads a confidential
+document and writes a summary produces an artefact whose closure still reaches
+the classified source, so the summary is confidential too.
+
+Sensitivity classes, from least to most sensitive:
+
+    public < internal < confidential < restricted
+
+Absence fails closed to the **highest** class, not the lowest: an unlabelled
+artefact of unknown origin is not assumed harmless. That is the same posture as
+the taint projection, taken at the opposite end of the order.
+
+Two properties fall out of anchoring the class on the graph rather than on a
+label attached to a file:
+
+* **It cannot be dropped by copying.** Re-saving, summarising or transforming
+  an artefact produces a new lineage entry naming the old one as a parent, so
+  the closure still reaches the classified source. Stripping the classification
+  means breaking that parent edge, which fails the signature, HMAC and
+  anchoring checks the lineage gate already enforces.
+* **The verdict explains itself.** It names the closure member that raised the
+  level and the path through the graph that reaches it, so a classification is
+  a walk an auditor can follow rather than a claim they have to accept.
+
+Strip the lineage graph and this collapses entirely -- exactly as
+:mod:`~bernstein.core.lineage.provenance` says of the trust direction.
+
+This module is the projection only. Enforcement at a read boundary, the
+operator-controlled source map and the reporting CLI are separate surfaces.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from bernstein.core.lineage.entry import LineageEntry, entry_hash
+from bernstein.core.lineage.provenance import resolve_artefact_tip
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+class SensitivityClass(StrEnum):
+    """Operator data classification of a source / artefact."""
+
+    PUBLIC = "public"
+    INTERNAL = "internal"
+    CONFIDENTIAL = "confidential"
+    RESTRICTED = "restricted"
+
+
+# Higher rank == more sensitive. The ordering is total and fixed; the
+# sensitivity projection takes the maximum rank over the closure.
+_SENSITIVITY_RANK: dict[SensitivityClass, int] = {
+    SensitivityClass.PUBLIC: 0,
+    SensitivityClass.INTERNAL: 1,
+    SensitivityClass.CONFIDENTIAL: 2,
+    SensitivityClass.RESTRICTED: 3,
+}
+
+#: The highest sensitivity class. Used as the fail-closed default when no
+#: classification is reachable (no record means most sensitive).
+HIGHEST_SENSITIVITY_CLASS: SensitivityClass = SensitivityClass.RESTRICTED
+
+
+def sensitivity_rank(sc: SensitivityClass) -> int:
+    """Return the total-order rank of *sc* (higher == more sensitive)."""
+    return _SENSITIVITY_RANK[sc]
+
+
+def max_sensitivity_class(a: SensitivityClass, b: SensitivityClass) -> SensitivityClass:
+    """Return the more sensitive of *a* and *b* (maximum rank wins)."""
+    return a if _SENSITIVITY_RANK[a] >= _SENSITIVITY_RANK[b] else b
+
+
+# ---------------------------------------------------------------------------
+# Deterministic sensitivity projection
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class SensitivityVerdict:
+    """Result of projecting sensitivity over an artefact's lineage closure.
+
+    Every field is a pure function of the log, so two independent verifiers
+    holding the same log compute an identical verdict with no live process.
+
+    Attributes:
+        target: The entry hash whose sensitivity was computed.
+        sensitivity: Effective sensitivity class (maximum over the closure).
+            ``restricted`` when no classification is reachable (fail closed).
+        resolved: False when ``target`` is not present in the log at all.
+        closure: Sorted tuple of every entry hash reachable from ``target``
+            (including ``target``) over ``parent_hashes`` edges.
+        sensitivity_records: Sorted tuple of ``(entry_hash, sensitivity)`` for
+            every classified entry found in the closure -- the signed labels
+            the verdict projected from.
+        raised_by: Entry hash of the nearest closure member carrying the
+            effective class, or ``None`` when the class came from the
+            fail-closed default rather than from a recorded label.
+        path: The walk from ``target`` to ``raised_by`` over ``parent_hashes``
+            edges, ``target`` first. Empty when ``raised_by`` is ``None``. This
+            is the answer to "why is this classified", not just "it is".
+    """
+
+    target: str
+    sensitivity: SensitivityClass
+    resolved: bool
+    closure: tuple[str, ...]
+    sensitivity_records: tuple[tuple[str, str], ...]
+    raised_by: str | None
+    path: tuple[str, ...]
+
+
+def _index_by_hash(entries: Sequence[LineageEntry]) -> dict[str, LineageEntry]:
+    return {entry_hash(e): e for e in entries}
+
+
+def _unresolved(target: str) -> SensitivityVerdict:
+    """Fail-closed verdict for a target that is not in the log."""
+    return SensitivityVerdict(
+        target=target,
+        sensitivity=HIGHEST_SENSITIVITY_CLASS,
+        resolved=False,
+        closure=(),
+        sensitivity_records=(),
+        raised_by=None,
+        path=(),
+    )
+
+
+def effective_sensitivity(target: str, entries: Sequence[LineageEntry]) -> SensitivityVerdict:
+    """Project the maximum sensitivity class over *target*'s lineage closure.
+
+    Args:
+        target: Entry hash (``sha256:...``) to evaluate.
+        entries: Every lineage entry available (order-independent).
+
+    Returns:
+        A :class:`SensitivityVerdict`. When ``target`` is absent from
+        ``entries`` the verdict is fail-closed (``restricted``,
+        ``resolved=False``).
+    """
+    index = _index_by_hash(entries)
+    if target not in index:
+        return _unresolved(target)
+
+    # Breadth-first walk of parent_hashes, each level visited in sorted order
+    # so both the discovery order and the recorded predecessor of every member
+    # are functions of the graph alone. A cycle is impossible in a valid
+    # content-addressed log (a parent's hash is fixed before a child can name
+    # it), but ``seen`` guards against a malformed input regardless.
+    seen: set[str] = set()
+    depth: dict[str, int] = {target: 0}
+    came_from: dict[str, str] = {}
+    frontier: list[str] = [target]
+    records: list[tuple[str, str]] = []
+    while frontier:
+        next_frontier: list[str] = []
+        for h in sorted(frontier):
+            if h in seen:
+                continue
+            seen.add(h)
+            entry = index.get(h)
+            if entry is None:
+                # A dangling parent is caught by the gate; here we simply stop
+                # walking that branch (its contribution cannot be attested).
+                continue
+            if entry.sensitivity is not None:
+                records.append((h, entry.sensitivity))
+            for parent in entry.parent_hashes:
+                if parent not in seen and parent not in came_from:
+                    came_from[parent] = h
+                    depth[parent] = depth[h] + 1
+                next_frontier.append(parent)
+        frontier = next_frontier
+
+    if not records:
+        # No classification anywhere in the closure -> fail closed to highest.
+        return SensitivityVerdict(
+            target=target,
+            sensitivity=HIGHEST_SENSITIVITY_CLASS,
+            resolved=True,
+            closure=tuple(sorted(seen)),
+            sensitivity_records=(),
+            raised_by=None,
+            path=(),
+        )
+
+    effective = SensitivityClass.PUBLIC
+    for _, sc in records:
+        effective = max_sensitivity_class(effective, SensitivityClass(sc))
+
+    # Blame the *nearest* member carrying the effective class, so the reported
+    # explanation is the shortest one; ties on depth break on the entry hash so
+    # the choice stays a pure function of the graph.
+    raised_by = min(
+        (h for h, sc in records if SensitivityClass(sc) is effective),
+        key=lambda h: (depth.get(h, len(seen)), h),
+    )
+
+    walk: list[str] = [raised_by]
+    cursor = raised_by
+    while cursor != target:
+        cursor = came_from[cursor]
+        walk.append(cursor)
+    walk.reverse()
+
+    return SensitivityVerdict(
+        target=target,
+        sensitivity=effective,
+        resolved=True,
+        closure=tuple(sorted(seen)),
+        sensitivity_records=tuple(sorted(records)),
+        raised_by=raised_by,
+        path=tuple(walk),
+    )
+
+
+def sensitivity_for_artefact(artefact_path: str, entries: Sequence[LineageEntry]) -> SensitivityVerdict:
+    """Compute the sensitivity verdict for the current tip of *artefact_path*.
+
+    An unknown path is fail-closed (``restricted``, ``resolved=False``).
+    """
+    tip = resolve_artefact_tip(artefact_path, entries)
+    if tip is None:
+        return _unresolved(artefact_path)
+    return effective_sensitivity(tip, entries)
+
+
+__all__ = [
+    "HIGHEST_SENSITIVITY_CLASS",
+    "SensitivityClass",
+    "SensitivityVerdict",
+    "effective_sensitivity",
+    "max_sensitivity_class",
+    "sensitivity_for_artefact",
+    "sensitivity_rank",
+]

--- a/src/bernstein/core/lineage/signed_write.py
+++ b/src/bernstein/core/lineage/signed_write.py
@@ -141,6 +141,7 @@ def seal_write(
     attachment_digests: list[str] | None = None,
     ts_ns: int | None = None,
     model_ref: ModelRef | None = None,
+    sensitivity: str | None = None,
 ) -> str:
     """Seal a single signed lineage write into ``store``. Returns the entry hash.
 
@@ -198,6 +199,12 @@ def seal_write(
             that produced the output, linking the lineage receipt to model
             governance. ``None`` is dropped from canonical bytes so entries
             without a model attribution keep their historical hashes.
+        sensitivity: Optional operator data classification (issue #5042), one
+            of ``SENSITIVITY_CLASSES``. Recorded inside the signed entry so the
+            classification is covered by the signature and the HMAC, and the
+            sensitivity projection has signed labels to project from. ``None``
+            is dropped from canonical bytes so an unclassified write keeps its
+            historical entry hash.
 
     Raises:
         ValueError: When ``artefact_path`` is absolute or contains a
@@ -245,6 +252,7 @@ def seal_write(
         trust_class=trust_class,
         attachment_digests=attachment_digests,
         model_ref=model_ref,
+        sensitivity=sensitivity,
     )
     operator_hmac = compute_operator_hmac(unsigned_entry, operator_hmac_key)
 
@@ -263,6 +271,7 @@ def seal_write(
         trust_class=trust_class,
         attachment_digests=attachment_digests,
         model_ref=model_ref,
+        sensitivity=sensitivity,
     )
 
     # Sign the JCS-canonical entry bytes. The auditor verifies the same bytes
@@ -334,6 +343,7 @@ class SignedLineageLog:
         attachment_digests: list[str] | None = None,
         ts_ns: int | None = None,
         model_ref: ModelRef | None = None,
+        sensitivity: str | None = None,
     ) -> str:
         """Seal one artefact write into the bound store. Returns the entry hash.
 
@@ -344,6 +354,8 @@ class SignedLineageLog:
             model_ref: Optional model reference (issue #5037). Records the model
                 that produced the output, linking the lineage receipt to model
                 governance.
+            sensitivity: Optional operator data classification (issue #5042)
+                recorded inside the signed entry.
         """
         return seal_write(
             self.store,
@@ -361,6 +373,7 @@ class SignedLineageLog:
             attachment_digests=attachment_digests,
             ts_ns=ts_ns,
             model_ref=model_ref,
+            sensitivity=sensitivity,
         )
 
 

--- a/src/bernstein/core/lineage/store.py
+++ b/src/bernstein/core/lineage/store.py
@@ -370,6 +370,8 @@ def _entry_from_dict(payload: dict[str, object]) -> LineageEntry:
         trust_class=(None if payload.get("trust_class") is None else str(payload["trust_class"])),
         # Additive (issue #1797), same absent -> None round-trip rule.
         attachment_digests=_optional_str_list(payload.get("attachment_digests")),
+        # Additive (issue #5042), same absent -> None round-trip rule.
+        sensitivity=(None if payload.get("sensitivity") is None else str(payload["sensitivity"])),
     )
 
 

--- a/tests/unit/lineage/test_sensitivity.py
+++ b/tests/unit/lineage/test_sensitivity.py
@@ -1,0 +1,454 @@
+"""Tests for sensitivity classes + deterministic sensitivity projection.
+
+The sensitivity of a source is recorded as a signed lineage entry; the
+*effective* sensitivity of any artefact is the **maximum** sensitivity class
+over its lineage closure -- the mirror of the trust projection in
+:mod:`bernstein.core.lineage.provenance`, with the propagation rule inverted.
+These tests pin that projection, the fail-closed-high default, the closure
+member the verdict blames, and the additive entry schema.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.lineage.entry import (
+    LineageEntry,
+    canonicalise,
+    compute_operator_hmac,
+    entry_hash,
+)
+from bernstein.core.lineage.gate import check
+from bernstein.core.lineage.identity import AgentCard, generate_keypair, sign_detached
+from bernstein.core.lineage.provenance import load_entries_from_log
+from bernstein.core.lineage.sensitivity import (
+    HIGHEST_SENSITIVITY_CLASS,
+    SensitivityClass,
+    SensitivityVerdict,
+    effective_sensitivity,
+    max_sensitivity_class,
+    sensitivity_for_artefact,
+    sensitivity_rank,
+)
+
+# ---------------------------------------------------------------------------
+# SensitivityClass ordering
+# ---------------------------------------------------------------------------
+
+
+def test_sensitivity_rank_total_order() -> None:
+    ranks = [sensitivity_rank(sc) for sc in SensitivityClass]
+    assert len(set(ranks)) == len(SensitivityClass)  # every class distinct
+    assert sensitivity_rank(SensitivityClass.RESTRICTED) > sensitivity_rank(SensitivityClass.CONFIDENTIAL)
+    assert sensitivity_rank(SensitivityClass.CONFIDENTIAL) > sensitivity_rank(SensitivityClass.INTERNAL)
+    assert sensitivity_rank(SensitivityClass.INTERNAL) > sensitivity_rank(SensitivityClass.PUBLIC)
+
+
+def test_max_sensitivity_class_picks_the_more_sensitive() -> None:
+    assert max_sensitivity_class(SensitivityClass.PUBLIC, SensitivityClass.RESTRICTED) is SensitivityClass.RESTRICTED
+    assert (
+        max_sensitivity_class(SensitivityClass.INTERNAL, SensitivityClass.CONFIDENTIAL)
+        is SensitivityClass.CONFIDENTIAL
+    )
+    assert max_sensitivity_class(SensitivityClass.INTERNAL, SensitivityClass.INTERNAL) is SensitivityClass.INTERNAL
+
+
+def test_highest_class_is_the_fail_closed_default() -> None:
+    assert HIGHEST_SENSITIVITY_CLASS is SensitivityClass.RESTRICTED
+    assert sensitivity_rank(HIGHEST_SENSITIVITY_CLASS) == max(sensitivity_rank(sc) for sc in SensitivityClass)
+
+
+# ---------------------------------------------------------------------------
+# 1. Additive entry schema (ADR-009 SS5.2)
+# ---------------------------------------------------------------------------
+
+#: Canonical bytes of an entry carrying no ``sensitivity``, captured from the
+#: pre-change schema. An entry that records no sensitivity must serialise to
+#: exactly these bytes, so every historical signature, HMAC and entry hash
+#: stays valid.
+_GOLDEN_PRE_CHANGE_CANONICAL = (
+    '{"agent_card_kid":"key-001","agent_id":"agent:worker","artefact_kind":"file",'
+    '"artefact_path":"docs/summary.md",'
+    '"content_hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",'
+    '"operator_hmac":"0000000000000000000000000000000000000000000000000000000000000000",'
+    '"parent_hashes":["sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],'
+    '"span_id":"span-1","tool_call_id":"tc-1","ts_ns":1700000000000000001,"v":1}'
+).encode("utf-8")
+
+_GOLDEN_PRE_CHANGE_ENTRY_HASH = "sha256:b05fdd36bee74e6b9cd5a502ac00145e333992830658f953bdd58049aa615eff"
+_GOLDEN_PRE_CHANGE_HMAC = "0250aa0dd6a431d99c81973caaa91cdad6793612b00d1e0539cd3eaff03c1570"
+
+
+def _golden_kwargs(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = dict(
+        v=1,
+        artefact_path="docs/summary.md",
+        artefact_kind="file",
+        content_hash="sha256:" + "a" * 64,
+        parent_hashes=["sha256:" + "b" * 64],
+        agent_id="agent:worker",
+        agent_card_kid="key-001",
+        tool_call_id="tc-1",
+        span_id="span-1",
+        ts_ns=1_700_000_000_000_000_001,
+        operator_hmac="00" * 32,
+    )
+    base.update(overrides)
+    return base
+
+
+def test_entry_without_sensitivity_canonicalises_byte_identically_to_the_pre_change_schema() -> None:
+    # Test 1. The drop-when-None rule of ADR-009 SS5.2: an entry that carries no
+    # sensitivity must produce the exact bytes the pre-change schema produced,
+    # so historical signatures, HMACs and entry hashes are untouched.
+    implicit = LineageEntry(**_golden_kwargs())
+    explicit_none = LineageEntry(**_golden_kwargs(sensitivity=None))
+
+    assert canonicalise(implicit) == _GOLDEN_PRE_CHANGE_CANONICAL
+    assert canonicalise(explicit_none) == _GOLDEN_PRE_CHANGE_CANONICAL
+    assert b"sensitivity" not in canonicalise(implicit)
+    assert entry_hash(implicit) == _GOLDEN_PRE_CHANGE_ENTRY_HASH
+    assert compute_operator_hmac(implicit, b"k" * 32) == _GOLDEN_PRE_CHANGE_HMAC
+
+
+def test_sensitivity_is_included_in_the_canonical_bytes_when_set() -> None:
+    labelled = LineageEntry(**_golden_kwargs(sensitivity="confidential"))
+    body = canonicalise(labelled)
+    assert b'"sensitivity":"confidential"' in body
+    # And it participates in the identity hash, so a label cannot be swapped
+    # without moving the entry hash.
+    assert entry_hash(labelled) != _GOLDEN_PRE_CHANGE_ENTRY_HASH
+
+
+def test_sensitivity_rejects_unknown_value() -> None:
+    with pytest.raises(ValueError, match="unknown sensitivity"):
+        LineageEntry(**_golden_kwargs(sensitivity="top_secret"))
+
+
+def test_operator_hmac_covers_sensitivity() -> None:
+    key = b"k" * 32
+    low = LineageEntry(**_golden_kwargs(sensitivity="internal"))
+    high = LineageEntry(**_golden_kwargs(sensitivity="restricted"))
+    assert compute_operator_hmac(low, key) != compute_operator_hmac(high, key)
+
+
+def test_sensitivity_and_trust_class_are_independent_fields() -> None:
+    # Opposite axes: a public web page can be low-trust and low-sensitivity;
+    # an operator-supplied document is high-trust and may be high-sensitivity.
+    both = LineageEntry(**_golden_kwargs(trust_class="operator", sensitivity="confidential"))
+    body = canonicalise(both)
+    assert b'"trust_class":"operator"' in body
+    assert b'"sensitivity":"confidential"' in body
+
+
+# ---------------------------------------------------------------------------
+# Projection fixtures
+# ---------------------------------------------------------------------------
+
+
+def _entry(
+    path: str,
+    content_hash: str,
+    parents: list[str],
+    *,
+    sensitivity: str | None = None,
+    ts_ns: int = 1,
+) -> LineageEntry:
+    return LineageEntry(
+        v=1,
+        artefact_path=path,
+        artefact_kind="file",
+        content_hash=content_hash,
+        parent_hashes=parents,
+        agent_id="agent:gw",
+        agent_card_kid="k",
+        tool_call_id="tc",
+        span_id="s",
+        ts_ns=ts_ns,
+        operator_hmac="",
+        sensitivity=sensitivity,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Maximum over the closure
+# ---------------------------------------------------------------------------
+
+
+def test_effective_sensitivity_is_the_maximum_over_the_closure() -> None:
+    # Test 2. A derived artefact whose closure unions a public source and a
+    # confidential source is as sensitive as the confidential source.
+    pub = _entry("docs/public.md", "sha256:" + "1" * 64, [], sensitivity="public")
+    conf = _entry("docs/secret.md", "sha256:" + "2" * 64, [], sensitivity="confidential")
+    derived = _entry("docs/merged.md", "sha256:" + "3" * 64, [entry_hash(pub), entry_hash(conf)], ts_ns=2)
+
+    verdict = effective_sensitivity(entry_hash(derived), [pub, conf, derived])
+
+    assert isinstance(verdict, SensitivityVerdict)
+    assert verdict.sensitivity is SensitivityClass.CONFIDENTIAL
+    assert verdict.resolved is True
+
+
+def test_effective_sensitivity_of_a_single_labelled_record_is_its_own_class() -> None:
+    e = _entry("docs/secret.md", "sha256:" + "1" * 64, [], sensitivity="restricted")
+    verdict = effective_sensitivity(entry_hash(e), [e])
+    assert verdict.sensitivity is SensitivityClass.RESTRICTED
+    assert verdict.resolved is True
+
+
+# ---------------------------------------------------------------------------
+# 3. Fail closed to the highest class
+# ---------------------------------------------------------------------------
+
+
+def test_absent_sensitivity_fails_closed_to_the_highest_class() -> None:
+    # Test 3. Two shapes of absence, both fail closed *high* -- the mirror of
+    # the taint projection failing closed *low*. An unlabelled artefact of
+    # unknown origin is not assumed harmless.
+    unknown = effective_sensitivity("sha256:" + "f" * 64, [])
+    assert unknown.resolved is False
+    assert unknown.sensitivity is SensitivityClass.RESTRICTED
+    assert unknown.raised_by is None
+
+    lone = _entry("docs/lone.md", "sha256:" + "9" * 64, [])
+    unlabelled = effective_sensitivity(entry_hash(lone), [lone])
+    assert unlabelled.resolved is True
+    assert unlabelled.sensitivity is SensitivityClass.RESTRICTED
+    assert unlabelled.raised_by is None
+
+
+def test_a_public_label_anywhere_in_the_closure_is_not_absence() -> None:
+    # An explicit ``public`` label is a classification, not a missing one, so
+    # it must not be promoted to the fail-closed default.
+    src = _entry("docs/public.md", "sha256:" + "1" * 64, [], sensitivity="public")
+    derived = _entry("docs/copy.md", "sha256:" + "2" * 64, [entry_hash(src)], ts_ns=2)
+    verdict = effective_sensitivity(entry_hash(derived), [src, derived])
+    assert verdict.sensitivity is SensitivityClass.PUBLIC
+
+
+# ---------------------------------------------------------------------------
+# 4. The summary case (load-bearing)
+# ---------------------------------------------------------------------------
+
+
+def test_derived_artefact_inherits_the_sensitivity_of_its_ancestor() -> None:
+    # Test 4. An agent reads a confidential document, summarises it, and writes
+    # the summary. The summary carries no label of its own; its lineage reaches
+    # the confidential source, so the projection says confidential.
+    source = _entry("docs/board-minutes.md", "sha256:" + "1" * 64, [], sensitivity="confidential")
+    summary = _entry("docs/summary.md", "sha256:" + "2" * 64, [entry_hash(source)], ts_ns=2)
+
+    verdict = sensitivity_for_artefact("docs/summary.md", [source, summary])
+
+    assert verdict.sensitivity is SensitivityClass.CONFIDENTIAL
+    assert verdict.resolved is True
+    assert verdict.raised_by == entry_hash(source)
+
+
+def test_sensitivity_propagates_through_multiple_hops() -> None:
+    src = _entry("docs/board-minutes.md", "sha256:" + "1" * 64, [], sensitivity="confidential")
+    notes = _entry("docs/notes.md", "sha256:" + "2" * 64, [entry_hash(src)], ts_ns=2)
+    slide = _entry("docs/slide.md", "sha256:" + "3" * 64, [entry_hash(notes)], ts_ns=3)
+
+    verdict = effective_sensitivity(entry_hash(slide), [src, notes, slide])
+
+    assert verdict.sensitivity is SensitivityClass.CONFIDENTIAL
+    assert verdict.path == (entry_hash(slide), entry_hash(notes), entry_hash(src))
+
+
+def test_sensitivity_for_artefact_resolves_the_latest_tip() -> None:
+    src = _entry("docs/board-minutes.md", "sha256:" + "1" * 64, [], sensitivity="confidential")
+    first = _entry("docs/summary.md", "sha256:" + "2" * 64, [], ts_ns=2, sensitivity="public")
+    second = _entry("docs/summary.md", "sha256:" + "3" * 64, [entry_hash(first), entry_hash(src)], ts_ns=3)
+
+    verdict = sensitivity_for_artefact("docs/summary.md", [src, first, second])
+
+    assert verdict.target == entry_hash(second)
+    assert verdict.sensitivity is SensitivityClass.CONFIDENTIAL
+
+
+def test_unknown_artefact_path_fails_closed_high() -> None:
+    verdict = sensitivity_for_artefact("docs/nowhere.md", [])
+    assert verdict.resolved is False
+    assert verdict.sensitivity is SensitivityClass.RESTRICTED
+
+
+# ---------------------------------------------------------------------------
+# 5. The verdict names what raised the level
+# ---------------------------------------------------------------------------
+
+
+def test_verdict_names_the_closure_member_that_raised_the_level() -> None:
+    # Test 5. "This is confidential" invites an argument; "this is confidential
+    # because it derives, through these hops, from that entry" ends it.
+    benign = _entry("docs/public.md", "sha256:" + "1" * 64, [], sensitivity="public")
+    classified = _entry("docs/board-minutes.md", "sha256:" + "2" * 64, [], sensitivity="restricted")
+    mid = _entry("docs/notes.md", "sha256:" + "3" * 64, [entry_hash(classified)], ts_ns=2)
+    summary = _entry("docs/summary.md", "sha256:" + "4" * 64, [entry_hash(benign), entry_hash(mid)], ts_ns=3)
+
+    verdict = effective_sensitivity(entry_hash(summary), [benign, classified, mid, summary])
+
+    assert verdict.sensitivity is SensitivityClass.RESTRICTED
+    assert verdict.raised_by == entry_hash(classified)
+    # The path is the walk through the graph from the target down to the
+    # member that raised the level, so an operator can follow the hops.
+    assert verdict.path == (entry_hash(summary), entry_hash(mid), entry_hash(classified))
+    # Every signed label the verdict projected from is reported.
+    assert verdict.sensitivity_records == tuple(
+        sorted([(entry_hash(benign), "public"), (entry_hash(classified), "restricted")])
+    )
+
+
+def test_verdict_blames_nothing_when_the_level_came_from_the_fail_closed_default() -> None:
+    lone = _entry("docs/lone.md", "sha256:" + "9" * 64, [])
+    verdict = effective_sensitivity(entry_hash(lone), [lone])
+    assert verdict.raised_by is None
+    assert verdict.path == ()
+    assert verdict.sensitivity_records == ()
+
+
+def test_verdict_blames_the_nearest_raising_member_on_a_tie() -> None:
+    # Two members carry the same top class at different depths. The verdict
+    # names the nearest one, so the shortest explanation is the reported one.
+    far = _entry("docs/far.md", "sha256:" + "1" * 64, [], sensitivity="confidential")
+    hop = _entry("docs/hop.md", "sha256:" + "2" * 64, [entry_hash(far)], ts_ns=2)
+    near = _entry("docs/near.md", "sha256:" + "3" * 64, [], sensitivity="confidential", ts_ns=3)
+    target = _entry("docs/t.md", "sha256:" + "4" * 64, [entry_hash(hop), entry_hash(near)], ts_ns=4)
+
+    verdict = effective_sensitivity(entry_hash(target), [far, hop, near, target])
+
+    assert verdict.raised_by == entry_hash(near)
+    assert verdict.path == (entry_hash(target), entry_hash(near))
+
+
+# ---------------------------------------------------------------------------
+# 6. Deterministic and recomputable offline
+# ---------------------------------------------------------------------------
+
+
+def test_projection_is_deterministic_and_recomputable_offline(tmp_path: Path) -> None:
+    # Test 6. The verdict is a pure function of the log: independent of input
+    # order, and reproducible by a verifier holding only ``log.jsonl``.
+    src = _entry("docs/board-minutes.md", "sha256:" + "1" * 64, [], sensitivity="confidential")
+    mid = _entry("docs/notes.md", "sha256:" + "2" * 64, [entry_hash(src)], ts_ns=2)
+    summary = _entry("docs/summary.md", "sha256:" + "3" * 64, [entry_hash(mid)], ts_ns=3)
+    entries = [src, mid, summary]
+    target = entry_hash(summary)
+
+    in_order = effective_sensitivity(target, entries)
+    reversed_order = effective_sensitivity(target, list(reversed(entries)))
+    assert in_order == reversed_order
+    assert in_order.closure == reversed_order.closure
+
+    # Offline: write the canonical log and recompute from the bytes alone.
+    log_path = tmp_path / "log.jsonl"
+    log_path.write_bytes(b"".join(canonicalise(e) + b"\n" for e in entries))
+    offline = effective_sensitivity(target, load_entries_from_log(log_path))
+    assert offline == in_order
+
+
+# ---------------------------------------------------------------------------
+# 7. The classification cannot be dropped by breaking the edge
+# ---------------------------------------------------------------------------
+
+_OP_SECRET = b"op-secret-xyz"
+
+
+class _Agent:
+    def __init__(self, agent_id: str, kid: str) -> None:
+        self.agent_id = agent_id
+        self.kid = kid
+        self.priv, self.pub = generate_keypair()
+        self.card = AgentCard(agent_id=agent_id, kid=kid, public_key_pem=self.pub)
+
+
+def _signed_entry(
+    agent: _Agent,
+    path: str,
+    content_hash: str,
+    parents: list[str],
+    *,
+    sensitivity: str | None = None,
+    ts_ns: int = 1,
+) -> LineageEntry:
+    fields: dict[str, object] = dict(
+        v=1,
+        artefact_path=path,
+        artefact_kind="file",
+        content_hash=content_hash,
+        parent_hashes=parents,
+        agent_id=agent.agent_id,
+        agent_card_kid=agent.kid,
+        tool_call_id="tc",
+        span_id="s",
+        ts_ns=ts_ns,
+        sensitivity=sensitivity,
+    )
+    unsigned = LineageEntry(operator_hmac="", **fields)  # type: ignore[arg-type]
+    return LineageEntry(operator_hmac=compute_operator_hmac(unsigned, _OP_SECRET), **fields)  # type: ignore[arg-type]
+
+
+def _write_card(cards_dir: Path, agent: _Agent) -> None:
+    d = cards_dir / agent.agent_id
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "card.json").write_text(
+        json.dumps(
+            {
+                "protocolVersion": "a2a/1.0",
+                "agent_id": agent.agent_id,
+                "kid": agent.kid,
+                "public_key_pem": agent.pub,
+            }
+        )
+    )
+
+
+def _write_log_and_sigs(log_path: Path, entries: list[LineageEntry], agent: _Agent) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    sig_root = log_path.parent / "signatures"
+    with log_path.open("wb") as f:
+        for e in entries:
+            f.write(canonicalise(e) + b"\n")
+    for e in entries:
+        jws = sign_detached(canonicalise(e), agent.priv, kid=agent.kid)
+        eh = entry_hash(e)
+        path_hash = hashlib.sha256(e.artefact_path.encode()).hexdigest()
+        dest = sig_root / path_hash[:2] / path_hash
+        dest.mkdir(parents=True, exist_ok=True)
+        (dest / (eh.replace("sha256:", "") + ".jws")).write_text(jws)
+
+
+def test_reparenting_to_drop_a_classified_ancestor_fails_signature_verification(tmp_path: Path) -> None:
+    # Test 7. Stripping the classification means breaking the parent edge, and
+    # that fails the same signature / HMAC / anchoring checks the lineage gate
+    # already enforces. Nor does breaking it buy an unclassified artefact: the
+    # orphaned summary falls to the fail-closed-high default instead.
+    agent = _Agent("agent:gw", "k1")
+    cards = tmp_path / "agents"
+    _write_card(cards, agent)
+    log = tmp_path / "lineage" / "log.jsonl"
+
+    source = _signed_entry(
+        agent, "docs/board-minutes.md", "sha256:" + "1" * 64, [], sensitivity="confidential", ts_ns=1
+    )
+    summary = _signed_entry(agent, "docs/summary.md", "sha256:" + "2" * 64, [entry_hash(source)], ts_ns=2)
+    _write_log_and_sigs(log, [source, summary], agent)
+
+    assert check(log_path=log, agent_cards_dir=cards, operator_secret=_OP_SECRET).ok is True
+    clean = sensitivity_for_artefact("docs/summary.md", load_entries_from_log(log))
+    assert clean.sensitivity is SensitivityClass.CONFIDENTIAL
+
+    # Cut the edge back to the classified source.
+    lines = log.read_text().splitlines()
+    obj = json.loads(lines[1])
+    obj["parent_hashes"] = []
+    lines[1] = json.dumps(obj, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
+    log.write_text("\n".join(lines) + "\n")
+
+    assert check(log_path=log, agent_cards_dir=cards, operator_secret=_OP_SECRET).ok is False
+    orphaned = sensitivity_for_artefact("docs/summary.md", load_entries_from_log(log))
+    assert orphaned.sensitivity is SensitivityClass.RESTRICTED

--- a/tests/unit/lineage/test_sensitivity.py
+++ b/tests/unit/lineage/test_sensitivity.py
@@ -51,8 +51,7 @@ def test_sensitivity_rank_total_order() -> None:
 def test_max_sensitivity_class_picks_the_more_sensitive() -> None:
     assert max_sensitivity_class(SensitivityClass.PUBLIC, SensitivityClass.RESTRICTED) is SensitivityClass.RESTRICTED
     assert (
-        max_sensitivity_class(SensitivityClass.INTERNAL, SensitivityClass.CONFIDENTIAL)
-        is SensitivityClass.CONFIDENTIAL
+        max_sensitivity_class(SensitivityClass.INTERNAL, SensitivityClass.CONFIDENTIAL) is SensitivityClass.CONFIDENTIAL
     )
     assert max_sensitivity_class(SensitivityClass.INTERNAL, SensitivityClass.INTERNAL) is SensitivityClass.INTERNAL
 
@@ -71,13 +70,13 @@ def test_highest_class_is_the_fail_closed_default() -> None:
 #: exactly these bytes, so every historical signature, HMAC and entry hash
 #: stays valid.
 _GOLDEN_PRE_CHANGE_CANONICAL = (
-    '{"agent_card_kid":"key-001","agent_id":"agent:worker","artefact_kind":"file",'
-    '"artefact_path":"docs/summary.md",'
-    '"content_hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",'
-    '"operator_hmac":"0000000000000000000000000000000000000000000000000000000000000000",'
-    '"parent_hashes":["sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],'
-    '"span_id":"span-1","tool_call_id":"tc-1","ts_ns":1700000000000000001,"v":1}'
-).encode("utf-8")
+    b'{"agent_card_kid":"key-001","agent_id":"agent:worker","artefact_kind":"file",'
+    b'"artefact_path":"docs/summary.md",'
+    b'"content_hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",'
+    b'"operator_hmac":"0000000000000000000000000000000000000000000000000000000000000000",'
+    b'"parent_hashes":["sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],'
+    b'"span_id":"span-1","tool_call_id":"tc-1","ts_ns":1700000000000000001,"v":1}'
+)
 
 _GOLDEN_PRE_CHANGE_ENTRY_HASH = "sha256:b05fdd36bee74e6b9cd5a502ac00145e333992830658f953bdd58049aa615eff"
 _GOLDEN_PRE_CHANGE_HMAC = "0250aa0dd6a431d99c81973caaa91cdad6793612b00d1e0539cd3eaff03c1570"

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -6022,6 +6022,7 @@ class TestAdaptivePollingBackoff:
         assert hasattr(orch, "_idle_multiplier")
         assert orch._idle_multiplier == 1
 
+
 # --- Reverse task-to-session index ---
 
 

--- a/verify_cli/bernstein_verify_receipt/__main__.py
+++ b/verify_cli/bernstein_verify_receipt/__main__.py
@@ -75,9 +75,7 @@ def cli() -> None:
     show_default=True,
     help="Which format(s) to verify.",
 )
-@click.option(
-    "--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details."
-)
+@click.option("--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details.")
 def verify_cmd(
     receipt_path: Path,
     jwk_path: Path | None,

--- a/verify_cli/bernstein_verify_receipt/verify.py
+++ b/verify_cli/bernstein_verify_receipt/verify.py
@@ -291,8 +291,7 @@ def verify_subject_binding(receipt: dict[str, Any]) -> tuple[CheckResult, str]:
                 "subject_binding",
                 ok=False,
                 detail=(
-                    f"recomputed head {recomputed[:16]}… "
-                    f"!= range.head_sha256 {range_head[:16]}…"
+                    f"recomputed head {recomputed[:16]}… != range.head_sha256 {range_head[:16]}…"
                 ),
             ),
             recomputed,
@@ -418,10 +417,7 @@ def verify_intoto(receipt: dict[str, Any], public_key: Any, recomputed_head: str
         return CheckResult(
             "intoto",
             ok=False,
-            detail=(
-                f"recomputed head {recomputed_head[:16]}… "
-                f"not in statement subject digests"
-            ),
+            detail=(f"recomputed head {recomputed_head[:16]}… not in statement subject digests"),
         )
     return CheckResult("intoto", ok=True, detail="DSSE/in-toto verified, subject bound to head")
 
@@ -469,8 +465,7 @@ def verify_transparency(
             "transparency",
             ok=False,
             detail=(
-                f"STH subject {subject_sha256[:16]}… "
-                f"!= recomputed head {recomputed_head[:16]}…"
+                f"STH subject {subject_sha256[:16]}… != recomputed head {recomputed_head[:16]}…"
             ),
         )
 
@@ -510,10 +505,7 @@ def verify_transparency(
             return CheckResult(
                 "transparency",
                 ok=False,
-                detail=(
-                    f"inclusion proof root {proven_root[:16]}… "
-                    f"!= STH root {root_hash[:16]}…"
-                ),
+                detail=(f"inclusion proof root {proven_root[:16]}… != STH root {root_hash[:16]}…"),
             )
     return CheckResult(
         "transparency", ok=True, detail="RFC6962 STH signed, root + inclusion proof verified"


### PR DESCRIPTION
## What

Slice 1 of #5042 — the field and the projection, nothing else.

- An additive optional `sensitivity` field on `LineageEntry`, dropped from the
  canonical bytes when `None` on the same rule as `trust_class`,
  `activity_source`, `attachment_digests` and `model_ref` (ADR-009 §5.2).
- A new `core/lineage/sensitivity.py`: the effective sensitivity of an artefact
  is the **maximum** class over its lineage closure, absence fails closed to the
  **highest** class, and the verdict names the closure member that raised the
  level plus the path through the graph that reaches it.
- The field is round-tripped by `LineageStore` and settable through
  `seal_write` / `SignedLineageLog.record_write`, so a classification lives
  inside the signed, HMAC-covered entry rather than beside it.

Explicitly **not** in this PR:

- No enforcement anywhere. Nothing refuses anything on the basis of a verdict.
- No source-labelling map, no `bernstein lineage sensitivity` CLI, no clearance
  levels for models or agents.
- No content-based inference. A scanner's guess must never land in the same
  field as an operator's classification, so this field is operator-set only.
- No change to `trust_class` semantics, ordering or defaults.

## Why

`core/lineage/provenance.py` propagates trust *inward*: the effective trust of
an artefact is the minimum `trust_class` over its lineage closure, fail-closed
to `public`. Nothing propagates in the other direction.

An agent reads a confidential document, summarises it, and writes the summary.
The summary's lineage records where it came from and carries no indication that
what it came from was confidential. Nothing in the log distinguishes that
summary from an artefact assembled out of public sources, so nothing downstream
can tell that writing it to a shared path, or handing it to a model the
operator never cleared for that data, is different from doing so with any other
file.

The adjacent surfaces do not cover it. `trust_class` tracks how much we trust
an input, not how sensitive it is — the opposite axis. The DLP scanner in
`core/security/dlp_scanner_v2.py` inspects content at a moment and cannot know
a document was classified by policy rather than by looking like a phone number.
`data_classification: bool` in `core/security/compliance_policies.py:139` is an
operator-asserted boolean that claims classification exists without
implementing it. `core/security/data_residency.py` governs *where* data may be,
not *who* may see it.

Anchoring the class on the graph rather than on a label attached to a file buys
two things a label cannot. It cannot be dropped by copying: re-saving,
summarising or transforming an artefact produces a new entry naming the old one
as a parent, so the closure still reaches the classified source, and stripping
the classification means breaking that edge — which fails the signature, HMAC
and anchoring checks the lineage gate already enforces. And the verdict
explains itself: not "this is confidential", which invites an argument, but
"this is confidential because it derives, through these hops, from that entry",
which an auditor can walk offline.

## How

`sensitivity.py` is `provenance.py` mirrored, structure for structure:

| provenance.py | sensitivity.py |
|---|---|
| `TrustClass` | `SensitivityClass` |
| `trust_rank` | `sensitivity_rank` |
| `min_trust_class` | `max_sensitivity_class` |
| `LOWEST_TRUST_CLASS` | `HIGHEST_SENSITIVITY_CLASS` |
| `TaintVerdict` | `SensitivityVerdict` |
| `effective_trust` | `effective_sensitivity` |
| `taint_for_artefact` | `sensitivity_for_artefact` |

The closure walk reuses `resolve_artefact_tip` from `provenance.py` rather than
re-deriving tip resolution, so the two projections can never disagree about
which entry is an artefact's current version.

Two decisions the issue leaves open, and how they are settled:

**The class ladder.** The issue names `confidential` and "the highest class in
scope" without fixing the set. This ships a four-rung ladder —
`public < internal < confidential < restricted` — as its own
`SENSITIVITY_CLASSES` frozenset beside `TRUST_CLASSES`, and its own entry field
rather than a widening of `trust_class`. Two fields because the axes are
independent and propagate in opposite directions: an operator-supplied contract
is high-trust *and* high-sensitivity, a fetched web page is low-trust and
low-sensitivity, and one totally-ordered field cannot carry both. Four rungs
because that is the smallest ladder that separates "may leave the company" from
"may leave the team" from "named handling", which is the distinction the
enforcement slice will need; adding a rung later is additive in the same way
this field is.

**Which closure member the verdict blames.** When several members carry the
effective class, the verdict names the nearest one, ties broken by entry hash.
Nearest, so the reported explanation is the shortest walk an operator has to
follow; by hash on a tie, so the choice stays a pure function of the graph and
two verifiers agree. The breadth-first walk visits each level in sorted order
for the same reason, which also makes `closure` and `path` order-independent.

`_canonical_body` drops the field when `None`, so an entry that records no
classification produces the exact bytes it produced before this change and
every historical signature, HMAC and entry hash is untouched. `_entry_from_dict`
in `store.py` reads it back with the same absent → `None` rule.

## Tests

`tests/unit/lineage/test_sensitivity.py`, 21 tests. Each of the seven below
failed on the unmodified tree — the projection module does not exist there, so
collection fails with `ModuleNotFoundError: No module named
'bernstein.core.lineage.sensitivity'`.

1. `test_entry_without_sensitivity_canonicalises_byte_identically_to_the_pre_change_schema`
   — the additive-optional rule, pinned against golden canonical bytes, a golden
   entry hash and a golden operator HMAC captured from the pre-change schema.
2. `test_effective_sensitivity_is_the_maximum_over_the_closure` — a closure
   unioning a public and a confidential source is confidential.
3. `test_absent_sensitivity_fails_closed_to_the_highest_class` — both shapes of
   absence (target not in the log; target present but nothing classified in its
   closure) land on `restricted`.
4. `test_derived_artefact_inherits_the_sensitivity_of_its_ancestor` — **the
   load-bearing one.** The summary case from the issue: a summary carrying no
   label of its own, whose only parent is a confidential document, is
   confidential.
5. `test_verdict_names_the_closure_member_that_raised_the_level` — the verdict
   blames the classified entry, not the benign sibling, and reports the walk
   that reaches it.
6. `test_projection_is_deterministic_and_recomputable_offline` — the verdict is
   independent of input order and reproduces exactly from `log.jsonl` bytes
   alone.
7. `test_reparenting_to_drop_a_classified_ancestor_fails_signature_verification`
   — cutting the edge back to the classified source makes the lineage gate fail,
   and does not buy an unclassified artefact either: the orphaned summary falls
   to the fail-closed-high default.

Supporting tests in the same file cover the class ordering and the fail-closed
constant, the canonical bytes when the field *is* set, rejection of an unknown
class, the operator HMAC moving with the classification, trust and sensitivity
coexisting as independent fields, an explicit `public` label not being read as
absence, multi-hop propagation and its reported path, tip resolution for an
artefact rewritten twice, an unknown artefact path, the verdict blaming nothing
when the class came from the fail-closed default, and the nearest-member
tie-break.

Verification run:

- `uv run python scripts/run_tests.py --parallel 2 -x tests/unit/lineage/test_sensitivity.py`
  — 21 passed.
- `--affected origin/main` selects 1533 files, far past the reviewable bound, so
  instead the tests of the touched modules and of their lineage importers were
  run. `tests/unit/lineage/` in full: 674 passed. Then
  `tests/unit/test_lineage_record.py`, `test_lineage_record_v1.py`,
  `test_lineage_export.py`, `test_lineage_seal_only_verify.py`,
  `test_lineage_regulatory_verify.py`,
  `tests/unit/security/test_lineage_toolcall_gate.py`,
  `test_lineage_adversarial.py`, `tests/property/test_lineage_properties.py`,
  `test_lineage_chain_properties.py`,
  `tests/integration/test_lineage_tamper_detection.py` and
  `test_lineage_integration.py`: 117 passed. CI runs the full suite.
- `uv run pytest tests/unit/test_unreleased_notes_rotation.py` — 10 passed.
- `uv run mypy --config-file mypy.gate.ini` — the new module is inside the gated
  strict zone and is clean.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes (no new findings on the touched files; the
      pre-existing `reportUnnecessaryIsInstance` on `entry.py:176` is untouched)
- [x] `uv run python scripts/run_tests.py -x` passes for the scope described
      above
- [x] New code has type hints

### Documentation duty

- [ ] N/A — user-visible README section: internal substrate, no user-facing
      surface added
- [ ] N/A — `docs/operations/<area>.md`: nothing operable ships until the CLI
      and enforcement slices
- [ ] N/A — `docs/api/` schema: no public schema changed; the entry field is
      additive-optional and absent from every existing record
- [x] `uv run bernstein agents-md sync` run — no changes produced
- [x] Tests cover the documented behaviour
- [x] `docs/release-notes/unreleased.md` entry added

Part of #5042

## Remaining

- Slice 2: source-labelling map, mirroring `load_trust_source_map()`.
- Slice 3: `bernstein lineage sensitivity <artefact>` rendering the verdict and
  its path.
- Slice 4: enforcement at `core/security/toolcall_interlock.py`, refusals
  written to the chain, off by default behind policy — acceptance test 8,
  `test_refusal_at_the_read_boundary_is_a_chain_event`.
- Slice 5: clearance levels for models and agents, tied to the registry in
  #5038.
