### PR TITLE
observability: record guard evaluations, not just violations (#3454)

### DIFF
--- a/docs/release-notes/fragments/3454-guard-evaluation-registry.md
+++ b/docs/release-notes/fragments/3454-guard-evaluation-registry.md
@@ -1,0 +1,5 @@
+## Guard evaluation reachability tracking
+
+Added `bernstein.core.observability.guard_registry.GuardRegistry`, a per-process registry that records every guard evaluation — not just violations — so "never fired" is distinguishable from "never evaluated". The `scope_violation` check is now instrumented; its evaluation count appears in `default_report()`.
+
+(#3454)

--- a/src/bernstein/core/observability/circuit_breaker.py
+++ b/src/bernstein/core/observability/circuit_breaker.py
@@ -27,11 +27,19 @@ from typing import TYPE_CHECKING, Any
 
 from bernstein.core.lifecycle import transition_agent
 from bernstein.core.models import KillReason
+from bernstein.core.observability.guard_registry import default_registry
 
 if TYPE_CHECKING:
     from bernstein.core.models import Task
 
 logger = logging.getLogger(__name__)
+
+# Guard id for the scope-violation check in check_scope_violations(). Every
+# session whose scope precondition is met (owned_files defined, worktree
+# present, changed files readable) evaluates this guard exactly once per
+# check, with outcome "clean" or "violation" - see guard_registry.py.
+SCOPE_VIOLATION_GUARD_ID = "circuit_breaker.scope_violation"
+default_registry.register(SCOPE_VIOLATION_GUARD_ID)
 
 # ---------------------------------------------------------------------------
 # Kill audit log
@@ -321,7 +329,10 @@ def check_scope_violations(orch: Any, result: Any) -> None:
 
         out_of_scope = _files_outside_scope(changed_files, owned_files)
         if not out_of_scope:
+            default_registry.record_evaluation(SCOPE_VIOLATION_GUARD_ID, "clean")
             continue
+
+        default_registry.record_evaluation(SCOPE_VIOLATION_GUARD_ID, "violation")
 
         detail = (
             f"{len(out_of_scope)} file(s) modified outside task scope: "

--- a/src/bernstein/core/observability/guard_registry.py
+++ b/src/bernstein/core/observability/guard_registry.py
@@ -1,0 +1,111 @@
+"""Guard evaluation registry.
+
+A recovery path that never fires and a recovery path that cannot fire look
+identical from the outside: neither leaves a trace. This module makes the
+*evaluation* of a guard - not just its firing - a recorded fact, so absence
+of firing becomes a claim with evidence behind it instead of a silence.
+
+Usage from an instrumented guard::
+
+    from bernstein.core.observability.guard_registry import default_registry
+
+    GUARD_ID = "circuit_breaker.scope_violation"
+    default_registry.register(GUARD_ID)  # visible with 0 evaluations even if never called
+
+    ...
+    default_registry.record_evaluation(GUARD_ID, "clean")
+    # or
+    default_registry.record_evaluation(GUARD_ID, "violation")
+
+This is step 1 of the guard-reachability work (issue #3454): one registry,
+one instrumented guard, one read-only report. Anchoring the report in a run
+record, aggregating across runs, and gating CI on it are follow-up slices -
+this module only has to make "evaluated, never fired" distinguishable from
+"never evaluated" for a single process's lifetime.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class GuardRecord:
+    """Per-guard evaluation count and outcome distribution."""
+
+    guard_id: str
+    evaluations: int = 0
+    outcomes: dict[str, int] = field(default_factory=dict)
+
+
+class GuardRegistry:
+    """Tracks how many times each guard's predicate was evaluated, and to what
+    outcome, within this process.
+
+    A guard that is registered but never evaluated reports zero evaluations.
+    A guard that is evaluated and never fires reports N evaluations with no
+    "fired" outcome in its distribution. The two are not the same report.
+    """
+
+    def __init__(self) -> None:
+        self._records: dict[str, GuardRecord] = {}
+
+    def register(self, guard_id: str) -> None:
+        """Make *guard_id* visible in reports even if it is never evaluated.
+
+        Idempotent: registering an already-known guard is a no-op.
+        """
+        self._records.setdefault(guard_id, GuardRecord(guard_id=guard_id))
+
+    def record_evaluation(self, guard_id: str, outcome: str) -> None:
+        """Record one evaluation of *guard_id* that resolved to *outcome*.
+
+        Implicitly registers the guard if this is its first evaluation.
+        """
+        record = self._records.setdefault(guard_id, GuardRecord(guard_id=guard_id))
+        record.evaluations += 1
+        record.outcomes[outcome] = record.outcomes.get(outcome, 0) + 1
+
+    def records(self) -> list[GuardRecord]:
+        """Return all known guard records, registered or evaluated."""
+        return list(self._records.values())
+
+    def record_for(self, guard_id: str) -> GuardRecord | None:
+        """Return the record for *guard_id*, or None if it is unknown."""
+        return self._records.get(guard_id)
+
+    def evaluations_for(self, guard_id: str) -> int:
+        """Return the evaluation count for *guard_id* (0 if unknown)."""
+        record = self._records.get(guard_id)
+        return record.evaluations if record is not None else 0
+
+    def outcomes_for(self, guard_id: str) -> dict[str, int]:
+        """Return a copy of the outcome distribution for *guard_id*."""
+        record = self._records.get(guard_id)
+        return dict(record.outcomes) if record is not None else {}
+
+
+def reachability_report(registry: GuardRegistry) -> list[tuple[str, int]]:
+    """Pure projection of *registry* into ``(guard_id, evaluation_count)``
+    pairs, ordered by guard id.
+
+    Includes every registered guard, evaluated or not - that is the whole
+    point: a guard with zero evaluations is present in the report, not
+    absent from it.
+    """
+    return sorted(
+        ((record.guard_id, record.evaluations) for record in registry.records()),
+        key=lambda pair: pair[0],
+    )
+
+
+# Process-wide registry that production guards record into. A dedicated
+# instance per orchestrator run (and anchoring the report in the run record)
+# is a follow-up slice; for now this is the single surface every instrumented
+# guard writes to and every reader reads from.
+default_registry = GuardRegistry()
+
+
+def default_report() -> list[tuple[str, int]]:
+    """Read-only view of :data:`default_registry` via :func:`reachability_report`."""
+    return reachability_report(default_registry)

--- a/tests/unit/observability/test_guard_registry.py
+++ b/tests/unit/observability/test_guard_registry.py
@@ -1,0 +1,100 @@
+"""Tests for GuardRegistry.
+
+The property this protects: a guard that was evaluated and never fired must
+be distinguishable from a guard that was never evaluated at all. Both look
+like "zero firings" from the outside; only a recorded evaluation count tells
+them apart.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.observability.guard_registry import (
+    GuardRegistry,
+    reachability_report,
+)
+
+
+class TestGuardRegistryRecording:
+    def test_record_evaluation_counts_calls_and_outcome_distribution(self) -> None:
+        registry = GuardRegistry()
+        registry.record_evaluation("guard-a", "clean")
+        registry.record_evaluation("guard-a", "clean")
+        registry.record_evaluation("guard-a", "violation")
+
+        [record] = registry.records()
+        assert record.guard_id == "guard-a"
+        assert record.evaluations == 3
+        assert record.outcomes == {"clean": 2, "violation": 1}
+
+    def test_register_without_recording_reports_zero_evaluations(self) -> None:
+        registry = GuardRegistry()
+        registry.register("guard-b")
+
+        [record] = registry.records()
+        assert record.evaluations == 0
+        assert record.outcomes == {}
+
+    def test_record_evaluation_implicitly_registers_the_guard(self) -> None:
+        registry = GuardRegistry()
+        registry.record_evaluation("guard-c", "clean")
+
+        assert [r.guard_id for r in registry.records()] == ["guard-c"]
+
+
+class TestReachabilityReport:
+    def test_orders_by_guard_id(self) -> None:
+        registry = GuardRegistry()
+        registry.record_evaluation("zebra", "clean")
+        registry.record_evaluation("alpha", "clean")
+        registry.record_evaluation("mid", "clean")
+
+        assert reachability_report(registry) == [
+            ("alpha", 1),
+            ("mid", 1),
+            ("zebra", 1),
+        ]
+
+    def test_includes_registered_but_never_evaluated_guards(self) -> None:
+        registry = GuardRegistry()
+        registry.register("never-called")
+        registry.record_evaluation("called", "clean")
+
+        assert reachability_report(registry) == [
+            ("called", 1),
+            ("never-called", 0),
+        ]
+
+    def test_is_a_pure_projection_not_a_live_view(self) -> None:
+        registry = GuardRegistry()
+        registry.record_evaluation("guard-d", "clean")
+
+        report = reachability_report(registry)
+        registry.record_evaluation("guard-d", "clean")
+
+        # The snapshot taken before the second call does not change under us.
+        assert report == [("guard-d", 1)]
+        assert reachability_report(registry) == [("guard-d", 2)]
+
+
+class TestEvaluatedGuardIsDistinguishableFromUnevaluatedGuard:
+    """This is the whole feature: two reports that both show zero firings
+    must not be equal when one of them was checked and the other was not."""
+
+    def test_ten_passing_checks_differ_from_a_guard_that_was_never_called(self) -> None:
+        evaluated = GuardRegistry()
+        for _ in range(10):
+            evaluated.record_evaluation("breaker", "clean")
+
+        never_called = GuardRegistry()
+        never_called.register("breaker")
+
+        evaluated_report = reachability_report(evaluated)
+        never_called_report = reachability_report(never_called)
+
+        assert evaluated_report == [("breaker", 10)]
+        assert never_called_report == [("breaker", 0)]
+        assert evaluated_report != never_called_report
+
+        [record] = evaluated.records()
+        assert record.outcomes.get("violation", 0) == 0
+        assert record.outcomes == {"clean": 10}

--- a/tests/unit/test_kill_switch.py
+++ b/tests/unit/test_kill_switch.py
@@ -225,9 +225,7 @@ class TestCheckScopeViolationsGuardRecording:
         assert after_outcomes.get("clean", 0) - before_outcomes.get("clean", 0) == 10
         assert after_outcomes.get("violation", 0) == before_outcomes.get("violation", 0)
 
-    def test_evaluated_and_never_fired_is_distinguishable_from_never_evaluated(
-        self, tmp_path: Path
-    ) -> None:
+    def test_evaluated_and_never_fired_is_distinguishable_from_never_evaluated(self, tmp_path: Path) -> None:
         """The whole feature, against the real production guard: driving ten
         clean checks through it must not look the same as never calling it."""
         from bernstein.core.observability.circuit_breaker import SCOPE_VIOLATION_GUARD_ID

--- a/tests/unit/test_kill_switch.py
+++ b/tests/unit/test_kill_switch.py
@@ -184,6 +184,89 @@ class TestCheckScopeViolations:
         assert kill_file.exists()
 
 
+class TestCheckScopeViolationsGuardRecording:
+    """check_scope_violations records every clean check into the guard
+    registry, not just violations (issue #3454 step 1)."""
+
+    def test_ten_clean_checks_are_recorded_as_evaluations_not_firings(self, tmp_path: Path) -> None:
+        from bernstein.core.observability.circuit_breaker import SCOPE_VIOLATION_GUARD_ID
+        from bernstein.core.observability.guard_registry import default_registry
+
+        before_evaluations = default_registry.evaluations_for(SCOPE_VIOLATION_GUARD_ID)
+        before_outcomes = default_registry.outcomes_for(SCOPE_VIOLATION_GUARD_ID)
+
+        wt_path = tmp_path / "worktree"
+        wt_path.mkdir()
+        task = MagicMock()
+        task.owned_files = ["src/"]
+
+        for i in range(10):
+            session = _make_session(f"clean-{i}")
+            session.task_ids = ["task-1"]
+            orch = _make_orch(tmp_path, [session])
+            orch._spawner.get_worktree_path.return_value = str(wt_path)
+
+            with (
+                patch("bernstein.core.observability.circuit_breaker._lookup_tasks", return_value=[task]),
+                patch(
+                    "bernstein.core.observability.circuit_breaker._get_worktree_changed_files",
+                    return_value=["src/inside.py"],
+                ),
+            ):
+                result = _make_result()
+                check_scope_violations(orch, result)
+            # Sanity: these are the passing (non-firing) checks.
+            assert result.reaped == []
+
+        after_evaluations = default_registry.evaluations_for(SCOPE_VIOLATION_GUARD_ID)
+        after_outcomes = default_registry.outcomes_for(SCOPE_VIOLATION_GUARD_ID)
+
+        assert after_evaluations - before_evaluations == 10
+        assert after_outcomes.get("clean", 0) - before_outcomes.get("clean", 0) == 10
+        assert after_outcomes.get("violation", 0) == before_outcomes.get("violation", 0)
+
+    def test_evaluated_and_never_fired_is_distinguishable_from_never_evaluated(
+        self, tmp_path: Path
+    ) -> None:
+        """The whole feature, against the real production guard: driving ten
+        clean checks through it must not look the same as never calling it."""
+        from bernstein.core.observability.circuit_breaker import SCOPE_VIOLATION_GUARD_ID
+        from bernstein.core.observability.guard_registry import GuardRegistry, default_registry
+
+        before = default_registry.evaluations_for(SCOPE_VIOLATION_GUARD_ID)
+
+        wt_path = tmp_path / "worktree"
+        wt_path.mkdir()
+        task = MagicMock()
+        task.owned_files = ["src/"]
+
+        for i in range(10):
+            session = _make_session(f"clean2-{i}")
+            session.task_ids = ["task-1"]
+            orch = _make_orch(tmp_path, [session])
+            orch._spawner.get_worktree_path.return_value = str(wt_path)
+
+            with (
+                patch("bernstein.core.observability.circuit_breaker._lookup_tasks", return_value=[task]),
+                patch(
+                    "bernstein.core.observability.circuit_breaker._get_worktree_changed_files",
+                    return_value=["src/inside.py"],
+                ),
+            ):
+                check_scope_violations(orch, _make_result())
+
+        driven_evaluations = default_registry.evaluations_for(SCOPE_VIOLATION_GUARD_ID)
+        assert driven_evaluations - before == 10
+
+        never_called = GuardRegistry()
+        never_called.register(SCOPE_VIOLATION_GUARD_ID)
+
+        # A registry that saw ten real, passing evaluations is not equal to
+        # one where the same guard was only ever registered.
+        assert driven_evaluations != never_called.evaluations_for(SCOPE_VIOLATION_GUARD_ID)
+        assert never_called.evaluations_for(SCOPE_VIOLATION_GUARD_ID) == 0
+
+
 # ---------------------------------------------------------------------------
 # check_budget_violations
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -6022,6 +6022,7 @@ class TestAdaptivePollingBackoff:
         assert hasattr(orch, "_idle_multiplier")
         assert orch._idle_multiplier == 1
 
+
 # --- Reverse task-to-session index ---
 
 

--- a/verify_cli/bernstein_verify_receipt/__main__.py
+++ b/verify_cli/bernstein_verify_receipt/__main__.py
@@ -75,9 +75,7 @@ def cli() -> None:
     show_default=True,
     help="Which format(s) to verify.",
 )
-@click.option(
-    "--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details."
-)
+@click.option("--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details.")
 def verify_cmd(
     receipt_path: Path,
     jwk_path: Path | None,

--- a/verify_cli/bernstein_verify_receipt/verify.py
+++ b/verify_cli/bernstein_verify_receipt/verify.py
@@ -291,8 +291,7 @@ def verify_subject_binding(receipt: dict[str, Any]) -> tuple[CheckResult, str]:
                 "subject_binding",
                 ok=False,
                 detail=(
-                    f"recomputed head {recomputed[:16]}… "
-                    f"!= range.head_sha256 {range_head[:16]}…"
+                    f"recomputed head {recomputed[:16]}… != range.head_sha256 {range_head[:16]}…"
                 ),
             ),
             recomputed,
@@ -418,10 +417,7 @@ def verify_intoto(receipt: dict[str, Any], public_key: Any, recomputed_head: str
         return CheckResult(
             "intoto",
             ok=False,
-            detail=(
-                f"recomputed head {recomputed_head[:16]}… "
-                f"not in statement subject digests"
-            ),
+            detail=(f"recomputed head {recomputed_head[:16]}… not in statement subject digests"),
         )
     return CheckResult("intoto", ok=True, detail="DSSE/in-toto verified, subject bound to head")
 
@@ -469,8 +465,7 @@ def verify_transparency(
             "transparency",
             ok=False,
             detail=(
-                f"STH subject {subject_sha256[:16]}… "
-                f"!= recomputed head {recomputed_head[:16]}…"
+                f"STH subject {subject_sha256[:16]}… != recomputed head {recomputed_head[:16]}…"
             ),
         )
 
@@ -510,10 +505,7 @@ def verify_transparency(
             return CheckResult(
                 "transparency",
                 ok=False,
-                detail=(
-                    f"inclusion proof root {proven_root[:16]}… "
-                    f"!= STH root {root_hash[:16]}…"
-                ),
+                detail=(f"inclusion proof root {proven_root[:16]}… != STH root {root_hash[:16]}…"),
             )
     return CheckResult(
         "transparency", ok=True, detail="RFC6962 STH signed, root + inclusion proof verified"

--- a/verify_cli/bernstein_verify_receipt/verify.py
+++ b/verify_cli/bernstein_verify_receipt/verify.py
@@ -291,7 +291,8 @@ def verify_subject_binding(receipt: dict[str, Any]) -> tuple[CheckResult, str]:
                 "subject_binding",
                 ok=False,
                 detail=(
-                    f"recomputed head {recomputed[:16]}… != range.head_sha256 {range_head[:16]}…"
+                    f"recomputed head {recomputed[:16]}… "
+                    f"!= range.head_sha256 {range_head[:16]}…"
                 ),
             ),
             recomputed,
@@ -417,7 +418,10 @@ def verify_intoto(receipt: dict[str, Any], public_key: Any, recomputed_head: str
         return CheckResult(
             "intoto",
             ok=False,
-            detail=(f"recomputed head {recomputed_head[:16]}… not in statement subject digests"),
+            detail=(
+                f"recomputed head {recomputed_head[:16]}… "
+                f"not in statement subject digests"
+            ),
         )
     return CheckResult("intoto", ok=True, detail="DSSE/in-toto verified, subject bound to head")
 
@@ -465,7 +469,8 @@ def verify_transparency(
             "transparency",
             ok=False,
             detail=(
-                f"STH subject {subject_sha256[:16]}… != recomputed head {recomputed_head[:16]}…"
+                f"STH subject {subject_sha256[:16]}… "
+                f"!= recomputed head {recomputed_head[:16]}…"
             ),
         )
 
@@ -505,7 +510,10 @@ def verify_transparency(
             return CheckResult(
                 "transparency",
                 ok=False,
-                detail=(f"inclusion proof root {proven_root[:16]}… != STH root {root_hash[:16]}…"),
+                detail=(
+                    f"inclusion proof root {proven_root[:16]}… "
+                    f"!= STH root {root_hash[:16]}…"
+                ),
             )
     return CheckResult(
         "transparency", ok=True, detail="RFC6962 STH signed, root + inclusion proof verified"


### PR DESCRIPTION
## What

Adds a guard evaluation registry and instruments one guard with it end to
end: `check_scope_violations` now records every scope check it performs,
not just the ones that find a violation.

This is a partial implementation of issue #3454 - the "Start here / Step 1"
slice: one registry, one instrumented guard, one read-only report.

## Why

Recovery guards in this codebase - retry budgets, circuit breakers, the
scope-violation check among them - log when they fire and stay silent
otherwise. That silence is ambiguous: a guard that ran a thousand times and
never had cause to fire looks identical, from the outside, to a guard whose
precondition can never be met and that has never run at all. The repository
has had both kinds turn up under the same name (nothing) more than once, and
nothing short of manual auditing has told them apart. Making the evaluation
itself a recorded fact - not just the outcome - turns "this guard didn't
need to fire" into a number instead of an assumption.

## How

- `src/bernstein/core/observability/guard_registry.py`: `GuardRegistry`
  holds, per guard id, an evaluation count and an outcome distribution.
  `record_evaluation(guard_id, outcome)` records one evaluation;
  `register(guard_id)` makes a guard visible with zero evaluations without
  requiring it to have run. `reachability_report(registry)` is a pure
  projection to `(guard_id, evaluation_count)` pairs ordered by guard id -
  it includes registered-but-unevaluated guards, which is the point.
  `default_registry` is the process-wide instance instrumented guards write
  into; `default_report()` is the read-only surface to it.
- `src/bernstein/core/observability/circuit_breaker.py`: instruments
  `check_scope_violations`, the guard the issue calls out as the smallest
  honest choice because it previously logged only on violation
  (`logger.warning` at the line the not-violated branch falls through to a
  bare `continue`). Both branches now call `record_evaluation` - "clean" for
  the previously-silent pass, "violation" for the existing fire path - and
  the guard is registered at import time so it is visible with zero
  evaluations even before the orchestrator ever calls it.

### Decision this PR makes

The issue's own "not in step 1" list excludes anchoring the report in the
run record, cross-run aggregation, and the CI gate - all deferred here as
stated. It does not explicitly rule on how "surface the report read-only"
should be shipped for this slice. This PR resolves that as: an importable
pure function (`default_report()`), not a new CLI command or API endpoint.
A CLI/API surface has to decide output format, auth, and where in the
existing command tree it lives, none of which this slice has enough
instrumented guards to inform yet; a plain function is the minimal thing
that satisfies "read-only" without inventing that surface prematurely.

## Tests

1. `test_record_evaluation_counts_calls_and_outcome_distribution` - a guard
   evaluated 3 times with 2 outcomes reports the right count and
   distribution.
2. `test_register_without_recording_reports_zero_evaluations` - a
   registered-but-never-called guard reports zero evaluations, not an
   absent record.
3. `test_record_evaluation_implicitly_registers_the_guard`
4. `test_orders_by_guard_id` (reachability_report ordering)
5. `test_includes_registered_but_never_evaluated_guards`
6. `test_is_a_pure_projection_not_a_live_view`
7. `test_ten_passing_checks_differ_from_a_guard_that_was_never_called` -
   the property from the issue's own acceptance test, at the registry level.
8. `test_ten_clean_checks_are_recorded_as_evaluations_not_firings` - drives
   the real `check_scope_violations` through ten passing checks and asserts
   the registry's evaluation and outcome counts advance by exactly ten, with
   zero new "violation" outcomes.
9. `test_evaluated_and_never_fired_is_distinguishable_from_never_evaluated` -
   **load-bearing**: the same ten real, passing checks compared against a
   registry where the guard was only ever registered. This is the assertion
   the issue calls "the whole feature."

Tests 8 and 9 failed before the `circuit_breaker.py` change with
`ImportError: cannot import name 'SCOPE_VIOLATION_GUARD_ID'` (the guard
wasn't wired to any registry yet); all nine pass after it.

Ran: `uv run python scripts/run_tests.py --parallel 2 -x
tests/unit/observability/test_guard_registry.py tests/unit/test_kill_switch.py`
(35 tests, all green). `--affected origin/main` selected 65 test files; the
change touches one new module with no other importers yet and two branches
inside one existing function, both covered directly by the tests above.
CI runs the full suite regardless.

## Checklist

- [x] `uv run ruff check src/` - clean
- [x] `uv run ruff format --check src/` - clean
- [ ] `pyright src/` - not run in this environment; no new type-ignore
      comments added, all new code is fully type-hinted
- [x] `uv run python scripts/run_tests.py -x <touched files>` - green
- [x] Type hints on all new public functions/classes
- [x] Docstrings: N/A beyond what's in the module/class/function docstrings
      above
- [x] No documented public CLI/API surface changed - `bernstein agents-md
      sync` not run (nothing in `src/bernstein/cli` touched)
- [x] No README or translation files touched

## Remaining

- Instrument the retry budget, the other circuit breakers, the stall
  detector, the escalation ladder, and the spawn supervisor (issue scope
  item 2).
- Anchor a run's guard-reachability record in the run record and make it
  recomputable offline from it (item 3).
- Cross-run aggregate view (item 4).
- CI surface that fails when a registered guard has zero evaluations across
  the eval suite (item 5).
- The "not disableable by an environment variable" done-means item has no
  environment-variable gate to violate yet, since this slice adds none; it
  becomes relevant once a disable path exists.

Part of #3454
