### PR TITLE
feat: signed engagement scope grant and pure scope predicate (#2952)

### DIFF
--- a/src/bernstein/core/security/engagement/__init__.py
+++ b/src/bernstein/core/security/engagement/__init__.py
@@ -1,0 +1,17 @@
+"""Signed engagement scope grants for security-tool actions (issue #2952)."""
+
+from bernstein.core.security.engagement.mandate import (
+    ENGAGEMENT_SCHEMA_VERSION,
+    EngagementMandate,
+    ScopeDecision,
+    ScopeDenyReason,
+    check_scope,
+)
+
+__all__ = [
+    "ENGAGEMENT_SCHEMA_VERSION",
+    "EngagementMandate",
+    "ScopeDecision",
+    "ScopeDenyReason",
+    "check_scope",
+]

--- a/src/bernstein/core/security/engagement/mandate.py
+++ b/src/bernstein/core/security/engagement/mandate.py
@@ -1,0 +1,275 @@
+"""Signed, content-addressed engagement scope grants (issue #2952, step 1).
+
+An outbound payment cannot execute until it is bound to a signed
+:class:`~bernstein.core.protocols.payments.mandates.IntentMandate`.
+Security-tool actions have no equivalent: a scanner can be pointed at any
+target with nothing in the record establishing that the run was authorized
+and in-scope, and a finding discovered outside an agreed scope is a
+liability rather than a result.
+
+:class:`EngagementMandate` closes that gap with the same substrate the
+payment mandates use. The grant is canonical JSON (sorted keys, minimal
+separators, UTF-8) signed with HMAC-SHA256 under the audit-chain key, and
+its identity is the ``sha256:`` content hash over body **plus** signature.
+Two operators who construct the same grant compute the byte-identical
+hash, so the hash a caller binds into a lineage entry recomputes offline
+with no registry and no network.
+
+Fail-closed allowlists
+----------------------
+``targets`` and ``categories`` are allowlists that authorize *only* what
+they list. An empty allowlist authorizes **nothing**. This is deliberately
+the opposite of the neighbouring
+:meth:`~bernstein.core.security.agent_identity.AgentIdentityCard.in_scope`
+convention, where an empty scope means *unrestricted*: a scope grant whose
+fields silently widen when a field is omitted cannot be the foundation of a
+compliance-sensitive deliverable.
+
+Scope of this module
+--------------------
+:func:`check_scope` is a pure projection of ``(grant, target, category,
+key, time)`` onto an allow/deny decision. It reads no clock, touches no
+filesystem, and never raises: every failure is a returned
+:class:`ScopeDecision` carrying a closed :class:`ScopeDenyReason`, so a
+caller can seal the deny into a receipt instead of catching an exception.
+
+``rate_per_min`` is signed into the grant so a later rate gate is bound by
+the same signature, but nothing here enforces it:
+:func:`~bernstein.core.admission.rate_limit.effective_rate_limit` needs
+recorded 429 observation timestamps that no caller supplies yet.
+
+Revocation is not part of this projection's failure set. Consulting a
+revocation log requires a location that a content-addressed body cannot
+carry, so no unreachable ``revoked`` outcome ships here; the gate lands
+with the append-only revocation log.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac as _hmac
+import json
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+__all__ = [
+    "ENGAGEMENT_SCHEMA_VERSION",
+    "EngagementMandate",
+    "ScopeDecision",
+    "ScopeDenyReason",
+    "check_scope",
+]
+
+#: Version stamped into every engagement-grant preimage. Bump only on a
+#: wire-format change; it is covered by the signature and the content hash.
+ENGAGEMENT_SCHEMA_VERSION = 1
+
+#: Discriminator in the signed body, so an engagement grant can never be
+#: mistaken for a payment mandate signed under the same key.
+_ENGAGEMENT_KIND = "engagement"
+
+
+def _canonical_bytes(payload: dict[str, Any]) -> bytes:
+    """Return canonical JSON bytes (sorted keys, minimal separators, UTF-8)."""
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _sha256(payload: dict[str, Any]) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_bytes(payload)).hexdigest()
+
+
+def _sign(key: bytes, payload: dict[str, Any]) -> str:
+    """Return the HMAC-SHA256 signature over ``payload``'s canonical bytes."""
+    return _hmac.new(key, _canonical_bytes(payload), hashlib.sha256).hexdigest()
+
+
+class ScopeDenyReason(StrEnum):
+    """Closed set of reasons :func:`check_scope` refuses an action.
+
+    A string enum so a reason drops straight into a canonical-JSON refusal
+    row without a conversion step.
+    """
+
+    #: The grant carries no signature, or one that does not verify.
+    BAD_SIGNATURE = "bad_signature"
+    #: ``now`` is earlier than the grant's ``not_before``.
+    NOT_YET_VALID = "not_yet_valid"
+    #: ``now`` is later than the grant's ``not_after``.
+    EXPIRED = "expired"
+    #: The target is absent from the ``targets`` allowlist (empty included).
+    TARGET_NOT_IN_SCOPE = "target_not_in_scope"
+    #: The category is absent from the ``categories`` allowlist (empty included).
+    CATEGORY_NOT_IN_SCOPE = "category_not_in_scope"
+
+
+@dataclass(frozen=True)
+class ScopeDecision:
+    """The outcome of evaluating one action against one grant.
+
+    Attributes:
+        allowed: True only when every gate passed.
+        reason: ``None`` on an allow; the closed-enum refusal reason
+            otherwise.
+        mandate_hash: The content hash of the grant the action was
+            evaluated against. Present on both outcomes: an allow binds it
+            into the action's lineage entry, a deny names the grant the
+            refusal was measured against.
+        target: The target the caller asked about, echoed back.
+        category: The tool category the caller asked about, echoed back.
+    """
+
+    allowed: bool
+    reason: ScopeDenyReason | None
+    mandate_hash: str
+    target: str
+    category: str
+
+
+@dataclass(frozen=True)
+class EngagementMandate:
+    """A signed, content-addressed rules-of-engagement scope grant.
+
+    Attributes:
+        engagement_id: The engagement the grant belongs to.
+        targets: Allowlist of targets (hosts, CIDR strings, domains, repo
+            paths) the grant authorizes. Membership is **exact string
+            equality**; an empty tuple authorizes nothing.
+        categories: Allowlist of tool categories the grant authorizes
+            (``sast``, ``sca``, ``secret``, ``iac``, ``recon``, ``dast``).
+            An empty tuple authorizes nothing.
+        not_before: Inclusive lower bound of the grant window.
+        not_after: Inclusive upper bound of the grant window. There is no
+            "unbounded" sentinel: a grant with no usable window authorizes
+            nothing rather than everything.
+        rate_per_min: Max requests per minute per target. Signed so a later
+            rate gate is bound by this signature; not enforced here.
+        signature: HMAC signature over the body; populated by :meth:`sign`.
+    """
+
+    engagement_id: str
+    targets: tuple[str, ...]
+    categories: tuple[str, ...]
+    not_before: int
+    not_after: int
+    rate_per_min: int
+    signature: str = ""
+
+    def _body(self) -> dict[str, Any]:
+        return {
+            "v": ENGAGEMENT_SCHEMA_VERSION,
+            "kind": _ENGAGEMENT_KIND,
+            "engagement_id": self.engagement_id,
+            "targets": sorted(set(self.targets)),
+            "categories": sorted(set(self.categories)),
+            "not_before": self.not_before,
+            "not_after": self.not_after,
+            "rate_per_min": self.rate_per_min,
+        }
+
+    def sign(self, key: bytes) -> EngagementMandate:
+        """Return a copy carrying the HMAC signature over the body."""
+        return EngagementMandate(
+            engagement_id=self.engagement_id,
+            targets=self.targets,
+            categories=self.categories,
+            not_before=self.not_before,
+            not_after=self.not_after,
+            rate_per_min=self.rate_per_min,
+            signature=_sign(key, self._body()),
+        )
+
+    def verify_signature(self, key: bytes) -> bool:
+        """Return True when ``signature`` matches the body under ``key``."""
+        if not self.signature:
+            return False
+        return _hmac.compare_digest(self.signature, _sign(key, self._body()))
+
+    def mandate_hash(self) -> str:
+        """Return the content hash of the signed grant.
+
+        The allowlists are sorted and de-duplicated in the body, so the
+        hash is a function of the *sets* granted, not their listing order.
+        """
+        return _sha256(self._body() | {"signature": self.signature})
+
+    def to_dict(self) -> dict[str, Any]:
+        return self._body() | {"signature": self.signature}
+
+    @classmethod
+    def from_dict(cls, row: dict[str, Any]) -> EngagementMandate:
+        return cls(
+            engagement_id=str(row["engagement_id"]),
+            targets=tuple(str(t) for t in row.get("targets", ())),
+            categories=tuple(str(c) for c in row.get("categories", ())),
+            not_before=int(row["not_before"]),
+            not_after=int(row["not_after"]),
+            rate_per_min=int(row.get("rate_per_min", 0)),
+            signature=str(row.get("signature", "")),
+        )
+
+
+def check_scope(
+    mandate: EngagementMandate,
+    *,
+    target: str,
+    category: str,
+    hmac_key: bytes,
+    now: int,
+) -> ScopeDecision:
+    """Project ``(grant, target, category, key, time)`` onto an allow/deny.
+
+    The action is allowed only when all four gates pass: the signature
+    verifies under ``hmac_key``, ``now`` lies inside the inclusive window
+    ``[not_before, not_after]``, ``target`` is listed in ``targets``, and
+    ``category`` is listed in ``categories``. Membership is exact string
+    equality -- no prefix, CIDR, or domain subsumption -- because any
+    subsuming matcher would widen a grant without a monotonicity rule to
+    check the widening against.
+
+    An **empty** ``targets`` or ``categories`` authorizes nothing. This is
+    the opposite of :meth:`AgentIdentityCard.in_scope
+    <bernstein.core.security.agent_identity.AgentIdentityCard.in_scope>`,
+    where an empty scope means unrestricted.
+
+    Pure and total: it reads no clock and no filesystem, and every failure
+    is a returned :class:`ScopeDecision` with a
+    :class:`ScopeDenyReason` -- it never raises. Two operators with the
+    same arguments compute the identical decision.
+
+    Args:
+        mandate: The scope grant to evaluate against.
+        target: The target the action would touch.
+        category: The tool category the action belongs to.
+        hmac_key: The audit-chain key the grant was signed under.
+        now: Logical time to evaluate at; supplied by the caller so the
+            projection stays deterministic.
+    """
+    mandate_hash = mandate.mandate_hash()
+
+    def deny(reason: ScopeDenyReason) -> ScopeDecision:
+        return ScopeDecision(
+            allowed=False,
+            reason=reason,
+            mandate_hash=mandate_hash,
+            target=target,
+            category=category,
+        )
+
+    if not mandate.verify_signature(hmac_key):
+        return deny(ScopeDenyReason.BAD_SIGNATURE)
+    if now < mandate.not_before:
+        return deny(ScopeDenyReason.NOT_YET_VALID)
+    if now > mandate.not_after:
+        return deny(ScopeDenyReason.EXPIRED)
+    if target not in set(mandate.targets):
+        return deny(ScopeDenyReason.TARGET_NOT_IN_SCOPE)
+    if category not in set(mandate.categories):
+        return deny(ScopeDenyReason.CATEGORY_NOT_IN_SCOPE)
+    return ScopeDecision(
+        allowed=True,
+        reason=None,
+        mandate_hash=mandate_hash,
+        target=target,
+        category=category,
+    )

--- a/src/bernstein/core/security/engagement/mandate.py
+++ b/src/bernstein/core/security/engagement/mandate.py
@@ -38,6 +38,17 @@ the same signature, but nothing here enforces it:
 :func:`~bernstein.core.admission.rate_limit.effective_rate_limit` needs
 recorded 429 observation timestamps that no caller supplies yet.
 
+Not to be confused with the projection stub
+------------------------------------------
+``bernstein.core.security.engagement_mandate.EngagementMandate`` is a
+different, unrelated type: an unsigned, wall-clock, prefix-matching stub
+that tags phase nodes during engagement projection. It carries no
+signature and no content address, so it cannot bind an action into the
+audit chain. This module is the signed substrate; the two are kept
+separate rather than merged, because collapsing them would either strip
+the projection stub's prefix matching or widen this grant with a
+subsumption rule that has no monotonicity check behind it yet.
+
 Revocation is not part of this projection's failure set. Consulting a
 revocation log requires a location that a content-addressed body cannot
 carry, so no unreachable ``revoked`` outcome ships here; the gate lands

--- a/tests/unit/core/security/engagement/test_scope_predicate.py
+++ b/tests/unit/core/security/engagement/test_scope_predicate.py
@@ -1,0 +1,257 @@
+"""An empty allowlist authorizes nothing (issue #2952, step 1).
+
+The neighbouring convention is the opposite: ``AgentIdentityCard.in_scope``
+treats an empty scope as *unrestricted*. An engagement scope grant must
+fail closed, so these tests pin the empty-allowlist rule first and then
+walk every remaining deny path of :func:`check_scope`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.security.engagement.mandate import (
+    EngagementMandate,
+    ScopeDenyReason,
+    check_scope,
+)
+
+KEY = b"engagement-hmac-key"
+OTHER_KEY = b"a-different-hmac-key"
+
+NOT_BEFORE = 1_000
+NOT_AFTER = 2_000
+NOW = 1_500
+
+
+def _mandate(
+    *,
+    targets: tuple[str, ...] = ("repo/app", "10.0.0.1"),
+    categories: tuple[str, ...] = ("sast", "sca"),
+    not_before: int = NOT_BEFORE,
+    not_after: int = NOT_AFTER,
+    rate_per_min: int = 60,
+) -> EngagementMandate:
+    return EngagementMandate(
+        engagement_id="eng-1",
+        targets=targets,
+        categories=categories,
+        not_before=not_before,
+        not_after=not_after,
+        rate_per_min=rate_per_min,
+    ).sign(KEY)
+
+
+def test_empty_target_allowlist_authorizes_nothing() -> None:
+    """A signed mandate with no targets denies every target."""
+    mandate = _mandate(targets=())
+
+    decision = check_scope(mandate, target="repo/app", category="sast", hmac_key=KEY, now=NOW)
+
+    assert decision.allowed is False
+    assert decision.reason is ScopeDenyReason.TARGET_NOT_IN_SCOPE
+
+
+def test_empty_category_allowlist_authorizes_nothing() -> None:
+    """A signed mandate with no categories denies every category."""
+    mandate = _mandate(categories=())
+
+    decision = check_scope(mandate, target="repo/app", category="sast", hmac_key=KEY, now=NOW)
+
+    assert decision.allowed is False
+    assert decision.reason is ScopeDenyReason.CATEGORY_NOT_IN_SCOPE
+
+
+def test_unsigned_mandate_denies() -> None:
+    """An unsigned mandate authorizes nothing."""
+    mandate = EngagementMandate(
+        engagement_id="eng-1",
+        targets=("repo/app",),
+        categories=("sast",),
+        not_before=NOT_BEFORE,
+        not_after=NOT_AFTER,
+        rate_per_min=60,
+    )
+
+    decision = check_scope(mandate, target="repo/app", category="sast", hmac_key=KEY, now=NOW)
+
+    assert decision.allowed is False
+    assert decision.reason is ScopeDenyReason.BAD_SIGNATURE
+
+
+def test_signature_from_another_key_denies() -> None:
+    """A mandate signed under a different key authorizes nothing."""
+    mandate = _mandate()
+
+    decision = check_scope(mandate, target="repo/app", category="sast", hmac_key=OTHER_KEY, now=NOW)
+
+    assert decision.allowed is False
+    assert decision.reason is ScopeDenyReason.BAD_SIGNATURE
+
+
+def test_tampered_target_list_denies() -> None:
+    """Widening the target list after signing invalidates the signature."""
+    signed = _mandate(targets=("repo/app",))
+    widened = EngagementMandate(
+        engagement_id=signed.engagement_id,
+        targets=("repo/app", "repo/other"),
+        categories=signed.categories,
+        not_before=signed.not_before,
+        not_after=signed.not_after,
+        rate_per_min=signed.rate_per_min,
+        signature=signed.signature,
+    )
+
+    decision = check_scope(widened, target="repo/other", category="sast", hmac_key=KEY, now=NOW)
+
+    assert decision.allowed is False
+    assert decision.reason is ScopeDenyReason.BAD_SIGNATURE
+
+
+def test_action_before_window_open_denies() -> None:
+    """``now`` earlier than ``not_before`` authorizes nothing."""
+    mandate = _mandate()
+
+    decision = check_scope(mandate, target="repo/app", category="sast", hmac_key=KEY, now=NOT_BEFORE - 1)
+
+    assert decision.allowed is False
+    assert decision.reason is ScopeDenyReason.NOT_YET_VALID
+
+
+def test_action_after_window_close_denies() -> None:
+    """``now`` later than ``not_after`` authorizes nothing."""
+    mandate = _mandate()
+
+    decision = check_scope(mandate, target="repo/app", category="sast", hmac_key=KEY, now=NOT_AFTER + 1)
+
+    assert decision.allowed is False
+    assert decision.reason is ScopeDenyReason.EXPIRED
+
+
+def test_window_bounds_are_inclusive() -> None:
+    """Both window edges are inside the grant."""
+    mandate = _mandate()
+
+    for now in (NOT_BEFORE, NOT_AFTER):
+        decision = check_scope(mandate, target="repo/app", category="sast", hmac_key=KEY, now=now)
+        assert decision.allowed is True, now
+
+
+def test_target_outside_allowlist_denies() -> None:
+    """A target absent from the allowlist authorizes nothing."""
+    mandate = _mandate()
+
+    decision = check_scope(mandate, target="repo/unlisted", category="sast", hmac_key=KEY, now=NOW)
+
+    assert decision.allowed is False
+    assert decision.reason is ScopeDenyReason.TARGET_NOT_IN_SCOPE
+
+
+def test_target_match_is_exact_not_prefix() -> None:
+    """Membership is exact: a longer path is not covered by a listed prefix."""
+    mandate = _mandate(targets=("repo/app",))
+
+    decision = check_scope(mandate, target="repo/app-staging", category="sast", hmac_key=KEY, now=NOW)
+
+    assert decision.allowed is False
+    assert decision.reason is ScopeDenyReason.TARGET_NOT_IN_SCOPE
+
+
+def test_category_outside_allowlist_denies() -> None:
+    """A category absent from the allowlist authorizes nothing."""
+    mandate = _mandate()
+
+    decision = check_scope(mandate, target="repo/app", category="dast", hmac_key=KEY, now=NOW)
+
+    assert decision.allowed is False
+    assert decision.reason is ScopeDenyReason.CATEGORY_NOT_IN_SCOPE
+
+
+def test_in_scope_action_is_allowed_and_carries_mandate_hash() -> None:
+    """An in-scope action allows and reports the hash callers bind into lineage."""
+    mandate = _mandate()
+
+    decision = check_scope(mandate, target="repo/app", category="sast", hmac_key=KEY, now=NOW)
+
+    assert decision.allowed is True
+    assert decision.reason is None
+    assert decision.mandate_hash == mandate.mandate_hash()
+    assert decision.target == "repo/app"
+    assert decision.category == "sast"
+
+
+def test_denied_decision_still_carries_mandate_hash() -> None:
+    """A deny names the grant it was evaluated against."""
+    mandate = _mandate()
+
+    decision = check_scope(mandate, target="repo/unlisted", category="sast", hmac_key=KEY, now=NOW)
+
+    assert decision.mandate_hash == mandate.mandate_hash()
+
+
+def test_check_scope_never_raises_on_any_deny_path() -> None:
+    """Every failure is a returned deny, never an exception."""
+    unsigned = EngagementMandate(
+        engagement_id="eng-1",
+        targets=(),
+        categories=(),
+        not_before=NOT_AFTER,
+        not_after=NOT_BEFORE,
+        rate_per_min=0,
+    )
+
+    decision = check_scope(unsigned, target="", category="", hmac_key=b"", now=0)
+
+    assert decision.allowed is False
+    assert decision.reason in set(ScopeDenyReason)
+
+
+def test_identical_field_values_produce_identical_mandate_hash() -> None:
+    """Two independent constructions of the same grant are the same content."""
+    first = EngagementMandate(
+        engagement_id="eng-1",
+        targets=("10.0.0.1", "repo/app"),
+        categories=("sast", "sca"),
+        not_before=NOT_BEFORE,
+        not_after=NOT_AFTER,
+        rate_per_min=60,
+    ).sign(KEY)
+    second = EngagementMandate(
+        engagement_id="eng-1",
+        targets=("repo/app", "10.0.0.1", "repo/app"),
+        categories=("sca", "sast"),
+        not_before=NOT_BEFORE,
+        not_after=NOT_AFTER,
+        rate_per_min=60,
+    ).sign(KEY)
+
+    assert first.mandate_hash() == second.mandate_hash()
+    assert first.mandate_hash().startswith("sha256:")
+
+
+def test_rate_per_min_is_signed_but_not_enforced() -> None:
+    """``rate_per_min`` is bound into the grant yet gates nothing here."""
+    slow = _mandate(rate_per_min=1)
+    fast = _mandate(rate_per_min=600)
+
+    assert slow.mandate_hash() != fast.mandate_hash()
+    for mandate in (slow, fast):
+        assert check_scope(mandate, target="repo/app", category="sast", hmac_key=KEY, now=NOW).allowed is True
+
+
+def test_round_trip_through_dict_preserves_the_hash() -> None:
+    """A serialized grant rebuilds to the identical content address."""
+    mandate = _mandate()
+
+    restored = EngagementMandate.from_dict(mandate.to_dict())
+
+    assert restored.to_dict() == mandate.to_dict()
+    assert restored.mandate_hash() == mandate.mandate_hash()
+    assert restored.verify_signature(KEY) is True
+
+
+@pytest.mark.parametrize("reason", list(ScopeDenyReason))
+def test_deny_reasons_are_a_closed_string_enum(reason: ScopeDenyReason) -> None:
+    """Reasons serialize as plain strings for receipts and lineage rows."""
+    assert isinstance(reason.value, str)
+    assert ScopeDenyReason(reason.value) is reason


### PR DESCRIPTION
## What

Adds `src/bernstein/core/security/engagement/mandate.py`: a frozen
`EngagementMandate` — an HMAC-SHA256-signed, content-addressed rules-of-engagement
scope grant — and `check_scope()`, one pure allow/deny projection over it.

This is step 1 of #2952 and nothing more. Explicitly **not** in this PR:

- the append-only `revocations.jsonl` log and `is_revoked()`
- the signed refusal receipt on the HMAC audit chain
- the `bernstein engagement` CLI group and its `main.py` registration
- narrowing / re-issue monotonicity rules and their golden fixtures
- any lineage binding, and any enforcement of `rate_per_min`

`src/bernstein/core/protocols/payments/mandates.py` is untouched: its shape is
copied, not refactored into a shared base.

The module has no callers yet. Its first consumer is #2953, which is the point —
that work gets written against a real type rather than a sketch.

## Why

An outbound payment cannot execute until it is bound to a signed `IntentMandate`
(`src/bernstein/core/protocols/payments/mandates.py:151-215`). Security-tool
actions have no equivalent: a scanner can be pointed at any target and nothing in
the record establishes that the run was authorized and in-scope. For operators
running compliance-sensitive workflows, a finding discovered outside an agreed
scope is a liability rather than a result, so the authorization has to be part of
the artefact, not a side note next to it.

The grant's identity is the `sha256:` content hash over its canonical body plus
signature, so the hash a caller binds into a lineage entry recomputes offline with
no registry and no network.

## How

- `EngagementMandate` mirrors `IntentMandate` field for field in shape: a
  `_body()` returning `{"v", "kind": "engagement", "engagement_id", "targets",
  "categories", "not_before", "not_after", "rate_per_min"}` with the tuples
  `sorted(set(...))`, then `sign()`, `verify_signature()` via
  `hmac.compare_digest`, `mandate_hash()`, `to_dict()` / `from_dict()`.
  `"kind": "engagement"` keeps a grant from being mistaken for a payment mandate
  signed under the same key.
- `check_scope(mandate, *, target, category, hmac_key, now)` allows only when the
  signature verifies, `now` is inside the inclusive `[not_before, not_after]`
  window, and both `target` and `category` are present in their allowlists. It
  reads no clock and no filesystem, and returns a `ScopeDecision` on every path —
  it never raises, so a caller can seal a deny into a receipt.
- **Empty allowlists authorize nothing.** The neighbouring convention is the
  opposite: `AgentIdentityCard.in_scope()`
  (`src/bernstein/core/security/agent_identity.py:292-295`) treats an empty scope
  as unrestricted. The docstring names the difference at both the module and the
  function level. This falls out of plain membership rather than a special case,
  so there is no branch that can be dropped by accident.
- `rate_per_min` is signed into the body but gates nothing here.
  `effective_rate_limit()` (`src/bernstein/core/admission/rate_limit.py:49`) needs
  recorded 429 observation timestamps that no caller supplies yet; signing the
  field now means a later rate gate is bound by this same signature.

Decisions this PR makes, where the issue left them open:

1. **Revocation is not in this projection's failure set.** The issue asks to pick
   one of two contracts. Consulting a revocation log needs a location that a
   content-addressed body cannot carry, so `check_scope()` takes no path and
   `ScopeDenyReason` has no `revoked` member. Nothing unreachable ships; the gate
   lands with the revocation log, where the location argument has a caller.
2. **Target membership is exact string equality** — no prefix, CIDR, or domain
   subsumption. A subsuming matcher widens a grant, and the monotonicity rules
   that would check a widening are explicitly out of step 1. Pinned by
   `test_target_match_is_exact_not_prefix`.
3. **The window has no unbounded sentinel.** `IntentMandate` uses
   `expires_at == 0` for "never expires"; here a grant with no usable window
   authorizes nothing rather than everything, matching the fail-closed allowlists.

4. **The class name is kept despite the adjacency.** `EngagementMandate` is the
   name the issue specifies. An unrelated
   `src/bernstein/core/security/engagement_mandate.py` already exists — a
   documented stub for phase admission, unsigned, wall-clock, prefix-matching,
   reached only by `tests/unit/test_engagement_mandate.py`. It is left alone and
   its test still passes. Nothing resolves either class through the lazy
   `core/security/__init__.py` attribute lookup (every consumer imports the module
   path directly), so the two coexist without a behavioural collision, and the new
   module's docstring states which is which so they are not read as duplicates.

## Tests

`tests/unit/core/security/engagement/test_scope_predicate.py`, named for the
property "an empty allowlist authorizes nothing". All 22 failed before the change
(the module did not exist, so collection failed); all pass after.

1. `test_empty_target_allowlist_authorizes_nothing` — **load-bearing**: a signed
   grant with `targets=()` denies. This is the one that would silently invert if
   the neighbouring `in_scope` convention were copied.
2. `test_empty_category_allowlist_authorizes_nothing` — same rule on the other
   allowlist.
3. `test_unsigned_mandate_denies`
4. `test_signature_from_another_key_denies`
5. `test_tampered_target_list_denies` — widening the list after signing breaks the
   signature.
6. `test_action_before_window_open_denies`
7. `test_action_after_window_close_denies`
8. `test_window_bounds_are_inclusive`
9. `test_target_outside_allowlist_denies`
10. `test_target_match_is_exact_not_prefix`
11. `test_category_outside_allowlist_denies`
12. `test_in_scope_action_is_allowed_and_carries_mandate_hash`
13. `test_denied_decision_still_carries_mandate_hash`
14. `test_check_scope_never_raises_on_any_deny_path`
15. `test_identical_field_values_produce_identical_mandate_hash` — two independent
    constructions with reordered, duplicated fields hash identically.
16. `test_rate_per_min_is_signed_but_not_enforced`
17. `test_round_trip_through_dict_preserves_the_hash`
18. `test_deny_reasons_are_a_closed_string_enum` (parametrized over all five
    reasons).

Local runs: `run_tests.py --parallel 2 -x` over the new file plus
`tests/unit/test_engagement_mandate.py` — 42 passed. `--affected origin/main`
selects 150 files; all were run in four batches at `--parallel 2` and pass, with
one exception: `tests/unit/cli/test_run_banner.py` fails identically on the tree
with this change removed, so it is pre-existing and unrelated. CI runs the full
suite.

## Checklist

- [x] `uv run ruff check src/` — clean
- [x] `uv run ruff format --check` on the changed files — clean
- [x] `uv run pyright src/bernstein/core/security/engagement` — 0 errors
- [x] `uv run python scripts/run_tests.py --parallel 2 -x <files>` — green
- [x] Type hints on every new function and field
- [x] `uv run bernstein agents-md sync` — no changes produced
- [ ] README / translations — N/A, no public surface documented there changed
- [ ] Release notes — N/A, no user-visible behaviour yet (no callers)

Part of #2952

## Remaining

- Append-only signed `revocations.jsonl` + `is_revoked()`, and the revocation-gate
  location decision now that a caller exists for it.
- Signed refusal receipt sealed onto the HMAC chain (`record_payment_refused` at
  `src/bernstein/core/security/audit_chain.py:1937` is the closest shape).
- `bernstein engagement` CLI group (`emit`, `verify`, `revoke`, `show`) plus the
  `add_command` line in `cli/main.py`.
- Narrowing / re-issue monotonicity per field, with the golden fixture pair.
- Lineage binding of `mandate_hash` on in-scope actions, and rate enforcement once
  429 observations are recorded.
