### PR TITLE
feat(cost): record budget cap halts in the audit chain (#2918)

### DIFF
--- a/docs/cost/budget-halt-receipts.md
+++ b/docs/cost/budget-halt-receipts.md
@@ -1,0 +1,74 @@
+# Budget halt receipts
+
+When a run's spend ledger crosses its soft or hard cap, the halt is
+recorded in the tamper-evident audit chain as a `cost.budget_halt` event,
+not only as a warning on stderr. "This run stopped because of its budget"
+is then answerable from the chain alone, after the process is gone and
+after the logs have rotated.
+
+## What is recorded
+
+`SpendLedger` marks each cap transition exactly once. On the first soft
+halt and on the first hard halt it appends one event:
+
+| Field | Meaning |
+|---|---|
+| `run_id` | Run whose ledger tripped the cap |
+| `band` | `soft` or `hard` - the closed set of caps that can halt a run |
+| `spent_nano_usd` | Cumulative spend at the halt, integer nano-USD |
+| `cap_nano_usd` | The cap that was crossed, integer nano-USD |
+| `ledger_entries_written` | Rows this ledger instance had appended when the cap tripped |
+| `prev_chain_digest` | Chain head at write time, embedded before the HMAC is computed |
+
+Amounts are integer nano-USD via
+[`nano_usd_from_float`](showback-canonical.md) - the same fixed-scale
+money policy showback statements use. No float reaches the recorded
+payload, so two readers summing the same events get the same digits.
+
+`ledger_entries_written` locates the boundary row: the halt fired on the
+row at that index in `.sdd/cost/ledger.jsonl`, so an operator can point at
+the exact call that crossed the line.
+
+## Attaching a chain
+
+The chain is optional. A ledger constructed without one behaves exactly
+as it did before - the caps still trip, the warnings still print, and no
+audit directory is created:
+
+```python
+from bernstein.core.cost.spend_ledger import SpendLedger
+from bernstein.core.security.audit_chain import AuditChainStore
+
+ledger = SpendLedger(
+    path=project / ".sdd" / "cost" / "ledger.jsonl",
+    run_id=run_id,
+    hard_budget_usd=25.0,
+    chain=AuditChainStore(project / ".sdd" / "audit"),
+)
+```
+
+Appending the receipt is best-effort in the same sense as the JSONL write:
+a chain that refuses the append is logged as a warning and never takes the
+orchestrator down. The ledger is not a gate.
+
+## Reading the halts back
+
+```python
+from bernstein.core.security.audit_chain import EVENT_BUDGET_HALT
+
+ok, errors = chain.verify()
+halts = chain.query(event_type=EVENT_BUDGET_HALT, resource_id=run_id)
+```
+
+Verify first, then project: an edit to a recorded cap, band, or spend
+figure breaks the HMAC of its entry and every entry after it, so
+`verify()` returns `False` rather than handing back an amount somebody
+adjusted afterwards.
+
+## Naming
+
+"Envelope" already means a named budget *bucket tag* in this subsystem
+(`CallTags.quota_envelope`, `cost_rollup_by_envelope`,
+[cost envelopes](../operations/cost-envelopes.md)). A halt receipt is a
+different thing: the record of one cap transition on one run, not a
+spending bucket.

--- a/docs/release-notes/fragments/2918-budget-halt.md
+++ b/docs/release-notes/fragments/2918-budget-halt.md
@@ -1,0 +1,21 @@
+## Budget Halt Emission to Audit Chain (Issue #2918)
+
+Bernstein now emits a `cost.budget_halt` event to the audit chain the first time a run's spend ledger crosses its soft or hard budget cap. Previously this information survived only as a ``logger.warning`` line in ``stderr``, so "this run stopped because of its budget" was not reconstructable from the tamper-evident chain.
+
+Key capabilities:
+
+- **Chain-anchored budget halts**: The first soft cap and first hard cap transition each append a ``cost.budget_halt`` event to the audit chain, with the band (`"soft"` or `"hard"`), spend and cap as integer nano-USD, and the previous chain digest. Operators can query ``chain.query(event_type=EVENT_BUDGET_HALT, resource_id=run_id)`` to reconstruct whether a run stopped due to budget.
+
+- **Exactly-once emission**: The ``_halt_lock`` in ``SpendLedger`` ensures that two racing writers do not both produce a halt receipt for the same cap transition — the event is appended at most once per cap type per run.
+
+- **Integer nano-USD payload**: Money is recorded as exact integers of nano-USD via ``nano_usd_from_float``, so the signed payload is independent of floating-point aggregation order and can be verified byte-identically across recomputations.
+
+- **Best-effort append**: If the chain append fails, the error is logged but the ledger continues functioning without the event — the ledger is not allowed to take the orchestrator down.
+
+- **Unattached ledgers unchanged**: When no audit chain is attached, the ledger behaves exactly as it did before: soft/halt flags are set on the status but no chain events are emitted.
+
+- **Distinct bands**: The soft cap halt uses band `"soft"` and the hard cap halt uses band `"hard"`, allowing operators to distinguish which threshold was tripped.
+
+- **Audit verification**: Each ``cost.budget_halt`` event includes ``prev_chain_digest`` so the full chain can be verified end-to-end. Editing a recorded cap after the fact causes chain verification to fail, making the halt tamper-evident.
+
+- **Exported constant**: ``EVENT_BUDGET_HALT = "cost.budget_halt"`` is added to ``__all__`` in ``audit_chain.py`` for external query use.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -375,6 +375,7 @@ nav:
           - Token growth monitor: operations/token-growth-monitor.md
           - Payment mandates: operations/payment-mandates.md
           - Showback canonicalization: cost/showback-canonical.md
+          - Budget halt receipts: cost/budget-halt-receipts.md
       - Observability:
           - Overview: operations/observability-overview.md
           - Instrumentation: operations/INSTRUMENTATION.md

--- a/src/bernstein/core/cost/spend_ledger.py
+++ b/src/bernstein/core/cost/spend_ledger.py
@@ -34,7 +34,10 @@ from collections import defaultdict
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path  # noqa: TC003 - runtime use in dataclass field default
-from typing import Any
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from bernstein.core.security.audit_chain import AuditChainStore
 
 logger = logging.getLogger(__name__)
 
@@ -200,6 +203,11 @@ class SpendLedger:
     run_id: str = "default"
     budget_usd: float = 0.0
     hard_budget_usd: float = 0.0
+    #: Optional audit chain. When attached, the first soft and the first
+    #: hard cap transition each append a ``cost.budget_halt`` event, so a
+    #: budget halt is reconstructable from the chain rather than only from
+    #: stderr. Unattached ledgers behave exactly as they did before.
+    chain: AuditChainStore | None = None
 
     # Internal state
     _spent_usd: float = field(default=0.0, init=False, repr=False)
@@ -213,6 +221,9 @@ class SpendLedger:
     _soft_warned: bool = field(default=False, init=False, repr=False)
     _soft_halted_at: float | None = field(default=None, init=False, repr=False)
     _hard_halted_at: float | None = field(default=None, init=False, repr=False)
+    # Separate from ``_lock`` so emitting a transition (logging, and the
+    # chain append) never blocks a concurrent ``record``'s totals update.
+    _halt_lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
 
     def __post_init__(self) -> None:
         # Normalise non-positive caps to 0 so "no cap" semantics are
@@ -373,26 +384,42 @@ class SpendLedger:
             logger.warning("SpendLedger: failed to append entry: %s", exc)
 
     def _emit_threshold_events(self, status: LedgerStatus) -> None:
-        """Log + stamp soft/hard threshold transitions exactly once each."""
+        """Log + stamp soft/hard threshold transitions exactly once each.
+
+        The stamps are claimed under ``_halt_lock`` so two threads that
+        cross the same cap in the same instant do not both report the
+        transition - the halt receipt appended below must be one event,
+        not one per racing writer.
+        """
         now = time.time()
-        if status.hard_halt and self._hard_halted_at is None:
-            self._hard_halted_at = now
+        with self._halt_lock:
+            first_hard = status.hard_halt and self._hard_halted_at is None
+            if first_hard:
+                self._hard_halted_at = now
+            first_soft = status.soft_halt and self._soft_halted_at is None
+            if first_soft:
+                self._soft_halted_at = now
+            first_warn = not first_soft and status.soft_warn and not self._soft_warned
+            if first_warn:
+                self._soft_warned = True
+
+        if first_hard:
             logger.warning(
                 "SpendLedger HARD CAP HIT: spent=$%.4f hard_cap=$%.4f run_id=%s",
                 status.spent_usd,
                 status.hard_budget_usd,
                 self.run_id,
             )
-        if status.soft_halt and self._soft_halted_at is None:
-            self._soft_halted_at = now
+            self._record_halt_receipt("hard", status.spent_usd, status.hard_budget_usd)
+        if first_soft:
             logger.warning(
                 "SpendLedger SOFT CAP HIT (100%%): spent=$%.4f budget=$%.4f run_id=%s",
                 status.spent_usd,
                 status.budget_usd,
                 self.run_id,
             )
-        elif status.soft_warn and not self._soft_warned:
-            self._soft_warned = True
+            self._record_halt_receipt("soft", status.spent_usd, status.budget_usd)
+        elif first_warn:
             logger.warning(
                 "SpendLedger SOFT CAP WARN (>=80%%): spent=$%.4f budget=$%.4f run_id=%s - "
                 "calls will be rerouted to cheaper models",
@@ -400,6 +427,35 @@ class SpendLedger:
                 status.budget_usd,
                 self.run_id,
             )
+
+    def _record_halt_receipt(self, band: Literal["soft", "hard"], spent_usd: float, cap_usd: float) -> None:
+        """Append the ``cost.budget_halt`` event for one cap transition.
+
+        Money crosses into the chain as integer nano-USD: the signed
+        payload must carry no float, and the sum of exact integers is
+        independent of aggregation order.
+
+        The append is best-effort in the same sense as the JSONL write -
+        the ledger is not allowed to take the orchestrator down - but the
+        failure is logged, never swallowed silently.
+        """
+        chain = self.chain
+        if chain is None:
+            return
+        from bernstein.core.cost.showback_canonical import nano_usd_from_float
+        from bernstein.core.security.audit_chain import record_budget_halt
+
+        try:
+            record_budget_halt(
+                chain=chain,
+                run_id=self.run_id,
+                band=band,
+                spent_nano_usd=nano_usd_from_float(spent_usd),
+                cap_nano_usd=nano_usd_from_float(cap_usd),
+                ledger_entries_written=self._entries_written,
+            )
+        except Exception as exc:  # intentional-broad-except: the halt receipt must never block the ledger
+            logger.warning("SpendLedger: failed to append %s cap halt receipt: %s", band, type(exc).__name__)
 
     # ------------------------------------------------------------------ load
 

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -29,7 +29,7 @@ import contextlib
 import hashlib
 import threading
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Mapping, Sequence
@@ -83,6 +83,14 @@ EVENT_COMPACTION_RECEIPT = "compaction.receipt"
 #: holding the ledger can recompute the report byte-identically and
 #: check it against the chain.
 EVENT_COST_PROFILE_REPORT = "cost.profile_report"
+
+#: Issue #2918 -- emitted the first time a run's spend ledger crosses its
+#: soft or hard budget cap. Until this event existed the halt survived
+#: only as a ``logger.warning`` line, so "this run stopped because of its
+#: budget" was not reconstructable from the tamper-evident chain. The
+#: event records the band that tripped, the spend and the cap as integer
+#: nano-USD, and the previous chain digest.
+EVENT_BUDGET_HALT = "cost.budget_halt"
 
 #: Issue #2247 -- emitted whenever ``bernstein eval ab`` writes a
 #: content-addressed profile comparison artifact. The event records the
@@ -1524,6 +1532,74 @@ def record_cost_profile_report(
         actor=actor,
         resource_type="cost_profile_report",
         resource_id=report_sha256,
+        details=payload,
+    )
+
+
+@dataclass(frozen=True)
+class BudgetHaltDetails:
+    """Structured payload for the ``cost.budget_halt`` event."""
+
+    run_id: str
+    band: Literal["soft", "hard"]
+    spent_nano_usd: int
+    cap_nano_usd: int
+    ledger_entries_written: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "band": self.band,
+            "spent_nano_usd": self.spent_nano_usd,
+            "cap_nano_usd": self.cap_nano_usd,
+            "ledger_entries_written": self.ledger_entries_written,
+        }
+
+
+def record_budget_halt(
+    *,
+    chain: AuditChainStore,
+    run_id: str,
+    band: Literal["soft", "hard"],
+    spent_nano_usd: int,
+    cap_nano_usd: int,
+    ledger_entries_written: int,
+    actor: str = "cost",
+) -> AuditEvent:
+    """Append a ``cost.budget_halt`` event into *chain*.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        run_id: Run whose ledger tripped the cap.
+        band: Which cap tripped -- ``"soft"`` or ``"hard"``. The two
+            bands are the closed vocabulary of this event; a reader
+            never has to interpret free text to know what stopped.
+        spent_nano_usd: Cumulative spend at the halt, in integer
+            nano-USD (never a float -- see
+            :func:`bernstein.core.cost.showback_canonical.nano_usd_from_float`).
+        cap_nano_usd: The cap that was crossed, in integer nano-USD.
+        ledger_entries_written: Rows the halting ledger instance had
+            appended when the cap tripped, so an operator can locate the
+            boundary row in ``.sdd/cost/ledger.jsonl``.
+        actor: Recorded actor; defaults to ``"cost"``.
+
+    Returns:
+        The recorded :class:`AuditEvent`. The event details payload
+        carries every input plus ``prev_chain_digest`` (set to the
+        chain head at write time).
+    """
+    payload = BudgetHaltDetails(
+        run_id=run_id,
+        band=band,
+        spent_nano_usd=spent_nano_usd,
+        cap_nano_usd=cap_nano_usd,
+        ledger_entries_written=ledger_entries_written,
+    ).to_dict()
+    return chain.log_with_prev_digest(
+        event_type=EVENT_BUDGET_HALT,
+        actor=actor,
+        resource_type="budget_halt",
+        resource_id=run_id,
         details=payload,
     )
 
@@ -9118,6 +9194,7 @@ __all__ = [
     "EVENT_APPROVAL_CARD_RESOLVED",
     "EVENT_AUDIT_RECEIPT_EXPORT",
     "EVENT_AUTOMATION_ACTION",
+    "EVENT_BUDGET_HALT",
     "EVENT_CACHE_DEDUP_CLAIM",
     "EVENT_CACHE_EVICTION",
     "EVENT_CACHE_HIT",
@@ -9246,6 +9323,7 @@ __all__ = [
     "GATE_TERMINAL_RESOLUTIONS",
     "UNRELEASED_CLAIM_PATHS",
     "AuditChainStore",
+    "BudgetHaltDetails",
     "CapabilityAuthorizationDetails",
     "CapabilityDeltaDetails",
     "ClearanceResolutionRefusal",
@@ -9271,6 +9349,7 @@ __all__ = [
     "record_adapter_version_posture_receipt",
     "record_audit_receipt_export",
     "record_automation_action",
+    "record_budget_halt",
     "record_cache_dedup_claim",
     "record_cache_eviction",
     "record_cache_hit",

--- a/tests/unit/cost/test_budget_halt_receipt.py
+++ b/tests/unit/cost/test_budget_halt_receipt.py
@@ -1,0 +1,165 @@
+"""A budget halt is reconstructable from the audit chain alone (issue #2918).
+
+``SpendLedger`` already marks each soft / hard cap transition exactly once
+and then only calls ``logger.warning``, so "this run stopped because of its
+budget" survived in stderr and nowhere else. These tests pin the property
+the chain entry is there to provide:
+
+1. A halt driven by the hard cap lands in the chain, exactly once.
+2. A second ``record()`` past the cap adds no second entry.
+3. The soft cap halt is a distinct, closed band on the same event.
+4. Amounts in the signed payload are integer nano-USD, never floats.
+5. Editing the recorded cap afterwards fails chain verification.
+6. With no chain attached the ledger behaves exactly as it does today.
+7. Threads racing past the cap still produce exactly one entry.
+8. A chain that refuses the append never breaks the ledger.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from typing import Any
+
+from bernstein.core.cost.showback_canonical import nano_usd_from_float
+from bernstein.core.cost.spend_ledger import CallTags, SpendLedger
+from bernstein.core.security.audit_chain import EVENT_BUDGET_HALT, AuditChainStore
+
+_KEY = b"k" * 32
+
+
+def _chain(tmp_path: Path) -> AuditChainStore:
+    return AuditChainStore(tmp_path / "audit", key=_KEY)
+
+
+def _halt_events(chain: AuditChainStore) -> list[Any]:
+    return chain.query(event_type=EVENT_BUDGET_HALT)
+
+
+class TestBudgetHaltIsInTheChain:
+    def test_hard_cap_halt_is_recorded_in_the_chain_not_only_stderr(self, tmp_path: Path) -> None:
+        chain = _chain(tmp_path)
+        led = SpendLedger(path=tmp_path / "ledger.jsonl", run_id="r-1", hard_budget_usd=2.0, chain=chain)
+
+        led.record(tags=CallTags(task_id="t-1"), model="opus", cost_usd=2.5)
+
+        events = _halt_events(chain)
+        assert len(events) == 1
+        details = events[0].details
+        assert details["run_id"] == "r-1"
+        assert details["band"] == "hard"
+        assert details["prev_chain_digest"] is not None
+        ok, errors = chain.verify()
+        assert ok, errors
+
+    def test_second_record_past_the_cap_adds_no_second_halt_event(self, tmp_path: Path) -> None:
+        chain = _chain(tmp_path)
+        led = SpendLedger(path=tmp_path / "ledger.jsonl", hard_budget_usd=2.0, chain=chain)
+
+        led.record(tags=CallTags(), model="opus", cost_usd=2.5)
+        led.record(tags=CallTags(), model="opus", cost_usd=1.0)
+
+        assert len(_halt_events(chain)) == 1
+
+    def test_soft_cap_halt_is_recorded_with_its_own_band(self, tmp_path: Path) -> None:
+        chain = _chain(tmp_path)
+        led = SpendLedger(path=tmp_path / "ledger.jsonl", budget_usd=5.0, chain=chain)
+
+        led.record(tags=CallTags(), model="sonnet", cost_usd=5.0)
+
+        events = _halt_events(chain)
+        assert len(events) == 1
+        assert events[0].details["band"] == "soft"
+        assert events[0].details["cap_nano_usd"] == nano_usd_from_float(5.0)
+
+    def test_halt_amounts_are_integer_nano_usd_not_floats(self, tmp_path: Path) -> None:
+        chain = _chain(tmp_path)
+        led = SpendLedger(path=tmp_path / "ledger.jsonl", hard_budget_usd=0.25, chain=chain)
+
+        led.record(tags=CallTags(), model="opus", cost_usd=0.30)
+
+        details = _halt_events(chain)[0].details
+        assert isinstance(details["spent_nano_usd"], int)
+        assert not isinstance(details["spent_nano_usd"], bool)
+        assert isinstance(details["cap_nano_usd"], int)
+        assert details["spent_nano_usd"] == nano_usd_from_float(0.30)
+        assert details["cap_nano_usd"] == nano_usd_from_float(0.25)
+
+
+class TestBudgetHaltCannotBeEditedAfterwards:
+    def test_edited_halt_cap_fails_chain_verification(self, tmp_path: Path) -> None:
+        """Load-bearing: the recorded cap is only worth something if a later
+        edit of it is detectable."""
+        audit_dir = tmp_path / "audit"
+        chain = AuditChainStore(audit_dir, key=_KEY)
+        led = SpendLedger(path=tmp_path / "ledger.jsonl", hard_budget_usd=2.0, chain=chain)
+        led.record(tags=CallTags(), model="opus", cost_usd=2.5)
+        assert AuditChainStore(audit_dir, key=_KEY).verify()[0] is True
+
+        log_file = next(audit_dir.glob("*.jsonl"))
+        lines = log_file.read_text(encoding="utf-8").splitlines()
+        for i, line in enumerate(lines):
+            entry = json.loads(line)
+            if entry.get("event_type") != EVENT_BUDGET_HALT:
+                continue
+            entry["details"]["cap_nano_usd"] = entry["details"]["cap_nano_usd"] * 10
+            lines[i] = json.dumps(entry, sort_keys=True)
+            break
+        else:  # pragma: no cover - the halt event must be on disk
+            raise AssertionError("no budget halt event written")
+        log_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        assert AuditChainStore(audit_dir, key=_KEY).verify()[0] is False
+
+
+class TestLedgerWithoutAChain:
+    def test_ledger_without_a_chain_records_no_events_and_still_halts(self, tmp_path: Path) -> None:
+        """Regression: unattached ledgers keep today's soft-halt behaviour."""
+        led = SpendLedger(path=tmp_path / "ledger.jsonl", budget_usd=5.0, hard_budget_usd=6.0)
+
+        status = led.record(tags=CallTags(), model="opus", cost_usd=6.0)
+
+        assert status.soft_halt is True
+        assert status.hard_halt is True
+        assert led.admits() is False
+        assert list((tmp_path / "audit").glob("*.jsonl")) == []
+
+
+class TestBudgetHaltUnderConcurrency:
+    def test_concurrent_records_past_the_hard_cap_emit_one_halt_event(self, tmp_path: Path) -> None:
+        chain = _chain(tmp_path)
+        led = SpendLedger(path=tmp_path / "ledger.jsonl", hard_budget_usd=1.0, chain=chain)
+        start = threading.Barrier(8)
+
+        def spend() -> None:
+            start.wait()
+            led.record(tags=CallTags(), model="opus", cost_usd=1.0)
+
+        threads = [threading.Thread(target=spend) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(_halt_events(chain)) == 1
+        ok, errors = chain.verify()
+        assert ok, errors
+
+
+class TestChainFailureNeverBreaksTheLedger:
+    def test_chain_append_failure_does_not_break_the_ledger(self, tmp_path: Path) -> None:
+        class _BrokenChain:
+            def log_with_prev_digest(self, **_kwargs: object) -> object:
+                raise OSError("chain unavailable")
+
+        led = SpendLedger(
+            path=tmp_path / "ledger.jsonl",
+            hard_budget_usd=1.0,
+            chain=_BrokenChain(),  # type: ignore[arg-type]
+        )
+
+        status = led.record(tags=CallTags(), model="opus", cost_usd=2.0)
+
+        assert status.hard_halt is True
+        assert led.entries_written == 1


### PR DESCRIPTION
## What

Records a spend-ledger budget halt in the audit chain as a `cost.budget_halt` event, instead of only writing it to stderr.

This is the first slice of #2918. It does **not** add the signed, scoped cap type, its content addressing, `bernstein budget issue / show / verify`, fan-out bounds (max concurrent spawns, max recursion depth), or enforcement at the spawn/admission boundary. Nothing changes for a ledger with no chain attached.

## Why

`SpendLedger._emit_threshold_events` (`src/bernstein/core/cost/spend_ledger.py`) already marks each soft and hard cap transition exactly once, guarded by `_soft_halted_at` / `_hard_halted_at`, and then only calls `logger.warning`. So "this run stopped because of its budget" survived in stderr and nowhere else: after the process exits, or after logs rotate, an operator reconstructing a run from `.sdd/audit/` finds the spend rows but no record that a limit existed and stopped the run at a specific point. The spend data was already in the ledger; the boundary decision was not anywhere tamper-evident.

## How

- `src/bernstein/core/security/audit_chain.py`: adds `EVENT_BUDGET_HALT = "cost.budget_halt"`, a frozen `BudgetHaltDetails` payload, and `record_budget_halt(...)`, copying the shape of `CostProfileReportDetails` / `record_cost_profile_report` in the same module, including the `chain.log_with_prev_digest(...)` call that embeds `prev_chain_digest`. Purely additive; the three names are exported.
- `src/bernstein/core/cost/spend_ledger.py`: `SpendLedger` gains an optional `chain: AuditChainStore | None = None` field. The two transition points call `_record_halt_receipt`, which appends the event. With no chain the method returns immediately and the ledger behaves exactly as before.
- Amounts cross into the payload as integer nano-USD via `nano_usd_from_float` (`showback_canonical`). No float reaches the recorded payload, so aggregation order cannot change a digit.
- `band` is typed `Literal["soft", "hard"]` - the closed vocabulary of what can halt a run, so a reader never interprets free text. That was the open decision in the issue; a closed literal is checked by pyright at every call site, which a validated free-form string is not.
- The once-only transition stamps are now claimed under a small dedicated `_halt_lock` rather than read-then-set unguarded. Two threads crossing the same cap in the same instant previously both passed the `is None` check; harmless for a log line, but it would have written two receipts for one halt. The lock is separate from `_lock` so emitting a transition never blocks a concurrent `record()`'s totals update.
- The append is best-effort in the same sense as the JSONL write - a chain that refuses it is logged as a warning and never takes the orchestrator down.
- Docs: `docs/cost/budget-halt-receipts.md` plus its `mkdocs.yml` nav entry.

**Naming.** "Envelope" already means a named budget *bucket tag* here (`CallTags.quota_envelope`, `cost_rollup_by_envelope.py`, `docs/operations/cost-envelopes.md`). Nothing in this PR is called an envelope; the recorded thing is a halt receipt for one cap transition on one run.

## Tests

All in `tests/unit/cost/test_budget_halt_receipt.py`. Tests 1-7 fail on the unmodified tree with `SpendLedger.__init__() got an unexpected keyword argument 'chain'`; test 8 is the no-chain regression and passes before and after by design, which is the property it protects.

1. `test_hard_cap_halt_is_recorded_in_the_chain_not_only_stderr` - a ledger driven past its hard cap emits exactly one `cost.budget_halt` carrying `run_id`, `band` and `prev_chain_digest`, and the chain still verifies.
2. `test_second_record_past_the_cap_adds_no_second_halt_event` - a second `record()` past the cap adds none.
3. `test_soft_cap_halt_is_recorded_with_its_own_band` - the soft cap halts under its own band with its own cap figure.
4. `test_halt_amounts_are_integer_nano_usd_not_floats` - `spent_nano_usd` / `cap_nano_usd` are `int` (and not `bool`) and equal `nano_usd_from_float` of the USD figures.
5. `test_edited_halt_cap_fails_chain_verification` - **load-bearing**. Editing the recorded cap in the JSONL makes `verify()` return `False`. The test asserts `verify()` is `True` before the edit, and a no-op reserialisation of every line was checked to be byte-identical to the on-disk form, so the failure is the edit and not the rewrite.
6. `test_ledger_without_a_chain_records_no_events_and_still_halts` - regression: an unattached ledger still trips both caps, still refuses admission, and creates no audit directory.
7. `test_concurrent_records_past_the_hard_cap_emit_one_halt_event` - eight threads released from a barrier past the cap produce one event, and the chain verifies.
8. `test_chain_append_failure_does_not_break_the_ledger` - a chain whose append raises leaves the status and the ledger row intact.

Local runs (`--parallel 2`): the 8 new tests, `tests/unit/test_spend_ledger.py` (26), every test file importing `spend_ledger` (22 files), and the core audit-chain files `test_audit.py`, `test_audit_integrity.py`, `test_audit_chain_byteflip_regression.py`, `test_audit_log_chain_verifier_invariants.py`, `test_audit_chain_crossprocess.py`, `tests/unit/cost/test_profile_report.py` - all green. `tests/unit/test_orchestrator.py` (228 passed) was run on its own; under two parallel workers it exceeds the runner's 300s per-file cap. `--affected origin/main` selects far more than 300 files because `audit_chain` is imported repo-wide, so it was not run locally; CI runs the full suite.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` - clean on the two changed modules (the diagnostics that remain there are pre-existing and untouched by this diff)
- [x] `uv run python scripts/run_tests.py -x` - run over the affected files listed above, not the whole suite
- [x] New code has type hints

### Documentation duty

- [ ] User-visible README section updated - N/A (no CLI or user-facing surface added)
- [x] `docs/cost/budget-halt-receipts.md` added and linked from `mkdocs.yml`
- [ ] `docs/api/` schema regenerated - N/A (no HTTP or schema surface changed)
- [x] `uv run bernstein agents-md sync` run; it produced no changes
- [x] Tests cover the documented behaviour

Part of #2918

## Remaining

- The signed, content-addressed scoped cap type and its chain anchoring at issue time.
- Enforcement at the spawn/admission boundary: refuse rather than soft-halt, with a refusal receipt carrying a closed reason hash-bound to the cap.
- An authorization anchor for an admitted spend, so both outcomes are receipts.
- Fan-out bounds (max concurrent spawns, max recursion depth) - there is no spawn-depth limit anywhere in `core/agents/` today.
- The interleaved-order property test against the cap at the admission boundary.
- `bernstein budget issue / show / verify` and a run-scoped default surface, plus `docs/cost/budget-envelopes.md`.
