### PR TITLE
fix: bind a finding artifact to its invocation instead of defaulting it away (#2953)

### DIFF
--- a/docs/release-notes/fragments/2953-finding-binding.md
+++ b/docs/release-notes/fragments/2953-finding-binding.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- The `finding` artifact canonicalisation rule now rejects payloads that were previously silently accepted. Missing or blank required fields, non-string values, and unknown keys now raise `CanonicalisationError` instead of producing a stable identity hash. The `artifact_content_hash(ArtifactKind.FINDING, ...)` contract is now enforced. ([#2953](https://github.com/sipyourdrink-ltd/bernstein/issues/2953))

--- a/src/bernstein/core/tasks/artifacts.py
+++ b/src/bernstein/core/tasks/artifacts.py
@@ -15,7 +15,11 @@ UTF-8, ``\\n`` newlines):
   policy the other canonical cores in the codebase apply;
 * JSONL kinds (``dataset`` / ``action_log``) emit one JCS-canonical JSON object
   per line, ``\\n``-separated;
-* the JSON-object kind (``ops_result``) emits a single JCS-canonical object.
+* the JSON-object kind (``ops_result``) emits a single JCS-canonical object;
+* the ``finding`` kind emits a JCS-canonical *projection* of a scanner result -
+  rule, normalised URI and snippet hash, bound to the invocation that produced
+  it - deliberately without the raw line number, so a cosmetic edit above a
+  finding does not re-identify it.
 
 This module deliberately has no dependency on the task model or the lineage
 store so it can be imported from both sides without a cycle.
@@ -53,6 +57,21 @@ _JSONL_KINDS: frozenset[ArtifactKind] = frozenset({ArtifactKind.DATASET, Artifac
 _JSON_OBJECT_KINDS: frozenset[ArtifactKind] = frozenset({ArtifactKind.OPS_RESULT})
 #: Kinds whose canonical form is raw bytes.
 _BYTE_KINDS: frozenset[ArtifactKind] = frozenset({ArtifactKind.BLOB})
+
+#: Closed key set of a ``finding`` payload. Every key is required - see
+#: :func:`_canonical_finding_bytes` for why an omission cannot be defaulted.
+_FINDING_KEYS: frozenset[str] = frozenset(
+    {
+        "ruleId",
+        "artifactLocation",
+        "region",
+        "tool",
+        "tool_version",
+        "pinned_digest",
+        "invocation_argv_hash",
+        "target",
+    }
+)
 
 #: The three typed criteria that operate on artifact bytes (issue #2608).
 ARTIFACT_CRITERION_TYPES: frozenset[str] = frozenset({"schema_valid", "criteria_match", "hash_stable"})
@@ -150,37 +169,75 @@ def _coerce_rows(raw: Any) -> list[Any]:
 # ---------------------------------------------------------------------------
 
 
+def _finding_text(value: Any, label: str, *, allow_empty: bool = False) -> str:
+    """Return ``value`` as a finding field, rejecting coercion and blanks.
+
+    ``str(8)`` and ``"8"`` are two different bindings; coercing them would let
+    both collide on one identity, so a non-string is rejected outright.
+    """
+    if not isinstance(value, str):
+        raise CanonicalisationError(f"finding field {label!r} must be a string, got {type(value).__name__}")
+    if not value and not allow_empty:
+        raise CanonicalisationError(f"finding field {label!r} must not be empty")
+    return value
+
+
+def _finding_mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise CanonicalisationError(f"finding field {label!r} must be a mapping, got {type(value).__name__}")
+    return value
+
+
 def _canonical_finding_bytes(raw: Any) -> bytes:
-    """Canonicalise a SARIF 2.1.0 finding artifact for content-addressing.
-    Projects the finding down to stable identity fields, deliberately dropping
-    the raw line number so cosmetic shifts don't change the hash. Binds tool
-    context so the identity is anchored to the exact invocation.
+    """Canonicalise a SARIF 2.1.0-derived finding for content-addressing.
+
+    The projection drops the raw line number on purpose: a cosmetic edit above
+    a finding shifts ``region.startLine`` and must not re-identify it. What
+    survives is ``ruleId`` + the normalised ``artifactLocation.uri`` + a hash of
+    the region snippet, bound to the invocation that produced it.
+
+    Because the projection discards input, the payload's key set is *closed* and
+    every key is required. A missing field must not fall back to an empty
+    default: that would hand an unbound finding - one naming no tool, no
+    version and no invocation - a stable, valid-looking identity, and carrying
+    that binding is the whole point of the kind. Same reject-don't-repair policy
+    the text core applies.
     """
     if not isinstance(raw, dict):
         raise CanonicalisationError(f"finding artifact must be a mapping, got {type(raw).__name__}")
 
-    # Extract SARIF result fields
-    rule_id = str(raw.get("ruleId", ""))
+    keys = set(raw)
+    unknown = sorted(keys - _FINDING_KEYS)
+    if unknown:
+        raise CanonicalisationError(f"finding artifact has unknown field(s): {', '.join(unknown)}")
+    missing = sorted(_FINDING_KEYS - keys)
+    if missing:
+        raise CanonicalisationError(f"finding artifact is missing required field(s): {', '.join(missing)}")
 
-    # Normalise artifact location URI to forward slashes
-    artifact_location = raw.get("artifactLocation", {})
-    uri = str(artifact_location.get("uri", "")).replace("\\", "/")
+    location = _finding_mapping(raw["artifactLocation"], "artifactLocation")
+    if "uri" not in location:
+        raise CanonicalisationError("finding artifact is missing required field(s): artifactLocation.uri")
+    # Path separators are cosmetic too: one file scanned on either platform is
+    # one finding.
+    uri = _finding_text(location["uri"], "artifactLocation.uri").replace("\\", "/")
 
-    # Hash the snippet text instead of using the raw line number
-    region = raw.get("region", {})
-    snippet_text = str(region.get("snippet", {}).get("text", ""))
-    snippet_hash = "sha256:" + hashlib.sha256(snippet_text.encode("utf-8")).hexdigest()
+    region = _finding_mapping(raw["region"], "region")
+    snippet = _finding_mapping(region.get("snippet", {}), "region.snippet")
+    # A finding need not quote source text - a port observation has none.
+    snippet_text = _finding_text(snippet.get("text", ""), "region.snippet.text", allow_empty=True)
 
-    # Bind context fields required by the issue
     projected = {
-        "ruleId": rule_id,
+        "ruleId": _finding_text(raw["ruleId"], "ruleId"),
         "uri": uri,
-        "snippet_hash": snippet_hash,
-        "tool": str(raw.get("tool", "")),
-        "tool_version": str(raw.get("tool_version", "")),
-        "pinned_digest": str(raw.get("pinned_digest", "")),
-        "invocation_argv_hash": str(raw.get("invocation_argv_hash", "")),
-        "target": str(raw.get("target", "")),
+        "snippet_hash": "sha256:" + hashlib.sha256(snippet_text.encode("utf-8")).hexdigest(),
+        "tool": _finding_text(raw["tool"], "tool"),
+        "tool_version": _finding_text(raw["tool_version"], "tool_version"),
+        # Empty is legal here and nowhere else: an adapter on the
+        # ``deterministic`` tier has no feed to pin, and recording "" says so
+        # explicitly rather than by omission.
+        "pinned_digest": _finding_text(raw["pinned_digest"], "pinned_digest", allow_empty=True),
+        "invocation_argv_hash": _finding_text(raw["invocation_argv_hash"], "invocation_argv_hash"),
+        "target": _finding_text(raw["target"], "target"),
     }
 
     return _canonical_json_bytes(projected)

--- a/tests/unit/core/tasks/test_finding_artifact.py
+++ b/tests/unit/core/tasks/test_finding_artifact.py
@@ -1,9 +1,27 @@
-from bernstein.core.tasks.artifacts import ArtifactKind, artifact_content_hash
+"""Identity rule for the ``finding`` artifact kind (#2953).
+
+The kind exists so an analysis result can be content-addressed *and* bound to
+the invocation that produced it. Both halves are load-bearing: the projection
+must survive a cosmetic edit, and it must refuse to mint an identity for a
+finding that names no tool, no version and no invocation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from bernstein.core.tasks.artifacts import (
+    ArtifactKind,
+    CanonicalisationError,
+    artifact_content_hash,
+)
 
 
-def test_finding_identity_stable_across_line_shift():
-    # The exact same finding, but startLine moved from 10 to 11
-    finding_at_line_10 = {
+def _finding(**overrides: Any) -> dict[str, Any]:
+    """A fully-bound finding; tests override exactly the field under test."""
+    payload: dict[str, Any] = {
         "ruleId": "G101",
         "artifactLocation": {"uri": "src/app.py"},
         "region": {"startLine": 10, "snippet": {"text": "password = 'hunter2'"}},
@@ -13,16 +31,16 @@ def test_finding_identity_stable_across_line_shift():
         "invocation_argv_hash": "sha256:def",
         "target": "src/app.py",
     }
-    finding_at_line_11 = {
-        "ruleId": "G101",
-        "artifactLocation": {"uri": "src/app.py"},
-        "region": {"startLine": 11, "snippet": {"text": "password = 'hunter2'"}},  # Line shifted!
-        "tool": "gitleaks",
-        "tool_version": "8.18.0",
-        "pinned_digest": "sha256:abc",
-        "invocation_argv_hash": "sha256:def",
-        "target": "src/app.py",
-    }
+    payload.update(overrides)
+    return payload
+
+
+def test_finding_identity_stable_across_line_shift():
+    # The exact same finding, but startLine moved from 10 to 11
+    finding_at_line_10 = _finding()
+    finding_at_line_11 = _finding(
+        region={"startLine": 11, "snippet": {"text": "password = 'hunter2'"}},  # Line shifted!
+    )
 
     hash_10 = artifact_content_hash(ArtifactKind.FINDING, finding_at_line_10)
     hash_11 = artifact_content_hash(ArtifactKind.FINDING, finding_at_line_11)
@@ -32,27 +50,97 @@ def test_finding_identity_stable_across_line_shift():
 
 
 def test_finding_identity_changes_when_snippet_changes():
-    finding_1 = {
-        "ruleId": "G101",
-        "region": {"startLine": 10, "snippet": {"text": "password = 'hunter2'"}},
-        "tool": "gitleaks",
-        "tool_version": "1",
-        "pinned_digest": "1",
-        "invocation_argv_hash": "1",
-        "target": "a",
-    }
-    finding_2 = {
-        "ruleId": "G101",
-        "region": {"startLine": 10, "snippet": {"text": "password = 'hunter3'"}},  # Snippet changed!
-        "tool": "gitleaks",
-        "tool_version": "1",
-        "pinned_digest": "1",
-        "invocation_argv_hash": "1",
-        "target": "a",
-    }
+    finding_1 = _finding()
+    finding_2 = _finding(
+        region={"startLine": 10, "snippet": {"text": "password = 'hunter3'"}},  # Snippet changed!
+    )
 
     hash_1 = artifact_content_hash(ArtifactKind.FINDING, finding_1)
     hash_2 = artifact_content_hash(ArtifactKind.FINDING, finding_2)
 
     # Rule is not just ignoring everything; snippet matters
     assert hash_1 != hash_2
+
+
+def test_windows_path_separators_do_not_change_finding_identity():
+    posix = _finding(artifactLocation={"uri": "src/app.py"})
+    windows = _finding(artifactLocation={"uri": "src\\app.py"})
+
+    assert artifact_content_hash(ArtifactKind.FINDING, posix) == artifact_content_hash(ArtifactKind.FINDING, windows)
+
+
+@pytest.mark.parametrize("omitted", ["tool", "tool_version", "invocation_argv_hash", "target", "ruleId"])
+def test_unbound_finding_is_rejected_not_given_an_identity(omitted: str):
+    """A finding that names no tool/version/invocation must not hash at all.
+
+    Defaulting the missing field to ``""`` would hand an unbound finding a
+    stable, valid-looking identity - and the binding is the whole point of the
+    kind.
+    """
+    payload = _finding()
+    del payload[omitted]
+
+    with pytest.raises(CanonicalisationError, match=omitted):
+        artifact_content_hash(ArtifactKind.FINDING, payload)
+
+
+def test_finding_without_a_location_is_rejected():
+    """No ``artifactLocation.uri`` means the finding points at nothing."""
+    no_block = _finding()
+    del no_block["artifactLocation"]
+    with pytest.raises(CanonicalisationError, match="artifactLocation"):
+        artifact_content_hash(ArtifactKind.FINDING, no_block)
+
+    with pytest.raises(CanonicalisationError, match=r"artifactLocation\.uri"):
+        artifact_content_hash(ArtifactKind.FINDING, _finding(artifactLocation={}))
+
+
+@pytest.mark.parametrize("blank", ["tool", "tool_version", "invocation_argv_hash", "target", "ruleId"])
+def test_blank_binding_field_is_rejected(blank: str):
+    with pytest.raises(CanonicalisationError, match=blank):
+        artifact_content_hash(ArtifactKind.FINDING, _finding(**{blank: ""}))
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("tool_version", 8),
+        ("ruleId", 101),
+        ("target", None),
+        ("tool", ["gitleaks"]),
+    ],
+)
+def test_non_string_binding_field_is_rejected_not_coerced(field_name: str, value: Any):
+    """``str(8)`` and ``"8"`` are two bindings; they must not share one identity."""
+    with pytest.raises(CanonicalisationError, match=field_name):
+        artifact_content_hash(ArtifactKind.FINDING, _finding(**{field_name: value}))
+
+
+def test_unknown_finding_field_is_rejected_not_silently_dropped():
+    """A misspelt binding key must fail loudly, not unbind the finding quietly."""
+    payload = _finding()
+    payload["toolVersion"] = payload.pop("tool_version")
+
+    with pytest.raises(CanonicalisationError, match="toolVersion"):
+        artifact_content_hash(ArtifactKind.FINDING, payload)
+
+
+def test_empty_pinned_digest_is_the_one_legal_blank():
+    """A ``deterministic``-tier adapter has no feed to pin and says so explicitly."""
+    unpinned = artifact_content_hash(ArtifactKind.FINDING, _finding(pinned_digest=""))
+    pinned = artifact_content_hash(ArtifactKind.FINDING, _finding(pinned_digest="sha256:abc"))
+
+    assert unpinned != pinned
+
+
+def test_finding_with_no_snippet_still_has_an_identity():
+    """Not every finding has source text - a port observation has none."""
+    no_snippet = artifact_content_hash(ArtifactKind.FINDING, _finding(region={}))
+    empty_snippet = artifact_content_hash(ArtifactKind.FINDING, _finding(region={"snippet": {"text": ""}}))
+
+    assert no_snippet == empty_snippet
+
+
+def test_finding_payload_must_be_a_mapping():
+    with pytest.raises(CanonicalisationError, match="mapping"):
+        artifact_content_hash(ArtifactKind.FINDING, ["not", "a", "mapping"])


### PR DESCRIPTION
## What

Makes the `finding` artifact kind actually bind a finding to the invocation
that produced it.

`_canonical_finding_bytes` (`src/bernstein/core/tasks/artifacts.py`) now treats
the payload's key set as closed and required, rejects non-string binding fields
instead of coercing them, and rejects a finding with no location. `pinned_digest`
is the single field allowed to be empty.

**Not in this PR:** the `ScannerAdapter` contract, the registry, the conformance
suite and the three reference adapters — all already on `main` from #3616 /
#3617 / #3618. Nothing under `src/bernstein/adapters/` is touched. Whether the
run-artifact posting surface (`core/evidence/run_artifacts.py`) should also carry
findings is still the separate decision the issue describes; it is untouched here.

## Why

The point of the `finding` kind is that a finding is content-addressed *and*
anchored to the tool, version, pinned digest and invocation that produced it.
The canonicaliser did not enforce the second half:

```python
"tool": str(raw.get("tool", "")),
"tool_version": str(raw.get("tool_version", "")),
"invocation_argv_hash": str(raw.get("invocation_argv_hash", "")),
```

Three concrete failures followed from that shape.

1. **An unbound finding got an identity.** A payload naming no tool, no version
   and no invocation hashed cleanly to a stable, valid-looking digest. Every
   field the kind exists to bind was optional in practice, so a finding could be
   sealed into lineage with nothing attesting where it came from.
2. **Coercion collapsed two bindings onto one identity.** `tool_version: 8` and
   `tool_version: "8"` produced the same hash. So did `target: None` and
   `target: "None"`.
3. **A misspelt key unbound the finding silently.** `toolVersion` (SARIF's own
   camelCase) was dropped as unknown and `tool_version` defaulted to `""` — no
   error, just a finding that no longer names its tool.

Right now nothing in the tree constructs a `FINDING` payload, so no recorded
finding carries a wrong identity yet. That is exactly why this is the moment to
fix the rule: once adapters start sealing findings under it, changing the
identity rule invalidates everything already recorded.

The module's own stated policy is reject-don't-repair — `_canonical_text_bytes`
rejects non-NFC input rather than normalising it. The finding canonicaliser was
the one core that repaired.

## How

- `_FINDING_KEYS` declares the closed key set next to the other per-kind tables.
  Unknown keys and missing keys each raise `CanonicalisationError` naming the
  offending field, in the same style as the other cores.
- `_finding_text` requires a `str` and rejects blanks; `_finding_mapping`
  requires a mapping. Neither coerces.
- `artifactLocation.uri` is required; the backslash-to-slash normalisation is
  kept, so one file scanned on either platform stays one finding.
- Two deliberate exceptions, both documented at the call site:
  - `pinned_digest` may be `""`. **This is the open decision the issue leaves,
    and this is the call:** an adapter on the `deterministic` tier has no feed to
    pin, and an explicit empty digest states that, where an omitted key cannot be
    told apart from a `feed_pinned` adapter that forgot to record one. Making it
    required-but-blankable keeps the tier distinction visible in the payload.
  - `region.snippet.text` may be absent or empty — a port observation quotes no
    source text, so requiring a snippet would exclude the `transcript_anchored`
    tier from the kind entirely.
- The projection itself is unchanged: `ruleId` + normalised uri + snippet hash +
  bindings, with the raw line number still deliberately excluded.

## Tests

`tests/unit/core/tasks/test_finding_artifact.py`. Tests 4–8 are new and all
failed on the unmodified tree with `DID NOT RAISE CanonicalisationError`
(16 failing parametrised cases); tests 1–3 and 9–10 passed before and after,
and are there to prove the change did not weaken the identity rule while
tightening the binding.

1. `test_finding_identity_stable_across_line_shift` — a cosmetic line shift
   above the finding does not change the hash. Pre-existing; the property the
   whole kind is for.
2. `test_finding_identity_changes_when_snippet_changes` — changing the snippet
   does change the hash, so the rule is not ignoring everything. Pre-existing.
3. `test_windows_path_separators_do_not_change_finding_identity` — separator
   normalisation survives the closed key set.
4. **`test_unbound_finding_is_rejected_not_given_an_identity`** — omitting
   `tool`, `tool_version`, `invocation_argv_hash`, `target` or `ruleId` raises
   instead of hashing. **Load-bearing:** this is the defect, and it is the
   acceptance criterion "the finding binds tool + version + pinned digest +
   invocation hash" turned into an assertion.
5. `test_finding_without_a_location_is_rejected` — a missing `artifactLocation`,
   and a present one with no `uri`, both raise.
6. `test_blank_binding_field_is_rejected` — an empty string is not a binding
   either, for every field except `pinned_digest`.
7. `test_non_string_binding_field_is_rejected_not_coerced` — `tool_version: 8`,
   `ruleId: 101`, `target: None` and `tool: ["gitleaks"]` raise rather than
   collapsing onto a string's identity.
8. `test_unknown_finding_field_is_rejected_not_silently_dropped` — a payload
   spelling `toolVersion` fails loudly.
9. `test_empty_pinned_digest_is_the_one_legal_blank` — an unpinned
   `deterministic`-tier finding canonicalises, and does not share an identity
   with a pinned one.
10. `test_finding_with_no_snippet_still_has_an_identity` — a finding with no
    source text (a port observation) is representable.
11. `test_finding_payload_must_be_a_mapping` — pre-existing guard, kept.

Also run green, to confirm no importer of the module regressed:
`tests/property/test_artifact_canon_properties.py`,
`tests/unit/tasks/test_artifact_contract.py`,
`tests/unit/tasks/test_artifact_completion.py`,
`tests/unit/lineage/test_artifact_record.py`,
`tests/unit/cli/test_artifact_verify_cmd.py`,
`tests/unit/test_janitor.py` and seven more — 14 files, 343 tests, all passing.

## Checklist

- [x] `uv run ruff check src/` — clean on the changed file
- [x] `uv run ruff format --check src/` — clean on the changed file
- [x] `uv run pyright src/` — errors on this file drop from 63 to 48; no new
      diagnostics introduced (the removed `raw.get(...)` chains were the source
      of the 15 that went away)
- [x] `uv run python scripts/run_tests.py --parallel 2 -x <files>` — 14 files
      green; `--affected origin/main` selected nothing, so the module's
      importers were enumerated by grep and run explicitly. CI runs the full
      suite.
- [x] Type hints on all new functions
- [x] `uv run bernstein agents-md sync` — no drift (no public surface changed)
- [x] README / translations — N/A, untouched
- [x] Release notes — N/A, no user-visible surface changes

Part of #2953

## Remaining

- The `ScannerAdapter` contract, registry and conformance suite (#3617) and the
  three reference adapters (#3618) are already merged; #3618 is still open as
  the tracking record for its slice.
- No production code path constructs a `FINDING` payload yet — wiring the
  scanner adapters' `Finding` output through `record_artifact` is the next step
  and is not in this PR.
- Whether `post_run_artifact()` should also accept findings remains the open
  decision the issue describes; deciding it needs the two-pipeline question
  settled first.
