### PR TITLE
fix(approval): fail closed when a review-mode gate times out (#5051)

### DIFF
--- a/docs/release-notes/fragments/5051-approval-timeout-fail-closed.md
+++ b/docs/release-notes/fragments/5051-approval-timeout-fail-closed.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- A review-mode approval gate that timed out with no decision resolved to
+  **approved** unless the caller had passed an explicit timeout, so an operator
+  who configured no timeout got the default wait followed by an auto-approval —
+  an approval record indistinguishable from one a person granted. The timeout
+  now fails closed in every path: `_default_poll_decision` reports an expiry as
+  `"timed_out"` rather than inventing an outcome, and `ApprovalGate` rejects on
+  expiry. `ApprovalResult` carries `resolution` (`"decided"` / `"timed_out"`)
+  so a reader of the trail can tell an expiry from a real decision, and the
+  "do not block" behaviour is still available through a named
+  `approve_on_timeout` opt-in that still records the expiry as such.
+  ([#5051](https://github.com/sipyourdrink-ltd/bernstein/issues/5051))

--- a/src/bernstein/core/security/approval.py
+++ b/src/bernstein/core/security/approval.py
@@ -55,11 +55,16 @@ class ApprovalResult:
         approved: True if the work should be merged directly.
         rejected: True if the work was rejected (no merge, no PR).
         pr_url: Non-empty when a PR was created; implies approved=False, rejected=False.
+        resolution: How the decision was reached -- ``"decided"`` when a person
+            (or a decision file) resolved the gate, ``"timed_out"`` when the wait
+            expired without one. A reader of the trail can tell an expiry from a
+            real decision even when ``approved``/``rejected`` look identical.
     """
 
     approved: bool
     rejected: bool = False
     pr_url: str = ""
+    resolution: str = "decided"
 
 
 # ---------------------------------------------------------------------------
@@ -73,24 +78,27 @@ def _default_poll_decision(
     *,
     poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S,
     max_wait_s: float = _DEFAULT_MAX_WAIT_S,
-    reject_on_timeout: bool = False,
 ) -> str:
-    """Poll for a decision file and return ``"approved"`` or ``"rejected"``.
+    """Poll for a decision file and return the raw outcome.
 
     Reads ``<approvals_dir>/<task_id>.approved`` or
-    ``<approvals_dir>/<task_id>.rejected`` until one appears or the timeout
-    expires.  On timeout, defaults to ``"approved"`` (or "rejected" if configured)
-    so a missed review does not permanently stall the orchestrator.
+    ``<approvals_dir>/<task_id>.rejected`` until one appears or the wait
+    expires.
+
+    This helper reports what happened, not what to do about it: a wait that
+    expires with no decision file returns ``"timed_out"``, and the caller
+    (:meth:`ApprovalGate._review`) decides whether an expiry fails closed
+    (the default) or is treated as an opt-in approval. It never returns
+    ``"approved"`` on its own for a review nobody performed.
 
     Args:
         task_id: Task ID to poll for.
         approvals_dir: Directory where decision files are written.
         poll_interval_s: Seconds between file-existence checks.
-        max_wait_s: Maximum seconds to wait before defaulting to approved.
-        reject_on_timeout: If True, returns "rejected" on timeout instead of "approved".
+        max_wait_s: Maximum seconds to wait for a decision file.
 
     Returns:
-        ``"approved"`` or ``"rejected"``.
+        ``"approved"``, ``"rejected"``, or ``"timed_out"``.
     """
     from bernstein.core.orchestration.approval_gate import approval_path_in
 
@@ -110,12 +118,11 @@ def _default_poll_decision(
         time.sleep(poll_interval_s)
 
     logger.warning(
-        "Approval gate: task %s timed out after %.0fs - defaulting to %s",
+        "Approval gate: task %s timed out after %.0fs with no decision - failing closed",
         task_id,
         max_wait_s,
-        "rejected" if reject_on_timeout else "approved",
     )
-    return "rejected" if reject_on_timeout else "approved"
+    return "timed_out"
 
 
 # ---------------------------------------------------------------------------
@@ -209,11 +216,8 @@ class ApprovalGate:
             task_id: str,
             approvals_dir: Path,
             max_wait_s: float = _DEFAULT_MAX_WAIT_S,
-            reject_on_timeout: bool = False,
         ) -> str:
-            return _default_poll_decision(
-                task_id, approvals_dir, max_wait_s=max_wait_s, reject_on_timeout=reject_on_timeout
-            )
+            return _default_poll_decision(task_id, approvals_dir, max_wait_s=max_wait_s)
 
         self._poll_decision: _PollDecisionFn = _poll_decision or _default_poll
         self._push_branch_fn = _push_branch_fn
@@ -232,6 +236,7 @@ class ApprovalGate:
         test_summary: str = "",
         override_mode: ApprovalMode | None = None,
         timeout_s: float | None = None,
+        approve_on_timeout: bool = False,
         bypass_enabled: bool = False,
     ) -> ApprovalResult:
         """Evaluate the approval gate for a verified task.
@@ -256,6 +261,11 @@ class ApprovalGate:
             test_summary: Optional one-line test-results summary.
             override_mode: Optional mode to override the global configuration.
             timeout_s: Optional overriding timeout for review mode.
+            approve_on_timeout: Named opt-out of the fail-closed default. When
+                True, a review that expires with no decision resolves to
+                approved instead of rejected; the returned result still records
+                ``resolution="timed_out"`` so the trail shows the approval was
+                never actually granted by a person.
             bypass_enabled: When True, bypass approval and return approved=True.
 
         Returns:
@@ -289,13 +299,19 @@ class ApprovalGate:
 
             # REVIEW mode
             result = self._review(
-                task, session_id=session_id, diff=diff, test_summary=test_summary, timeout_s=timeout_s
+                task,
+                session_id=session_id,
+                diff=diff,
+                test_summary=test_summary,
+                timeout_s=timeout_s,
+                approve_on_timeout=approve_on_timeout,
             )
             logger.info(
-                "Approval gate decision: task=%s session=%s decision=%s reason=review_mode_poll",
+                "Approval gate decision: task=%s session=%s decision=%s reason=review_mode_%s",
                 task.id,
                 session_id,
                 "rejected" if result.rejected else "approved",
+                "timeout" if result.resolution == "timed_out" else "poll",
             )
             return result
         except Exception:
@@ -472,8 +488,17 @@ class ApprovalGate:
         diff: str,
         test_summary: str,
         timeout_s: float | None = None,
+        approve_on_timeout: bool = False,
     ) -> ApprovalResult:
-        """Write pending file, block on poll, return decision."""
+        """Write pending file, block on poll, return decision.
+
+        A poll that expires with no decision fails closed: the task is
+        rejected and the result records ``resolution="timed_out"`` so an
+        expiry is never mistaken for a review someone performed. Passing
+        ``approve_on_timeout=True`` is the one way to make an expiry resolve
+        to approved, and it still leaves ``resolution="timed_out"`` on the
+        record.
+        """
         pending_dir = self._workdir / ".sdd" / "runtime" / "pending_approvals"
         approvals_dir = self._workdir / ".sdd" / "runtime" / "approvals"
         pending_dir.mkdir(parents=True, exist_ok=True)
@@ -498,10 +523,22 @@ class ApprovalGate:
         kwargs: dict[str, Any] = {}
         if timeout_s is not None:
             kwargs["max_wait_s"] = timeout_s
-            kwargs["reject_on_timeout"] = True
 
         decision = self._poll_decision(task.id, approvals_dir, **kwargs)
 
+        if decision == "timed_out":
+            if approve_on_timeout:
+                logger.warning(
+                    "Approval gate: task %s expired with no decision - resolving to approved "
+                    "(approve_on_timeout opt-in); recorded as timed_out, not a granted approval",
+                    task.id,
+                )
+                return ApprovalResult(approved=True, resolution="timed_out")
+            logger.warning(
+                "Approval gate: task %s expired with no decision - failing closed to rejected",
+                task.id,
+            )
+            return ApprovalResult(approved=False, rejected=True, resolution="timed_out")
         if decision == "rejected":
             return ApprovalResult(approved=False, rejected=True)
         return ApprovalResult(approved=True)

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -3576,7 +3576,19 @@ def _evaluate_approval_gate(
             timeout_s=timeout_s,
         )
         if approval_result.rejected:
-            logger.warning("Approval gate: task %s rejected -- skipping merge for agent %s", task.id, session.id)
+            if approval_result.resolution == "timed_out":
+                logger.warning(
+                    "Approval gate: task %s rejected on timeout (no decision within the review window) "
+                    "-- skipping merge for agent %s",
+                    task.id,
+                    session.id,
+                )
+            else:
+                logger.warning(
+                    "Approval gate: task %s rejected -- skipping merge for agent %s",
+                    task.id,
+                    session.id,
+                )
             return True
         if not approval_result.approved:
             _create_approval_pr(orch, task, session, completion_data)

--- a/tests/unit/test_approval.py
+++ b/tests/unit/test_approval.py
@@ -109,18 +109,15 @@ def test_approval_gate_with_override_mode(tmp_path: Path, make_task: Any) -> Non
     assert result.pr_url == ""
 
 
-def test_approval_gate_reject_on_timeout(tmp_path: Path, make_task: Any) -> None:
+def test_approval_gate_forwards_timeout_s_and_fails_closed_on_expiry(tmp_path: Path, make_task: Any) -> None:
     task = make_task(id="T-timeout-reject")
 
-    # Evaluate with a tiny timeout and reject_on_timeout=True
-    # The default _poll_decision doesn't have an easy mock to bypass sleep, but we can mock it
-    # However, since we mock _poll_decision in other tests, let's just assert that reject_on_timeout is passed correctly.
-    # We can inject a mock _poll_decision that verifies reject_on_timeout is True
-
-    def _mock_poll(task_id: str, approvals_dir: Path, max_wait_s: float = 0, reject_on_timeout: bool = False) -> str:
+    # An overriding timeout is forwarded to the poller as max_wait_s; an expiry
+    # (the poller reporting "timed_out") fails closed to rejected without the
+    # caller having to ask for it.
+    def _mock_poll(task_id: str, approvals_dir: Path, max_wait_s: float = 0) -> str:
         assert max_wait_s == pytest.approx(0.01)
-        assert reject_on_timeout is True
-        return "rejected"
+        return "timed_out"
 
     gate_mocked = ApprovalGate(ApprovalMode.REVIEW, tmp_path, _poll_decision=_mock_poll)
     result = gate_mocked.evaluate(
@@ -129,3 +126,39 @@ def test_approval_gate_reject_on_timeout(tmp_path: Path, make_task: Any) -> None
         timeout_s=0.01,
     )
     assert result.rejected is True
+    assert result.approved is False
+    assert result.resolution == "timed_out"
+
+
+def test_approval_gate_fails_closed_on_timeout_with_no_timeout_configured(tmp_path: Path, make_task: Any) -> None:
+    task = make_task(id="T-timeout-default")
+
+    # No timeout_s configured -- the historically fail-open path. The gate must
+    # still refuse to approve a review nobody performed.
+    gate = ApprovalGate(
+        ApprovalMode.REVIEW,
+        tmp_path,
+        _poll_decision=lambda task_id, approvals_dir: "timed_out",
+    )
+    result = gate.evaluate(task, session_id="S-timeout-default")
+
+    assert result.approved is False
+    assert result.rejected is True
+    assert result.resolution == "timed_out"
+
+
+def test_approval_gate_approve_on_timeout_opt_in_records_the_expiry(tmp_path: Path, make_task: Any) -> None:
+    task = make_task(id="T-timeout-optout")
+
+    gate = ApprovalGate(
+        ApprovalMode.REVIEW,
+        tmp_path,
+        _poll_decision=lambda task_id, approvals_dir: "timed_out",
+    )
+    result = gate.evaluate(task, session_id="S-timeout-optout", approve_on_timeout=True)
+
+    # The opt-in makes the expiry resolve to approved, but the record still
+    # says the approval expired rather than that a person granted it.
+    assert result.approved is True
+    assert result.rejected is False
+    assert result.resolution == "timed_out"

--- a/tests/unit/test_approval_gates.py
+++ b/tests/unit/test_approval_gates.py
@@ -208,16 +208,20 @@ class TestApprovalGateReviewFilePoll:
         decision = _default_poll_decision("T-rejpoll", approvals_dir, poll_interval_s=0.01, max_wait_s=1.0)
         assert decision == "rejected"
 
-    def test_default_poller_returns_approved_on_timeout(self, tmp_path: Path) -> None:
-        """When no decision file appears, defaults to approved (non-blocking)."""
+    def test_default_poller_reports_timed_out_on_expiry(self, tmp_path: Path) -> None:
+        """When no decision file appears, the poller reports the expiry as such.
+
+        It never returns "approved" for a review nobody performed; the caller
+        decides what an expiry means (fail closed by default).
+        """
         from bernstein.core.approval import _default_poll_decision
 
         approvals_dir = tmp_path / ".sdd" / "runtime" / "approvals"
         approvals_dir.mkdir(parents=True)
 
-        # No file written - should time out and default to approved
+        # No file written - should time out and report "timed_out"
         decision = _default_poll_decision("T-timeout", approvals_dir, poll_interval_s=0.01, max_wait_s=0.05)
-        assert decision == "approved"
+        assert decision == "timed_out"
 
 
 # ---------------------------------------------------------------------------
@@ -364,6 +368,18 @@ class TestApprovalResult:
         assert r.approved is True
         assert r.rejected is False
         assert r.pr_url == ""
+        assert r.resolution == "decided"
+
+    def test_timed_out_resolution_is_distinct_from_a_decision(self) -> None:
+        from bernstein.core.approval import ApprovalResult
+
+        decided = ApprovalResult(approved=False, rejected=True)
+        expired = ApprovalResult(approved=False, rejected=True, resolution="timed_out")
+
+        # approved/rejected look identical; resolution is what tells them apart.
+        assert (decided.approved, decided.rejected) == (expired.approved, expired.rejected)
+        assert decided.resolution == "decided"
+        assert expired.resolution == "timed_out"
 
     def test_rejected_result(self) -> None:
         from bernstein.core.approval import ApprovalResult


### PR DESCRIPTION
Fixes #5051.

## Problem

`_default_poll_decision` returns `"approved"` when the review wait expires, and
the fail-closed branch is only reachable when the caller passes an explicit
timeout. `reject_on_timeout` defaults to `False` and `ApprovalGate._review` set
it `True` only when `timeout_s is not None`, so an operator who configures no
timeout gets `_DEFAULT_MAX_WAIT_S` **and** fail-open. The resulting approval
record is indistinguishable from one a person actually granted.

## Change

- **`_default_poll_decision` stops deciding policy.** It reports the raw outcome
  and returns `"timed_out"` when the wait expires with no decision file, instead
  of synthesising `"approved"` / `"rejected"`. The `reject_on_timeout` parameter
  is gone.
- **`ApprovalGate._review` fails closed on `"timed_out"`** in both paths (timeout
  configured or not).
- **`ApprovalResult` carries `resolution`** (`"decided"` / `"timed_out"`), so a
  reader of the trail can tell an expiry from a real decision even when the
  `approved` / `rejected` flags look identical. `_evaluate_approval_gate` logs the
  timeout rejection distinctly.
- **The "do not block" behaviour stays available**, but has to be named:
  `evaluate(..., approve_on_timeout=True)` resolves an expiry to approved and
  still records `resolution="timed_out"` so the record never presents the expiry
  as a granted approval.

## Design note (the one open decision in the issue)

The issue leaves open whether the poller should keep returning
`"approved"`/`"rejected"` or gain a third outcome. I went with the third outcome
(`"timed_out"`): returning a bare `"rejected"` on expiry would satisfy "fail
closed" but not "an expiry is distinguishable from a decision" (Target
behaviour + acceptance criteria 3 and 5), and it keeps the policy choice
(fail open vs. closed) in the gate rather than in the file poller.

## Acceptance criteria

- [x] `_default_poll_decision` no longer returns `"approved"` on timeout.
- [x] Both call paths in `ApprovalGate` agree: timeout ⇒ rejected by default.
- [x] `ApprovalResult` distinguishes a decision from an expiry (`resolution`).
- [x] A test drives the gate to timeout with no timeout configured and asserts
  the task is **not** approved (fails against the previous implementation).
- [x] A test covers the explicit opt-out and asserts the record says the
  approval expired.

## Tests

New/updated in `tests/unit/test_approval.py` and `tests/unit/test_approval_gates.py`.
Ran every test module that imports the approval package
(`test_approval*.py`, `test_approval_gate*`, `orchestration/test_approval_gate_dark_paths.py`,
`security/test_approval_gate_fail_closed.py`, `test_task_lifecycle*.py`,
`test_approval_workflow_e2e.py`, `test_task_suspension.py`, `test_unreleased_notes_rotation.py`) —
all green. `ruff check` / `ruff format --check` clean; `mypy` reports no new errors
on the touched files.

Release note: `docs/release-notes/fragments/5051-approval-timeout-fail-closed.md`.
