### PR TITLE
Govern the GitHub push webhook route with trigger rules (#4545)

### DIFF
--- a/docs/release-notes/fragments/4545-push-trigger-governance.md
+++ b/docs/release-notes/fragments/4545-push-trigger-governance.md
@@ -1,0 +1,4 @@
+## push
+
+`POST /webhooks/github` push events now respect `triggers.yaml` cooldown, dedup,
+and filter rules for `source: github_push`. Closes #4545.

--- a/src/bernstein/core/orchestration/trigger_manager.py
+++ b/src/bernstein/core/orchestration/trigger_manager.py
@@ -18,7 +18,7 @@ import os
 import re
 import tempfile
 import time
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -406,6 +406,27 @@ def render_task_payload(
         payload["metadata"] = dict(event.metadata)
 
     return payload
+
+
+@dataclass(frozen=True)
+class TriggerGateResult:
+    """Outcome of :meth:`TriggerManager.gate_direct_task` for one event.
+
+    ``trigger_name`` is ``None`` when no enabled trigger configured for the
+    event's source has filters matching it - the transparent pass-through
+    case, covering both "no ``triggers.yaml``" and "no rule targets this
+    event". Callers proceed exactly as they did before this gate existed.
+
+    When a trigger did match, ``suppressed`` says whether the caller should
+    skip creating its task. When it is not suppressed, the caller must create
+    the task and then call :meth:`TriggerManager.record_fire` with
+    ``dedup_key`` so later cooldown/dedup checks see this fire.
+    """
+
+    trigger_name: str | None
+    suppressed: bool
+    reason: str | None
+    dedup_key: str | None
 
 
 # ---------------------------------------------------------------------------
@@ -815,6 +836,52 @@ class TriggerManager:
             event_summary=summary,
         )
         self._record_fire(record)
+
+    # -- Direct-route governance ---------------------------------------------
+
+    def gate_direct_task(self, event: TriggerEvent) -> TriggerGateResult:
+        """Decide whether ``triggers.yaml`` governance suppresses a task a
+        production route is about to build directly from its own mapper.
+
+        Routes such as the GitHub/GitLab webhook handlers normalize the
+        inbound payload and build task content themselves rather than
+        through :meth:`evaluate`'s template rendering. This checks only the
+        *governance* half of the pipeline - filters, cooldown, dedup, and the
+        other per-trigger conditions - for the first enabled trigger
+        configured for ``event.source`` whose filters match; the mapper's own
+        payload content is untouched either way, so triggers.yaml governs
+        whether a task is created, not what it says.
+
+        Returns a :class:`TriggerGateResult`. See its docstring for how to
+        read ``trigger_name``/``suppressed``/``dedup_key``.
+        """
+        if self.is_disabled:
+            return TriggerGateResult(None, False, None, None)
+
+        self._try_reload_config()
+        for trigger in self._configs:
+            if not trigger.enabled or trigger.source != event.source:
+                continue
+            if not _matches_filter(event, trigger):
+                continue
+
+            # An enabled trigger for this source has matching filters -
+            # governance now applies to this event.
+            reason = self._check_conditions(trigger, event)
+            dedup_key = compute_dedup_key(trigger.name, event)
+            if reason is None and self._check_dedup(dedup_key):
+                reason = "deduplicated"
+            if reason is not None:
+                logger.info("Trigger %s suppressed a direct %s task: %s", trigger.name, event.source, reason)
+                return TriggerGateResult(trigger.name, True, reason, None)
+
+            cooldown_s = trigger.conditions.get("cooldown_s", 300)
+            self._record_dedup(dedup_key, max(cooldown_s, 300))
+            self._record_rate()
+            logger.info("Trigger %s governance passed for a direct %s task", trigger.name, event.source)
+            return TriggerGateResult(trigger.name, False, None, dedup_key)
+
+        return TriggerGateResult(None, False, None, None)
 
     # -- Cron evaluation (called from orchestrator tick) ---------------------
 

--- a/src/bernstein/core/routes/webhooks.py
+++ b/src/bernstein/core/routes/webhooks.py
@@ -27,6 +27,7 @@ from bernstein.core.webhook_signatures import verify_hmac_sha256
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from bernstein.core.orchestration.trigger_manager import TriggerGateResult, TriggerManager
     from bernstein.core.trigger_sources.receipt import TriggerAdmission
 
 logger = logging.getLogger(__name__)
@@ -447,22 +448,118 @@ def _handle_workflow_run(event: Any, store: TaskStore, tenant_id: str) -> list[d
     return list(workflow_run_to_task(event, retry_count=retry_count))
 
 
-def _dispatch_github_event(event: Any, store: TaskStore, tenant_id: str) -> list[dict[str, Any]] | JSONResponse:
-    """Route a parsed GitHub webhook event to the appropriate handler."""
+def _get_trigger_manager(request: Request) -> TriggerManager | None:
+    """Return a ``TriggerManager`` scoped to this install's ``.sdd`` dir.
+
+    Returns ``None`` when there is nowhere to load ``triggers.yaml`` from (no
+    ``.sdd`` layout on ``request.app.state``, mirroring ``_bridge_paths``
+    above) or when no ``triggers.yaml`` is configured - the transparent
+    pass-through case must not create ``TriggerManager``'s runtime state
+    directory for installs that never opted into trigger rules, the same way
+    ``bernstein triggers list`` skips construction when the file is absent.
+    """
+    from bernstein.core.orchestration.trigger_manager import TriggerManager
+
+    sdd_dir = getattr(request.app.state, "sdd_dir", None)
+    if sdd_dir is None or not (sdd_dir / "config" / "triggers.yaml").exists():
+        return None
+    return TriggerManager(sdd_dir)
+
+
+def _push_trigger_event(event: Any) -> Any:
+    """Normalize a parsed GitHub ``push`` webhook event into a ``TriggerEvent``.
+
+    Carries the fields the ``github_push`` filters and dedup key in
+    ``trigger_manager`` read: branch (from ``ref``), sha (``after``), sender,
+    and the union of changed files across every commit in the push.
+    """
+    from bernstein.core.models import TriggerEvent
+
+    payload: dict[str, Any] = event.payload
+    commits: list[dict[str, Any]] = payload.get("commits", [])
+    changed_files: set[str] = set()
+    for commit in commits:
+        changed_files.update(commit.get("added", []))
+        changed_files.update(commit.get("modified", []))
+        changed_files.update(commit.get("removed", []))
+    ref: str = payload.get("ref", "")
+    branch = ref.rsplit("/", 1)[-1] if ref else ""
+    head_message = commits[-1].get("message", "") if commits else ""
+    return TriggerEvent(
+        source="github_push",
+        raw_payload=payload,
+        repo=event.repo_full_name,
+        branch=branch,
+        sha=payload.get("after", ""),
+        sender=event.sender,
+        changed_files=tuple(changed_files),
+        message=head_message,
+    )
+
+
+def _handle_push(
+    event: Any, request: Request
+) -> tuple[list[dict[str, Any]], TriggerGateResult | None] | JSONResponse:
+    """Map a GitHub ``push`` event to task payloads, governed by ``triggers.yaml``.
+
+    ``triggers.yaml`` cooldown/dedup/filter rules for ``source: github_push``
+    decide whether this push's verification task gets created; the mapper
+    (``push_to_tasks``) still builds the task's title/description. With no
+    enabled trigger matching this event - including no ``triggers.yaml`` at
+    all - this is a transparent pass-through: a task is created for every
+    push, exactly as before this gate existed.
+
+    Returns ``(task_payloads, gate)`` where ``gate`` is the
+    :class:`TriggerGateResult` to record a fire against once the task is
+    created, or ``None`` when no trigger governs this event. Returns a
+    ``JSONResponse`` directly when a matching trigger suppresses the push.
+    """
     from bernstein.github_app.mapper import push_to_tasks
 
+    task_payloads = list(push_to_tasks(event))
+    if not task_payloads:
+        return task_payloads, None
+
+    mgr = _get_trigger_manager(request)
+    if mgr is None:
+        return task_payloads, None
+
+    gate = mgr.gate_direct_task(_push_trigger_event(event))
+    if gate.trigger_name is None:
+        return task_payloads, None
+    if gate.suppressed:
+        return JSONResponse(
+            status_code=200,
+            content={
+                "event_type": event.event_type,
+                "action": event.action,
+                "tasks_created": 0,
+                "task_ids": [],
+                "skipped_reason": f"trigger_suppressed ({gate.trigger_name}: {gate.reason})",
+            },
+        )
+    return task_payloads, gate
+
+
+def _dispatch_github_event(
+    event: Any, store: TaskStore, tenant_id: str, request: Request
+) -> tuple[list[dict[str, Any]], TriggerGateResult | None] | JSONResponse:
+    """Route a parsed GitHub webhook event to the appropriate handler."""
     match (event.event_type, event.action):
         case ("issues", "opened"):
-            return _handle_issue_opened(event)
+            return _handle_issue_opened(event), None
         case ("issues", "labeled"):
-            return _handle_issue_labeled(event)
+            return _handle_issue_labeled(event), None
         case ("pull_request_review_comment", _) | ("issue_comment", _):
-            return _handle_comment(event)
+            return _handle_comment(event), None
         case ("push", _):
-            return list(push_to_tasks(event))
+            return _handle_push(event, request)
         case ("workflow_run", "completed"):
-            return _handle_workflow_run(event, store, tenant_id)
-    return []
+            result = _handle_workflow_run(event, store, tenant_id)
+            if isinstance(result, JSONResponse):
+                return result
+            return result, None
+    return [], None
 
 
 @router.post("/webhooks/github", status_code=200)
@@ -544,10 +641,10 @@ async def github_webhook(request: Request) -> JSONResponse:
             content={"detail": "Bad webhook payload"},
         )
 
-    result = _dispatch_github_event(event, store, tenant_id)
+    result = _dispatch_github_event(event, store, tenant_id, request)
     if isinstance(result, JSONResponse):
         return result
-    task_payloads = result
+    task_payloads, gate = result
 
     # Create tasks in the store
     created_ids: list[str] = []
@@ -555,6 +652,22 @@ async def github_webhook(request: Request) -> JSONResponse:
     for payload in task_payloads:
         task = await store.create(TaskCreate(**payload, tenant_id=tenant_id))
         created_ids.append(task.id)
+
+    if gate is not None and created_ids:
+        # A triggers.yaml rule matched and passed conditions for this push
+        # (see _handle_push) - record the fire so the next push's cooldown
+        # and dedup checks see it via gate_direct_task.
+        assert gate.trigger_name is not None
+        assert gate.dedup_key is not None
+        mgr = _get_trigger_manager(request)
+        if mgr is not None:
+            mgr.record_fire(
+                trigger_name=gate.trigger_name,
+                source="github_push",
+                task_id=created_ids[0],
+                dedup_key=gate.dedup_key,
+                summary=f"push to {event.payload.get('ref', '')} by {event.sender}",
+            )
 
     return JSONResponse(
         status_code=200,

--- a/src/bernstein/core/routes/webhooks.py
+++ b/src/bernstein/core/routes/webhooks.py
@@ -497,9 +497,7 @@ def _push_trigger_event(event: Any) -> Any:
     )
 
 
-def _handle_push(
-    event: Any, request: Request
-) -> tuple[list[dict[str, Any]], TriggerGateResult | None] | JSONResponse:
+def _handle_push(event: Any, request: Request) -> tuple[list[dict[str, Any]], TriggerGateResult | None] | JSONResponse:
     """Map a GitHub ``push`` event to task payloads, governed by ``triggers.yaml``.
 
     ``triggers.yaml`` cooldown/dedup/filter rules for ``source: github_push``

--- a/tests/unit/test_github_push_trigger_governance.py
+++ b/tests/unit/test_github_push_trigger_governance.py
@@ -1,0 +1,178 @@
+"""POST /webhooks/github push events are governed by triggers.yaml (#4545).
+
+`triggers.yaml` promises rule-governed event handling - cooldowns, dedup,
+glob filters - but the production `POST /webhooks/github` route built its QA
+verification task directly, bypassing `TriggerManager` entirely. A cooldown
+or dedup rule authored for `source: github_push` was silently ignored.
+
+These tests drive the real HTTP route with signed fixture push events, not
+`TriggerManager.evaluate()` called directly, so they prove the gate is wired
+into production task creation rather than just implemented in isolation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from bernstein.core.orchestration.trigger_manager import TriggerManager
+from bernstein.core.server import create_app
+
+_WEBHOOK_SECRET = "gh-push-governance-secret"
+
+
+def _sign(body: bytes, secret: str = _WEBHOOK_SECRET) -> str:
+    digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def _push_body(
+    *,
+    ref: str = "refs/heads/main",
+    after: str = "abc123def456",
+    sender: str = "alice",
+    message: str = "fix: tidy up",
+) -> bytes:
+    payload: dict[str, Any] = {
+        "ref": ref,
+        "after": after,
+        "commits": [{"id": after, "message": message, "added": [], "modified": ["src/app.py"], "removed": []}],
+        "repository": {"full_name": "acme/widgets"},
+        "sender": {"login": sender},
+    }
+    return json.dumps(payload).encode()
+
+
+@pytest.fixture()
+def sdd_dir(tmp_path: Path) -> Path:
+    return tmp_path / ".sdd"
+
+
+@pytest.fixture()
+def app(sdd_dir: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", _WEBHOOK_SECRET)
+    jsonl_path = sdd_dir / "tasks" / "tasks.jsonl"
+    jsonl_path.parent.mkdir(parents=True, exist_ok=True)
+    return create_app(jsonl_path=jsonl_path)
+
+
+@pytest.fixture()
+async def client(app) -> AsyncClient:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+def _write_triggers_config(sdd_dir: Path, *, cooldown_s: int = 300, branch: str = "main") -> None:
+    config = {
+        "triggers": [
+            {
+                "name": "push-cooldown",
+                "source": "github_push",
+                "enabled": True,
+                "filters": {"branches": [branch]},
+                "conditions": {"cooldown_s": cooldown_s},
+                "task": {"title": "Governed push task"},
+            },
+        ],
+    }
+    config_path = sdd_dir / "config" / "triggers.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(yaml.dump(config))
+
+
+async def _post_push(client: AsyncClient, **kw: Any) -> Any:
+    body = _push_body(**kw)
+    headers = {"x-hub-signature-256": _sign(body), "x-github-event": "push"}
+    return await client.post("/webhooks/github", content=body, headers=headers)
+
+
+@pytest.mark.anyio
+async def test_cooldown_rule_suppresses_second_push_within_window(client: AsyncClient, sdd_dir: Path) -> None:
+    """AC1: a cooldown rule on github_push suppresses the second push in-window."""
+    _write_triggers_config(sdd_dir, cooldown_s=300)
+
+    first = await _post_push(client, after="sha-one")
+    assert first.status_code == 200
+    assert first.json()["tasks_created"] == 1
+
+    second = await _post_push(client, after="sha-two")
+    assert second.status_code == 200
+    body = second.json()
+    assert body["tasks_created"] == 0
+    assert "cooldown" in body["skipped_reason"]
+
+
+@pytest.mark.anyio
+async def test_suppressed_fire_is_recorded_in_history(client: AsyncClient, sdd_dir: Path) -> None:
+    """The first push's fire lands in TriggerManager fire history - the
+    record the cooldown check on the second push depends on."""
+    _write_triggers_config(sdd_dir, cooldown_s=300)
+
+    first = await _post_push(client, after="sha-one")
+    assert first.json()["tasks_created"] == 1
+    task_id = first.json()["task_ids"][0]
+
+    history = TriggerManager(sdd_dir).get_fire_history()
+    assert len(history) == 1
+    assert history[0]["trigger_name"] == "push-cooldown"
+    assert history[0]["source"] == "github_push"
+    assert history[0]["task_id"] == task_id
+
+    # The suppressed second push does not add a second fire record.
+    await _post_push(client, after="sha-two")
+    assert len(TriggerManager(sdd_dir).get_fire_history()) == 1
+
+
+@pytest.mark.anyio
+async def test_dedup_rule_applies_to_github_push_route(client: AsyncClient, sdd_dir: Path) -> None:
+    """A redelivered push (identical branch+sha - the GitHub redelivery case)
+    is deduplicated rather than creating a second task."""
+    _write_triggers_config(sdd_dir, cooldown_s=0)
+
+    first = await _post_push(client, after="same-sha")
+    assert first.json()["tasks_created"] == 1
+
+    replay = await _post_push(client, after="same-sha")
+    body = replay.json()
+    assert body["tasks_created"] == 0
+    assert body["skipped_reason"] == "trigger_suppressed (push-cooldown: deduplicated)"
+
+
+@pytest.mark.anyio
+async def test_routes_without_rules_config_are_behavior_identical(client: AsyncClient, sdd_dir: Path) -> None:
+    """AC2: with no triggers.yaml, every push still creates its task -
+    the regression the existing route tests already cover, repeated back
+    to back to prove there is no hidden cooldown/dedup gate by default."""
+    assert not (sdd_dir / "config" / "triggers.yaml").exists()
+
+    first = await _post_push(client, after="sha-one")
+    assert first.status_code == 200
+    assert first.json()["tasks_created"] == 1
+
+    second = await _post_push(client, after="sha-two")
+    assert second.status_code == 200
+    assert second.json()["tasks_created"] == 1
+
+    # Even an identical redelivery is unaffected without a trigger rule.
+    replay = await _post_push(client, after="sha-one")
+    assert replay.json()["tasks_created"] == 1
+
+
+@pytest.mark.anyio
+async def test_push_on_unfiltered_branch_is_not_governed(client: AsyncClient, sdd_dir: Path) -> None:
+    """A trigger scoped to `branches: [main]` does not gate pushes to other
+    branches - `no_filter_match` is not a suppression of the direct task."""
+    _write_triggers_config(sdd_dir, cooldown_s=300, branch="main")
+
+    first = await _post_push(client, ref="refs/heads/feature-x", after="sha-one")
+    assert first.json()["tasks_created"] == 1
+    second = await _post_push(client, ref="refs/heads/feature-x", after="sha-two")
+    assert second.json()["tasks_created"] == 1

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -6022,6 +6022,7 @@ class TestAdaptivePollingBackoff:
         assert hasattr(orch, "_idle_multiplier")
         assert orch._idle_multiplier == 1
 
+
 # --- Reverse task-to-session index ---
 
 

--- a/verify_cli/bernstein_verify_receipt/__main__.py
+++ b/verify_cli/bernstein_verify_receipt/__main__.py
@@ -75,9 +75,7 @@ def cli() -> None:
     show_default=True,
     help="Which format(s) to verify.",
 )
-@click.option(
-    "--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details."
-)
+@click.option("--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details.")
 def verify_cmd(
     receipt_path: Path,
     jwk_path: Path | None,

--- a/verify_cli/bernstein_verify_receipt/verify.py
+++ b/verify_cli/bernstein_verify_receipt/verify.py
@@ -291,8 +291,7 @@ def verify_subject_binding(receipt: dict[str, Any]) -> tuple[CheckResult, str]:
                 "subject_binding",
                 ok=False,
                 detail=(
-                    f"recomputed head {recomputed[:16]}… "
-                    f"!= range.head_sha256 {range_head[:16]}…"
+                    f"recomputed head {recomputed[:16]}… != range.head_sha256 {range_head[:16]}…"
                 ),
             ),
             recomputed,
@@ -418,10 +417,7 @@ def verify_intoto(receipt: dict[str, Any], public_key: Any, recomputed_head: str
         return CheckResult(
             "intoto",
             ok=False,
-            detail=(
-                f"recomputed head {recomputed_head[:16]}… "
-                f"not in statement subject digests"
-            ),
+            detail=(f"recomputed head {recomputed_head[:16]}… not in statement subject digests"),
         )
     return CheckResult("intoto", ok=True, detail="DSSE/in-toto verified, subject bound to head")
 
@@ -469,8 +465,7 @@ def verify_transparency(
             "transparency",
             ok=False,
             detail=(
-                f"STH subject {subject_sha256[:16]}… "
-                f"!= recomputed head {recomputed_head[:16]}…"
+                f"STH subject {subject_sha256[:16]}… != recomputed head {recomputed_head[:16]}…"
             ),
         )
 
@@ -510,10 +505,7 @@ def verify_transparency(
             return CheckResult(
                 "transparency",
                 ok=False,
-                detail=(
-                    f"inclusion proof root {proven_root[:16]}… "
-                    f"!= STH root {root_hash[:16]}…"
-                ),
+                detail=(f"inclusion proof root {proven_root[:16]}… != STH root {root_hash[:16]}…"),
             )
     return CheckResult(
         "transparency", ok=True, detail="RFC6962 STH signed, root + inclusion proof verified"


### PR DESCRIPTION
## What

`POST /webhooks/github` push events now go through `TriggerManager` governance
before the verification task is created. A `triggers.yaml` rule for
`source: github_push` can suppress a push's task via cooldown, dedup, or its
other conditions - the same rules `bernstein triggers list/history/fire`
already expose for the CLI/manual-fire path.

This PR covers the GitHub push route only - the first slice named in the
issue's agent brief ("one route first - repository pushes - then
generalize"). GitLab push, Slack, and the generic `/webhook` route are not
touched here; see Remaining below.

**Explicitly out of scope for this PR:**
- GitLab push, chat events, and the generic `/webhook` route - not gated yet.
- The manager's own cron poller (`evaluate_cron_triggers`) - untouched, no
  new callers added.
- Entry-point plugin loading and new rule types - filed separately per the
  issue.
- The fate of the two adapters `docs/operations/trigger-sources.md` already
  documents as unwired (`trigger_sources/webhook.py`,
  `trigger_sources/file_watch.py`) - deciding wire-in-or-remove for those is
  a separate, larger change than gating one route's cooldown/dedup.

## Why

`triggers.yaml` documents cooldown, dedup, and glob-filter rules as the way
to govern automated task creation from repository events. The GitHub push
route built its verification task directly from the parsed webhook payload
and never consulted `TriggerManager`, so a cooldown or dedup rule written
for `source: github_push` had no effect on the route that actually receives
GitHub's traffic - an operator's rule silently did nothing.

## How

- **New `TriggerManager.gate_direct_task(event)`** (`trigger_manager.py`):
  checks only the governance half of the existing pipeline - the first
  enabled trigger for `event.source` whose filters match, then its
  cooldown/dedup/other conditions - without rendering a task payload. It
  reuses the existing `_matches_filter`, `_check_conditions`, `_check_dedup`,
  `_record_dedup`, and `_record_rate` helpers, so the semantics are
  identical to the CLI's `evaluate()` path for the checks it runs.
- **Placement decision** (the one the issue left open): the manager sits
  **between the mapper and the store**, not before the mapper. The mapper
  (`push_to_tasks`) keeps building the task's title/description from the
  actual push data; the manager only decides whether that task gets created.
  Putting the manager first would mean re-deriving GitHub-specific fields
  (branch, sha, changed files) twice, once for the manager's own matching
  and once for the mapper's task content, and would tie the manager to
  GitHub's payload shape directly. Sitting after the mapper keeps the
  manager source-agnostic (it already is, for the CLI path) and only
  duplicates event normalization once (`_push_trigger_event`), which mirrors
  the shape `TriggerEvent` already documents for this source.
- **`POST /webhooks/github`** (`webhooks.py`): `_handle_push` normalizes the
  parsed push into a `TriggerEvent` and calls `gate_direct_task`. No
  `.sdd/config/triggers.yaml` (or no matching trigger) is a transparent
  pass-through - the route builds and stores the task exactly as before.
  When a trigger's conditions suppress the push, the route returns
  `tasks_created: 0` with a `skipped_reason`, the same shape the existing
  `workflow_run` retry-cap path already uses for a governed skip. When a
  trigger fires, the route calls `TriggerManager.record_fire` after the task
  is created, so the next push's cooldown/dedup check sees it - the same
  post-creation call the CLI's manual-fire command makes.
- `_get_trigger_manager` only constructs a `TriggerManager` (which creates
  its runtime state directory) when `.sdd/config/triggers.yaml` actually
  exists, mirroring `bernstein triggers list`'s own early-exit - an install
  with no trigger config gets no new filesystem writes from this change.

## Tests

New file: `tests/unit/test_github_push_trigger_governance.py`. All five
drive the real `POST /webhooks/github` route with signed fixture events, not
`TriggerManager.evaluate()` called directly.

1. `test_cooldown_rule_suppresses_second_push_within_window` - **load-bearing**.
   A cooldown rule suppresses the second push inside the window;
   `tasks_created: 0` and the `skipped_reason` names the cooldown. Confirmed
   failing on the unmodified tree first (both pushes created a task).
2. `test_suppressed_fire_is_recorded_in_history` - the first push's fire
   lands in `TriggerManager.get_fire_history()` with the created task's id;
   the suppressed second push adds no second record.
3. `test_dedup_rule_applies_to_github_push_route` - a redelivered push
   (identical branch + sha, the GitHub-redelivery case) is deduplicated
   rather than creating a second task.
4. `test_routes_without_rules_config_are_behavior_identical` - with no
   `triggers.yaml`, every push (including an identical redelivery) still
   creates its task - no hidden gate by default.
5. `test_push_on_unfiltered_branch_is_not_governed` - a trigger scoped to
   `branches: [main]` does not suppress pushes to other branches; a
   filter miss is not the same as an active suppression.

Regression: full targeted run of every existing test file that imports
`trigger_manager.py` or `routes/webhooks.py` (`test_trigger_manager.py` - 81
tests, `test_webhook_route.py`, `test_generic_webhook.py`,
`test_automation_bridge.py`, `test_automation_bridge_route.py`,
`test_ci_routing.py`, `test_gitlab_webhooks.py`, `test_github_app.py`,
`test_github_issue_to_task.py`, `test_webhook_verify.py`,
`test_webhook_handler.py`, `test_webhook_signatures.py`,
`test_events_triggers.py`, `test_trigger_source_registry.py`) - all pass.
The repo-wide `--affected` sweep could not complete against `origin/main` in
this environment (the shared dev machine was running dozens of unrelated
concurrent test processes and the 409-file sweep did not finish in a
reasonable window); the targeted set above covers every test file with a
direct import dependency on the two changed modules.

## Checklist

- [x] `ruff check src/` - passes.
- [x] `ruff format --check src/` - passes.
- [x] `uv run python scripts/run_tests.py -x tests/unit/test_github_push_trigger_governance.py` - passes (5/5).
- [ ] `pyright src/` - `webhooks.py` is already in `[tool.pyright].exclude`
      (pending cleanup, pre-existing); `trigger_manager.py` is not excluded,
      but the repo-wide pyright run is documented as advisory in
      `pyproject.toml` with a large pre-existing backlog (24,876 errors
      before this change). `gate_direct_task` follows the identical
      attribute-access pattern already used by every neighboring method on
      `TriggerConfig`/`TriggerEvent` and adds no new error category - the
      new errors are the same pre-existing `Unknown`-attribute cascade,
      confirmed by running pyright against the pre-change file directly.
- [x] Type hints on all new/changed signatures.
- N/A - no README or translated docs touched.
- N/A - no documented CLI surface changed; `bernstein agents-md sync` produced no diff beyond the file this PR already changed.

## Remaining

- Gate the GitLab push route and the generic `/webhook` route the same way
  (acceptance criterion 3 in the issue only requires github_push here plus
  these two later).
- Decide and document the fate of `trigger_sources/webhook.py` and
  `trigger_sources/file_watch.py` (acceptance criterion 4) - both already
  called out as unwired in `docs/operations/trigger-sources.md`; wiring or
  removing them is independent of this route's governance gate.

Part of #4545
