### PR TITLE
feat(agents): record and surface the digest of harness-local agent directories (#3969)

### DIFF
--- a/docs/release-notes/fragments/3969-harness-local-discovery.md
+++ b/docs/release-notes/fragments/3969-harness-local-discovery.md
@@ -1,0 +1,2 @@
+## Harness Local Discovery
+This PR adds a `--harness-local` CLI flag to `bernstein agents discover` that surfaces harness directory paths, status, and content digests, with a new `content_digest` field recording the digest of each harness-local directory read. #3969

--- a/src/bernstein/agents/discovery.py
+++ b/src/bernstein/agents/discovery.py
@@ -41,6 +41,11 @@ class DirectoryEntry:
         agents: Number of agents found in this directory.
         last_sync: ISO-8601 timestamp of the last sync.
         enabled: Whether this directory is active.
+        content_digest: SHA-256 digest of the directory content as it was
+            read, empty for sources whose content is not read locally
+            (GitHub/npm search hits). Recorded for refused directories too,
+            so a refusal reports what is on disk rather than only what was
+            pinned.
     """
 
     name: str
@@ -50,6 +55,7 @@ class DirectoryEntry:
     agents: int = 0
     last_sync: str | None = None
     enabled: bool = True
+    content_digest: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         """Serialise to JSON-compatible dict."""
@@ -61,6 +67,7 @@ class DirectoryEntry:
             "agents": self.agents,
             "last_sync": self.last_sync,
             "enabled": self.enabled,
+            "content_digest": self.content_digest,
         }
 
     @classmethod
@@ -74,6 +81,7 @@ class DirectoryEntry:
             agents=d.get("agents", 0),
             last_sync=d.get("last_sync"),
             enabled=d.get("enabled", True),
+            content_digest=d.get("content_digest", ""),
         )
 
 
@@ -308,6 +316,12 @@ class AgentDiscovery:
         OFF by default: when *enabled* is False, makes zero filesystem reads outside
         the project directory and returns an empty list.
 
+        Every directory that is read records the digest of its content on the
+        returned entry, whether it was admitted or refused, so the registry can
+        say what was loaded and from where. A directory pinned by an
+        ``agents.lock`` whose digest no longer matches is returned disabled
+        rather than dropped.
+
         Args:
             enabled: Explicit opt-in flag. Must be True to perform discovery.
 
@@ -336,18 +350,24 @@ class AgentDiscovery:
             agent_count = 0
             is_refused = False
 
+            # The digest of what is on disk right now. Computed for every
+            # directory, pinned or not: it is the answer to "at what digest"
+            # that the registry has to carry, and a refusal reports the
+            # content actually present rather than the pin it failed.
+            try:
+                actual_digest = compute_catalog_digest(hdir)
+            except OSError:
+                actual_digest = ""
+                is_refused = True
+
             # Lockfile digest verification (#3973)
             lock_file = hdir / "agents.lock"
-            if lock_file.is_file():
+            if not is_refused and lock_file.is_file():
                 try:
                     data = json.loads(lock_file.read_text(encoding="utf-8"))
                     expected_digest = data.get("content_digest", "") if isinstance(data, dict) else ""
-                    if not expected_digest:
+                    if not expected_digest or actual_digest != expected_digest:
                         is_refused = True
-                    else:
-                        actual_digest = compute_catalog_digest(hdir)
-                        if actual_digest != expected_digest:
-                            is_refused = True
                 except (json.JSONDecodeError, UnicodeDecodeError, OSError):
                     # A lockfile that is present but unusable - malformed JSON, undecodable
                     # bytes, or an unreadable file under it - refuses the directory rather
@@ -363,6 +383,7 @@ class AgentDiscovery:
                     agents=0,
                     last_sync=_now_iso(),
                     enabled=False,
+                    content_digest=actual_digest,
                 )
                 self.directories.append(entry)
                 added.append(entry)
@@ -382,6 +403,7 @@ class AgentDiscovery:
                 agents=agent_count,
                 last_sync=_now_iso(),
                 enabled=True,
+                content_digest=actual_digest,
             )
             self.directories.append(entry)
             added.append(entry)

--- a/src/bernstein/cli/commands/agents_cmd.py
+++ b/src/bernstein/cli/commands/agents_cmd.py
@@ -697,7 +697,14 @@ def agents_trust(workdir: str, agent_id: str | None, as_json: bool) -> None:
 
 @agents_group.command("discover")
 @click.option("--net", "include_network", is_flag=True, default=False, help="Also search GitHub and npm.")
-def agents_discover(include_network: bool) -> None:
+@click.option(
+    "--harness-local",
+    "include_harness_local",
+    is_flag=True,
+    default=False,
+    help="Also read agent definitions the operator installed for their own harness (read-only, off by default).",
+)
+def agents_discover(include_network: bool, include_harness_local: bool) -> None:
     """Scan known sources for agent directories and update the registry.
 
     \b
@@ -706,17 +713,37 @@ def agents_discover(include_network: bool) -> None:
       .sdd/agents/local/       project-level definitions
       GitHub (--net)           repos tagged bernstein-agents
       npm (--net)              packages with bernstein-agent keyword
+      harness dirs             ~/.claude/agents, ~/.claude/plugins,
+      (--harness-local)        ./.claude/agents - read-only, opt-in
+
+    Harness-local directories hold third-party prompts the operator
+    installed for a different tool, so they are read only when
+    --harness-local is passed. Each one is listed with its path and the
+    content digest it was read at; a directory pinned by an agents.lock
+    whose digest no longer matches is listed as refused.
     """
     from bernstein.agents.discovery import AgentDiscovery
 
     discovery = AgentDiscovery.load()
 
     console.print("[bold]Discovering agent directories…[/bold]\n")
-    results = discovery.full_sync(include_network=include_network)
+    results = discovery.full_sync(
+        include_network=include_network,
+        include_harness_local=include_harness_local,
+    )
 
     for source, count in results.items():
         icon = "[green]✓[/green]" if count >= 0 else "[yellow]![/yellow]"
         console.print(f"  {icon} [cyan]{source}[/cyan]  {count} agent(s)")
+
+    if include_harness_local:
+        harness_entries = [d for d in discovery.directories if d.name.startswith("harness:")]
+        if harness_entries:
+            console.print(f"\n  [magenta]harness-local[/magenta] ({len(harness_entries)} directories)")
+            for e in harness_entries:
+                status = "[green]ok[/green]" if e.enabled else "[red]refused[/red]"
+                digest = e.content_digest[:12] if e.content_digest else "(none)"
+                console.print(f"    {status}  [dim]{e.path}[/dim]  digest {digest}")
 
     if include_network:
         gh_entries = [d for d in discovery.directories if d.source_type == "github"]

--- a/tests/unit/test_agents_discover_harness_flag.py
+++ b/tests/unit/test_agents_discover_harness_flag.py
@@ -1,0 +1,99 @@
+"""Tests for the operator opt-in to harness-local discovery (#3969 P5).
+
+``AgentDiscovery.discover_harness_local`` is off unless a caller passes
+``enabled=True``, but until this change no operator-reachable surface could
+pass it: ``bernstein agents discover`` only ever called ``full_sync`` with
+the network flag. These tests drive the real CLI so the opt-in is asserted
+where an operator hits it, not at the Python boundary underneath.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from bernstein.agents.agency_provider import compute_catalog_digest
+from bernstein.cli.commands.agents_cmd import agents_group
+
+
+def _registry_entries(fs_root: Path) -> list[dict[str, Any]]:
+    """Read the directory entries the ``discover`` command wrote."""
+    registry_path = fs_root / ".sdd" / "agents" / "registry.json"
+    raw: dict[str, Any] = json.loads(registry_path.read_text(encoding="utf-8"))
+    return list(raw["directories"])
+
+
+def _write_harness_agent(root: Path) -> Path:
+    """Create ``<root>/.claude/agents`` holding one parseable agent file."""
+    claude_agents = root / ".claude" / "agents"
+    claude_agents.mkdir(parents=True)
+    (claude_agents / "reviewer.md").write_text(
+        "---\nname: Code Reviewer\ndescription: Reviews code\n---\nPrompt",
+        encoding="utf-8",
+    )
+    return claude_agents
+
+
+def test_discover_without_the_flag_ingests_no_harness_resource(tmp_path: Path) -> None:
+    """Default ``agents discover`` leaves harness-local resources untouched.
+
+    The opt-in is the whole trust boundary: a third-party prompt sitting in
+    the operator's own harness directory must not become a bernstein agent
+    source because a routine discovery scan happened to run.
+    """
+    runner = CliRunner()
+
+    with runner.isolated_filesystem(temp_dir=tmp_path) as fs:
+        _write_harness_agent(Path(fs))
+        with patch("pathlib.Path.home", return_value=Path(fs)):
+            result = runner.invoke(agents_group, ["discover"])
+
+    assert result.exit_code == 0, result.output
+    assert "harness" not in result.output
+
+
+def test_discover_with_the_flag_lists_source_path_and_digest(tmp_path: Path) -> None:
+    """With the explicit flag, a discovered directory reports where and at what digest.
+
+    The rendered listing is width-elided, so the full source path is asserted
+    against the registry the command writes; the digest prefix is asserted in
+    the operator-visible output.
+    """
+    runner = CliRunner()
+
+    with runner.isolated_filesystem(temp_dir=tmp_path) as fs:
+        claude_agents = _write_harness_agent(Path(fs))
+        digest = compute_catalog_digest(claude_agents)
+        with patch("pathlib.Path.home", return_value=Path(fs)):
+            result = runner.invoke(agents_group, ["discover", "--harness-local"])
+        assert result.exit_code == 0, result.output
+        registry = _registry_entries(Path(fs))
+
+    harness = [e for e in registry if str(e.get("name", "")).startswith("harness:")]
+    assert harness, registry
+    assert all(e["path"] == str(claude_agents) for e in harness)
+    assert all(e["content_digest"] == digest for e in harness)
+    assert digest[:12] in result.output
+
+
+def test_discover_lists_a_refused_directory_as_refused(tmp_path: Path) -> None:
+    """A directory failing digest verification is listed as refused, not dropped."""
+    runner = CliRunner()
+
+    with runner.isolated_filesystem(temp_dir=tmp_path) as fs:
+        claude_agents = _write_harness_agent(Path(fs))
+        (claude_agents / "agents.lock").write_text('{"content_digest": "invalid_digest_0000"}', encoding="utf-8")
+        with patch("pathlib.Path.home", return_value=Path(fs)):
+            result = runner.invoke(agents_group, ["discover", "--harness-local"])
+        assert result.exit_code == 0, result.output
+        registry = _registry_entries(Path(fs))
+
+    harness = [e for e in registry if str(e.get("name", "")).startswith("harness:")]
+    assert harness, registry
+    assert all(e["path"] == str(claude_agents) for e in harness)
+    assert all(e["enabled"] is False for e in harness)
+    assert "refused" in result.output.lower()

--- a/tests/unit/test_harness_local_discovery.py
+++ b/tests/unit/test_harness_local_discovery.py
@@ -126,3 +126,82 @@ def test_unusable_lockfile_refuses_the_directory(tmp_path: Path, case: str, payl
     assert harness_entry is not None, case
     assert harness_entry.enabled is False, case
     assert harness_entry.agents == 0, case
+
+
+# ---------------------------------------------------------------------- #
+# Recorded provenance: "at what digest" (#3969 P5)                        #
+# ---------------------------------------------------------------------- #
+
+
+def test_admitted_harness_directory_records_its_content_digest(tmp_path: Path) -> None:
+    """An admitted directory carries the digest of the content it admitted.
+
+    A harness directory with no lockfile is the common case - nobody ships
+    ``agents.lock`` inside ``~/.claude/agents``. Admitting it without
+    recording a digest leaves the registry unable to say what was loaded,
+    which is the one question the discovery pass exists to answer.
+    """
+    claude_agents = _harness_dir_with_agent(tmp_path)
+
+    entries = _discover(tmp_path)
+
+    harness_entry = next((e for e in entries if "harness:agents" in e.name), None)
+    assert harness_entry is not None
+    assert harness_entry.enabled is True
+    assert harness_entry.content_digest == compute_catalog_digest(claude_agents)
+
+
+def test_refused_harness_directory_records_the_digest_found_on_disk(tmp_path: Path) -> None:
+    """A refused directory reports the digest actually present, not the pin.
+
+    Recording only the pinned digest would tell the operator what was
+    expected; recording the on-disk digest tells them what they have, which
+    is what a refusal has to be diagnosed from.
+    """
+    claude_agents = _harness_dir_with_agent(tmp_path)
+    (claude_agents / "agents.lock").write_text(json.dumps({"content_digest": "invalid_digest_0000"}), encoding="utf-8")
+    on_disk = compute_catalog_digest(claude_agents)
+
+    entries = _discover(tmp_path)
+
+    harness_entry = next((e for e in entries if "harness:agents" in e.name), None)
+    assert harness_entry is not None
+    assert harness_entry.enabled is False
+    assert harness_entry.content_digest == on_disk
+    assert harness_entry.content_digest != "invalid_digest_0000"
+
+
+def test_registry_round_trip_preserves_the_recorded_digest(tmp_path: Path) -> None:
+    """The digest survives save/load, so a later run reads the same answer."""
+    _harness_dir_with_agent(tmp_path)
+    registry_path = tmp_path / "registry.json"
+    discovery = AgentDiscovery(registry_path=registry_path, project_dir=tmp_path)
+    with patch("pathlib.Path.home", return_value=tmp_path):
+        discovery.discover_harness_local(enabled=True)
+    discovery.save()
+
+    reloaded = AgentDiscovery.load(registry_path)
+
+    harness_entry = next((e for e in reloaded.directories if "harness:agents" in e.name), None)
+    assert harness_entry is not None
+    assert harness_entry.content_digest == compute_catalog_digest(tmp_path / ".claude" / "agents")
+
+
+def test_registry_written_before_digests_still_loads(tmp_path: Path) -> None:
+    """A registry file predating the digest field loads with an empty digest."""
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "directories": [{"name": "harness:agents", "source_type": "local", "path": "/somewhere", "agents": 1}],
+                "metrics": {},
+                "total_agents": 1,
+                "last_full_sync": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    reloaded = AgentDiscovery.load(registry_path)
+
+    assert reloaded.directories[0].content_digest == ""


### PR DESCRIPTION
## What

Completes the operator-facing half of the harness-local discovery slice (P5).

- `DirectoryEntry` gains a `content_digest` field, recorded for every harness-local directory that is read — admitted or refused — and round-tripped through the registry file.
- `bernstein agents discover` gains an explicit `--harness-local` opt-in flag; without it the command reads nothing outside the project, exactly as before.
- With the flag on, each discovered directory is listed with its source path, its content digest, and whether it was admitted or refused.

Explicitly not in this PR: the plugin-format reader (P1), wiring `catalogs:` into the match path (P2), lockfile/signature/receipt machinery for agent sources (P3), and the spawn bridges (P4). No auto-ingest, no network read, no new lockfile is written — an existing per-directory `agents.lock` pin is still the only thing verified.

## Why

`discover_harness_local()` already refused a directory whose `agents.lock` pin no longer matched, but the digest it computed to make that decision was thrown away, and there was no way to reach the code path from the CLI at all. The result was that an operator could not answer "what did this run load, from where, at what digest" for harness-local sources: the registry recorded a path and a count, and the refusal was visible only in a log line. Recording the digest on the entry and surfacing it from `agents discover` makes the answer readable from the same place the directories are listed.

The digest is recorded on refused entries too. A refusal is more useful when it reports the content actually present on disk than when it reports only the pin it failed, since that is what the operator has to compare against.

## How

`discover_harness_local()` now computes the directory digest once, up front, for every directory it reads, and reuses it for the lockfile comparison instead of computing it only inside the pinned branch. An `OSError` while digesting refuses the directory with an empty digest rather than escaping and aborting the sweep. The digest is written onto both the admitted and the refused `DirectoryEntry`; `to_dict`/`from_dict` carry it, defaulting to `""` so registry files written before this change still load.

`agents_discover` grows a `--harness-local` flag (default off) that is passed through to `full_sync(include_harness_local=...)`, plus a listing block that prints path, status and short digest for each `harness:` entry.

Open question 2 in the issue — whether P5 should read agent definitions from harness formats beyond the plugin layout — is decided here as plugin layout only for v1: discovery keeps parsing through `parse_agent_file`, so a second format would arrive as a second parser rather than as a change to this code path.

## Tests

All four new tests fail on the unmodified tree; the two digest tests fail with `AttributeError: 'DirectoryEntry' object has no attribute 'content_digest'`, and the CLI tests fail with `Error: No such option '--harness-local'`.

1. `test_admitted_harness_directory_records_its_content_digest` — an admitted directory carries the digest of the content that was read.
2. `test_refused_harness_directory_records_the_digest_found_on_disk` — **load-bearing**: a directory refused on a digest mismatch reports the digest present on disk, not the pin it failed, so the refusal is actionable.
3. `test_registry_round_trip_preserves_the_recorded_digest` — the digest survives `to_dict`/`from_dict`.
4. `test_registry_written_before_digests_still_loads` — a registry entry written without the field loads with an empty digest instead of raising.
5. `test_discover_without_the_flag_ingests_no_harness_resource` — the default invocation ingests nothing from outside the project.
6. `test_discover_with_the_flag_lists_source_path_and_digest` — the opt-in lists each directory with its path and digest.
7. `test_discover_lists_a_refused_directory_as_refused` — a pinned directory whose digest moved is shown as refused rather than silently omitted.

`--affected origin/main` did not finish inside the local budget, so the run was the touched modules plus every test importing them: `tests/unit/test_harness_local_discovery.py`, `tests/unit/test_agents_discover_harness_flag.py`, `tests/unit/test_agents_cmd_match.py`, `tests/unit/test_a2a_agntcy_ads.py`, `tests/unit/test_capability_surfaces.py`, `tests/unit/test_timeout_behavior.py` — 84 passed. CI runs the full suite.

## Checklist

- [x] `uv run ruff check src/` — clean
- [x] `uv run ruff format --check` on the changed files — clean
- [x] `uv run pyright` on the changed files — 86 pre-existing findings, identical count on `origin/main`; no new ones
- [x] `uv run python scripts/run_tests.py -x` on the new test files — green
- [x] Type hints on all new and changed signatures
- [x] `uv run bernstein agents-md sync` — no changes produced
- [ ] README / translations — N/A, not touched
- [ ] Migration or schema change — N/A, the new field defaults to `""` for registry files written earlier

Part of #3969

## Remaining

- P1 — plugin/subagent format reader hardening beyond the current `parse_agent_file` path.
- P2 — configured `catalogs:` entries reaching `loaded_agents` and the `match()` path.
- P3 — lockfile with lineage receipts, signature verification and revocation for agent sources.
- P4 — installed skill packs reaching the task worktree, and catalog agents reaching `build_agents_json`.
- P5 remainder — discovered resources landing in a shared lockfile alongside the other sources.
