### PR TITLE
feat: derive the AI-BOM snapshot from a run's lineage spine (#2916)

### DIFF
--- a/docs/operations/run-bom.md
+++ b/docs/operations/run-bom.md
@@ -1,0 +1,77 @@
+# AI bill of materials
+
+`bernstein bom` projects an AI bill of materials — the inventory of what a run
+depended on — out of state the run already produced. It records nothing new: a
+BOM is a projection over the lineage spine, so it can be re-derived at any time
+and any line item resolves back into the chain.
+
+## Emit a BOM from a run's lineage chain
+
+```bash
+bernstein bom emit --run 20260101-104501 --from-lineage
+```
+
+`--from-lineage` walks `.sdd/lineage/<run>/spine.jsonl` and builds the document
+from it. Without the flag, `--run` reads a hand-assembled
+`.sdd/runs/<run>/bom_snapshot.json` instead — useful when a snapshot comes from
+another system, but nothing in Bernstein writes that file.
+
+`--format` accepts `json` (default), `cyclonedx` and `spdx`; `--out <path>`
+writes to a file instead of stdout.
+
+## What the projection carries
+
+| Field | Drawn from |
+|---|---|
+| `run_id` | the spine run directory |
+| `started_at` / `finished_at` | earliest and latest spine entry timestamp |
+| `lineage_root_hash` | the chain head — the run's provenance identity |
+| `models[].name` | the `model` string recorded on the spine entry |
+| `models[].invocation_count` | number of spine entries naming that model |
+| `models[].sha256` | `entry_hash` of the first spine entry naming that model |
+
+Each model's `sha256` is a lineage entry hash, so a reviewer can resolve a line
+item against `bernstein lineage replay <run>` rather than taking it on trust.
+
+Spine entries that recorded no model — the shape every non-model artifact write
+uses — contribute no component: an artifact write that named no model did not
+invoke one.
+
+`provider` and `version` are empty for a lineage-derived BOM. The spine records
+the model string only, and splitting a provider out of it would be a fresh
+claim rather than a projection.
+
+`prompts`, `adapters`, `tools` and `data_sources` are empty for a
+lineage-derived BOM today; the spine does not carry those component classes.
+
+## Requirements and failure modes
+
+The spine is HMAC-tagged, so `--from-lineage` loads the audit key the chain was
+written under (`$BERNSTEIN_AUDIT_KEY_PATH`, else the XDG state key). It is
+loaded read-only and never minted: a freshly generated key cannot authenticate
+an existing chain, so emitting under one would produce a document off a chain
+this install cannot vouch for.
+
+| Situation | Result |
+|---|---|
+| Run has no spine entries | exit 1, names the run and the spine path |
+| Audit key missing or world-readable | exit 1, names the key problem |
+| `--from-lineage` without `--run` | exit 2 |
+| `--from-lineage` with `--snapshot` | exit 2 |
+
+## Verify a BOM document
+
+```bash
+bernstein bom verify ./bom.json
+```
+
+`verify` is structural: it checks the schema version, that every element
+carries a well-formed `sha256:` value, and that the deterministic ordering has
+not been edited. Verifying the chain itself is `bernstein lineage verify <run>`.
+
+## Determinism
+
+Two derivations of the same run's BOM are byte-identical. The encoder is
+canonical JSON (sorted keys, minimal separators, UTF-8) and every field is a
+pure function of the spine, so a reviewer who re-runs the command against the
+same chain gets the same bytes.

--- a/docs/release-notes/fragments/2916-bom-from-lineage.md
+++ b/docs/release-notes/fragments/2916-bom-from-lineage.md
@@ -1,0 +1,9 @@
+## `bernstein bom emit --from-lineage` (Issue #2916)
+
+`bernstein bom emit --from-lineage` derives the AI-BOM snapshot from the run's
+lineage spine instead of requiring a hand-assembled `bom_snapshot.json`. The
+spine is HMAC-tagged, so the command uses the run's own audit key and never
+mints a fresh one. Each model's `sha256` is the lineage entry hash of its first
+invocation, so a reviewer can resolve any line item with `bernstein lineage
+replay <run>` without trusting the document on its own. Two derivations of the
+same run are byte-identical. (#2916)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -452,6 +452,7 @@ nav:
           - PII scan gate: security/pii-scan-gate.md
       - Compliance & audit:
           - Compliance overview: operations/compliance.md
+          - AI bill of materials: operations/run-bom.md
           - SOC 2 audit: security/AUDIT.md
           - Audit log: security/audit-log.md
           - Multi-tenant audit export: security/audit-multitenant.md

--- a/src/bernstein/cli/commands/bom_cmd.py
+++ b/src/bernstein/cli/commands/bom_cmd.py
@@ -10,6 +10,9 @@ Commands:
   Read the run snapshot (or load a custom snapshot JSON via
   ``--snapshot``) and emit the encoded BOM. ``--format`` defaults to
   ``json`` and accepts ``json``, ``cyclonedx`` and ``spdx``.
+  ``--from-lineage`` derives the snapshot from the run's lineage spine
+  under ``.sdd/lineage/<run>/`` instead of requiring a hand-assembled
+  ``bom_snapshot.json`` (issue #2916).
 * ``bernstein bom verify <path>`` -- structural verification report.
 
 Both subcommands are pure projections / pure verifications: no network
@@ -54,6 +57,13 @@ def bom_group() -> None:
     help="Explicit snapshot JSON path. Mutually exclusive with --run.",
 )
 @click.option(
+    "--from-lineage",
+    "from_lineage",
+    is_flag=True,
+    default=False,
+    help="Project the snapshot from .sdd/lineage/<run>/ instead of reading bom_snapshot.json.",
+)
+@click.option(
     "--format",
     "fmt",
     default="json",
@@ -77,23 +87,36 @@ def bom_group() -> None:
 def emit_cmd(
     run_id: str | None,
     snapshot_path: str | None,
+    from_lineage: bool,
     fmt: str,
     out_path: str | None,
     workdir: str,
 ) -> None:
     """Emit an AI-BOM derived from an existing run snapshot."""
-    from bernstein.core.compliance.ai_bom import (
-        BOMError,
-        encode_bom,
-        generate_bom,
-    )
+    from bernstein.core.compliance.ai_bom import BOMError
 
     if run_id and snapshot_path:
         click.echo("error: --run and --snapshot are mutually exclusive", err=True)
         raise SystemExit(2)
+    if from_lineage and snapshot_path:
+        click.echo("error: --from-lineage and --snapshot are mutually exclusive", err=True)
+        raise SystemExit(2)
+    if from_lineage and not run_id:
+        click.echo("error: --from-lineage requires --run", err=True)
+        raise SystemExit(2)
     if not run_id and not snapshot_path:
         click.echo("error: one of --run or --snapshot is required", err=True)
         raise SystemExit(2)
+
+    if from_lineage:
+        assert run_id is not None
+        try:
+            snapshot = _snapshot_from_lineage(run_id, workdir)
+        except BOMError as exc:
+            click.echo(f"error: {exc}", err=True)
+            raise SystemExit(1) from None
+        _write_bom(snapshot, fmt=fmt, out_path=out_path)
+        return
 
     if run_id:
         snap_path = Path(workdir).resolve() / ".sdd" / "runs" / run_id / "bom_snapshot.json"
@@ -116,9 +139,40 @@ def emit_cmd(
 
     snapshot: dict[str, Any] = cast("dict[str, Any]", snapshot_raw)
 
+    _write_bom(snapshot, fmt=fmt, out_path=out_path)
+
+
+def _snapshot_from_lineage(run_id: str, workdir: str) -> dict[str, Any]:
+    """Derive the BOM snapshot from the run's lineage spine.
+
+    The spine constructor needs the HMAC key the chain was written under.
+    It is loaded read-only: a projection path must never mint key material,
+    because a freshly minted key cannot authenticate an existing chain
+    (issue #2639).
+    """
+    from bernstein.core.compliance.ai_bom import BOMError, snapshot_from_spine
+    from bernstein.core.lineage.spine import LineageSpine
+    from bernstein.core.security.audit import (
+        AuditKeyMissingError,
+        AuditKeyPermissionError,
+        load_audit_key,
+    )
+
     try:
-        bom = generate_bom(snapshot)
-        payload = encode_bom(bom, fmt=fmt)
+        hmac_key = load_audit_key()
+    except (AuditKeyMissingError, AuditKeyPermissionError) as exc:
+        raise BOMError(f"cannot read the audit key the lineage chain was written under: {exc}") from None
+
+    spine = LineageSpine(Path(workdir).resolve() / ".sdd" / "lineage", run_id=run_id, hmac_key=hmac_key)
+    return snapshot_from_spine(spine)
+
+
+def _write_bom(snapshot: dict[str, Any], *, fmt: str, out_path: str | None) -> None:
+    """Encode ``snapshot`` and write it to ``out_path`` or stdout."""
+    from bernstein.core.compliance.ai_bom import BOMError, encode_bom, generate_bom
+
+    try:
+        payload = encode_bom(generate_bom(snapshot), fmt=fmt)
     except BOMError as exc:
         click.echo(f"error: {exc}", err=True)
         raise SystemExit(1) from None

--- a/src/bernstein/cli/commands/bom_cmd.py
+++ b/src/bernstein/cli/commands/bom_cmd.py
@@ -151,7 +151,7 @@ def _snapshot_from_lineage(run_id: str, workdir: str) -> dict[str, Any]:
     (issue #2639).
     """
     from bernstein.core.compliance.ai_bom import BOMError, snapshot_from_spine
-    from bernstein.core.lineage.spine import LineageSpine
+    from bernstein.core.lineage.spine import LineageSpine, SpineRunIdError
     from bernstein.core.security.audit import (
         AuditKeyMissingError,
         AuditKeyPermissionError,
@@ -163,7 +163,10 @@ def _snapshot_from_lineage(run_id: str, workdir: str) -> dict[str, Any]:
     except (AuditKeyMissingError, AuditKeyPermissionError) as exc:
         raise BOMError(f"cannot read the audit key the lineage chain was written under: {exc}") from None
 
-    spine = LineageSpine(Path(workdir).resolve() / ".sdd" / "lineage", run_id=run_id, hmac_key=hmac_key)
+    try:
+        spine = LineageSpine(Path(workdir).resolve() / ".sdd" / "lineage", run_id=run_id, hmac_key=hmac_key)
+    except SpineRunIdError as exc:
+        raise BOMError(f"invalid run id: {exc}") from None
     return snapshot_from_spine(spine)
 
 

--- a/src/bernstein/core/compliance/ai_bom.py
+++ b/src/bernstein/core/compliance/ai_bom.py
@@ -31,12 +31,16 @@ validator accepts the document.
 
 from __future__ import annotations
 
+import datetime as _dt
 import hashlib
 import json
 import re
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import asdict, dataclass, field
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from bernstein.core.lineage.spine import LineageSpine
 
 __all__ = [
     "AIBOM",
@@ -52,6 +56,7 @@ __all__ = [
     "ToolEntry",
     "encode_bom",
     "generate_bom",
+    "snapshot_from_spine",
     "verify_bom",
 ]
 
@@ -259,6 +264,112 @@ def generate_bom(snapshot: Mapping[str, Any]) -> AIBOM:
         tools=tools,
         data_sources=data_sources,
     )
+
+
+# ---------------------------------------------------------------------------
+# Snapshot projection from the lineage spine
+# ---------------------------------------------------------------------------
+
+#: ``LineageSpine.record`` documents ``timestamp`` as "ns or s; caller-chosen",
+#: and the tree uses both: ``core/evidence/run_artifacts.py`` stamps
+#: ``int(time.time())`` while ``core/tasks/task_lifecycle.py`` stamps
+#: ``time.time_ns()``. The BOM window is an ISO-8601 UTC instant (the SPDX
+#: encoder puts ``finished_at`` in ``created``), so the unit is recovered from
+#: the magnitude: anything at or above a threshold is divided down to seconds.
+#: The thresholds sit far from any plausible wall-clock second value, so the
+#: mapping is total and deterministic rather than a per-run guess.
+_TIMESTAMP_UNIT_DIVISORS: tuple[tuple[int, int], ...] = (
+    (10**17, 1_000_000_000),  # nanoseconds
+    (10**14, 1_000_000),  # microseconds
+    (10**11, 1_000),  # milliseconds
+)
+
+
+def _spine_timestamp_to_iso(timestamp: int, *, label: str) -> str:
+    """Render a spine ``timestamp`` as an ISO-8601 UTC second."""
+    seconds = timestamp
+    for threshold, divisor in _TIMESTAMP_UNIT_DIVISORS:
+        if abs(timestamp) >= threshold:
+            seconds = timestamp // divisor
+            break
+    try:
+        moment = _dt.datetime.fromtimestamp(seconds, tz=_dt.UTC)
+    except (OSError, OverflowError, ValueError) as exc:
+        raise BOMError(f"{label} is not a representable timestamp: {timestamp!r} ({exc})") from None
+    return moment.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def snapshot_from_spine(spine: LineageSpine) -> dict[str, Any]:
+    """Project a run's lineage spine into a :func:`generate_bom` snapshot.
+
+    The BOM is a projection over state the run already produced, so its
+    input is derived from the chain rather than hand-assembled: without
+    this, ``bernstein bom emit --run`` only worked when an operator wrote
+    ``.sdd/runs/<run>/bom_snapshot.json`` themselves, and no code path in
+    the tree ever wrote that file.
+
+    Every emitted model entry carries the ``entry_hash`` of the lineage
+    record it was drawn from -- the first entry in append order that named
+    that model -- so a line item resolves back into the chain instead of
+    asserting a component out of nowhere. ``invocation_count`` is the number
+    of spine entries naming the model, and ``lineage_root_hash`` is the
+    chain head that anchors them all.
+
+    Entries that recorded no model (``model=""``, the shape every non-model
+    artifact write uses) contribute no component: an artifact write that
+    named no model did not invoke one.
+
+    Args:
+        spine: The run's :class:`~bernstein.core.lineage.spine.LineageSpine`.
+
+    Returns:
+        A snapshot dict accepted by :func:`generate_bom`. ``provider`` and
+        ``version`` are empty strings: the spine records the model string
+        only, and parsing a provider out of it would be a fresh claim rather
+        than a projection.
+
+    Raises:
+        BOMError: When the run has no lineage entries, or the chain head
+            cannot be read. An empty run has nothing to attest, and letting
+            the empty head reach :class:`AIBOM` would surface as a confusing
+            ``lineage_root_hash`` format error instead.
+    """
+    run_id = spine.run_dir.name
+    entries = list(spine.iter_entries())
+    if not entries:
+        raise BOMError(
+            f"run {run_id!r} has no lineage spine entries at {spine.spine_path}: nothing to project into a BOM",
+        )
+    head = spine.head_hash()
+    if not head:
+        raise BOMError(
+            f"run {run_id!r} has lineage entries but no readable chain head at {spine.spine_path}",
+        )
+
+    models: dict[str, dict[str, Any]] = {}
+    for entry in entries:
+        if not entry.model:
+            continue
+        known = models.get(entry.model)
+        if known is None:
+            models[entry.model] = {
+                "name": entry.model,
+                "provider": "",
+                "version": "",
+                "sha256": entry.entry_hash,
+                "invocation_count": 1,
+            }
+        else:
+            known["invocation_count"] = int(known["invocation_count"]) + 1
+
+    timestamps = [entry.timestamp for entry in entries]
+    return {
+        "run_id": run_id,
+        "started_at": _spine_timestamp_to_iso(min(timestamps), label=f"run {run_id!r} started_at"),
+        "finished_at": _spine_timestamp_to_iso(max(timestamps), label=f"run {run_id!r} finished_at"),
+        "lineage_root_hash": head,
+        "models": list(models.values()),
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_bom_cli.py
+++ b/tests/integration/test_bom_cli.py
@@ -501,3 +501,18 @@ class TestBOMEmitFromLineage:
 
         assert result.exit_code != 0
         assert not key_file.exists()
+
+    def test_emit_from_lineage_rejects_a_run_id_that_escapes_its_directory(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _install_audit_key(tmp_path, monkeypatch)
+
+        result = CliRunner().invoke(
+            bom_group,
+            ["emit", "--run", "../elsewhere", "--from-lineage", "--workdir", str(tmp_path)],
+        )
+
+        assert result.exit_code == 1
+        assert "invalid run id" in result.output

--- a/tests/integration/test_bom_cli.py
+++ b/tests/integration/test_bom_cli.py
@@ -13,9 +13,11 @@ import json
 from pathlib import Path
 from typing import Any
 
+import pytest
 from click.testing import CliRunner
 
 from bernstein.cli.commands.bom_cmd import bom_group
+from bernstein.core.lineage.spine import LineageSpine
 
 
 def _sha(label: str) -> str:
@@ -348,3 +350,154 @@ class TestRoundTrip:
             assert result.exit_code == 0, result.output
             decoded = json.loads(out.read_text(encoding="utf-8"))
             assert key in decoded
+
+
+# ---------------------------------------------------------------------------
+# 4. ``bom emit --from-lineage`` -- project the snapshot off the run spine
+# ---------------------------------------------------------------------------
+
+
+_SPINE_KEY = b"k" * 32
+
+
+def _seed_spine(workdir: Path, run_id: str) -> LineageSpine:
+    spine = LineageSpine(workdir / ".sdd" / "lineage", run_id=run_id, hmac_key=_SPINE_KEY)
+    spine.record(
+        artifact_path="src/a.py",
+        content=b"a",
+        actor="agent:worker",
+        step_id="s1",
+        model="claude-sonnet",
+        timestamp=1767225600,
+    )
+    spine.record(
+        artifact_path="src/b.py",
+        content=b"b",
+        actor="agent:worker",
+        step_id="s2",
+        model="claude-sonnet",
+        timestamp=1767225660,
+    )
+    return spine
+
+
+def _install_audit_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    key_file = tmp_path / "audit.key"
+    key_file.write_bytes(_SPINE_KEY)
+    key_file.chmod(0o600)
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(key_file))
+
+
+class TestBOMEmitFromLineage:
+    def test_emit_from_lineage_projects_the_run_spine(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _install_audit_key(tmp_path, monkeypatch)
+        spine = _seed_spine(tmp_path, "20260101-run-a")
+
+        result = CliRunner().invoke(
+            bom_group,
+            ["emit", "--run", "20260101-run-a", "--from-lineage", "--workdir", str(tmp_path)],
+        )
+
+        assert result.exit_code == 0, result.output
+        doc = json.loads(result.stdout)
+        assert doc["run_id"] == "20260101-run-a"
+        assert doc["lineage_root_hash"] == spine.head_hash()
+        assert [(m["name"], m["invocation_count"]) for m in doc["models"]] == [("claude-sonnet", 2)]
+
+    def test_emit_from_lineage_needs_no_hand_written_snapshot(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The whole point: ``.sdd/runs/<run>/bom_snapshot.json`` need not exist."""
+        _install_audit_key(tmp_path, monkeypatch)
+        _seed_spine(tmp_path, "20260101-run-b")
+        assert not (tmp_path / ".sdd" / "runs" / "20260101-run-b" / "bom_snapshot.json").exists()
+
+        result = CliRunner().invoke(
+            bom_group,
+            ["emit", "--run", "20260101-run-b", "--from-lineage", "--workdir", str(tmp_path)],
+        )
+        assert result.exit_code == 0, result.output
+
+    def test_emit_from_lineage_output_passes_structural_verify(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _install_audit_key(tmp_path, monkeypatch)
+        _seed_spine(tmp_path, "20260101-run-c")
+        out = tmp_path / "bom.json"
+
+        emit = CliRunner().invoke(
+            bom_group,
+            [
+                "emit",
+                "--run",
+                "20260101-run-c",
+                "--from-lineage",
+                "--workdir",
+                str(tmp_path),
+                "--out",
+                str(out),
+            ],
+        )
+        assert emit.exit_code == 0, emit.output
+
+        verify = CliRunner().invoke(bom_group, ["verify", str(out)])
+        assert verify.exit_code == 0, verify.output
+
+    def test_emit_from_lineage_rejects_a_run_with_an_empty_spine(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _install_audit_key(tmp_path, monkeypatch)
+        (tmp_path / ".sdd" / "lineage").mkdir(parents=True)
+
+        result = CliRunner().invoke(
+            bom_group,
+            ["emit", "--run", "20260101-empty", "--from-lineage", "--workdir", str(tmp_path)],
+        )
+        assert result.exit_code == 1
+        assert "20260101-empty" in result.output
+
+    def test_emit_from_lineage_requires_run_and_excludes_snapshot(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _install_audit_key(tmp_path, monkeypatch)
+        snap_path = tmp_path / "snap.json"
+        snap_path.write_text(json.dumps(_snapshot()), encoding="utf-8")
+
+        no_run = CliRunner().invoke(bom_group, ["emit", "--from-lineage", "--workdir", str(tmp_path)])
+        assert no_run.exit_code == 2
+
+        with_snapshot = CliRunner().invoke(
+            bom_group,
+            ["emit", "--from-lineage", "--snapshot", str(snap_path), "--workdir", str(tmp_path)],
+        )
+        assert with_snapshot.exit_code == 2
+
+    def test_emit_from_lineage_fails_closed_without_an_audit_key(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A read-only projection must never mint key material (issue #2639)."""
+        _seed_spine(tmp_path, "20260101-run-d")
+        key_file = tmp_path / "absent.key"
+        monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(key_file))
+
+        result = CliRunner().invoke(
+            bom_group,
+            ["emit", "--run", "20260101-run-d", "--from-lineage", "--workdir", str(tmp_path)],
+        )
+
+        assert result.exit_code != 0
+        assert not key_file.exists()

--- a/tests/unit/compliance/test_ai_bom.py
+++ b/tests/unit/compliance/test_ai_bom.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -29,8 +30,10 @@ from bernstein.core.compliance.ai_bom import (
     bom_content_hash,
     encode_bom,
     generate_bom,
+    snapshot_from_spine,
     verify_bom,
 )
+from bernstein.core.lineage.spine import LineageSpine
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1005,3 +1008,144 @@ class TestProperties:
         for pkg in decoded["packages"]:
             assert pkg["checksums"][0]["algorithm"] == "SHA256"
             assert len(pkg["checksums"][0]["checksumValue"]) == 64
+
+
+# ---------------------------------------------------------------------------
+# Snapshot projection from the lineage spine (issue #2916)
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotFromSpine:
+    """``snapshot_from_spine`` derives the BOM input from the run's chain.
+
+    Before this projection existed the ``bom emit --run`` path only worked
+    if an operator hand-assembled ``bom_snapshot.json``: nothing in the tree
+    wrote that file. These tests pin that the snapshot is a faithful,
+    deterministic projection of the spine rather than a fresh claim.
+    """
+
+    @staticmethod
+    def _spine(tmp_path: Path, run_id: str = "run-bom-1") -> LineageSpine:
+        return LineageSpine(tmp_path / ".sdd" / "lineage", run_id=run_id, hmac_key=b"k" * 32)
+
+    @staticmethod
+    def _seed(spine: LineageSpine) -> None:
+        spine.record(
+            artifact_path="src/a.py",
+            content=b"a",
+            actor="agent:worker",
+            step_id="s1",
+            model="claude-sonnet",
+            timestamp=1767225600,
+        )
+        spine.record(
+            artifact_path="src/b.py",
+            content=b"b",
+            actor="agent:worker",
+            step_id="s2",
+            model="claude-sonnet",
+            timestamp=1767225660,
+        )
+        spine.record(
+            artifact_path="src/c.py",
+            content=b"c",
+            actor="agent:reviewer",
+            step_id="s3",
+            model="gpt-mini",
+            timestamp=1767225720,
+        )
+
+    def test_bom_snapshot_from_spine_is_byte_identical_across_derivations(self, tmp_path: Path) -> None:
+        spine = self._spine(tmp_path)
+        self._seed(spine)
+
+        first = snapshot_from_spine(spine)
+        second = snapshot_from_spine(spine)
+        assert encode_bom(generate_bom(first)) == encode_bom(generate_bom(second))
+
+        # Every line item is a link into the chain, not a claim: each emitted
+        # model hash must be an entry hash the spine actually yields.
+        entry_hashes = {entry.entry_hash for entry in spine.iter_entries()}
+        emitted = {model.sha256 for model in generate_bom(first).models}
+        assert emitted
+        assert emitted <= entry_hashes
+
+    def test_snapshot_from_spine_counts_invocations_per_distinct_model(self, tmp_path: Path) -> None:
+        spine = self._spine(tmp_path)
+        self._seed(spine)
+
+        bom = generate_bom(snapshot_from_spine(spine))
+        counts = {model.name: model.invocation_count for model in bom.models}
+        assert counts == {"claude-sonnet": 2, "gpt-mini": 1}
+
+    def test_snapshot_from_spine_skips_entries_that_recorded_no_model(self, tmp_path: Path) -> None:
+        spine = self._spine(tmp_path)
+        spine.record(
+            artifact_path="run-artifacts/x/v1",
+            content=b"x",
+            actor="agent:worker",
+            step_id="artifact:x:v1",
+            model="",
+            timestamp=1767225600,
+        )
+        spine.record(
+            artifact_path="src/a.py",
+            content=b"a",
+            actor="agent:worker",
+            step_id="s1",
+            model="claude-sonnet",
+            timestamp=1767225660,
+        )
+
+        bom = generate_bom(snapshot_from_spine(spine))
+        assert [model.name for model in bom.models] == ["claude-sonnet"]
+
+    def test_snapshot_from_spine_anchors_lineage_root_at_the_chain_head(self, tmp_path: Path) -> None:
+        spine = self._spine(tmp_path)
+        self._seed(spine)
+
+        bom = generate_bom(snapshot_from_spine(spine))
+        assert bom.lineage_root_hash == spine.head_hash()
+        assert bom.run_id == "run-bom-1"
+
+    def test_snapshot_from_spine_rejects_a_run_with_no_entries(self, tmp_path: Path) -> None:
+        spine = self._spine(tmp_path, run_id="empty-run")
+        with pytest.raises(BOMError, match="empty-run"):
+            snapshot_from_spine(spine)
+
+    def test_snapshot_from_spine_window_spans_first_and_last_entry(self, tmp_path: Path) -> None:
+        spine = self._spine(tmp_path)
+        self._seed(spine)
+
+        snapshot = snapshot_from_spine(spine)
+        assert snapshot["started_at"] == "2026-01-01T00:00:00Z"
+        assert snapshot["finished_at"] == "2026-01-01T00:02:00Z"
+
+    def test_snapshot_from_spine_reads_second_and_nanosecond_stamps_alike(self, tmp_path: Path) -> None:
+        """The spine's ``timestamp`` unit is caller-chosen and mixed in-tree.
+
+        ``core/evidence/run_artifacts.py`` stamps ``int(time.time())`` while
+        ``core/tasks/task_lifecycle.py`` stamps ``time.time_ns()``, so the same
+        instant reaches the chain in two units and must project to one date.
+        """
+        seconds = self._spine(tmp_path, run_id="run-seconds")
+        seconds.record(
+            artifact_path="src/a.py",
+            content=b"a",
+            actor="agent:worker",
+            step_id="s1",
+            model="claude-sonnet",
+            timestamp=1767225600,
+        )
+        nanos = self._spine(tmp_path, run_id="run-nanos")
+        nanos.record(
+            artifact_path="src/a.py",
+            content=b"a",
+            actor="agent:worker",
+            step_id="s1",
+            model="claude-sonnet",
+            timestamp=1767225600 * 1_000_000_000,
+        )
+
+        assert snapshot_from_spine(seconds)["started_at"] == snapshot_from_spine(nanos)["started_at"]
+        assert snapshot_from_spine(nanos)["started_at"] == "2026-01-01T00:00:00Z"


### PR DESCRIPTION
## What

Derives the AI-BOM snapshot from a run's lineage spine, so `bernstein bom emit`
works against a real run instead of a hand-assembled file.

* `snapshot_from_spine(spine)` in `src/bernstein/core/compliance/ai_bom.py` —
  walks `LineageSpine.iter_entries()` and fills the dict `generate_bom` already
  consumes.
* `bernstein bom emit --run <id> --from-lineage` in
  `src/bernstein/cli/commands/bom_cmd.py`.
* `docs/operations/run-bom.md` plus a nav entry.

Explicitly **not** in this PR (the issue's own step-1 boundary): Ed25519
signing and the `.jws` sidecar, the offline `--verify` re-derivation, `--diff`
between two runs, and the skill / data-source component classes. `prompts`,
`adapters`, `tools` and `data_sources` stay empty tuples — the spine does not
carry them and `generate_bom` already defaults them. `bernstein_version` keeps
its existing `generate_bom` default; the spine is not a source for it.

## Why

`bernstein bom emit --run <id>` read `.sdd/runs/<run>/bom_snapshot.json`
(`bom_cmd.py:99`), and no code path in the tree ever wrote that file — the only
other reference was the CLI test. So the command only produced a document when
an operator assembled the JSON by hand, which is exactly the untrusted
spreadsheet a BOM is supposed to replace: nothing in it resolves back to
anything.

The data was already there. Every artifact write goes through
`LineageSpine.record`, which stamps the model, an `entry_hash` and a chained
head. This PR closes the packaging gap between that chain and the BOM, so the
document is a projection of what actually ran.

## How

`snapshot_from_spine` reads the run's spine and returns:

| Field | Source |
|---|---|
| `run_id` | `spine.run_dir.name` |
| `started_at` / `finished_at` | min / max `SpineEntry.timestamp` |
| `lineage_root_hash` | `LineageSpine.head_hash()` |
| `models[].name` | distinct `SpineEntry.model` |
| `models[].invocation_count` | number of entries naming that model |
| `models[].sha256` | `entry_hash` of the first entry naming that model |

Three decisions the issue left open:

1. **`provider` / `version` are empty strings.** The spine records the model
   string only. Splitting a provider out of it would be a fresh claim, not a
   projection.
2. **A run with no spine entries raises `BOMError` naming the run and the spine
   path.** `head_hash()` returns `""` for an empty chain, which would otherwise
   surface as a confusing `lineage_root_hash` format error from
   `AIBOM.__post_init__`. Same for a chain whose head cannot be read.
3. **The timestamp unit is recovered from magnitude.** `LineageSpine.record`
   documents `timestamp` as "ns or s; caller-chosen" and the tree uses both:
   `core/evidence/run_artifacts.py` stamps `int(time.time())`,
   `core/tasks/task_lifecycle.py` stamps `time.time_ns()`. The BOM window is an
   ISO-8601 UTC instant (the SPDX encoder puts `finished_at` in `created`), so
   emitting the raw integer would produce an invalid document. Thresholds sit
   far from any plausible wall-clock second value, so the mapping is total and
   deterministic rather than a per-run guess.

Entries that recorded no model (`model=""`, the shape every non-model artifact
write uses) contribute no component.

The CLI path loads the audit key with `load_audit_key` — read-only, never
minting — because the spine constructor needs the key the chain was written
under and a freshly minted key cannot authenticate an existing chain. An
unusable run id and a missing key both fail closed with a message rather than a
traceback.

## Tests

Each failed on the unmodified tree: the unit file failed at collection
(`snapshot_from_spine` did not exist) and the CLI file at
`No such option '--from-lineage'`.

`tests/unit/compliance/test_ai_bom.py::TestSnapshotFromSpine`

1. `test_bom_snapshot_from_spine_is_byte_identical_across_derivations` —
   **load-bearing.** Two derivations over one hermetic spine encode to
   identical bytes, and every emitted `ModelEntry.sha256` is an `entry_hash`
   the spine actually yields. This is the property that makes a line item a
   link into the chain rather than a claim.
2. `test_snapshot_from_spine_counts_invocations_per_distinct_model`
3. `test_snapshot_from_spine_skips_entries_that_recorded_no_model`
4. `test_snapshot_from_spine_anchors_lineage_root_at_the_chain_head`
5. `test_snapshot_from_spine_rejects_a_run_with_no_entries`
6. `test_snapshot_from_spine_window_spans_first_and_last_entry`
7. `test_snapshot_from_spine_reads_second_and_nanosecond_stamps_alike`

`tests/integration/test_bom_cli.py::TestBOMEmitFromLineage`

8. `test_emit_from_lineage_projects_the_run_spine`
9. `test_emit_from_lineage_needs_no_hand_written_snapshot`
10. `test_emit_from_lineage_output_passes_structural_verify`
11. `test_emit_from_lineage_rejects_a_run_with_an_empty_spine`
12. `test_emit_from_lineage_requires_run_and_excludes_snapshot`
13. `test_emit_from_lineage_fails_closed_without_an_audit_key`
14. `test_emit_from_lineage_rejects_a_run_id_that_escapes_its_directory`

Local runs: both files green (115 + 26). `--affected origin/main` did not
finish inside the local budget, so I ran the two files above plus the tests of
the touched modules' importers and the docs/CLI drift guards:
`test_cli_command_registration.py` (699 passed, run alone — it exceeds the
harness's 300s per-file cap on `main` too), `test_cli_decomposition.py`,
`test_docs_prose_cli_drift.py`, `test_docs_capability_reachability.py`,
`test_docs_url_hygiene.py`, `test_docs_drift_deleted_sources.py`,
`test_capability_surfaces.py`, `test_feature_matrix_drift.py`,
`test_naming_policy_docs.py`. CI runs the full suite.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes (run on the two changed modules)
- [x] `uv run python scripts/run_tests.py -x` passes for the affected files
- [x] New code has type hints

### Documentation duty

- [x] User-visible README section updated — N/A (no README surface changed)
- [x] `docs/operations/<area>.md` updated — `docs/operations/run-bom.md` added
      and linked from the mkdocs nav
- [x] `docs/api/` schema regenerated — N/A (the BOM schema shape is unchanged;
      `BOM_SCHEMA_VERSION` stays `1.0`)
- [x] `uv run bernstein agents-md sync` run — produced no changes (no new
      module)
- [x] Tests cover the documented behaviour

Part of #2916

## Remaining

- Ed25519 signing off the install identity and the content-addressed BOM id
  (`bom_content_hash` already content-addresses the document, which is the
  anchoring this slice needs).
- Offline `bernstein run bom <run> --verify` that re-derives the projection and
  fails at the named line item on a tampered component or a removed record.
- `--diff <run_a> <run_b>` reporting added / removed / version-changed
  components.
- Skill (#2899) and data-source (#2887) component classes, plus prompt-template
  and adapter/tool entries once the spine carries them.
