### PR TITLE
fix: wire per-task token budget kill switch into orchestrator tick (#3374)

### DIFF
--- a/docs/release-notes/fragments/3374-fix-wiring-tokens.md
+++ b/docs/release-notes/fragments/3374-fix-wiring-tokens.md
@@ -1,0 +1,3 @@
+## Fixed per-task token budget wiring in orchestrator
+
+The per-task token budget kill switch is now correctly wired into the orchestrator tick, ensuring token limits are enforced during task execution. (#3374)

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -53,6 +53,7 @@ from bernstein.core.approval import ApprovalGate, ApprovalMode
 from bernstein.core.bandit_router import BanditRouter
 from bernstein.core.batch_api import ProviderBatchManager
 from bernstein.core.bulletin import BulletinBoard, BulletinMessage, SignalActionFailure
+from bernstein.core.circuit_breaker import check_budget_violations
 from bernstein.core.cluster import NodeHeartbeatClient
 from bernstein.core.config.run_overlay import effective_mtime
 from bernstein.core.context import refresh_knowledge_base
@@ -2159,6 +2160,12 @@ class Orchestrator:
 
         # 4d-ii. Token growth monitor: alert on quadratic growth, kill runaway agents
         check_token_growth(self)
+
+        # 4d-ii.a Per-task token budget kill switch: hard-kill agents that
+        # blow through 2x their configured `max_tokens_per_task` budget
+        # (issue #3374). `token_budget` defaults to 0 (disabled) so this is
+        # a no-op for sessions spawned without a scope budget configured.
+        check_budget_violations(self, result)
 
         # 4d-ii.5 Loop and deadlock detection: kill looping agents, break lock cycles
         check_loops_and_deadlocks(self)

--- a/tests/unit/test_budget_violation_tick_wiring.py
+++ b/tests/unit/test_budget_violation_tick_wiring.py
@@ -78,9 +78,7 @@ class TestBudgetViolationTickWiring:
         """A single tick calls `check_budget_violations(self, result)` exactly once."""
         orch = _build_orch(tmp_path)
 
-        with patch(
-            "bernstein.core.orchestration.orchestrator.check_budget_violations"
-        ) as mock_check:
+        with patch("bernstein.core.orchestration.orchestrator.check_budget_violations") as mock_check:
             orch.tick()
 
         assert mock_check.call_count == 1

--- a/tests/unit/test_budget_violation_tick_wiring.py
+++ b/tests/unit/test_budget_violation_tick_wiring.py
@@ -1,0 +1,91 @@
+"""Tests for wiring the per-task token budget kill switch into the tick loop.
+
+`check_budget_violations` (bernstein.core.observability.circuit_breaker) holds
+the "hard-kill at 2x budget" backstop documented on
+`OrchestratorConfig.max_tokens_per_task`, and is already exercised in
+isolation by tests/unit/test_kill_switch.py. What was missing is the tick
+loop actually calling it -- the function had zero callers in src/, so the
+documented backstop never fired; the only path that ran every tick was
+`check_token_growth`, which enforces an unrelated fixed global threshold.
+
+These tests prove `Orchestrator._tick_internal` now calls
+`check_budget_violations` once per tick.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+from bernstein.core.models import OrchestratorConfig
+from bernstein.core.spawner import AgentSpawner
+
+from bernstein.adapters.base import CLIAdapter, SpawnResult
+from bernstein.core.orchestration.orchestrator import Orchestrator, TickResult
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _mock_adapter() -> MagicMock:
+    adapter = MagicMock(spec=CLIAdapter)
+    adapter.spawn.return_value = SpawnResult(pid=42, log_path=Path("/tmp/t.log"))
+    adapter.is_alive.return_value = True
+    adapter.is_rate_limited.return_value = False
+    adapter.kill.return_value = None
+    adapter.name.return_value = "MockCLI"
+    return adapter
+
+
+def _build_orch(tmp_path: Path) -> Orchestrator:
+    """Build a minimal orchestrator with a no-op httpx client, no live agents."""
+    cfg = OrchestratorConfig(max_agents=1, poll_interval_s=1, server_url="http://testserver")
+    templates_dir = tmp_path / "templates" / "roles"
+    templates_dir.mkdir(parents=True, exist_ok=True)
+    spawner = AgentSpawner(_mock_adapter(), templates_dir, tmp_path)
+
+    def _handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"tasks": [], "total": 0})
+
+    client = httpx.Client(transport=httpx.MockTransport(_handler), base_url="http://testserver")
+    return Orchestrator(cfg, spawner, tmp_path, client=client)
+
+
+# ---------------------------------------------------------------------------
+# TestBudgetViolationTickWiring
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetViolationTickWiring:
+    def test_tick_body_references_check_budget_violations(self) -> None:
+        """`_tick_internal` source must call `check_budget_violations`.
+
+        Regression guard for the concrete defect in issue #3374: the
+        per-task token budget's "hard-killed at 2x" comment on
+        `max_tokens_per_task` (models.py) described behaviour that
+        `check_budget_violations` implemented but nothing invoked.
+        """
+        src = inspect.getsource(Orchestrator._tick_internal)
+        assert "check_budget_violations" in src, (
+            "Orchestrator._tick_internal does not wire up the per-task token budget kill switch"
+        )
+
+    def test_tick_invokes_check_budget_violations_once(self, tmp_path: Path) -> None:
+        """A single tick calls `check_budget_violations(self, result)` exactly once."""
+        orch = _build_orch(tmp_path)
+
+        with patch(
+            "bernstein.core.orchestration.orchestrator.check_budget_violations"
+        ) as mock_check:
+            orch.tick()
+
+        assert mock_check.call_count == 1
+        called_orch: Any
+        called_result: Any
+        called_orch, called_result = mock_check.call_args[0]
+        assert called_orch is orch
+        assert isinstance(called_result, TickResult)

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -6022,6 +6022,7 @@ class TestAdaptivePollingBackoff:
         assert hasattr(orch, "_idle_multiplier")
         assert orch._idle_multiplier == 1
 
+
 # --- Reverse task-to-session index ---
 
 

--- a/verify_cli/bernstein_verify_receipt/__main__.py
+++ b/verify_cli/bernstein_verify_receipt/__main__.py
@@ -75,9 +75,7 @@ def cli() -> None:
     show_default=True,
     help="Which format(s) to verify.",
 )
-@click.option(
-    "--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details."
-)
+@click.option("--verbose", "-v", is_flag=True, default=False, help="Print PASS-line details.")
 def verify_cmd(
     receipt_path: Path,
     jwk_path: Path | None,

--- a/verify_cli/bernstein_verify_receipt/verify.py
+++ b/verify_cli/bernstein_verify_receipt/verify.py
@@ -291,8 +291,7 @@ def verify_subject_binding(receipt: dict[str, Any]) -> tuple[CheckResult, str]:
                 "subject_binding",
                 ok=False,
                 detail=(
-                    f"recomputed head {recomputed[:16]}… "
-                    f"!= range.head_sha256 {range_head[:16]}…"
+                    f"recomputed head {recomputed[:16]}… != range.head_sha256 {range_head[:16]}…"
                 ),
             ),
             recomputed,
@@ -418,10 +417,7 @@ def verify_intoto(receipt: dict[str, Any], public_key: Any, recomputed_head: str
         return CheckResult(
             "intoto",
             ok=False,
-            detail=(
-                f"recomputed head {recomputed_head[:16]}… "
-                f"not in statement subject digests"
-            ),
+            detail=(f"recomputed head {recomputed_head[:16]}… not in statement subject digests"),
         )
     return CheckResult("intoto", ok=True, detail="DSSE/in-toto verified, subject bound to head")
 
@@ -469,8 +465,7 @@ def verify_transparency(
             "transparency",
             ok=False,
             detail=(
-                f"STH subject {subject_sha256[:16]}… "
-                f"!= recomputed head {recomputed_head[:16]}…"
+                f"STH subject {subject_sha256[:16]}… != recomputed head {recomputed_head[:16]}…"
             ),
         )
 
@@ -510,10 +505,7 @@ def verify_transparency(
             return CheckResult(
                 "transparency",
                 ok=False,
-                detail=(
-                    f"inclusion proof root {proven_root[:16]}… "
-                    f"!= STH root {root_hash[:16]}…"
-                ),
+                detail=(f"inclusion proof root {proven_root[:16]}… != STH root {root_hash[:16]}…"),
             )
     return CheckResult(
         "transparency", ok=True, detail="RFC6962 STH signed, root + inclusion proof verified"


### PR DESCRIPTION
## What

Wires the existing per-task token budget hard-kill (`check_budget_violations`) into the orchestrator tick loop, so agents that consume more than 2x their configured `max_tokens_per_task` budget are actually stopped instead of only logged about.

This PR does **not** implement the full context-fill budget ladder (nudge -> forced compaction -> split/dead-letter, with an audit-chain event per transition) described in the issue. It fixes the one concrete piece of dead code the issue calls out: a documented hard-kill backstop that was never invoked.

## Why

`OrchestratorConfig.max_tokens_per_task` is commented "agents warned at 80%, hard-killed at 2x". The 80% warning is wired (`check_token_growth` -> `_handle_budget_nudge`). The 2x hard-kill is not: `check_budget_violations` (`src/bernstein/core/observability/circuit_breaker.py`) implements it, is exhaustively unit-tested (`tests/unit/test_kill_switch.py`), and has zero callers anywhere in `src/`. A worker that runs away on a scoped task budget today gets a log line, not a kill, until it eventually hits a provider error on its own.

## How

- Import `check_budget_violations` into `bernstein.core.orchestration.orchestrator` and call it from `_tick_internal`, right after `check_token_growth`, passing the tick's `TickResult` so reaped sessions flow through the same `agent_reaped` audit-chain recording that scope and guardrail kills already use.
- `AgentSession.token_budget` defaults to 0 (disabled) and is only set when a spawn resolves a non-zero `max_tokens_per_task` entry for its scope, so this is a no-op for any run that doesn't configure per-task budgets - no behaviour change for existing runs.
- No changes to `check_budget_violations` itself; its kill/quarantine/audit-log behaviour was already correct and tested.

## Tests

1. `test_tick_body_references_check_budget_violations` - static check that `Orchestrator._tick_internal`'s source calls `check_budget_violations`; guards against the wiring being dropped again.
2. `test_tick_invokes_check_budget_violations_once` (load-bearing) - builds a real `Orchestrator` and asserts a single `tick()` calls `check_budget_violations(orch, result)` exactly once with the live `TickResult`.

Both tests were confirmed failing on the unmodified tree (`test_tick_body_references_check_budget_violations` fails with `AssertionError: Orchestrator._tick_internal does not wire up the per-task token budget kill switch`; `test_tick_invokes_check_budget_violations_once` fails because the patched function is never called) before the fix, and pass after it.

`tests/unit/test_kill_switch.py` (26 tests covering `check_budget_violations` itself) and the other orchestrator/token-monitor suites (`test_budget_killswitch.py`, `test_ci_autofix_orchestrator.py`, `test_token_monitor.py`, `test_auto_compact_circuit_breaker.py`) pass unmodified.

## Checklist

- [x] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` - the touched file (`orchestrator.py`) has a large pre-existing pyright baseline (1999 errors, unrelated to this change - the file's lazy cross-module import-alias pattern isn't resolvable by pyright's static analysis, the same class of error appears on every neighbouring import). This change adds 2 more errors of that identical pre-existing category on the new import line; no new *kind* of error is introduced.
- [x] `uv run python scripts/run_tests.py -x` passes on the new test file, `test_kill_switch.py`, the orchestrator/token-monitor suites listed under Tests, and the full `tests/unit/test_orchestrator.py` (228 passed, confirmed both before and after this change to rule out the file's own runtime variance under load). The repo-wide `--affected` run against `origin/main` did not finish locally in reasonable time (this file is imported very widely, so `--affected` selects a large slice of the suite); CI will run it.
- [x] New code has type hints

### Documentation duty

- [x] User-visible README section updated - N/A, no user-facing surface changed
- [x] `docs/operations/<area>.md` updated - N/A
- [x] `docs/api/` schema regenerated - N/A, no public API changed
- [x] `uv run bernstein agents-md sync` - N/A, no new module or documented public surface added
- [x] Tests cover the documented behaviour - see Tests section

## Remaining

Not addressed by this PR (from the issue's "Done means" list):

- Configurable fill-fraction ladder evaluated mid-run (nudge -> forced compaction -> terminal action)
- Forced-compaction step promoted from opt-in to a ladder step, with escalation on repeated failure
- Split path: `should_split` extended with a context-pressure criterion, parent/child relation recorded
- Dead-letter path: DLQ entry carrying reason, utilization series, and last compaction receipt reference
- Audit-chain event per ladder transition, with a replay test asserting a deterministic transition sequence for a synthetic utilization series

Part of #3374
