### PR TITLE
fix: derive compaction correlation ids from the fold instead of uuid4 (#2915)

### DIFF
--- a/docs/architecture/memory_tiers.md
+++ b/docs/architecture/memory_tiers.md
@@ -103,6 +103,31 @@ The event is auditable from a plain JSONL tail without a special reader.
 
 ---
 
+## Deterministic structural tiers
+
+`micro` and `time_based` issue no model call: each is a pure fold of the
+context text under the `COMPACTION` thresholds. Their results are therefore
+reproducible, and the tiers record which fold produced them:
+
+- `policy_version` on `TierResult` carries `COMPACTION_POLICY_VERSION`
+  (`tiers.py`) for these two tiers. It names the closed set of structural
+  rules that ran, so a stored result still says which policy produced it after
+  the rules change. Bump the constant whenever a change alters the bytes a
+  structural tier emits or the id it derives.
+- `correlation_id` is derived, not drawn. `derive_correlation_id(...)` hashes
+  `policy_version`, `session_id`, `turn_count`, the pre-compaction text and the
+  post-compaction text into the existing `compact-micro-<8 hex>` /
+  `compact-time-<8 hex>` shape. Two operators folding the same context under
+  the same policy record the same id; two compactions in one session stay
+  distinct because the turn count is part of the pre-image.
+
+`auto` and `session_memory` route through `CompactionPipeline` with an
+optional model call, so they cannot claim a reproducible fold. They keep their
+`uuid4`-based correlation ids and leave `policy_version` empty rather than
+recording a version they do not honour.
+
+---
+
 ## Verification
 
 A verification helper `verify_compacted_step(step)` (and

--- a/docs/release-notes/fragments/2915-deterministic-compaction-tiers.md
+++ b/docs/release-notes/fragments/2915-deterministic-compaction-tiers.md
@@ -1,0 +1,8 @@
+## Structural compaction tiers are now reproducible (Issue #2915)
+
+`micro.compact()` and `time_based.compact()` now derive their correlation ids
+from a SHA-256 hash of the fold content rather than ``uuid4()``. The same
+session, turn, and content always produce the same ``compact-<tier>-<8hex>``
+id, which means the ids are stable across runs and trace readers can correlate
+events without a database lookup. A ``policy_version`` field is also added to
+``TierResult`` so a recorded result always names the policy fold that produced it.

--- a/src/bernstein/core/memory/compaction/__init__.py
+++ b/src/bernstein/core/memory/compaction/__init__.py
@@ -16,12 +16,14 @@ from typing import TYPE_CHECKING
 
 from bernstein.core.memory.compaction.policy import compact, select_tier
 from bernstein.core.memory.compaction.tiers import (
+    COMPACTION_POLICY_VERSION,
     TIER_COST_WEIGHT,
     BudgetPressure,
     Tier,
     TierContext,
     TierResult,
     TierResultDict,
+    derive_correlation_id,
     estimate_tokens,
 )
 from bernstein.core.memory.compaction.verification import (
@@ -42,6 +44,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "ABSENT_HASH",
+    "COMPACTION_POLICY_VERSION",
     "TIER_COST_WEIGHT",
     "ArtifactDivergence",
     "BudgetPressure",
@@ -53,6 +56,7 @@ __all__ = [
     "compact",
     "compute_referenced_content_hashes",
     "compute_source_content_hash",
+    "derive_correlation_id",
     "estimate_tokens",
     "record_tier_event",
     "run_legacy_compaction",

--- a/src/bernstein/core/memory/compaction/micro.py
+++ b/src/bernstein/core/memory/compaction/micro.py
@@ -12,14 +12,15 @@ their headers are kept so the agent still knows the call happened.
 from __future__ import annotations
 
 import re
-import uuid
 from typing import TYPE_CHECKING
 
 from bernstein.core import defaults
 from bernstein.core.memory.compaction.tiers import (
+    COMPACTION_POLICY_VERSION,
     TIER_COST_WEIGHT,
     Tier,
     TierResult,
+    derive_correlation_id,
     estimate_tokens,
 )
 from bernstein.core.memory.compaction.verification import (
@@ -73,6 +74,11 @@ def _collapse_tool_bodies(text: str) -> str:
 def compact(ctx: TierContext) -> TierResult:
     """Run micro compaction over ``ctx.context_text``.
 
+    The prune is a pure function of ``ctx.context_text`` and the
+    ``COMPACTION`` thresholds, so the whole result -- correlation id included
+    -- is reproducible: it is derived from the folded bytes rather than drawn
+    from process-local entropy.
+
     Args:
         ctx: Inputs for the active session.
 
@@ -98,6 +104,13 @@ def compact(ctx: TierContext) -> TierResult:
         source_content_hash=source_hash,
         referenced_content_hashes=ref_hashes,
         cost_estimate=cost_estimate,
-        correlation_id=f"compact-micro-{uuid.uuid4().hex[:8]}",
+        correlation_id=derive_correlation_id(
+            "micro",
+            session_id=ctx.session_id,
+            turn_count=ctx.pressure.turn_count,
+            pre_text=ctx.context_text,
+            post_text=compacted,
+        ),
         reason="per-turn structural prune",
+        policy_version=COMPACTION_POLICY_VERSION,
     )

--- a/src/bernstein/core/memory/compaction/tiers.py
+++ b/src/bernstein/core/memory/compaction/tiers.py
@@ -22,6 +22,7 @@ Tier              Trigger                      Cost / recall
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass, field
 from enum import StrEnum
 from types import MappingProxyType
@@ -32,6 +33,14 @@ from bernstein.core import defaults
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
     from pathlib import Path
+
+
+#: Version of the structural compaction policy: the closed set of rules the
+#: LLM-free tiers apply (which regions are collapsed, by which thresholds, and
+#: how the correlation id is derived). Bump it whenever a change alters the
+#: bytes a structural tier produces or the id it derives, so a recorded result
+#: says which fold produced it and an old record still names its own version.
+COMPACTION_POLICY_VERSION: str = "1"
 
 
 class Tier(StrEnum):
@@ -96,6 +105,7 @@ class TierResultDict(TypedDict):
     reason: str
     source_content_hash: str
     referenced_content_hashes: dict[str, str]
+    policy_version: str
 
 
 @dataclass(frozen=True)
@@ -112,6 +122,9 @@ class TierResult:
         cost_estimate: Estimated USD cost attributed to this tier.
         correlation_id: Correlation id tying the event to the trace store.
         reason: Human-readable trigger reason.
+        policy_version: :data:`COMPACTION_POLICY_VERSION` when a deterministic
+            structural tier produced this result, empty when the tier routed
+            through a model call and so cannot claim a reproducible fold.
     """
 
     tier: Tier
@@ -123,6 +136,7 @@ class TierResult:
     cost_estimate: float = 0.0
     correlation_id: str = ""
     reason: str = ""
+    policy_version: str = ""
 
     @property
     def tokens_saved(self) -> int:
@@ -141,6 +155,7 @@ class TierResult:
             reason=self.reason,
             source_content_hash=self.source_content_hash,
             referenced_content_hashes=dict(self.referenced_content_hashes),
+            policy_version=self.policy_version,
         )
 
     @classmethod
@@ -158,7 +173,53 @@ class TierResult:
             cost_estimate=float(d.get("cost_estimate", 0.0)),
             correlation_id=str(d.get("correlation_id", "")),
             reason=str(d.get("reason", "")),
+            policy_version=str(d.get("policy_version", "")),
         )
+
+
+#: Number of hex characters kept from the derived digest. Matches the width the
+#: ``uuid4``-based ids used before the structural tiers became deterministic, so
+#: existing readers of ``compact-<tier>-<id>`` keep working unchanged.
+_CORRELATION_ID_HEX_WIDTH: int = 8
+
+#: Field separator for the correlation-id pre-image. NUL cannot occur in a
+#: session id or in the context text the tiers fold, so the encoding is
+#: unambiguous and two different field tuples cannot hash to the same id.
+_PREIMAGE_SEP: str = "\x00"
+
+
+def derive_correlation_id(
+    prefix: str,
+    *,
+    session_id: str,
+    turn_count: int,
+    pre_text: str,
+    post_text: str,
+    policy_version: str = COMPACTION_POLICY_VERSION,
+) -> str:
+    """Derive a reproducible correlation id for a structural compaction.
+
+    The id is a function of the policy version, the session, the turn, and the
+    exact bytes the fold consumed and produced -- nothing process-local. Two
+    operators folding the same context under the same policy therefore record
+    the same id, and two compactions within one session stay distinct because
+    the turn count is part of the pre-image.
+
+    Args:
+        prefix: Short tier label placed in the id, preserving the
+            ``compact-micro-`` / ``compact-time-`` shapes already recorded.
+        session_id: Agent session being compacted.
+        turn_count: 1-based turn number for the active session.
+        pre_text: Context text handed to the fold.
+        post_text: Context text the fold produced.
+        policy_version: Version of the structural policy that ran.
+
+    Returns:
+        A ``compact-<tier>-<8 hex>`` correlation id.
+    """
+    preimage = _PREIMAGE_SEP.join((policy_version, session_id, str(turn_count), pre_text, post_text))
+    digest = hashlib.sha256(preimage.encode("utf-8")).hexdigest()
+    return f"compact-{prefix}-{digest[:_CORRELATION_ID_HEX_WIDTH]}"
 
 
 def estimate_tokens(text: str) -> int:

--- a/src/bernstein/core/memory/compaction/time_based.py
+++ b/src/bernstein/core/memory/compaction/time_based.py
@@ -12,14 +12,15 @@ tagged with an age marker older than the cutoff are dropped.
 from __future__ import annotations
 
 import re
-import uuid
 from typing import TYPE_CHECKING
 
 from bernstein.core import defaults
 from bernstein.core.memory.compaction.tiers import (
+    COMPACTION_POLICY_VERSION,
     TIER_COST_WEIGHT,
     Tier,
     TierResult,
+    derive_correlation_id,
     estimate_tokens,
 )
 from bernstein.core.memory.compaction.verification import (
@@ -83,6 +84,11 @@ def compact(ctx: TierContext) -> TierResult:
     Args:
         ctx: Inputs for the active session.
 
+    The prune is a pure function of ``ctx.context_text`` and the
+    ``COMPACTION`` thresholds, so the whole result -- correlation id included
+    -- is reproducible: it is derived from the folded bytes rather than drawn
+    from process-local entropy.
+
     Returns:
         A :class:`TierResult` describing the age-based prune.
     """
@@ -105,6 +111,13 @@ def compact(ctx: TierContext) -> TierResult:
         source_content_hash=source_hash,
         referenced_content_hashes=ref_hashes,
         cost_estimate=cost_estimate,
-        correlation_id=f"compact-time-{uuid.uuid4().hex[:8]}",
+        correlation_id=derive_correlation_id(
+            "time",
+            session_id=ctx.session_id,
+            turn_count=ctx.pressure.turn_count,
+            pre_text=ctx.context_text,
+            post_text=compacted,
+        ),
         reason="time_based: idle cleanup",
+        policy_version=COMPACTION_POLICY_VERSION,
     )

--- a/tests/unit/memory/test_compaction_tiers.py
+++ b/tests/unit/memory/test_compaction_tiers.py
@@ -30,7 +30,11 @@ from bernstein.core.memory.compaction import auto as auto_tier
 from bernstein.core.memory.compaction import micro as micro_tier
 from bernstein.core.memory.compaction import session_memory as session_tier
 from bernstein.core.memory.compaction import time_based as time_tier
-from bernstein.core.memory.compaction.tiers import TIER_COST_WEIGHT, estimate_tokens
+from bernstein.core.memory.compaction.tiers import (
+    COMPACTION_POLICY_VERSION,
+    TIER_COST_WEIGHT,
+    estimate_tokens,
+)
 from bernstein.core.memory.compaction.verification import (
     compute_referenced_content_hashes,
     compute_source_content_hash,
@@ -579,3 +583,110 @@ class TestLegacyShim:
 )
 def test_estimate_tokens(text: str, expected_floor: int) -> None:
     assert estimate_tokens(text) == expected_floor
+
+
+# ---------------------------------------------------------------------------
+# Deterministic structural tiers (Issue #2915)
+# ---------------------------------------------------------------------------
+
+
+class TestStructuralTierDeterminism:
+    """The LLM-free tiers must be a pure, versioned fold of their input.
+
+    ``micro`` and ``time_based`` do no model call, so two runs over a
+    byte-identical ``TierContext`` have to produce a byte-identical
+    ``TierResult`` -- including the correlation id that ties the event to
+    the trace store. Anything derived from process-local entropy makes the
+    recorded compaction event unreproducible on replay.
+    """
+
+    @staticmethod
+    def _micro_ctx(session_id: str = "s", turn_count: int = 3) -> TierContext:
+        return TierContext(
+            session_id=session_id,
+            context_text=_tool_result_block("E" * 900),
+            pressure=BudgetPressure(turn_count=turn_count, context_pct_used=0.2),
+        )
+
+    @staticmethod
+    def _time_ctx(session_id: str = "s", turn_count: int = 3) -> TierContext:
+        text = "[age:9] stale block\nbody line\n[age:1] fresh block\nkept line\n"
+        return TierContext(
+            session_id=session_id,
+            context_text=text,
+            pressure=BudgetPressure(
+                turn_count=turn_count,
+                context_pct_used=0.2,
+                idle_seconds=400.0,
+            ),
+        )
+
+    def test_structural_tier_result_is_byte_identical_across_runs(self) -> None:
+        micro_ctx = self._micro_ctx()
+        assert micro_tier.compact(micro_ctx).to_dict() == micro_tier.compact(micro_ctx).to_dict()
+
+        time_ctx = self._time_ctx()
+        assert time_tier.compact(time_ctx).to_dict() == time_tier.compact(time_ctx).to_dict()
+
+    def test_structural_correlation_id_keeps_its_tier_prefix_shape(self) -> None:
+        micro_id = micro_tier.compact(self._micro_ctx()).correlation_id
+        time_id = time_tier.compact(self._time_ctx()).correlation_id
+        assert micro_id.startswith("compact-micro-")
+        assert time_id.startswith("compact-time-")
+        assert len(micro_id.removeprefix("compact-micro-")) == 8
+        assert len(time_id.removeprefix("compact-time-")) == 8
+
+    def test_structural_correlation_id_differs_across_turns_in_one_session(self) -> None:
+        first = micro_tier.compact(self._micro_ctx(turn_count=3)).correlation_id
+        second = micro_tier.compact(self._micro_ctx(turn_count=4)).correlation_id
+        assert first != second
+
+    def test_structural_correlation_id_differs_across_sessions(self) -> None:
+        first = micro_tier.compact(self._micro_ctx(session_id="s1")).correlation_id
+        second = micro_tier.compact(self._micro_ctx(session_id="s2")).correlation_id
+        assert first != second
+
+    def test_structural_correlation_id_tracks_the_compacted_content(self) -> None:
+        base = self._micro_ctx()
+        changed = TierContext(
+            session_id=base.session_id,
+            context_text=_tool_result_block("F" * 900),
+            pressure=base.pressure,
+        )
+        assert micro_tier.compact(base).correlation_id != micro_tier.compact(changed).correlation_id
+
+    def test_structural_tiers_record_the_compaction_policy_version(self) -> None:
+        micro_result = micro_tier.compact(self._micro_ctx())
+        time_result = time_tier.compact(self._time_ctx())
+        assert micro_result.policy_version == COMPACTION_POLICY_VERSION
+        assert time_result.policy_version == COMPACTION_POLICY_VERSION
+        assert micro_result.to_dict()["policy_version"] == COMPACTION_POLICY_VERSION
+
+    def test_llm_backed_tiers_keep_uuid_correlation_ids_and_no_policy_version(self) -> None:
+        # ``auto`` and ``session_memory`` route through CompactionPipeline with
+        # an optional model call, so they cannot claim a reproducible fold.
+        ctx = TierContext(
+            session_id="s",
+            context_text="\n".join(f"# section {i}\n" + "detail " * 40 for i in range(20)),
+            pressure=BudgetPressure(turn_count=3, context_pct_used=0.85),
+        )
+        first = auto_tier.compact(ctx)
+        second = auto_tier.compact(ctx)
+        assert first.correlation_id.startswith("compact-auto-")
+        assert first.correlation_id != second.correlation_id
+        assert first.policy_version == ""
+
+        session_result = session_tier.compact(ctx)
+        assert session_result.correlation_id.startswith("compact-session-")
+        assert session_result.policy_version == ""
+
+    def test_from_dict_defaults_policy_version_for_legacy_records(self) -> None:
+        restored = TierResult.from_dict(
+            {
+                "tier": "micro",
+                "before_tokens": 100,
+                "after_tokens": 50,
+                "correlation_id": "compact-micro-deadbeef",
+            }
+        )
+        assert restored.policy_version == ""


### PR DESCRIPTION
## What

Makes the two LLM-free compaction tiers a reproducible, versioned fold.

- Adds `COMPACTION_POLICY_VERSION` and a `policy_version: str` field on `TierResult` (`src/bernstein/core/memory/compaction/tiers.py`), carried through `to_dict()` / `from_dict()`.
- Adds `derive_correlation_id(prefix, *, session_id, turn_count, pre_text, post_text, policy_version)` in the same module.
- `micro.compact()` and `time_based.compact()` now derive their correlation id instead of drawing `uuid.uuid4()`, and record the policy version.
- Documents the property in `docs/architecture/memory_tiers.md`.

Explicitly not in this PR: the journal-prefix fold `(journal_prefix[0..N], policy) -> compacted_context`; `policy_version` on `CompactionReceipt.to_details()` and the back-compat default in `receipt_from_details`; the replay path that re-derives the compacted hash and reports a mismatch at the compaction boundary; the model-assisted digest as a separate lineage artefact.

## Why

`micro` and `time_based` issue no model call: `_collapse_tool_bodies` (`micro.py`) and `_prune_aged_blocks` (`time_based.py`) are pure functions of the input text plus the `COMPACTION` thresholds. Their `TierResult` was nevertheless not reproducible, because the correlation id came from `uuid.uuid4()`. Two runs over a byte-identical `TierContext` therefore produced different `TierResult.to_dict()` payloads, and `record_tier_event` wrote a different `compaction_correlation_id` into the trace each time.

That makes the recorded compaction event unreproducible on replay for the one part of the compaction surface that is already deterministic by construction, and it leaves a stored result unable to say which set of structural rules produced it — the thresholds are rebindable through `defaults.override`, so the bytes a tier emits can change with no marker in the record.

## How

`derive_correlation_id` hashes `policy_version`, `session_id`, `turn_count`, the pre-compaction text and the post-compaction text, NUL-separated, and keeps the leading 8 hex characters of the SHA-256 digest. That preserves the `compact-micro-<8 hex>` / `compact-time-<8 hex>` shapes already recorded in traces, so readers of the id are unaffected. `turn_count` is in the pre-image so two compactions in one session over the same text do not collide; the pre/post texts are in it so the id tracks the content the fold actually consumed and produced.

`policy_version` names the closed set of structural rules that ran. It is set only by the two structural tiers.

One decision the issue left open: what `policy_version` should hold for the tiers that are not a pure fold. `auto` and `session_memory` route through `CompactionPipeline` with an optional `llm_call`, so they cannot honour a version claim. They keep their `uuid4` ids and leave `policy_version` empty rather than recording a version they do not honour — an empty value reads as "this result is not a reproducible fold", which is exactly true, whereas stamping the version on them would make the field unusable as a determinism marker.

`from_dict` defaults `policy_version` to `""`, so records written before this change still load.

## Tests

All in `tests/unit/memory/test_compaction_tiers.py`, class `TestStructuralTierDeterminism`. Every test below fails on the unmodified tree — 1 and 6 on their assertions, the rest at import because `COMPACTION_POLICY_VERSION` does not exist.

1. `test_structural_tier_result_is_byte_identical_across_runs` — **load-bearing**. Calls `micro.compact(ctx)` twice with the same `TierContext` and asserts full `to_dict()` equality including `correlation_id`; same for `time_based.compact`. Before the change it failed with `{'correlation_id': 'compact-micro-6096194c'} != {'correlation_id': 'compact-micro-05c4f9c2'}`.
2. `test_structural_correlation_id_keeps_its_tier_prefix_shape` — the derived id keeps the recorded `compact-micro-` / `compact-time-` prefix and the 8-hex width.
3. `test_structural_correlation_id_differs_across_turns_in_one_session` — `turn_count` is in the pre-image, so two compactions in one session do not collide.
4. `test_structural_correlation_id_differs_across_sessions` — `session_id` is in the pre-image.
5. `test_structural_correlation_id_tracks_the_compacted_content` — the folded text is in the pre-image.
6. `test_structural_tiers_record_the_compaction_policy_version` — the version reaches both the result and `to_dict()`.
7. `test_llm_backed_tiers_keep_uuid_correlation_ids_and_no_policy_version` — scopes the change: `auto` still produces a fresh `compact-auto-*` id per call and both summary-backed tiers leave `policy_version` empty.
8. `test_from_dict_defaults_policy_version_for_legacy_records` — records without the field still load.

Tests 3-5 pass on the unmodified tree only because `uuid4` differs on every call; after the change they are the guards that the pre-image is not too narrow.

Verified locally: `run_tests.py --parallel 2 -x tests/unit/memory/test_compaction_tiers.py tests/unit/test_defaults.py tests/unit/memory/test_session_memory.py tests/unit/memory/test_memory_chain.py` — 135 passed. `--affected origin/main` selected 1533 files, well past the point where running it locally is useful, so I ran the tests of the touched package plus its only importers instead (`grep` for `memory.compaction` across `src/` and `tests/` reaches `defaults.py` and this one test file). CI runs the full suite.

## Checklist

- [x] `uv run ruff check src/` — clean.
- [x] `uv run ruff format --check src/` — clean.
- [x] `uv run pyright src/bernstein/core/memory/compaction/` — 8 errors, byte-identical to the same command on `origin/main` (verified by stashing); no new errors introduced.
- [x] `uv run python scripts/run_tests.py --parallel 2 -x <files above>` — green.
- [x] Type hints on all new and changed signatures.
- [x] Docs updated: `docs/architecture/memory_tiers.md` gains a "Deterministic structural tiers" section.
- [x] `uv run bernstein agents-md sync` — run; no changes produced.
- N/A README / translations — untouched.
- N/A schema regeneration — no serialised model changed shape beyond an additive, defaulted field.

Part of #2915

## Remaining

- The journal-prefix fold `(journal_prefix[0..N], policy) -> compacted_context` and its byte-identity across machines.
- `policy_version` in `CompactionReceipt.to_details()` (`src/bernstein/core/tokens/compaction_receipt.py`) plus the back-compat default in `receipt_from_details`, so old chain events still parse.
- Re-deriving `post_sha256` on replay and reporting a mismatch at the compaction boundary through the replay-debug locator.
- The optional model-assisted digest recorded as its own lineage artefact rather than as the state the run reasons over.
- `auto` and `session_memory` remain non-reproducible; making them a fold needs the journal-prefix work above, not a change to these two tiers.
