### PR TITLE
feat(audit): atomically-replaced newest-checkpoint pointer, and the verify that reads it (#3160)

### DIFF
--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -953,6 +953,7 @@ def _verify_checkpoints() -> bool:
         CheckpointFileError,
         authorize_divergence,
         check_extension,
+        check_pointer,
         find_divergence_acks,
         load_checkpoints,
     )
@@ -977,6 +978,16 @@ def _verify_checkpoints() -> bool:
         console.print(Panel("[bold red]Checkpoint Verification FAILED[/bold red]", border_style="red", expand=False))
         for err in exc.errors:
             console.print(f"  [red]![/red] {err}")
+        return False
+
+    # The ledger is append-only, so truncating it back over a pin leaves a
+    # shorter file that still validates and an older pin the history still
+    # extends. The atomically-replaced pointer names the checkpoint that was
+    # actually published, which is what makes that regression visible.
+    pointer_problem = check_pointer(AUDIT_DIR, state, key=key)
+    if pointer_problem is not None:
+        console.print(Panel("[bold red]Checkpoint Verification FAILED[/bold red]", border_style="red", expand=False))
+        console.print(f"  [red]![/red] {pointer_problem}")
         return False
 
     last = state.last

--- a/src/bernstein/core/persistence/chain_checkpoint.py
+++ b/src/bernstein/core/persistence/chain_checkpoint.py
@@ -40,6 +40,16 @@ fails validation. A crash-torn trailing fragment (an append that never
 completed) is skipped: the previous complete checkpoint stays authoritative,
 which can only make the pin *older*, never weaker than the last durable seal.
 
+Beside the ledger sits ``checkpoints/latest.json``, the newest-checkpoint
+pointer. It is the one object a reader that wants only the current pin has
+to open, and the one object in this directory that is *replaced* rather than
+appended to - temp file, fsync, ``os.replace``, directory fsync - so a reader
+opening it while a writer publishes sees the old record or the new one, never
+a partial file. It carries the same signed record shape as a ledger line and
+is treated as untrusted input: an unusable pointer degrades to a full ledger
+read, and a signature-valid pointer naming a checkpoint the ledger no longer
+holds is reported as a truncated ledger (:func:`check_pointer`).
+
 Determinism: checkpoint payloads carry no timestamps and are canonically
 serialised, so two byte-identical audit directories sealed with the same key
 produce byte-identical checkpoint files.
@@ -74,6 +84,12 @@ CHECKPOINTS_SUBDIR = "checkpoints"
 
 #: File name of the append-only checkpoint log.
 CHECKPOINTS_FILE = "checkpoints.jsonl"
+
+#: File name of the atomically-replaced pointer at the newest checkpoint.
+#: The ledger is append-only, so a reader that wants only the current pin
+#: would otherwise have to read and validate the whole file while a writer
+#: appends to it. This is the one object such a reader opens.
+LATEST_POINTER_FILE = "latest.json"
 
 #: ``prev_checkpoint_sha256`` of the first checkpoint in a file.
 GENESIS_PREV = "0" * 64
@@ -189,6 +205,118 @@ def _record_sha256(doc: dict[str, Any]) -> str:
 def checkpoints_path(audit_dir: Path) -> Path:
     """Return the append-only checkpoints file path for *audit_dir*."""
     return audit_dir / CHECKPOINTS_SUBDIR / CHECKPOINTS_FILE
+
+
+def latest_pointer_path(audit_dir: Path) -> Path:
+    """Return the atomically-replaced newest-checkpoint pointer for *audit_dir*."""
+    return audit_dir / CHECKPOINTS_SUBDIR / LATEST_POINTER_FILE
+
+
+# ---------------------------------------------------------------------------
+# Newest-checkpoint pointer
+# ---------------------------------------------------------------------------
+
+
+def write_latest_pointer(audit_dir: Path, payload: dict[str, Any], *, key: bytes) -> None:
+    """Publish *payload* as the newest-checkpoint pointer, atomically.
+
+    The pointer carries the same ``{"payload": ..., "hmac": ...}`` record
+    shape as a ledger line, so a reader authenticates it with the audit key
+    exactly as it authenticates the ledger. It is replaced, never appended
+    to: :func:`bernstein.core.persistence.atomic_write.write_atomic_bytes`
+    writes a sibling temp file, ``fsync``s it, ``os.replace``s it onto the
+    pointer and ``fsync``s the directory, so a reader opening the pointer
+    concurrently with a publish sees the old record or the new one and never
+    a partial file.
+
+    Publishing is part of recording a checkpoint, not a best-effort extra: a
+    directory that accepted the ledger append accepts this write, so a
+    failure here is a real filesystem problem and propagates.
+
+    Args:
+        audit_dir: The audit directory.
+        payload: The checkpoint payload now pinning the log.
+        key: Audit HMAC key.
+    """
+    from bernstein.core.persistence.atomic_write import write_atomic_bytes
+
+    doc = {"payload": payload, "hmac": _sign(payload, key)}
+    write_atomic_bytes(latest_pointer_path(audit_dir), _canonical(doc) + b"\n")
+
+
+def load_latest_checkpoint(audit_dir: Path, key: bytes) -> dict[str, Any] | None:
+    """Return the pointer's checkpoint payload, or ``None`` when unusable.
+
+    A pure read: no lock is taken and nothing is written, so it works against
+    a read-only copy of the audit directory while a writer appends to the
+    live one.
+
+    The pointer is untrusted input. A missing, unreadable, unparsable,
+    wrong-version or wrongly-signed pointer yields ``None`` and the caller
+    falls back to :func:`load_checkpoints`, which is why deleting the pointer
+    costs a full ledger read and never correctness.
+
+    Args:
+        audit_dir: The audit directory.
+        key: Audit HMAC key.
+
+    Returns:
+        The signature-valid checkpoint payload, or ``None``.
+    """
+    try:
+        raw = latest_pointer_path(audit_dir).read_bytes()
+    except OSError:
+        return None
+    try:
+        doc = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(doc, dict):
+        return None
+    payload = doc.get("payload")
+    if not isinstance(payload, dict):
+        return None
+    payload = cast("dict[str, Any]", payload)
+    if not _hmac.compare_digest(str(doc.get("hmac", "")), _sign(payload, key)):
+        return None
+    if payload.get("version") != CHECKPOINT_VERSION:
+        return None
+    return payload
+
+
+def check_pointer(audit_dir: Path, state: CheckpointFileState, *, key: bytes) -> str | None:
+    """Return the problem the pointer exposes in *state*, or ``None``.
+
+    The pointer is published only after its checkpoint is durably in the
+    ledger, so in a healthy directory the pointed-at payload is always one of
+    the ledger's checkpoints - usually the head, or an older one when a crash
+    landed between the append and the publish. A signature-valid pointer that
+    names a checkpoint the ledger no longer holds means the ledger was
+    truncated or rewritten back over a pin that was already published, which
+    is exactly the shrink the checkpoint substrate exists to make sticky.
+
+    An unusable pointer is never a verdict: it degrades to the ledger.
+
+    Args:
+        audit_dir: The audit directory.
+        state: The already-validated ledger content.
+        key: Audit HMAC key.
+
+    Returns:
+        A message naming the pointer file, or ``None`` when consistent.
+    """
+    pinned = load_latest_checkpoint(audit_dir, key)
+    if pinned is None:
+        return None
+    published = _canonical(pinned)
+    if any(_canonical(cp) == published for cp in state.checkpoints):
+        return None
+    root = str(pinned.get("root_hash", ""))[:16]
+    return (
+        f"{CHECKPOINTS_SUBDIR}/{LATEST_POINTER_FILE}: published checkpoint "
+        f"(root={root}..., entry_count={pinned.get('entry_count', '?')}) is absent from "
+        f"{CHECKPOINTS_FILE}; the checkpoint ledger was truncated or rewritten over a published pin"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -634,6 +762,10 @@ def _record_checkpoint_locked(
     if prev is not None:
         same = all(payload[k] == prev.get(k) for k in ("origin", "entry_count", "root_hash", "leaves"))
         if same:
+            # Nothing to append, but republish the pointer: a re-seal of an
+            # unchanged tree is how a deleted or stale pointer heals without
+            # minting a new pin.
+            write_latest_pointer(audit_dir, prev, key=key)
             return prev
         conflicts = check_extension(audit_dir, prev)
         divergence_ack: dict[str, Any] | None = None
@@ -663,6 +795,10 @@ def _record_checkpoint_locked(
         os.fsync(fd)
     finally:
         os.close(fd)
+    # Publish the pointer only after the ledger append is durable, so a crash
+    # between the two can only leave the pointer *behind* the ledger - a
+    # stale pin, never one the ledger has never held.
+    write_latest_pointer(audit_dir, payload, key=key)
     return payload
 
 
@@ -671,6 +807,7 @@ __all__ = [
     "CHECKPOINTS_FILE",
     "CHECKPOINTS_SUBDIR",
     "CHECKPOINT_VERSION",
+    "LATEST_POINTER_FILE",
     "CheckpointConflict",
     "CheckpointConsistencyError",
     "CheckpointFileError",
@@ -678,10 +815,14 @@ __all__ = [
     "authorize_divergence",
     "chain_snapshot",
     "check_extension",
+    "check_pointer",
     "checkpoints_path",
     "compute_origin",
     "count_entries",
     "find_divergence_acks",
+    "latest_pointer_path",
     "load_checkpoints",
+    "load_latest_checkpoint",
     "record_checkpoint",
+    "write_latest_pointer",
 ]

--- a/src/bernstein/core/persistence/chain_checkpoint.py
+++ b/src/bernstein/core/persistence/chain_checkpoint.py
@@ -273,11 +273,12 @@ def load_latest_checkpoint(audit_dir: Path, key: bytes) -> dict[str, Any] | None
         return None
     if not isinstance(doc, dict):
         return None
-    payload = doc.get("payload")
+    record = cast("dict[str, Any]", doc)
+    payload = record.get("payload")
     if not isinstance(payload, dict):
         return None
     payload = cast("dict[str, Any]", payload)
-    if not _hmac.compare_digest(str(doc.get("hmac", "")), _sign(payload, key)):
+    if not _hmac.compare_digest(str(record.get("hmac", "")), _sign(payload, key)):
         return None
     if payload.get("version") != CHECKPOINT_VERSION:
         return None

--- a/tests/unit/cli/test_audit_verify_checkpoint_pointer.py
+++ b/tests/unit/cli/test_audit_verify_checkpoint_pointer.py
@@ -1,0 +1,85 @@
+"""``bernstein audit verify`` consults the newest-checkpoint pointer.
+
+The checkpoints ledger is append-only, so truncating it back over a pin used
+to be invisible to the checkpoint pillar: the shorter file still validates,
+and the older pin it now ends on is still consistently extended by the
+history. The atomically-replaced pointer names the checkpoint that was
+actually published, so the verifier can tell the difference.
+"""
+
+from __future__ import annotations
+
+import stat
+from typing import TYPE_CHECKING
+
+import pytest
+from click.testing import CliRunner, Result
+
+from bernstein.cli.commands.audit_cmd import audit_group
+from bernstein.core.persistence.chain_checkpoint import checkpoints_path, latest_pointer_path
+from bernstein.core.security.audit import AUDIT_KEY_ENV, AuditLog, load_or_create_audit_key
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """An isolated project with its own chain and a pinned tmp HMAC key."""
+    key_path = tmp_path / "audit.key"
+    monkeypatch.setenv(AUDIT_KEY_ENV, str(key_path))
+    monkeypatch.chdir(tmp_path)
+    key = load_or_create_audit_key()
+    key_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    log = AuditLog(tmp_path / ".sdd" / "audit", key=key)
+    for i in range(3):
+        log.log("task.complete", "agent-1", "task", f"t-{i}", {"i": i})
+    return tmp_path
+
+
+def _run(*args: str) -> Result:
+    return CliRunner().invoke(audit_group, list(args))
+
+
+def _audit_dir(project: Path) -> Path:
+    return project / ".sdd" / "audit"
+
+
+def _seal(project: Path) -> Result:
+    return _run("seal")
+
+
+def _append(project: Path, marker: str) -> None:
+    key = load_or_create_audit_key()
+    AuditLog(_audit_dir(project), key=key).log("task.complete", "agent-1", "task", marker, {})
+
+
+def test_seal_publishes_the_pointer_for_the_verifier(project: Path) -> None:
+    """13. The command that records a pin also publishes the object readers open."""
+    assert _seal(project).exit_code == 0
+    assert latest_pointer_path(_audit_dir(project)).is_file()
+
+
+def test_verify_reports_a_checkpoint_ledger_truncated_over_a_published_pin(project: Path) -> None:
+    """14. Load-bearing: the verdict names the pointer file, and verify fails."""
+    assert _seal(project).exit_code == 0
+    _append(project, "later")
+    assert _seal(project).exit_code == 0
+
+    ledger = checkpoints_path(_audit_dir(project))
+    ledger.write_bytes(ledger.read_bytes().split(b"\n")[0] + b"\n")
+
+    result = _run("verify")
+    assert result.exit_code != 0
+    assert "latest.json" in result.output
+
+
+def test_verify_passes_on_an_untouched_checkpoint_layout(project: Path) -> None:
+    """15. Positive control: the pointer check adds no verdict of its own."""
+    assert _seal(project).exit_code == 0
+    _append(project, "later")
+    assert _seal(project).exit_code == 0
+
+    result = _run("verify")
+    assert result.exit_code == 0
+    assert "latest.json" not in result.output

--- a/tests/unit/test_chain_checkpoint_pointer.py
+++ b/tests/unit/test_chain_checkpoint_pointer.py
@@ -1,0 +1,259 @@
+"""The atomically-replaced checkpoint pointer readers consult.
+
+The checkpoints ledger (``checkpoints/checkpoints.jsonl``) is append-only on
+purpose: never rewriting it is what makes a crash-torn trailing append safe.
+That leaves a reader wanting only the newest pin with no single object to
+open - it must read and validate the whole ledger while a writer appends to
+it.
+
+The pointer (``checkpoints/latest.json``) is that single object: written once
+per recorded checkpoint via temp + fsync + rename, signature-validated on
+read, and never trusted beyond what its HMAC proves. These tests pin the
+properties an operator depends on, including the one the pointer exists to
+close: a ledger truncated back over a published pin no longer verifies clean.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.persistence.chain_checkpoint import (
+    check_pointer,
+    checkpoints_path,
+    latest_pointer_path,
+    load_checkpoints,
+    load_latest_checkpoint,
+    record_checkpoint,
+)
+from bernstein.core.persistence.merkle import compute_seal
+from bernstein.core.security.audit import AuditLog
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_KEY = b"checkpoint-pointer-test-key-0123456"
+
+
+def _seed(tmp_path: Path, count: int = 4) -> Path:
+    audit_dir = tmp_path / "audit"
+    log = AuditLog(audit_dir, key=_KEY)
+    for i in range(count):
+        log.log("test.event", "tester", "task", f"t-{i}", {"i": i})
+    return audit_dir
+
+
+def _append(audit_dir: Path, marker: str) -> None:
+    AuditLog(audit_dir, key=_KEY).log("test.event", "tester", "task", marker, {})
+
+
+def _seal_and_pin(audit_dir: Path) -> dict[str, Any]:
+    _tree, seal = compute_seal(audit_dir, key=_KEY)
+    return record_checkpoint(audit_dir, seal, key=_KEY)
+
+
+class TestPointerPublication:
+    def test_pointer_is_published_without_rewriting_the_append_only_ledger(self, tmp_path: Path) -> None:
+        """1. Recording a checkpoint publishes the pointer; the ledger only grows."""
+        audit_dir = _seed(tmp_path)
+        _seal_and_pin(audit_dir)
+
+        pointer = latest_pointer_path(audit_dir)
+        assert pointer.is_file()
+        ledger_after_first = checkpoints_path(audit_dir).read_bytes()
+
+        _append(audit_dir, "extra")
+        _seal_and_pin(audit_dir)
+
+        ledger_after_second = checkpoints_path(audit_dir).read_bytes()
+        assert ledger_after_second.startswith(ledger_after_first)
+        assert len(ledger_after_second) > len(ledger_after_first)
+
+    def test_pointer_replacement_leaves_no_temp_files_behind(self, tmp_path: Path) -> None:
+        """2. The publish is a rename, not an accumulation of scratch files."""
+        audit_dir = _seed(tmp_path)
+        _seal_and_pin(audit_dir)
+        _append(audit_dir, "extra")
+        _seal_and_pin(audit_dir)
+
+        leftovers = [p.name for p in latest_pointer_path(audit_dir).parent.iterdir() if ".tmp" in p.name]
+        assert leftovers == []
+
+    def test_pointer_payload_is_the_ledger_head(self, tmp_path: Path) -> None:
+        """3. The single mutable object a reader opens names the current pin."""
+        audit_dir = _seed(tmp_path)
+        _seal_and_pin(audit_dir)
+        _append(audit_dir, "extra")
+        second = _seal_and_pin(audit_dir)
+
+        assert load_latest_checkpoint(audit_dir, _KEY) == second
+        assert load_latest_checkpoint(audit_dir, _KEY) == load_checkpoints(audit_dir, _KEY).last
+
+
+class TestPointerIsUntrustedInput:
+    def test_tampered_pointer_is_not_trusted(self, tmp_path: Path) -> None:
+        """4. A pointer edited without the key is rejected, not believed."""
+        audit_dir = _seed(tmp_path)
+        _seal_and_pin(audit_dir)
+
+        pointer = latest_pointer_path(audit_dir)
+        doc = json.loads(pointer.read_text())
+        doc["payload"]["entry_count"] = 999_999
+        pointer.write_text(json.dumps(doc))
+
+        assert load_latest_checkpoint(audit_dir, _KEY) is None
+        # A forged pointer degrades to the ledger; it cannot manufacture a
+        # verification failure either.
+        assert check_pointer(audit_dir, load_checkpoints(audit_dir, _KEY), key=_KEY) is None
+
+    def test_unparsable_pointer_degrades_to_the_ledger(self, tmp_path: Path) -> None:
+        """5. Garbage in the pointer costs the fast path, never correctness."""
+        audit_dir = _seed(tmp_path)
+        pinned = _seal_and_pin(audit_dir)
+        latest_pointer_path(audit_dir).write_text("{not json")
+
+        assert load_latest_checkpoint(audit_dir, _KEY) is None
+        assert load_checkpoints(audit_dir, _KEY).last == pinned
+        assert check_pointer(audit_dir, load_checkpoints(audit_dir, _KEY), key=_KEY) is None
+
+    def test_deleting_the_pointer_costs_time_never_correctness(self, tmp_path: Path) -> None:
+        """6. The pointer is a cache of the ledger head and heals on re-seal."""
+        audit_dir = _seed(tmp_path)
+        pinned = _seal_and_pin(audit_dir)
+        latest_pointer_path(audit_dir).unlink()
+
+        assert load_latest_checkpoint(audit_dir, _KEY) is None
+        assert load_checkpoints(audit_dir, _KEY).last == pinned
+        assert check_pointer(audit_dir, load_checkpoints(audit_dir, _KEY), key=_KEY) is None
+
+        # Re-sealing an unchanged tree appends nothing but republishes the
+        # pointer, so a deleted pointer is recoverable without a new pin.
+        _seal_and_pin(audit_dir)
+        assert load_latest_checkpoint(audit_dir, _KEY) == pinned
+        assert len(load_checkpoints(audit_dir, _KEY).checkpoints) == 1
+
+
+class TestPointerCatchesLedgerTruncation:
+    def test_ledger_truncated_over_a_published_pin_is_reported(self, tmp_path: Path) -> None:
+        """7. Load-bearing: the pointer names the file when the ledger regresses."""
+        audit_dir = _seed(tmp_path)
+        _seal_and_pin(audit_dir)
+        _append(audit_dir, "extra")
+        _seal_and_pin(audit_dir)
+
+        ledger = checkpoints_path(audit_dir)
+        first_line = ledger.read_bytes().split(b"\n")[0] + b"\n"
+        ledger.write_bytes(first_line)
+
+        problem = check_pointer(audit_dir, load_checkpoints(audit_dir, _KEY), key=_KEY)
+        assert problem is not None
+        assert "latest.json" in problem
+
+    def test_intact_ledger_is_reported_clean(self, tmp_path: Path) -> None:
+        """8. Positive control: an unmodified layout produces no pointer verdict."""
+        audit_dir = _seed(tmp_path)
+        _seal_and_pin(audit_dir)
+        _append(audit_dir, "extra")
+        _seal_and_pin(audit_dir)
+
+        assert check_pointer(audit_dir, load_checkpoints(audit_dir, _KEY), key=_KEY) is None
+
+    def test_pointer_lagging_the_ledger_is_not_a_failure(self, tmp_path: Path) -> None:
+        """9. A crash between the append and the publish leaves a stale pointer."""
+        audit_dir = _seed(tmp_path)
+        first = _seal_and_pin(audit_dir)
+        pointer_bytes = latest_pointer_path(audit_dir).read_bytes()
+
+        _append(audit_dir, "extra")
+        _seal_and_pin(audit_dir)
+        # Rewind the pointer to the older published pin, which is what a crash
+        # between the ledger append and the pointer publish leaves behind.
+        latest_pointer_path(audit_dir).write_bytes(pointer_bytes)
+
+        assert load_latest_checkpoint(audit_dir, _KEY) == first
+        assert check_pointer(audit_dir, load_checkpoints(audit_dir, _KEY), key=_KEY) is None
+
+
+class TestPointerReadTakesNothing:
+    def test_pointer_reads_on_a_read_only_directory(self, tmp_path: Path) -> None:
+        """10. A verifier holding a read-only copy resolves the pin."""
+        audit_dir = _seed(tmp_path)
+        pinned = _seal_and_pin(audit_dir)
+
+        checkpoints_dir = latest_pointer_path(audit_dir).parent
+        original_mode = checkpoints_dir.stat().st_mode
+        os.chmod(checkpoints_dir, 0o500)
+        try:
+            assert load_latest_checkpoint(audit_dir, _KEY) == pinned
+            assert check_pointer(audit_dir, load_checkpoints(audit_dir, _KEY), key=_KEY) is None
+        finally:
+            os.chmod(checkpoints_dir, original_mode)
+
+    def test_pointer_reads_while_another_process_holds_the_append_lock(self, tmp_path: Path) -> None:
+        """11. The reader coordinates with no writer: no lock is taken."""
+        audit_dir = _seed(tmp_path)
+        pinned = _seal_and_pin(audit_dir)
+
+        script = (
+            "import sys, time\n"
+            "from pathlib import Path\n"
+            "from bernstein.core.security.audit import _chain_append_lock\n"
+            "with _chain_append_lock(Path(sys.argv[1])):\n"
+            "    print('held', flush=True)\n"
+            "    time.sleep(30)\n"
+        )
+        env = {**os.environ, "UV_NO_SYNC": "1"}
+        holder = subprocess.Popen(
+            [sys.executable, "-c", script, str(audit_dir)],
+            stdout=subprocess.PIPE,
+            text=True,
+            env=env,
+        )
+        try:
+            assert holder.stdout is not None
+            assert holder.stdout.readline().strip() == "held"
+            assert load_latest_checkpoint(audit_dir, _KEY) == pinned
+        finally:
+            holder.kill()
+            holder.wait(timeout=30)
+
+    def test_concurrent_republish_is_never_observed_partial(self, tmp_path: Path) -> None:
+        """12. Readers see the old pointer or the new one, never a torn file."""
+        audit_dir = _seed(tmp_path)
+        _seal_and_pin(audit_dir)
+        pointer = latest_pointer_path(audit_dir)
+
+        script = (
+            "import sys\n"
+            "from pathlib import Path\n"
+            "from bernstein.core.persistence.chain_checkpoint import (\n"
+            "    load_latest_checkpoint, write_latest_pointer,\n"
+            ")\n"
+            "audit_dir = Path(sys.argv[1])\n"
+            "key = bytes.fromhex(sys.argv[2])\n"
+            "base = load_latest_checkpoint(audit_dir, key)\n"
+            "assert base is not None\n"
+            "for i in range(400):\n"
+            "    payload = dict(base)\n"
+            "    payload['entry_count'] = base['entry_count'] + (i % 2)\n"
+            "    write_latest_pointer(audit_dir, payload, key=key)\n"
+        )
+        env = {**os.environ, "UV_NO_SYNC": "1"}
+        writer = subprocess.Popen(
+            [sys.executable, "-c", script, str(audit_dir), _KEY.hex()],
+            env=env,
+        )
+        try:
+            reads = 0
+            torn = 0
+            while writer.poll() is None and reads < 4000:
+                reads += 1
+                if load_latest_checkpoint(audit_dir, _KEY) is None and pointer.exists():
+                    torn += 1
+            assert torn == 0
+        finally:
+            writer.wait(timeout=60)
+        assert writer.returncode == 0


### PR DESCRIPTION
## What

Adds `.sdd/audit/checkpoints/latest.json` — the newest-checkpoint pointer — and gives it a reader.

The pointer is a signed copy of the checkpoint that currently pins the chain, published by `bernstein audit seal` via temp file + fsync + `os.replace` + directory fsync. It is the one object in the audit directory that is *replaced* rather than appended to, so a reader that wants only the current pin opens exactly one mutable file and sees the old record or the new one, never a partial file.

`bernstein audit verify` now cross-checks the append-only ledger against that pointer and fails, naming the file, when the ledger no longer holds the checkpoint that was published.

**This PR does not**: change the checkpoints ledger, which stays append-only and byte-identical in shape; move the checkpoint gate (`compute_seal` / `record_checkpoint`) off the ledger — the linkage chain needs the whole file and the writer keeps reading it; change tile generation or the incremental-verify path; add a CLI flag or any other new operator surface.

## Why

The checkpoints ledger is append-only on purpose: never rewriting it is what makes a crash-torn trailing append safe, since the pin can only regress to the last complete entry (`chain_checkpoint.py` module docstring). The cost is that a reader wanting only the newest pin has to read and validate the entire ledger, and it must do so while a writer is appending to that same file — the only coordination available today is "readers do not take the lock and accept the race".

That has a sharper consequence than cost. Truncating the ledger back over a pin was invisible to `bernstein audit verify`: the shorter file still validates line by line, and the older pin it now ends on is still consistently extended by the history, so the composite verify passed. The checkpoint substrate exists to make an audit-history shrink sticky, and the ledger's own append-only discipline is what an actor removes to un-stick it. A separately published, signature-bearing record of the pin is what makes that removal visible: it cannot be forged without the audit key, and the ledger cannot silently disagree with it.

## How

In `src/bernstein/core/persistence/chain_checkpoint.py`:

- `write_latest_pointer(audit_dir, payload, *, key)` writes `{"payload": ..., "hmac": ...}` — the same signed record shape as a ledger line — through the project's existing `write_atomic_bytes` (`atomic_write.py`), which already handles temp + fsync + `os.replace` + directory fsync including the Windows directory-fsync gap. Nothing is hand-rolled.
- `record_checkpoint` publishes the pointer *after* the ledger append is durable, so a crash between the two can only leave the pointer behind the ledger — a stale pin, never one the ledger has never held. The idempotent path (an unchanged tree) republishes without appending, which is how a deleted pointer heals.
- `load_latest_checkpoint(audit_dir, key)` is a pure read: no lock, no write, works against a read-only copy. The pointer is untrusted input — missing, unreadable, unparsable, wrong-version or wrongly-signed all yield `None` and the caller falls back to the full ledger read.
- `check_pointer(audit_dir, state, *, key)` returns the problem or `None`. A signature-valid pointer whose payload is not among the ledger's checkpoints means the ledger was truncated or rewritten over a published pin.

In `src/bernstein/cli/commands/audit_cmd.py`, `_verify_checkpoints` runs `check_pointer` immediately after loading the ledger — before the "no checkpoint recorded yet" branch, so a ledger truncated to empty is caught too.

Two decisions this PR makes, since the issue left the reader/writer split open:

1. **The pointer is a cross-check, not a replacement.** The writer's gate keeps reading the whole ledger, because the `prev_checkpoint_sha256` linkage is only meaningful over the full file. Making the pointer authoritative for the writer would trade the linkage chain for a single file, which is strictly weaker. As a cross-check it is strictly stronger than the status quo: it closes a shrink the ledger alone cannot see, and it can never weaken a verdict, because an unusable pointer degrades to the ledger.
2. **A pointer that lags the ledger is not a failure.** That is the exact state a crash between the append and the publish leaves, and refusing on it would turn an ordinary crash into an operator escalation. Only pointer-ahead-of-ledger — a published pin the ledger no longer holds — is reported.

## Tests

`tests/unit/test_chain_checkpoint_pointer.py` (12) and `tests/unit/cli/test_audit_verify_checkpoint_pointer.py` (3). Every one of them failed on the unmodified tree: the library file failed at collection (the four functions did not exist), and the CLI file's truncation test failed with `assert 0 != 0` — `verify` exited 0 on a ledger cut back over a published pin, which is the defect.

1. `test_pointer_is_published_without_rewriting_the_append_only_ledger` — recording a checkpoint publishes the pointer, and the ledger after the second checkpoint still starts with the exact bytes it had after the first.
2. `test_pointer_replacement_leaves_no_temp_files_behind` — the publish is a rename, not an accumulation of scratch files.
3. `test_pointer_payload_is_the_ledger_head` — the single mutable object a reader opens names the current pin.
4. `test_tampered_pointer_is_not_trusted` — a pointer edited without the key is rejected, and cannot manufacture a failure either.
5. `test_unparsable_pointer_degrades_to_the_ledger` — garbage costs the fast path, never correctness.
6. `test_deleting_the_pointer_costs_time_never_correctness` — after deletion the ledger head is unchanged, and re-sealing an unchanged tree republishes the pointer while appending nothing.
7. `test_ledger_truncated_over_a_published_pin_is_reported` — **load-bearing**: two pins, ledger cut to the first line, the verdict names `latest.json`.
8. `test_intact_ledger_is_reported_clean` — positive control, so an unconditional failure cannot satisfy 7.
9. `test_pointer_lagging_the_ledger_is_not_a_failure` — the crash-between-append-and-publish state is accepted.
10. `test_pointer_reads_on_a_read_only_directory` — `chmod 0o500` on the checkpoints directory; the pin still resolves and the cross-check still runs.
11. `test_pointer_reads_while_another_process_holds_the_append_lock` — a real subprocess holds the chain append lock for the duration; the reader returns the pin without blocking, proving it takes no lock.
12. `test_concurrent_republish_is_never_observed_partial` — a real subprocess republishes the pointer 400 times while the parent reads it in a loop; zero reads observe a file that exists but does not authenticate.
13. `test_seal_publishes_the_pointer_for_the_verifier` — the command that records a pin also publishes the object readers open.
14. `test_verify_reports_a_checkpoint_ledger_truncated_over_a_published_pin` — the CLI half of 7: non-zero exit, `latest.json` in the output.
15. `test_verify_passes_on_an_untouched_checkpoint_layout` — positive control for 14.

Also re-ran, all green, as regression coverage on the substrate this extends: `test_chain_checkpoint.py`, `test_merkle.py`, `test_merkle_second_preimage.py`, `test_merkle_post_seal_appends.py`, `test_merkle_seal_properties.py`, `test_atomic_write.py`, `test_tiles.py`, `test_audit_tile_verification.py`, `test_audit_verify_is_read_only.py` (the verifier must not write — the pointer check is a pure read), `test_audit_verify_active.py`, `test_audit_verify_cards.py`, `test_audit_verify_gates_cmd.py`, `test_audit_verify_grants.py`, `test_audit_cmd_paths.py`, `test_audit_archive_cmd.py`, `test_audit_taint_cmd.py`, `test_audit_verify_summary_panel.py`, `test_verification_exit_codes.py`, `test_audit_tear_detection.py`, `test_audit_slice.py`.

`--affected origin/main` selected more than this machine could finish in the time budget, so the set above is the tests of the two modules touched plus the tests of their importers; CI runs the full suite.

`uv run pyright` on each touched file reports the same error count as the same file on `origin/main` (12 for `chain_checkpoint.py`, 114 for `audit_cmd.py`) — this change adds none.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` — run per touched file; both match their `origin/main` baselines exactly
- [x] `uv run python scripts/run_tests.py -x` passes for the files listed above
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [ ] User-visible README section updated — N/A (no user-facing surface added; `audit verify` gains a verdict, not a flag)
- [ ] `docs/operations/<area>.md` updated — N/A (the storage discipline is documented in the `chain_checkpoint.py` module docstring, where the ledger's append-only rationale already lives)
- [ ] `docs/api/` schema regenerated — N/A (no API schema change)
- [x] `uv run bernstein agents-md sync` run — produced no changes (no new module)
- [x] Tests cover the documented behaviour

Part of #3160

## Remaining

The three sub-issues of #3160 (#3829 tile generation, #3830 static read path, #3831 incremental verify) are merged, and this PR adds the piece of #3830's acceptance criteria that its closing PR did not carry: the atomically-replaced checkpoint object. Still open against the parent's own criteria:

- **Full-history verify on a read-only filesystem.** The pointer half is done and tested here. The remaining half is the segment and tile half: `_verify_hmac_chain`, `_verify_merkle_tree` and the tile trust path in `src/bernstein/core/security/audit.py` still read the live `*.jsonl` segments, and the incremental-verify counter writes `.tiles-read.json` into the audit directory, so a genuinely read-only mount is not yet exercised end to end.
- **A flipped byte in any tile is reported naming the file.** Segment byte-flips are covered today; tile byte-flips fall through to a segment read rather than being reported as a tile fault.
- **The writer never rewrites a published tile.** `generate_tiles` in `src/bernstein/core/persistence/tiles.py` deliberately replaces a tile when the sealed prefix length changed between seals. That is a documented trade against failing the second seal of a run, but it is not the parent's criterion, and reconciling the two is its own slice.
