### PR TITLE
feat: report decision provenance for approval-gated actions (#2917)

### DIFF
--- a/src/bernstein/cli/commands/compliance_cmd.py
+++ b/src/bernstein/cli/commands/compliance_cmd.py
@@ -520,6 +520,74 @@ def export_rego(framework: str, output_dir: Path | None, workdir: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# `bernstein compliance decisions` - decision provenance for gated actions
+# ---------------------------------------------------------------------------
+
+
+@compliance_group.command("decisions")
+@click.option(
+    "--audit-dir",
+    default=".sdd/audit",
+    show_default=True,
+    type=click.Path(path_type=Path),
+    help="Directory holding the HMAC-chained audit log.",
+)
+@click.option("--json-output", "as_json", is_flag=True, help="Emit the closed-schema records as JSON.")
+def decisions(audit_dir: Path, as_json: bool) -> None:
+    """Report decision provenance for every approval-gated action.
+
+    One record per settled approval card: who approved it, what tool call it
+    authorised, the intent and blast-radius estimate they were shown, and the
+    two audit-chain events each field was taken from.
+
+    The report is emitted only when the chain verifies and only for cards the
+    approval-card verifier could fully reconstruct. A decision-provenance
+    report drawn from a chain that failed verification would be an ordinary
+    claims document, which is what this command exists to replace, so a failed
+    verdict prints the errors and exits non-zero instead.
+    """
+    from bernstein.core.approval.card_verify import verify_approval_card_events
+    from bernstein.core.compliance.decision_record import (
+        build_decision_records,
+        render_decision_records,
+    )
+    from bernstein.core.security.audit import (
+        AuditKeyMissingError,
+        AuditKeyPermissionError,
+        load_audit_key,
+    )
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+    try:
+        key = load_audit_key()
+    except (AuditKeyMissingError, AuditKeyPermissionError) as exc:
+        raise click.ClickException(f"cannot authenticate audit rows: {exc}") from exc
+
+    # One locked snapshot: the rows projected below are exactly the rows the
+    # verdict covers. Verifying and querying separately would let an append
+    # land in between, so the report could carry a decision the verification
+    # never saw.
+    chain = AuditChainStore(audit_dir, key=key)
+    chain_ok, chain_errors, events = chain.verify_and_query(include_archived=True)
+    if not chain_ok:
+        for error in chain_errors:
+            click.echo(f"audit chain verification failed: {error}", err=True)
+        raise SystemExit(1)
+
+    result = verify_approval_card_events(events)
+    if not result.ok:
+        for error in [*result.errors, *result.verifier_errors]:
+            click.echo(f"approval card verification failed: {error}", err=True)
+        raise SystemExit(1)
+
+    records = build_decision_records(result)
+    if as_json:
+        click.echo(json.dumps([record.to_dict() for record in records], indent=2, sort_keys=False))
+        return
+    click.echo(render_decision_records(records))
+
+
+# ---------------------------------------------------------------------------
 # `bernstein compliance pack` - regulator-mapped evidence packs
 #
 # ``pack`` is a group. With no subcommand (or a leading option) it defaults to

--- a/src/bernstein/core/approval/card_verify.py
+++ b/src/bernstein/core/approval/card_verify.py
@@ -40,11 +40,56 @@ from bernstein.core.security.audit_chain import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from pathlib import Path
 
     from bernstein.core.security.audit import AuditEvent
 
-__all__ = ["ApprovalCardVerifyResult", "verify_approval_cards"]
+__all__ = [
+    "ApprovalCardVerifyResult",
+    "VerifiedApprovalCard",
+    "verify_approval_card_events",
+    "verify_approval_cards",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedApprovalCard:
+    """One issue/resolve pair that survived every check in this module.
+
+    Reconstructing the pair and then discarding it makes the verifier able to
+    say *that* a decision is sound but not *what* it was, so anything that
+    wants to project the decision has to read the chain a second time and
+    re-derive the pairing -- a second read that can disagree with the verdict.
+    Returning the reconstruction keeps the projection and the verdict on the
+    same evidence.
+
+    ``issued_hmac`` and ``resolved_hmac`` are the chain anchors of the two
+    events the pair was reconstructed from: they name exactly which entries a
+    reader must re-verify to re-derive this record.
+
+    Attributes:
+        card: The issued envelope, rehydrated from the issue event.
+        card_hash: The committed envelope hash, and the decision identity.
+        decision: The settled decision, one of :data:`ALLOWED_DECISIONS`.
+        approver: Identity recorded on the settlement.
+        resolved_at: Settlement time, validated against the envelope window.
+        issued_hmac: Chain anchor of the ``chat.approval_card.issued`` event.
+        resolved_hmac: Chain anchor of the ``chat.approval_card.resolved``
+            event.
+        issued_timestamp: ISO timestamp of the issue event.
+        resolved_timestamp: ISO timestamp of the settlement event.
+    """
+
+    card: ApprovalCardV2
+    card_hash: str
+    decision: str
+    approver: str
+    resolved_at: float
+    issued_hmac: str
+    resolved_hmac: str
+    issued_timestamp: str
+    resolved_timestamp: str
 
 
 @dataclass(frozen=True)
@@ -72,6 +117,11 @@ class ApprovalCardVerifyResult:
         ok: ``True`` only when neither list has entries.
         errors: Records that were evaluated and failed. Accuses the data.
         verifier_errors: Records that could not be evaluated. Accuses this code.
+        records: The fully reconstructed issue/resolve pairs, in chain order.
+            Exactly the settlements counted by ``reconstructed_count``: a card
+            that failed any check contributes an entry to ``errors`` and no
+            record here, so a consumer projecting these cannot project a
+            decision that has no verifying source event.
     """
 
     ok: bool
@@ -80,12 +130,14 @@ class ApprovalCardVerifyResult:
     resolved_count: int = 0
     reconstructed_count: int = 0
     verifier_errors: list[str] = field(default_factory=lambda: [])
+    records: tuple[VerifiedApprovalCard, ...] = ()
 
 
 def _admit_issue(
     event: AuditEvent,
     issued: dict[str, ApprovalCardV2],
     origins: dict[str, tuple[str, str]],
+    issue_events: dict[str, AuditEvent],
     errors: list[str],
 ) -> None:
     """Admit one issue event into *issued*, flagging mutation or a bad envelope."""
@@ -113,6 +165,7 @@ def _admit_issue(
         )
         return
     issued[stored_hash] = card
+    issue_events[stored_hash] = event
     origins[stored_hash] = (
         str(details.get("worktree_id", "")),
         str(details.get("thread_id", "")),
@@ -220,12 +273,16 @@ def _check_resolution(
     event: AuditEvent,
     issued: dict[str, ApprovalCardV2],
     origins: dict[str, tuple[str, str]],
+    issue_events: dict[str, AuditEvent],
     settled: set[str],
     errors: list[str],
-) -> bool:
+) -> VerifiedApprovalCard | None:
     """Validate one resolve event against the issues seen earlier in the chain.
 
-    Returns ``True`` when the resolution is fully reconstructable.
+    Returns the reconstructed pair when the resolution is fully
+    reconstructable, and ``None`` otherwise. The reconstruction is the return
+    value rather than a side effect so a caller cannot end up holding a pair
+    that failed a check.
     """
     details: dict[str, Any] = event.details
     echoed = str(details.get("card_hash", ""))
@@ -238,7 +295,7 @@ def _check_resolution(
         errors.append(
             f"approval card {echoed!r} was settled more than once; a card settles exactly once",
         )
-        return False
+        return None
     card = issued.get(echoed)
     if card is None:
         # Either the hash names no issued envelope at all, or the issue event
@@ -248,7 +305,7 @@ def _check_resolution(
             f"resolved approval card {echoed!r} has no matching issued envelope with an intact hash "
             f"recorded before it in the chain",
         )
-        return False
+        return None
     resolved_at = _resolved_at(details)
     if resolved_at is None:
         errors.append(
@@ -256,62 +313,68 @@ def _check_resolution(
             f"({details.get('resolved_at')!r}); a settlement with no usable timestamp cannot be "
             f"checked against the envelope's window",
         )
-        return False
+        return None
     if resolved_at < card.created_at:
         errors.append(
             f"resolved approval card {echoed!r} was decided at {resolved_at:.0f}, "
             f"before its envelope's created_at {card.created_at:.0f}",
         )
-        return False
+        return None
     if resolved_at >= card.not_after:
         errors.append(
             f"resolved approval card {echoed!r} was decided at {resolved_at:.0f} "
             f"at or after its not_after {card.not_after:.0f}",
         )
-        return False
+        return None
     # Both are evaluated (not short-circuited) so one settlement reports every
     # way in which it is invalid rather than only the first.
     decision_ok = _check_decision(echoed, details, errors)
     origin_ok = _check_origin(echoed, details, origins.get(echoed), errors)
-    return decision_ok and origin_ok
+    if not (decision_ok and origin_ok):
+        return None
+    issue_event = issue_events[echoed]
+    return VerifiedApprovalCard(
+        card=card,
+        card_hash=echoed,
+        decision=str(details.get("decision", "")),
+        approver=str(details.get("approver") or event.actor),
+        resolved_at=resolved_at,
+        issued_hmac=str(issue_event.hmac),
+        resolved_hmac=str(event.hmac),
+        issued_timestamp=str(issue_event.timestamp),
+        resolved_timestamp=str(event.timestamp),
+    )
 
 
-def verify_approval_cards(audit_dir: Path, *, key: bytes | None = None) -> ApprovalCardVerifyResult:
-    """Verify every resolved approval card in *audit_dir* offline.
+def verify_approval_card_events(events: Iterable[AuditEvent]) -> ApprovalCardVerifyResult:
+    """Verify the approval-card semantics carried by *events*.
 
-    Args:
-        audit_dir: Directory holding the HMAC-chained audit JSONL files.
-        key: Optional HMAC key. Only used to read the events; the semantic
-            checks here do not depend on the key (the HMAC chain check does).
+    *events* must be in chain order, and may contain unrelated event types
+    (they are ignored). This is the whole of the check; the ``audit_dir`` entry
+    point below is a convenience that reads the chain first.
 
-    Returns:
-        An :class:`ApprovalCardVerifyResult`. ``ok`` is ``True`` when no
-        resolved card references a mutated envelope, an unknown ``card_hash``,
-        or a decision made after expiry (and when there are no cards at all).
-        Records that failed evaluation land in ``errors``; records this code
-        could not evaluate land in ``verifier_errors``. Either keeps ``ok`` at
-        ``False``.
+    Taking pre-read events matters for a caller that needs the verdict and a
+    projection of the same rows: it can read once under
+    :meth:`AuditChainStore.verify_and_query` and hand the result here, rather
+    than verifying one snapshot and projecting another.
     """
-    log = AuditLog(audit_dir=audit_dir, key=key) if key is not None else AuditLog(audit_dir=audit_dir)
-
     # One ordered pass over the chain rather than two independent queries. The
     # order is the evidence: reading issues and resolutions separately loses the
     # happens-before relation between them, which is exactly what lets a
     # backfilled issue event legitimise a resolution that was recorded first.
-    events = [
-        event for event in log.query() if event.event_type in {EVENT_APPROVAL_CARD_ISSUED, EVENT_APPROVAL_CARD_RESOLVED}
-    ]
-
     errors: list[str] = []
     verifier_errors: list[str] = []
     issued: dict[str, ApprovalCardV2] = {}
     origins: dict[str, tuple[str, str]] = {}
+    issue_events: dict[str, AuditEvent] = {}
     settled: set[str] = set()
+    records: list[VerifiedApprovalCard] = []
     issued_count = 0
     resolved_count = 0
-    reconstructed = 0
 
     for event in events:
+        if event.event_type not in {EVENT_APPROVAL_CARD_ISSUED, EVENT_APPROVAL_CARD_RESOLVED}:
+            continue
         # A verifier that its own input can crash is a denial-of-audit
         # primitive: `bernstein audit verify` runs this pillar before three
         # others, with no try/except of its own, so an escaping exception
@@ -327,11 +390,12 @@ def verify_approval_cards(audit_dir: Path, *, key: bytes | None = None) -> Appro
         try:
             if event.event_type == EVENT_APPROVAL_CARD_ISSUED:
                 issued_count += 1
-                _admit_issue(event, issued, origins, errors)
+                _admit_issue(event, issued, origins, issue_events, errors)
                 continue
             resolved_count += 1
-            if _check_resolution(event, issued, origins, settled, errors):
-                reconstructed += 1
+            reconstructed = _check_resolution(event, issued, origins, issue_events, settled, errors)
+            if reconstructed is not None:
+                records.append(reconstructed)
             settled.add(str(event.details.get("card_hash", "")))
         except Exception as exc:
             verifier_errors.append(
@@ -348,6 +412,28 @@ def verify_approval_cards(audit_dir: Path, *, key: bytes | None = None) -> Appro
         errors=errors,
         issued_count=issued_count,
         resolved_count=resolved_count,
-        reconstructed_count=reconstructed,
+        reconstructed_count=len(records),
         verifier_errors=verifier_errors,
+        records=tuple(records),
     )
+
+
+def verify_approval_cards(audit_dir: Path, *, key: bytes | None = None) -> ApprovalCardVerifyResult:
+    """Verify every resolved approval card in *audit_dir* offline.
+
+    Args:
+        audit_dir: Directory holding the HMAC-chained audit JSONL files.
+        key: Optional HMAC key. Only used to read the events; the semantic
+            checks here do not depend on the key (the HMAC chain check does).
+
+    Returns:
+        An :class:`ApprovalCardVerifyResult`. ``ok`` is ``True`` when no
+        resolved card references a mutated envelope, an unknown ``card_hash``,
+        or a decision made after expiry (and when there are no cards at all).
+        Records that failed evaluation land in ``errors``; records this code
+        could not evaluate land in ``verifier_errors``. Either keeps ``ok`` at
+        ``False``. The settlements that passed every check are returned in
+        ``records``.
+    """
+    log = AuditLog(audit_dir=audit_dir, key=key) if key is not None else AuditLog(audit_dir=audit_dir)
+    return verify_approval_card_events(log.query())

--- a/src/bernstein/core/compliance/decision_record.py
+++ b/src/bernstein/core/compliance/decision_record.py
@@ -1,0 +1,211 @@
+"""Decision-provenance records projected out of verified approval cards.
+
+Issue #2917. The audit chain already records who authorised a consequential
+tool call, against what displayed context, and when -- but it records it as
+HMAC-chained JSONL. A reviewer who is not an engineer cannot read that, so
+today they read an engineer's summary of it instead, which is precisely the
+trust the chain exists to remove.
+
+This module folds a verified issue/resolve pair into a closed-schema
+:class:`DecisionRecord`: one row per settled approval, every field taken from
+a source event rather than typed by hand, and each record naming the chain
+anchors of the two events it was derived from so a reader can re-verify it.
+
+The projection is deliberately total and dumb: it maps
+:class:`~bernstein.core.approval.card_verify.VerifiedApprovalCard` values into
+record fields and does no checking of its own. All the checking happens in
+:func:`~bernstein.core.approval.card_verify.verify_approval_card_events`,
+which only reconstructs a pair when the stored envelope still hashes to its
+committed ``card_hash``, the decision echoed that hash, the issue preceded the
+settlement, the card settled exactly once, and the settlement landed inside
+the envelope's window. A settlement that fails any of those contributes no
+reconstructed pair, so it can produce no record here -- there is no path that
+emits a record with a caveat attached.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from bernstein.core.approval.card_verify import (
+        ApprovalCardVerifyResult,
+        VerifiedApprovalCard,
+    )
+
+__all__ = [
+    "DECISION_RECORD_SCHEMA_VERSION",
+    "DecisionRecord",
+    "build_decision_records",
+    "render_decision_records",
+]
+
+#: Schema marker carried by every emitted record. The record is a closed
+#: schema on purpose: a reviewer's checklist maps onto fixed fields, and a
+#: projection that could grow free-form keys would let an engineer smuggle
+#: unattested prose into an attested document.
+DECISION_RECORD_SCHEMA_VERSION = "decision-record/v1"
+
+#: How much of a hash to show inline in the human-readable rendering. The full
+#: value is always in :meth:`DecisionRecord.to_dict`, so the short form is a
+#: reading aid and never the only place a reviewer can find the anchor.
+_SHORT_HASH_CHARS = 16
+
+
+@dataclass(frozen=True, slots=True)
+class DecisionRecord:
+    """One settled approval, projected into reviewer-facing fields.
+
+    Attributes:
+        decision_id: The envelope's ``card_hash``. It is the decision's
+            identity because it commits to the whole context the approver was
+            shown, so two decisions are the same decision exactly when they
+            were made against the same displayed facts.
+        approver: The identity recorded on the settlement event.
+        decision: ``approve`` or ``reject``.
+        tool_name: The tool the approval gated.
+        args_digest: Canonical digest of the arguments the tool would run
+            with, so the approval binds the concrete invocation.
+        reasoning: The agent's stated intent, as it was displayed and hashed.
+        impact_score: Blast-radius score in ``[0, 1]``.
+        impact_hard_one_way: ``True`` when the change contains a one-way door.
+        impact_rationale: The scorer's structured rationale.
+        fired_detectors: Ordered ids of every blast-radius detector that fired.
+        rollback_procedure: The undo path shown alongside the request.
+        rollback_irreversible: ``True`` when no clean automatic undo exists.
+        issued_at: Envelope creation time (unix epoch seconds).
+        not_after: Envelope expiry (unix epoch seconds).
+        resolved_at: Settlement time (unix epoch seconds).
+        source_events: Chain anchors keyed by role -- ``issued`` and
+            ``resolved`` map to the HMAC of the event each field came from.
+    """
+
+    decision_id: str
+    approver: str
+    decision: str
+    tool_name: str
+    args_digest: str
+    reasoning: str
+    impact_score: float
+    impact_hard_one_way: bool
+    impact_rationale: str
+    fired_detectors: tuple[str, ...]
+    rollback_procedure: str
+    rollback_irreversible: bool
+    issued_at: float
+    not_after: float
+    resolved_at: float
+    source_events: dict[str, str]
+
+    def statement(self) -> str:
+        """Return the plain-language sentence a non-engineer reads first.
+
+        The sentence names the approving identity, the action it authorised,
+        and the ``card_hash`` that locates the approval receipt in the chain,
+        so the reviewer can follow the claim back to the event that backs it
+        without being handed a JSONL file.
+        """
+        verb = "approved" if self.decision == "approve" else f"recorded a {self.decision!r} decision on"
+        irreversible = (
+            " The change was flagged as a one-way door with no clean automatic undo."
+            if self.rollback_irreversible
+            else ""
+        )
+        return (
+            f"{self.approver} {verb} the tool call {self.tool_name} "
+            f"(arguments {self.args_digest[:_SHORT_HASH_CHARS]}), "
+            f"with a blast-radius score of {self.impact_score:.2f}."
+            f"{irreversible} "
+            f"The approval receipt is approval card {self.decision_id}, "
+            f"anchored in the audit chain at {self.source_events['resolved'][:_SHORT_HASH_CHARS]}."
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the record as a JSON-ready dict, in schema field order."""
+        return {
+            "schema": DECISION_RECORD_SCHEMA_VERSION,
+            "decision_id": self.decision_id,
+            "approver": self.approver,
+            "decision": self.decision,
+            "tool_name": self.tool_name,
+            "args_digest": self.args_digest,
+            "reasoning": self.reasoning,
+            "impact_score": self.impact_score,
+            "impact_hard_one_way": self.impact_hard_one_way,
+            "impact_rationale": self.impact_rationale,
+            "fired_detectors": list(self.fired_detectors),
+            "rollback_procedure": self.rollback_procedure,
+            "rollback_irreversible": self.rollback_irreversible,
+            "issued_at": self.issued_at,
+            "not_after": self.not_after,
+            "resolved_at": self.resolved_at,
+            "source_events": dict(self.source_events),
+        }
+
+
+def _record_from(verified: VerifiedApprovalCard) -> DecisionRecord:
+    """Fold one verified pair into its decision record."""
+    card = verified.card
+    return DecisionRecord(
+        decision_id=verified.card_hash,
+        approver=verified.approver,
+        decision=verified.decision,
+        tool_name=card.action.tool_name,
+        args_digest=card.action.args_digest,
+        reasoning=card.reasoning,
+        impact_score=card.impact.score,
+        impact_hard_one_way=card.impact.hard_one_way,
+        impact_rationale=card.impact.rationale,
+        fired_detectors=card.impact.fired_detectors,
+        rollback_procedure=card.rollback.procedure,
+        rollback_irreversible=card.rollback.irreversible,
+        issued_at=card.created_at,
+        not_after=card.not_after,
+        resolved_at=verified.resolved_at,
+        source_events={"issued": verified.issued_hmac, "resolved": verified.resolved_hmac},
+    )
+
+
+def build_decision_records(result: ApprovalCardVerifyResult) -> list[DecisionRecord]:
+    """Project the settlements *result* reconstructed into decision records.
+
+    Only ``result.records`` is read, so a settlement the verifier could not
+    reconstruct -- a mutated envelope, an unmatched hash, a double settlement,
+    a decision outside the envelope's window -- yields no record at all rather
+    than a record carrying a warning. A reviewer holding this list is holding
+    only decisions whose whole context re-derives from the chain.
+    """
+    return [_record_from(verified) for verified in result.records]
+
+
+def render_decision_records(records: Sequence[DecisionRecord] | Iterable[DecisionRecord]) -> str:
+    """Render *records* as the human-readable decision-provenance report."""
+    materialised = list(records)
+    if not materialised:
+        return "No verified approval decisions were reconstructed from the audit chain."
+
+    lines: list[str] = [
+        f"Decision-provenance report ({DECISION_RECORD_SCHEMA_VERSION})",
+        f"{len(materialised)} verified decision(s); every field below is taken from a referenced audit event.",
+        "",
+    ]
+    for index, record in enumerate(materialised, start=1):
+        lines.extend(
+            [
+                f"[{index}] decision {record.decision_id[:_SHORT_HASH_CHARS]}",
+                f"    {record.statement()}",
+                f"    Stated intent      : {record.reasoning}",
+                f"    Impact rationale   : {record.impact_rationale}",
+                f"    Detectors fired    : {', '.join(record.fired_detectors) or 'none'}",
+                f"    Rollback           : {record.rollback_procedure}",
+                f"    Decided at         : {record.resolved_at:.0f} "
+                f"(valid {record.issued_at:.0f} to {record.not_after:.0f})",
+                f"    Source events      : issued {record.source_events['issued']}, "
+                f"resolved {record.source_events['resolved']}",
+                "",
+            ],
+        )
+    return "\n".join(lines).rstrip() + "\n"

--- a/tests/unit/compliance/test_decision_record.py
+++ b/tests/unit/compliance/test_decision_record.py
@@ -146,9 +146,7 @@ def test_every_rendered_field_is_reachable_from_a_referenced_event(tmp_path: Pat
 
     events = AuditChainStore(audit_dir, key=_KEY).query()
     referenced = [
-        event
-        for event in events
-        if event.hmac in {record.source_events["issued"], record.source_events["resolved"]}
+        event for event in events if event.hmac in {record.source_events["issued"], record.source_events["resolved"]}
     ]
     assert len(referenced) == 2
     haystack = json.dumps([{"details": event.details, "hmac": event.hmac} for event in referenced], sort_keys=True)

--- a/tests/unit/compliance/test_decision_record.py
+++ b/tests/unit/compliance/test_decision_record.py
@@ -1,0 +1,219 @@
+"""Decision-provenance projection over verified approval cards (issue #2917).
+
+Every test pins one property of the projection, not a code path:
+
+1. a verified issue/resolve pair is returned with the chain anchors of both
+   source events, so the projection has something to link to at all,
+2. no decision record exists without a verifying source event -- the
+   load-bearing property: a mutated envelope removes the record, it does not
+   annotate it,
+3. the plain-language statement names the approving human identity and links
+   the approval receipt,
+4. every field the record prints is reachable from a referenced event,
+5. `bernstein compliance decisions` reports the approver and the tool over a
+   real audit directory,
+6. the same command emits no record when the chain fails verification.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.compliance_cmd import compliance_group
+from bernstein.core.approval.card import build_card
+from bernstein.core.approval.card_gate import ApprovalCardGate
+from bernstein.core.approval.card_verify import verify_approval_cards
+from bernstein.core.compliance.decision_record import (
+    build_decision_records,
+    render_decision_records,
+)
+from bernstein.core.security.audit_chain import AuditChainStore
+
+_KEY = b"deterministic-test-key-2917"
+
+
+def _seed(audit_dir: Path, *, approver: str = "alice@example.com") -> str:
+    """Write one issued/resolved approval-card pair and return its card hash."""
+    chain = AuditChainStore(audit_dir, key=_KEY)
+    gate = ApprovalCardGate(chain)
+    issued = gate.issue(
+        build_card(
+            approval_id="ap-1",
+            tool_name="Edit",
+            tool_args={"file_path": "src/app.py", "new_string": "x = 1"},
+            reasoning="Add the constant the new endpoint reads.",
+            created_at=1_000.0,
+            ttl_seconds=600.0,
+        ),
+    )
+    gate.resolve(card_hash=issued.card_hash, decision="approve", approver=approver, now=1_100.0)
+    return issued.card_hash
+
+
+def _mutate_stored_envelope(audit_dir: Path) -> None:
+    """Rewrite the issued event's stored envelope in place, as a tamperer would."""
+    for path in sorted(audit_dir.glob("*.jsonl")):
+        lines = path.read_text(encoding="utf-8").splitlines()
+        changed = False
+        for index, line in enumerate(lines):
+            entry = json.loads(line)
+            envelope = entry.get("details", {}).get("envelope")
+            if isinstance(envelope, dict) and "action" in envelope:
+                envelope["action"]["tool_name"] = "Bash"
+                lines[index] = json.dumps(entry)
+                changed = True
+        if changed:
+            path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+            return
+    msg = "no issued approval-card envelope found to mutate"
+    raise AssertionError(msg)
+
+
+# ---------------------------------------------------------------------------
+# 1. The verifier hands back what it reconstructed
+# ---------------------------------------------------------------------------
+
+
+def test_verified_cards_are_returned_with_their_chain_anchors(tmp_path: Path) -> None:
+    audit_dir = tmp_path / "audit"
+    card_hash = _seed(audit_dir)
+
+    result = verify_approval_cards(audit_dir, key=_KEY)
+
+    assert result.ok, result.errors
+    assert [record.card_hash for record in result.records] == [card_hash]
+    record = result.records[0]
+    assert record.approver == "alice@example.com"
+    assert record.decision == "approve"
+    # Both halves of the pair are anchored, not just the settlement.
+    assert record.issued_hmac
+    assert record.resolved_hmac
+    assert record.issued_hmac != record.resolved_hmac
+
+
+# ---------------------------------------------------------------------------
+# 2. No decision record exists without a verifying source event (load-bearing)
+# ---------------------------------------------------------------------------
+
+
+def test_no_decision_record_exists_without_a_verifying_source_event(tmp_path: Path) -> None:
+    audit_dir = tmp_path / "audit"
+    _seed(audit_dir)
+    assert build_decision_records(verify_approval_cards(audit_dir, key=_KEY))
+
+    _mutate_stored_envelope(audit_dir)
+
+    result = verify_approval_cards(audit_dir, key=_KEY)
+    assert not result.ok
+    # Not emitted-with-a-warning: not emitted.
+    assert build_decision_records(result) == []
+    assert result.records == ()
+
+
+# ---------------------------------------------------------------------------
+# 3. The statement names the approver and links the receipt
+# ---------------------------------------------------------------------------
+
+
+def test_decision_statement_names_the_approver_and_links_the_receipt(tmp_path: Path) -> None:
+    audit_dir = tmp_path / "audit"
+    card_hash = _seed(audit_dir, approver="bob@example.com")
+
+    (record,) = build_decision_records(verify_approval_cards(audit_dir, key=_KEY))
+
+    statement = record.statement()
+    assert "bob@example.com" in statement
+    assert "Edit" in statement
+    # The receipt the reviewer follows to check the claim.
+    assert card_hash in statement
+
+
+# ---------------------------------------------------------------------------
+# 4. Every printed field is reachable from a referenced event
+# ---------------------------------------------------------------------------
+
+
+def test_every_rendered_field_is_reachable_from_a_referenced_event(tmp_path: Path) -> None:
+    audit_dir = tmp_path / "audit"
+    _seed(audit_dir)
+
+    (record,) = build_decision_records(verify_approval_cards(audit_dir, key=_KEY))
+
+    events = AuditChainStore(audit_dir, key=_KEY).query()
+    referenced = [
+        event
+        for event in events
+        if event.hmac in {record.source_events["issued"], record.source_events["resolved"]}
+    ]
+    assert len(referenced) == 2
+    haystack = json.dumps([{"details": event.details, "hmac": event.hmac} for event in referenced], sort_keys=True)
+    for field, value in record.to_dict().items():
+        # ``schema`` names the projection's own shape and ``source_events``
+        # carries the anchors themselves; every remaining field is a claim
+        # about the run and must be backed by one of the referenced events.
+        if field in {"schema", "source_events"}:
+            continue
+        for atom in value if isinstance(value, list) else [value]:
+            assert json.dumps(atom) in haystack or str(atom) in haystack, f"{field} is not backed by a source event"
+
+
+# ---------------------------------------------------------------------------
+# 5 & 6. The CLI over a real audit directory
+# ---------------------------------------------------------------------------
+
+
+def _audit_key_file(tmp_path: Path) -> Path:
+    key_path = tmp_path / "audit.key"
+    key_path.write_bytes(_KEY)
+    key_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    return key_path
+
+
+def _run_decisions(audit_dir: Path, key_path: Path, *extra: str) -> object:
+    env = dict(os.environ, BERNSTEIN_AUDIT_KEY_PATH=str(key_path))
+    return CliRunner().invoke(
+        compliance_group,
+        ["decisions", "--audit-dir", str(audit_dir), *extra],
+        env=env,
+        catch_exceptions=False,
+    )
+
+
+def test_decisions_command_reports_the_approved_tool_and_approver(tmp_path: Path) -> None:
+    audit_dir = tmp_path / "audit"
+    card_hash = _seed(audit_dir, approver="carol@example.com")
+
+    result = _run_decisions(audit_dir, _audit_key_file(tmp_path))
+
+    assert result.exit_code == 0, result.output
+    assert "carol@example.com" in result.output
+    assert "Edit" in result.output
+    assert card_hash[:16] in result.output
+
+
+def test_decisions_command_emits_nothing_when_the_chain_fails_verification(tmp_path: Path) -> None:
+    audit_dir = tmp_path / "audit"
+    _seed(audit_dir, approver="carol@example.com")
+    _mutate_stored_envelope(audit_dir)
+
+    result = _run_decisions(audit_dir, _audit_key_file(tmp_path))
+
+    assert result.exit_code != 0
+    assert "carol@example.com" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# Rendering is a projection of the records, not an independent read
+# ---------------------------------------------------------------------------
+
+
+def test_rendering_no_records_states_that_none_were_verified(tmp_path: Path) -> None:
+    audit_dir = tmp_path / "audit"
+    audit_dir.mkdir(parents=True)
+
+    assert "no verified" in render_decision_records([]).lower()


### PR DESCRIPTION
## What

Step 1 of the decision-provenance report: the approval-gated slice.

Adds `bernstein compliance decisions`, which turns the settled approval cards
in an audit directory into a human-readable decision-provenance report — one
record per settled card, naming the approving identity, the tool call that was
authorised, the intent and blast-radius estimate the approver was shown, and
the HMAC anchors of the two chain events every field was taken from.

It explicitly does **not** do: the other decision families (spawn, merge,
scheduler decisions, gate adjudication), a standalone offline-verifier binary
and its distribution path, charter/tenant scoping of the export, a
chain-anchored receipt for the export operation itself, or
`docs/compliance/decision-provenance.md`.

**Open decision, and how it was settled.** The report could be emitted for a
chain whose verification failed, with the unverifiable rows marked. It is not:
a failed chain verdict, or a failed approval-card verdict, prints the errors on
stderr and exits non-zero with no report at all. A provenance document that a
reviewer has to read caveats out of is an ordinary claims document, which is
the thing this command exists to replace. The same rule holds per record —
a settlement the verifier could not reconstruct yields no record, not a record
with a warning attached.

## Why

`verify_approval_cards` in `src/bernstein/core/approval/card_verify.py` already
reconstructs every issue/resolve pair in the chain and proves, per card, that
the stored envelope still hashes to its committed `card_hash`, that the
decision echoed that hash, that issue happened before resolve, that no card was
settled twice, and that the decision landed inside the envelope's window. It
then throws the reconstruction away and returns only counts and error strings.

So the evidence for "who authorised this tool call, against what displayed
context" exists and is authoritative, but the only surface that exposes it is
an HMAC-chained JSONL file. Anyone who is not going to read JSONL currently
reads a hand-written summary of it instead — which is exactly the trust the
chain was built to remove. This closes that surfacing gap for the approval
family.

## How

1. `card_verify.py` gains `VerifiedApprovalCard` and returns the reconstructed
   pairs on `ApprovalCardVerifyResult.records`. The pair is now the return
   value of `_check_resolution` rather than a boolean, so a caller cannot end
   up holding a pair that failed a check.
2. The body of the verifier moves into a new `verify_approval_card_events(events)`
   taking pre-read events; `verify_approval_cards(audit_dir)` keeps its exact
   signature and behaviour and is now a thin reader on top. This is what lets
   the CLI verify and project **one** snapshot: it reads through
   `AuditChainStore.verify_and_query`, so the rows the report covers are
   exactly the rows the verdict covers, instead of two independent reads that
   an append can slide between.
3. New `src/bernstein/core/compliance/decision_record.py` holds the closed
   schema (`decision-record/v1`), the projection `build_decision_records`, and
   the rendering. The projection is total and does no checking of its own — all
   checking stays in the verifier, so there is no code path that emits a record
   the chain does not back.
4. New `decisions` subcommand on the existing `compliance_group`.

## Tests

`tests/unit/compliance/test_decision_record.py`, 7 tests. With
`card_verify.py` at `origin/main`, 6 of the 7 fail (`AttributeError` /
`IndexError` reaching `.records`); with `decision_record.py` absent all 7 fail
at import. Both were run before the implementation was written and again on the
reverted tree just now.

1. `test_verified_cards_are_returned_with_their_chain_anchors` — the verifier
   hands back the pair it reconstructed, anchored on **both** source events,
   not just the settlement.
2. `test_no_decision_record_exists_without_a_verifying_source_event` —
   **load-bearing.** Mutating the stored envelope in the JSONL removes the
   record entirely; it is not emitted with a warning.
3. `test_decision_statement_names_the_approver_and_links_the_receipt` — the
   plain-language sentence names the approving identity, the tool, and the
   `card_hash` that locates the approval receipt.
4. `test_every_rendered_field_is_reachable_from_a_referenced_event` — every
   field of the emitted record is found in the details of one of the two
   events the record references. Nothing is free text.
5. `test_decisions_command_reports_the_approved_tool_and_approver` — end to
   end over a real audit directory and a real key file.
6. `test_decisions_command_emits_nothing_when_the_chain_fails_verification` —
   non-zero exit, no report, over a tampered chain.
7. `test_rendering_no_records_states_that_none_were_verified` — the empty
   report says nothing was verified rather than rendering as a clean bill.

Also run green: `tests/unit/approval/`, `tests/unit/compliance/`,
`tests/unit/cli/test_audit_verify_cards.py`,
`tests/unit/test_eu_ai_act_task_risk.py` — 15 files, 318 tests, the tests of
every module touched plus every importer of `card_verify` and
`compliance_cmd`. `--affected origin/main` did not finish inside the local time
budget, so the importer set was selected by grep instead; CI runs the full
suite.

## Checklist

- [x] `uv run ruff check src/` — clean
- [x] `uv run ruff format --check` on the changed files — clean
- [x] `uv run pyright src/` — 132 diagnostics, all pre-existing in
      `compliance_cmd.py`; 0 in `decision_record.py`, `card_verify.py`, or the
      new command block
- [x] `uv run python scripts/run_tests.py --parallel 2 -x <files>` — green
- [x] Type hints on all new functions and dataclass fields
- [x] `uv run bernstein agents-md sync` — run; produced no documentation
      changes (the new subcommand hangs off an already-listed group)
- [ ] `docs/compliance/decision-provenance.md` — N/A for this slice; the issue
      lists it under the later steps, together with the standalone verifier it
      documents
- [ ] README / translations — N/A, untouched

Part of #2917

## Remaining

- The other decision families: spawn, merge, scheduler decisions, gate
  adjudication.
- The standalone offline verifier and its distribution path (this slice
  verifies through the installed CLI).
- Charter/tenant scoping of the export.
- A chain-anchored receipt for the export operation itself.
- `docs/compliance/decision-provenance.md`.
