### PR TITLE
Partial implementation of #2958: add Semgrep scanner adapter

### DIFF
--- a/docs/sdd/module-map.md
+++ b/docs/sdd/module-map.md
@@ -181,6 +181,7 @@ Full per-file module map. `AGENTS.md`'s own "Module map" section links here inst
 | `scanner_finding.py`        | Scanner Finding dataclass |
 | `scanner_registry.py`       | Scanner registry - look up scanner adapters by name |
 | `security_floor.py`         | Adapter security-floor spawn preflight with signed refusal receipts (#2515) |
+| `semgrep.py`                | Deterministic Semgrep scanner adapter and SARIF normalization |
 | `session_id.py`             | Deterministic session-id binding for adapter replay isolation |
 | `skills_injector.py`        | Inject per-task Claude Code skills into the worktree before spawn |
 | `skyvern.py`                | Skyvern adapter: drives an existing Skyvern server over HTTP |

--- a/src/bernstein/adapters/scanner_registry.py
+++ b/src/bernstein/adapters/scanner_registry.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 from bernstein.adapters.gitleaks import GitleaksAdapter
 from bernstein.adapters.nmap import NmapAdapter
 from bernstein.adapters.scanner import ScannerAdapter
+from bernstein.adapters.semgrep import SemgrepAdapter
 from bernstein.adapters.trivy import TrivyAdapter
 
 if TYPE_CHECKING:
@@ -155,4 +156,5 @@ def scanner_name_for_provider(provider_name: str | None, model: str) -> str | No
 
 register_scanner(GitleaksAdapter.registry_name, GitleaksAdapter)
 register_scanner(NmapAdapter.registry_name, NmapAdapter)
+register_scanner(SemgrepAdapter.registry_name, SemgrepAdapter)
 register_scanner(TrivyAdapter.registry_name, TrivyAdapter)

--- a/src/bernstein/adapters/semgrep.py
+++ b/src/bernstein/adapters/semgrep.py
@@ -1,0 +1,352 @@
+"""Deterministic Semgrep scanner adapter and SARIF normalization."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+from bernstein.adapters._contract import (
+    ScannerCategory as ContractScannerCategory,
+)
+from bernstein.adapters._contract import (
+    ScannerDeterminism,
+    ScannerOutputFormat,
+    register_scanner_capabilities,
+)
+from bernstein.adapters.env_isolation import build_filtered_env  # pyright: ignore[reportUnknownVariableType]
+from bernstein.adapters.scanner import (
+    DeterminismTier,
+    OutputFormat,
+    ScannerAdapter,
+    ScannerCategory,
+    ScanResult,
+    ScanScope,
+)
+from bernstein.adapters.scanner_finding import Finding
+
+SEMGREP_REGISTRY_NAME = "semgrep"
+_SCAN_TIMEOUT_SECONDS = 600
+
+#: SARIF ``level`` -> Bernstein finding severity. Semgrep's own rule severity
+#: (ERROR/WARNING/INFO) is surfaced through SARIF as ``level``.
+_LEVEL_TO_SEVERITY: dict[str, str] = {
+    "error": "high",
+    "warning": "medium",
+    "note": "informational",
+}
+
+
+class SemgrepError(RuntimeError):
+    """Base error raised when Semgrep cannot complete a scan."""
+
+
+class SemgrepNotInstalledError(SemgrepError):
+    """Raised when the Semgrep executable cannot be found on ``PATH``."""
+
+
+@dataclass(frozen=True)
+class SemgrepInvocation:
+    """Stable provenance for one Semgrep invocation."""
+
+    tool_version: str
+    ruleset_digest: str
+    argv_hash: str
+
+
+class SemgrepAdapter(ScannerAdapter):
+    """Run Semgrep scans against a pinned local ruleset and normalize SARIF findings.
+
+    Semgrep is only deterministic when it cannot resolve rules from its remote
+    registry (``--config auto`` or a ``p/...`` registry id pulls a ruleset that
+    can change between runs). This adapter therefore requires an explicit local
+    rule file or directory and refuses to scan without one, rather than
+    silently falling back to a network-resolved ruleset.
+    """
+
+    registry_name = SEMGREP_REGISTRY_NAME
+    output_format = OutputFormat.SARIF
+    determinism = DeterminismTier.DETERMINISTIC
+    pinned_inputs: tuple[str, ...] = ()
+    category = ScannerCategory.SAST
+
+    def __init__(self, *, binary: str = "semgrep", config_path: str | Path | None = None) -> None:
+        super().__init__()
+        self._binary = binary
+        self._config_path = Path(config_path) if config_path is not None else None
+        self.last_invocation: SemgrepInvocation | None = None
+
+    def name(self) -> str:
+        """Return the registry key used by the conformance capability lookup."""
+        return self.registry_name
+
+    def scan(self, target: Path, scope: ScanScope, workdir: Path) -> ScanResult:
+        """Run a deterministic Semgrep scan against a pinned local ruleset.
+
+        Semgrep exits 0 on a normal scan regardless of whether findings were
+        produced (this adapter never passes ``--error``, which is the only
+        thing that turns findings into a nonzero exit code), so any nonzero
+        exit code here means the run itself failed.
+        """
+        self.enforce_network_policy()
+        _validate_scope(target, scope)
+        resolved_target = target.resolve()
+        if not resolved_target.exists():
+            raise SemgrepError(f"Semgrep target does not exist: {target}")
+        binary = shutil.which(self._binary)
+        if binary is None:
+            raise SemgrepNotInstalledError(
+                f"Semgrep executable {self._binary!r} was not found on PATH; install semgrep or configure its binary"
+            )
+
+        config_path = self._resolve_config_path(scope, resolved_target)
+        tool_version = _read_version(binary)
+        ruleset_digest = _ruleset_digest(config_path)
+
+        workdir.mkdir(parents=True, exist_ok=True)
+        report_path = (workdir / "semgrep.sarif").resolve()
+        report_path.unlink(missing_ok=True)
+        command = _build_command(binary, resolved_target, report_path, config_path)
+        self.last_invocation = SemgrepInvocation(
+            tool_version=tool_version,
+            ruleset_digest=ruleset_digest,
+            argv_hash=_invocation_argv_hash(tool_version, ruleset_digest),
+        )
+
+        try:
+            completed = subprocess.run(
+                command,
+                check=False,
+                capture_output=True,
+                text=True,
+                env=build_filtered_env([]),
+                timeout=_SCAN_TIMEOUT_SECONDS,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise SemgrepError(f"Semgrep execution failed: {exc}") from exc
+
+        if completed.returncode != 0:
+            detail = completed.stderr.strip() or completed.stdout.strip() or "no diagnostic output"
+            raise SemgrepError(f"Semgrep exited with code {completed.returncode}: {detail}")
+        if not report_path.is_file():
+            raise SemgrepError("Semgrep completed without writing its SARIF report")
+
+        findings = parse_semgrep_sarif(report_path.read_bytes(), target_root=resolved_target)
+        return ScanResult(findings=findings)
+
+    def _resolve_config_path(self, scope: ScanScope, target: Path) -> Path:
+        configured = scope.config.get("config_path")
+        config_path = Path(str(configured)) if configured is not None else self._config_path
+        if config_path is None:
+            config_root = target if target.is_dir() else target.parent
+            yaml_config = config_root / ".semgrep.yml"
+            dir_config = config_root / ".semgrep"
+            if yaml_config.is_file():
+                config_path = yaml_config
+            elif dir_config.is_dir():
+                config_path = dir_config
+            else:
+                raise SemgrepError(
+                    "SemgrepAdapter requires a local rule file or directory (config_path); "
+                    "remote rule resolution (registry lookups such as 'auto' or 'p/...') is not deterministic"
+                )
+        if not config_path.exists():
+            raise SemgrepError(f"Semgrep config does not exist: {config_path}")
+        return config_path.resolve()
+
+
+def _validate_scope(target: Path, scope: ScanScope) -> None:
+    if scope.include or scope.exclude or scope.max_depth is not None:
+        raise ValueError("SemgrepAdapter does not yet support include, exclude, or max_depth scan scope fields")
+    unsupported = set(scope.config) - {"config_path"}
+    if unsupported:
+        raise ValueError(f"Unsupported Semgrep scan configuration: {', '.join(sorted(unsupported))}")
+    if scope.roots:
+        resolved_target = target.resolve()
+        target_is_allowed = any(
+            resolved_target == root.resolve() or resolved_target.is_relative_to(root.resolve()) for root in scope.roots
+        )
+        if not target_is_allowed:
+            raise ValueError("Semgrep target is outside the allowed ScanScope roots")
+
+
+def _read_version(binary: str) -> str:
+    try:
+        completed = subprocess.run(
+            [binary, "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=build_filtered_env([]),
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise SemgrepError(f"Could not read Semgrep version: {exc}") from exc
+    if completed.returncode != 0:
+        raise SemgrepError(f"Could not read Semgrep version: {completed.stderr.strip()}")
+    version = completed.stdout.strip()
+    if not version:
+        raise SemgrepError("Semgrep returned an empty version")
+    return version
+
+
+def _build_command(binary: str, target: Path, report_path: Path, config_path: Path) -> list[str]:
+    return [
+        binary,
+        "scan",
+        "--metrics=off",
+        "--disable-version-check",
+        "--config",
+        str(config_path),
+        "--sarif",
+        "--output",
+        str(report_path),
+        str(target),
+    ]
+
+
+def _ruleset_digest(config_path: Path) -> str:
+    hasher = hashlib.sha256()
+    if config_path.is_dir():
+        hasher.update(b"semgrep-ruleset-dir-v1\0")
+        for rule_file in sorted(p for p in config_path.rglob("*") if p.is_file()):
+            hasher.update(str(rule_file.relative_to(config_path)).encode("utf-8"))
+            hasher.update(b"\0")
+            hasher.update(rule_file.read_bytes())
+            hasher.update(b"\0")
+    else:
+        hasher.update(b"semgrep-ruleset-file-v1\0")
+        hasher.update(config_path.read_bytes())
+    return "sha256:" + hasher.hexdigest()
+
+
+def _invocation_argv_hash(tool_version: str, ruleset_digest: str) -> str:
+    semantic_invocation = {
+        "command": "scan",
+        "report_format": "sarif",
+        "ruleset_digest": ruleset_digest,
+        "tool": SEMGREP_REGISTRY_NAME,
+        "tool_version": tool_version,
+    }
+    canonical = json.dumps(semantic_invocation, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(canonical).hexdigest()
+
+
+def parse_semgrep_sarif(report: str | bytes, *, target_root: Path | None = None) -> list[Finding]:
+    """Parse a Semgrep SARIF report into stable Bernstein findings.
+
+    Source coordinates are deliberately excluded from the finding identity.
+    Only ``ruleId`` + normalised path + a hash of the matched snippet feed the
+    hash, so a cosmetic line shift elsewhere in the file does not change it.
+
+    Args:
+        report: UTF-8 SARIF JSON emitted by ``semgrep scan --sarif``.
+        target_root: Scan root used to make absolute Semgrep paths portable.
+
+    Returns:
+        Findings in report order.
+
+    Raises:
+        ValueError: If the report is not valid Semgrep SARIF.
+    """
+    try:
+        raw = json.loads(report)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ValueError(f"Invalid Semgrep SARIF JSON: {exc}") from exc
+
+    root = _mapping(raw, "SARIF root")
+    if root.get("version") != "2.1.0":
+        raise ValueError("Semgrep report must use SARIF 2.1.0")
+
+    findings: list[Finding] = []
+    for run_index, run_raw in enumerate(_sequence(root.get("runs"), "runs")):
+        run = _mapping(run_raw, f"runs[{run_index}]")
+        driver = _mapping(_mapping(run.get("tool"), "tool").get("driver"), "tool.driver")
+        if driver.get("name") != "semgrep":
+            raise ValueError("SARIF tool.driver.name must be 'semgrep'")
+
+        descriptions = _rule_descriptions(driver)
+        for result_index, result_raw in enumerate(_sequence(run.get("results", []), "results")):
+            result = _mapping(result_raw, f"results[{result_index}]")
+            rule = str(result.get("ruleId") or "")
+            if not rule:
+                raise ValueError(f"results[{result_index}] is missing ruleId")
+
+            physical = _physical_location(result, result_index)
+            artifact = _mapping(physical.get("artifactLocation"), "artifactLocation")
+            path = str(artifact.get("uri") or "").replace("\\", "/")
+            if not path:
+                raise ValueError(f"results[{result_index}] is missing artifactLocation.uri")
+            normalized_path = _normalize_path(path, target_root)
+
+            region = _mapping(physical.get("region"), "region")
+            snippet = str(_mapping(region.get("snippet"), "region.snippet").get("text") or "")
+            snippet_hash = "sha256:" + hashlib.sha256(snippet.encode("utf-8")).hexdigest()
+
+            level = str(result.get("level") or "warning")
+            severity = _LEVEL_TO_SEVERITY.get(level, "informational")
+
+            findings.append(
+                Finding(
+                    rule=rule,
+                    path=normalized_path,
+                    severity=severity,
+                    summary=descriptions.get(rule, rule),
+                    extra={"snippet_hash": snippet_hash},
+                )
+            )
+
+    return findings
+
+
+def _normalize_path(path: str, target_root: Path | None) -> str:
+    candidate = Path(path)
+    if target_root is not None and candidate.is_absolute():
+        with suppress(ValueError):
+            candidate = candidate.relative_to(target_root.resolve())
+    return candidate.as_posix()
+
+
+def _rule_descriptions(driver: dict[str, Any]) -> dict[str, str]:
+    descriptions: dict[str, str] = {}
+    for rule_raw in _sequence(driver.get("rules", []), "tool.driver.rules"):
+        rule = _mapping(rule_raw, "tool.driver.rules entry")
+        rule_id = str(rule.get("id") or "")
+        short = _mapping(rule.get("shortDescription", {}), "rule.shortDescription")
+        if rule_id:
+            descriptions[rule_id] = str(short.get("text") or rule_id)
+    return descriptions
+
+
+def _physical_location(result: dict[str, Any], result_index: int) -> dict[str, Any]:
+    locations = _sequence(result.get("locations"), f"results[{result_index}].locations")
+    if not locations:
+        raise ValueError(f"results[{result_index}] has no location")
+    location = _mapping(locations[0], "location")
+    return _mapping(location.get("physicalLocation"), "physicalLocation")
+
+
+def _mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    return cast("dict[str, Any]", value)
+
+
+def _sequence(value: Any, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValueError(f"{label} must be an array")
+    return cast("list[Any]", value)
+
+
+register_scanner_capabilities(
+    SEMGREP_REGISTRY_NAME,
+    output_format=ScannerOutputFormat.SARIF,
+    determinism=ScannerDeterminism.DETERMINISTIC,
+    pinned_inputs=(),
+    category=ContractScannerCategory.SAST,
+)

--- a/tests/fixtures/scanners/semgrep/semgrep-1.45.0.sarif
+++ b/tests/fixtures/scanners/semgrep/semgrep-1.45.0.sarif
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "semgrep",
+          "semanticVersion": "1.45.0",
+          "informationUri": "https://semgrep.dev",
+          "rules": [
+            {
+              "id": "bernstein-test-eval-use",
+              "shortDescription": {
+                "text": "Bernstein synthetic dangerous eval() use"
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "bernstein-test-eval-use",
+          "level": "error",
+          "message": {
+            "text": "Bernstein synthetic dangerous eval() use"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "vulnerable.py"
+                },
+                "region": {
+                  "startLine": 2,
+                  "startColumn": 1,
+                  "endLine": 2,
+                  "endColumn": 18,
+                  "snippet": {
+                    "text": "eval(user_input)"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/scanners/semgrep/semgrep-conformance.yaml
+++ b/tests/fixtures/scanners/semgrep/semgrep-conformance.yaml
@@ -1,0 +1,17 @@
+name: semgrep-recorded-sarif
+adapter_class: bernstein.adapters.semgrep.SemgrepAdapter
+ctor_kwargs:
+  config_path: tests/fixtures/scanners/semgrep/semgrep-rules.yml
+steps:
+  - target: tests/fixtures/scanners/semgrep/target
+    scope:
+      roots:
+        - tests/fixtures/scanners/semgrep/target
+    expected_finding_hashes:
+      - 3d0748e73ec1bb23ddbf051d12242af996c225ecc210560ad43f77a4f78cf48f
+  - target: tests/fixtures/scanners/semgrep/target
+    scope:
+      roots:
+        - tests/fixtures/scanners/semgrep/target
+    expected_finding_hashes:
+      - 3d0748e73ec1bb23ddbf051d12242af996c225ecc210560ad43f77a4f78cf48f

--- a/tests/fixtures/scanners/semgrep/semgrep-rules.yml
+++ b/tests/fixtures/scanners/semgrep/semgrep-rules.yml
@@ -1,0 +1,6 @@
+rules:
+  - id: bernstein-test-eval-use
+    languages: [python]
+    message: Bernstein synthetic dangerous eval() use
+    severity: ERROR
+    pattern: eval(...)

--- a/tests/fixtures/scanners/semgrep/target/vulnerable.py
+++ b/tests/fixtures/scanners/semgrep/target/vulnerable.py
@@ -1,0 +1,2 @@
+user_input = "1 + 1"
+eval(user_input)

--- a/tests/unit/adapters/test_semgrep_scanner.py
+++ b/tests/unit/adapters/test_semgrep_scanner.py
@@ -1,0 +1,261 @@
+"""Tests for deterministic normalization of recorded Semgrep SARIF."""
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from bernstein.adapters._contract import ScannerDeterminism, scanner_determinism
+from bernstein.adapters.scanner import DeterminismTier, OutputFormat, ScannerCategory, ScanScope
+from bernstein.adapters.scanner_conformance import (
+    ScannerConformanceHarness,
+    load_scanner_golden_transcripts,
+)
+from bernstein.adapters.scanner_registry import get_scanner
+from bernstein.adapters.semgrep import (
+    SemgrepAdapter,
+    SemgrepError,
+    SemgrepNotInstalledError,
+    _invocation_argv_hash,
+    _ruleset_digest,
+    parse_semgrep_sarif,
+)
+
+_FIXTURE = Path("tests/fixtures/scanners/semgrep/semgrep-1.45.0.sarif")
+_CONFIG = Path("tests/fixtures/scanners/semgrep/semgrep-rules.yml")
+_FIXTURE_DIR = _FIXTURE.parent
+
+
+def _fixture_text() -> str:
+    return _FIXTURE.read_text(encoding="utf-8")
+
+
+def _fake_semgrep_run(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+    if argv[1:] == ["--version"]:
+        return subprocess.CompletedProcess(argv, 0, stdout="1.45.0\n", stderr="")
+    report_path = Path(argv[argv.index("--output") + 1])
+    report_path.write_text(_fixture_text(), encoding="utf-8")
+    return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+
+def test_real_semgrep_sarif_is_normalized_to_a_finding() -> None:
+    finding = parse_semgrep_sarif(_fixture_text())[0]
+
+    assert finding.rule == "bernstein-test-eval-use"
+    assert finding.path == "vulnerable.py"
+    assert finding.severity == "high"
+    assert finding.summary == "Bernstein synthetic dangerous eval() use"
+    assert finding.extra["snippet_hash"].startswith("sha256:")
+
+
+def test_two_parses_of_the_same_recorded_run_have_identical_hashes() -> None:
+    first = [finding.finding_hash() for finding in parse_semgrep_sarif(_fixture_text())]
+    second = [finding.finding_hash() for finding in parse_semgrep_sarif(_fixture_text())]
+
+    assert first == second
+
+
+def test_cosmetic_line_shift_does_not_change_the_finding_hash() -> None:
+    original = json.loads(_fixture_text())
+    shifted = copy.deepcopy(original)
+    region = shifted["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"]
+    region["startLine"] += 7
+    region["endLine"] += 7
+
+    original_hashes = [finding.finding_hash() for finding in parse_semgrep_sarif(json.dumps(original))]
+    shifted_hashes = [finding.finding_hash() for finding in parse_semgrep_sarif(json.dumps(shifted))]
+
+    assert shifted_hashes == original_hashes
+
+
+def test_changing_the_snippet_does_change_the_finding_hash() -> None:
+    original = json.loads(_fixture_text())
+    changed = copy.deepcopy(original)
+    changed["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"]["snippet"]["text"] = (
+        "eval(other_input)"
+    )
+
+    original_hash = parse_semgrep_sarif(json.dumps(original))[0].finding_hash()
+    changed_hash = parse_semgrep_sarif(json.dumps(changed))[0].finding_hash()
+
+    assert changed_hash != original_hash
+
+
+def test_absolute_report_path_is_normalized_to_the_scan_target() -> None:
+    report = json.loads(_fixture_text())
+    artifact = report["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["artifactLocation"]
+    artifact["uri"] = "/checkout/project/vulnerable.py"
+
+    finding = parse_semgrep_sarif(json.dumps(report), target_root=Path("/checkout/project"))[0]
+
+    assert finding.path == "vulnerable.py"
+
+
+def test_non_semgrep_sarif_is_rejected() -> None:
+    report = json.loads(_fixture_text())
+    report["runs"][0]["tool"]["driver"]["name"] = "another-scanner"
+
+    with pytest.raises(ValueError, match="must be 'semgrep'"):
+        parse_semgrep_sarif(json.dumps(report))
+
+
+def test_invalid_json_is_rejected() -> None:
+    with pytest.raises(ValueError, match="Invalid Semgrep SARIF JSON"):
+        parse_semgrep_sarif("not-json")
+
+
+def test_adapter_declares_the_deterministic_sast_scanner_contract() -> None:
+    adapter = SemgrepAdapter(config_path=_CONFIG)
+
+    assert adapter.name() == "semgrep"
+    assert adapter.output_format is OutputFormat.SARIF
+    assert adapter.determinism is DeterminismTier.DETERMINISTIC
+    assert adapter.category is ScannerCategory.SAST
+    assert scanner_determinism(adapter.name()) is ScannerDeterminism.DETERMINISTIC
+
+
+def test_scanner_registry_resolves_semgrep() -> None:
+    assert isinstance(get_scanner("semgrep"), SemgrepAdapter)
+
+
+def test_invocation_hash_binds_version_and_ruleset() -> None:
+    baseline = _invocation_argv_hash("1.45.0", "sha256:rules-a")
+
+    assert _invocation_argv_hash("1.45.0", "sha256:rules-a") == baseline
+    assert _invocation_argv_hash("1.45.1", "sha256:rules-a") != baseline
+    assert _invocation_argv_hash("1.45.0", "sha256:rules-b") != baseline
+
+
+def test_ruleset_digest_hashes_a_rule_directory(tmp_path: Path) -> None:
+    rule_dir = tmp_path / "rules"
+    rule_dir.mkdir()
+    (rule_dir / "a.yml").write_text("rules: []\n", encoding="utf-8")
+
+    before = _ruleset_digest(rule_dir)
+    (rule_dir / "b.yml").write_text("rules: []\n", encoding="utf-8")
+    after = _ruleset_digest(rule_dir)
+
+    assert before != after
+
+
+def test_scan_refuses_to_run_without_a_pinned_local_ruleset(tmp_path: Path) -> None:
+    """Load-bearing: a Semgrep scan without a pinned local ruleset would fall
+    back to remote rule resolution, which is not deterministic, so the
+    adapter must refuse rather than silently degrade its determinism tier."""
+    target = tmp_path / "target"
+    target.mkdir()
+    adapter = SemgrepAdapter()
+
+    with (
+        patch("bernstein.adapters.semgrep.shutil.which", return_value="/usr/local/bin/semgrep"),
+        patch("bernstein.adapters.semgrep.subprocess.run") as run,
+        pytest.raises(SemgrepError, match="requires a local rule file or directory"),
+    ):
+        adapter.scan(target, ScanScope(roots=(target,)), tmp_path / "work")
+    run.assert_not_called()
+
+
+def test_scan_runs_semgrep_and_parses_its_sarif_report(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    adapter = SemgrepAdapter(config_path=_CONFIG)
+
+    with (
+        patch("bernstein.adapters.semgrep.shutil.which", return_value="/usr/local/bin/semgrep"),
+        patch("bernstein.adapters.semgrep.subprocess.run", side_effect=_fake_semgrep_run) as run,
+    ):
+        result = adapter.scan(target, ScanScope(roots=(target,)), tmp_path / "work")
+
+    expected_hash = parse_semgrep_sarif(_fixture_text())[0].finding_hash()
+    assert result.finding_hashes() == [expected_hash]
+    scan_argv = run.call_args_list[1].args[0]
+    assert scan_argv[1:3] == ["scan", "--metrics=off"]
+    assert "--config" in scan_argv
+    assert scan_argv[-1] == str(target.resolve())
+    assert adapter.last_invocation is not None
+    assert adapter.last_invocation.tool_version == "1.45.0"
+    assert adapter.last_invocation.ruleset_digest == _ruleset_digest(_CONFIG)
+
+
+def test_target_local_config_is_discovered(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    local_config = target / ".semgrep.yml"
+    local_config.write_bytes(_CONFIG.read_bytes())
+    adapter = SemgrepAdapter()
+
+    with (
+        patch("bernstein.adapters.semgrep.shutil.which", return_value="/usr/local/bin/semgrep"),
+        patch("bernstein.adapters.semgrep.subprocess.run", side_effect=_fake_semgrep_run) as run,
+    ):
+        adapter.scan(target, ScanScope(roots=(target,)), tmp_path / "work")
+
+    scan_argv = run.call_args_list[1].args[0]
+    assert scan_argv[scan_argv.index("--config") + 1] == str(local_config.resolve())
+
+
+def test_stale_report_cannot_be_reused(tmp_path: Path) -> None:
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    (workdir / "semgrep.sarif").write_text(_fixture_text(), encoding="utf-8")
+
+    def no_report(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if argv[1:] == ["--version"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="1.45.0\n", stderr="")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    adapter = SemgrepAdapter(config_path=_CONFIG)
+    with (
+        patch("bernstein.adapters.semgrep.shutil.which", return_value="/usr/local/bin/semgrep"),
+        patch("bernstein.adapters.semgrep.subprocess.run", side_effect=no_report),
+        pytest.raises(SemgrepError, match="without writing its SARIF report"),
+    ):
+        adapter.scan(tmp_path, ScanScope(), workdir)
+
+
+def test_scan_reports_missing_semgrep_without_invoking_a_process(tmp_path: Path) -> None:
+    adapter = SemgrepAdapter(config_path=_CONFIG)
+    with (
+        patch("bernstein.adapters.semgrep.shutil.which", return_value=None),
+        patch("bernstein.adapters.semgrep.subprocess.run") as run,
+        pytest.raises(SemgrepNotInstalledError, match="not found on PATH"),
+    ):
+        adapter.scan(tmp_path, ScanScope(), tmp_path / "work")
+    run.assert_not_called()
+
+
+def test_scan_rejects_a_real_semgrep_execution_error(tmp_path: Path) -> None:
+    def fail_scan(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if argv[1:] == ["--version"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="1.45.0\n", stderr="")
+        return subprocess.CompletedProcess(argv, 2, stdout="", stderr="bad rule syntax")
+
+    adapter = SemgrepAdapter(config_path=_CONFIG)
+    with (
+        patch("bernstein.adapters.semgrep.shutil.which", return_value="/usr/local/bin/semgrep"),
+        patch("bernstein.adapters.semgrep.subprocess.run", side_effect=fail_scan),
+        pytest.raises(SemgrepError, match="code 2: bad rule syntax"),
+    ):
+        adapter.scan(tmp_path, ScanScope(), tmp_path / "work")
+
+
+def test_conformance_replays_two_identical_semgrep_runs(tmp_path: Path) -> None:
+    transcripts = load_scanner_golden_transcripts(_FIXTURE_DIR)
+    assert len(transcripts) == 1
+
+    with (
+        patch("bernstein.adapters.semgrep.shutil.which", return_value="/usr/local/bin/semgrep"),
+        patch("bernstein.adapters.semgrep.subprocess.run", side_effect=_fake_semgrep_run) as run,
+    ):
+        result = ScannerConformanceHarness().replay_transcript(transcripts[0], workdir=tmp_path)
+
+    assert result.passed
+    assert result.adapter_name == "semgrep"
+    assert result.determinism_tier is DeterminismTier.DETERMINISTIC
+    assert sum(call.args[0][1] == "scan" for call in run.call_args_list) == 2


### PR DESCRIPTION
## What

Adds `SemgrepAdapter`, a `ScannerAdapter` implementation for Semgrep, and
registers it in the scanner registry. This is one tool from the checklist in
#2958 (`semgrep — sast, deterministic with pinned local rules, SARIF`).

This PR does not touch any other tool on that list (bandit, osv-scanner,
checkov, nuclei, ZAP, the export sinks, or the community-tier tools) and does
not change the `ScannerAdapter` contract itself.

## Why

`ScannerAdapter` (#2953) and its two reference adapters, Gitleaks and Trivy,
are already on `main`. Semgrep is a static analyzer with no built-in
provenance metadata in the tool itself, so bringing it in through the adapter
contract is what makes its findings content-addressed and replayable the same
way the existing scanner adapters are, instead of each caller shelling out to
`semgrep --sarif` and normalizing output ad hoc.

Semgrep's own registry-resolved configs (`--config auto`, `p/...`) are not
deterministic — the ruleset can change between runs without any local
change. The open question in the checklist ("declare `pinned_inputs`") is
resolved here by making the adapter refuse to run unless it is given a local
rule file or directory: `pinned_inputs` stays empty because the ruleset
digest is derived from the file content itself (hashed into the invocation
provenance) rather than from a separate pinned identifier, matching how the
Gitleaks adapter pins its own local config.

## How

- `src/bernstein/adapters/semgrep.py`: `SemgrepAdapter(ScannerAdapter)`,
  `category=SAST`, `determinism=DETERMINISTIC`, `output_format=SARIF`.
  - Resolves a local `--config` (explicit `config_path`, or a discovered
    `.semgrep.yml` / `.semgrep/` next to the scan target); raises if none is
    found rather than falling back to a registry lookup.
  - Runs `semgrep scan --metrics=off --disable-version-check --sarif` and
    parses the report.
  - `parse_semgrep_sarif` normalizes each SARIF result into a `Finding`,
    content-addressed on `ruleId` + normalized POSIX path + a hash of the
    matched snippet text — explicitly not the SARIF `region` line numbers, so
    a cosmetic line shift elsewhere in the file does not change the hash.
  - Records `SemgrepInvocation` (tool version, ruleset digest, argv hash) for
    `bernstein finding verify --re-execute`.
- `src/bernstein/adapters/scanner_registry.py`: registers
  `SemgrepAdapter` under `"semgrep"`.
- `docs/sdd/module-map.md`: regenerated via `bernstein agents-md sync` to add
  the new module row (only change in that file).

## Tests

All in `tests/unit/adapters/test_semgrep_scanner.py` (18 tests). Load-bearing:
`test_scan_refuses_to_run_without_a_pinned_local_ruleset` — it is the test
that pins the determinism argument above; without it, nothing stops the
adapter from silently degrading to a non-deterministic remote-rule scan.

1. `test_real_semgrep_sarif_is_normalized_to_a_finding`
2. `test_two_parses_of_the_same_recorded_run_have_identical_hashes`
3. `test_cosmetic_line_shift_does_not_change_the_finding_hash`
4. `test_changing_the_snippet_does_change_the_finding_hash`
5. `test_absolute_report_path_is_normalized_to_the_scan_target`
6. `test_non_semgrep_sarif_is_rejected`
7. `test_invalid_json_is_rejected`
8. `test_adapter_declares_the_deterministic_sast_scanner_contract`
9. `test_scanner_registry_resolves_semgrep`
10. `test_invocation_hash_binds_version_and_ruleset`
11. `test_ruleset_digest_hashes_a_rule_directory`
12. `test_scan_refuses_to_run_without_a_pinned_local_ruleset` (load-bearing)
13. `test_scan_runs_semgrep_and_parses_its_sarif_report`
14. `test_target_local_config_is_discovered`
15. `test_stale_report_cannot_be_reused`
16. `test_scan_reports_missing_semgrep_without_invoking_a_process`
17. `test_scan_rejects_a_real_semgrep_execution_error`
18. `test_conformance_replays_two_identical_semgrep_runs`

Verified all 18 fail on the unmodified tree (the module does not exist, so
collection fails with `ModuleNotFoundError`) and pass after the change.

`--affected origin/main` was run but timed out selecting an unexpectedly wide
file set through `bernstein/adapters/__init__.py` (a known re-export
breadth issue in this codebase, not specific to this change). Ran the touched
modules' own tests plus the other scanner-adapter tests that share
`scanner_registry.py` instead:

```
uv run python scripts/run_tests.py --parallel 2 -x \
  tests/unit/adapters/test_semgrep_scanner.py \
  tests/unit/test_scanner_registry.py \
  tests/unit/adapters/test_trivy_scanner.py \
  tests/unit/adapters/test_gitleaks_scanner.py \
  tests/unit/adapters/test_nmap_scanner.py
```

All 5 files pass (77 tests). CI runs the full suite.

## Checklist

- [x] `uv run ruff check src/` — clean
- [x] `uv run ruff format --check` on the changed files — clean
- [x] `uv run python scripts/run_tests.py -x <files>` — clean (see above)
- [ ] `pyright src/` — one pre-existing `reportUnusedFunction` on
      `scanner_registry.py:140` (`_registered_scanner_name`), present on
      `main` before this change and outside the two lines this PR touches in
      that file; not introduced here.
- [x] Type hints on new/changed public functions
- [x] Docstrings on new public functions/classes
- N/A README / translated docs — no user-facing CLI surface changed
- N/A migration — no schema or data change

Part of #2958

## Remaining

Everything else in the checklist (bandit, osv-scanner, checkov, nuclei, ZAP,
the export sinks, and the community-tier tools) is still open, one PR per
tool as the issue asks. Gitleaks, Trivy, and Nmap are already done on
`main`.
