### PR TITLE
feat(quality): add the absence_verified completion signal (#3650)

### DIFF
--- a/docs/architecture/plans.md
+++ b/docs/architecture/plans.md
@@ -117,6 +117,7 @@ keys depend on `type`:
 | `file_contains` | `path`, `contains` | File must exist and include the substring. |
 | `llm_review` | `value` (criteria) | LLM judge applies the given criteria. |
 | `llm_judge` | `value` | Free-form LLM judgement. |
+| `absence_verified` | `value` (tool_call_id) | The named tool call reported "nothing found" and its anchored coverage record proves what it searched. |
 
 Source: `plan_schema.py:49-77`, `plan_loader.py:70-97`.
 

--- a/docs/architecture/quality-pipeline.md
+++ b/docs/architecture/quality-pipeline.md
@@ -38,6 +38,7 @@ The janitor evaluates each `CompletionSignal` declared on the task
 | `file_contains`  | A regex matches the file's content.                                     |
 | `llm_review`     | Synchronous LLM review against a written rubric.                        |
 | `llm_judge`      | Async LLM judge (`judge_task()`, `janitor.py:462`); used for ambiguous tasks. |
+| `absence_verified` | The claim is an *absence* ("no occurrences found"). `value` is the `tool_call_id` that reported it; the signal passes only when that call's recorded coverage payload hash-matches a `coverage` lineage entry anchored to the same `tool_call_id` and describes a complete, exit-checked walk. Every missing or mismatched piece fails closed as `unverified`. |
 | `schema_valid` / `criteria_match` / `hash_stable` / `figures_grounded` | Artifact-mode criteria over the produced artifact's canonical bytes. They fail closed on the filesystem path; only `evaluate_artifact_signals()`, called with the artifact in scope, can pass one. |
 
 A `test_passes` command is resolved against the tree before it runs. The path in

--- a/src/bernstein/core/planning/plan_schema.py
+++ b/src/bernstein/core/planning/plan_schema.py
@@ -56,6 +56,7 @@ COMPLETION_SIGNAL_TYPES: list[str] = [
     "file_contains",
     "llm_review",
     "llm_judge",
+    "absence_verified",
 ]
 
 # Issue #3110: the declared artifact contract. The strict parser in

--- a/src/bernstein/core/quality/absence_coverage.py
+++ b/src/bernstein/core/quality/absence_coverage.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
+import logging
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from bernstein.core.replay.journal import (
     JournalCoverageStatus,
@@ -20,6 +22,14 @@ if TYPE_CHECKING:
     from bernstein.core.lineage.entry import LineageEntry
     from bernstein.core.lineage.store import LineageStore
     from bernstein.core.replay.journal import JournalSeal
+
+logger = logging.getLogger(__name__)
+
+#: Glob for the per-agent tool-call ledgers written by
+#: :class:`bernstein.core.instrumentation.RunInstrumenter` under a project's
+#: ``.sdd/`` tree. Mirrors
+#: :func:`bernstein.core.instrumentation.resolve_agent_dir`.
+_TOOL_CALLS_GLOB = ".sdd/runs/*/tasks/*/agents/*/tool-calls.jsonl"
 
 
 class CompletionCoverageStatus(StrEnum):
@@ -235,4 +245,123 @@ def classify_completion_coverage(
         is_verified=False,
         passed=passed,
         detail=detail or "unverified: no coverage record",
+    )
+
+
+def _canonical_coverage_bytes(payload: dict[str, Any]) -> bytes:
+    """Encode a coverage payload exactly as :func:`anchor_coverage_record` does."""
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _recorded_coverage_payload(workdir: Path, tool_call_id: str) -> dict[str, Any] | None:
+    """Return the coverage payload the instrumenter recorded for ``tool_call_id``.
+
+    Scans the per-agent ``tool-calls.jsonl`` ledgers under ``workdir/.sdd/runs``.
+    A batched agent mirrors identical lines into several task directories, so
+    the first match is authoritative; paths are sorted to keep the choice
+    deterministic when several runs are present.
+    """
+    for path in sorted(workdir.glob(_TOOL_CALLS_GLOB)):
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except OSError as exc:
+            logger.warning("absence coverage: cannot read tool-call ledger %s: %s", path, exc)
+            continue
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                parsed: object = json.loads(line)
+            except ValueError:
+                # A torn or corrupted ledger line is exactly the "the search may
+                # not have run" case; skip it rather than treat it as evidence.
+                continue
+            if not isinstance(parsed, dict):
+                continue
+            row = cast("dict[str, Any]", parsed)
+            if row.get("call_id") != tool_call_id:
+                continue
+            payload = row.get("coverage")
+            if isinstance(payload, dict):
+                return cast("dict[str, Any]", payload)
+    return None
+
+
+def verify_anchored_absence_claim(
+    *,
+    tool_call_id: str,
+    workdir: Path,
+    lineage_store: LineageStore | None = None,
+) -> tuple[bool, str]:
+    """Verify one absence claim against the coverage anchored to its own tool call.
+
+    An absence claim ("no occurrences found") is readable as verified only when
+    all of the following hold:
+
+    1. The tool call recorded a coverage payload (issue #3769).
+    2. A lineage entry of kind ``coverage`` is anchored to the *same*
+       ``tool_call_id`` (issue #3770) - coverage anchored to another call is
+       not this claim's scope and never stands in for it.
+    3. The recorded payload's canonical digest equals that entry's
+       ``content_hash``, so the scope cannot be rewritten after sealing.
+    4. The walk terminated normally (``coverage == "complete"``, not truncated)
+       and the tool's exit status was actually checked.
+
+    Any failure returns ``(False, "unverified: ...")`` rather than raising, so a
+    caller evaluating a list of signals needs no guard at the call site.
+
+    Args:
+        tool_call_id: Identifier of the call that reported the absence.
+        workdir: Project root containing ``.sdd/``.
+        lineage_store: Store override; defaults to ``workdir/.sdd/lineage``.
+
+    Returns:
+        Tuple of ``(verified, detail)``.
+    """
+    payload = _recorded_coverage_payload(workdir, tool_call_id)
+    if payload is None:
+        return False, f"unverified: absence claim for tool call {tool_call_id!r} has no coverage record"
+
+    store = lineage_store
+    if store is None:
+        store_root = workdir / ".sdd" / "lineage"
+        if not store_root.exists():
+            return False, f"unverified: coverage for tool call {tool_call_id!r} is not anchored (no lineage log)"
+        from bernstein.core.lineage.store import LineageStore as _LineageStore
+
+        store = _LineageStore(store_root)
+
+    from bernstein.core.lineage.coverage import find_coverage_for_tool_call
+
+    entry = find_coverage_for_tool_call(store, tool_call_id)
+    if entry is None:
+        return False, f"unverified: coverage for tool call {tool_call_id!r} is not anchored in lineage"
+
+    digest = "sha256:" + hashlib.sha256(_canonical_coverage_bytes(payload)).hexdigest()
+    if digest != entry.content_hash:
+        return (
+            False,
+            f"unverified: recorded coverage for tool call {tool_call_id!r} does not match its anchor "
+            f"(recorded {digest}, anchored {entry.content_hash})",
+        )
+
+    record = ToolCoverageRecord.from_dict(payload)
+    if record.truncated or record.coverage != "complete":
+        reason = record.truncation_reason or "no reason recorded"
+        return (
+            False,
+            f"unverified: coverage for tool call {tool_call_id!r} is {record.coverage} "
+            f"(truncated={record.truncated}, reason={reason})",
+        )
+    if not record.exit_checked:
+        return (
+            False,
+            f"unverified: coverage for tool call {tool_call_id!r} reports exit status "
+            f"{record.exit_status!r} that was never checked",
+        )
+
+    return (
+        True,
+        f"verified absence: tool call {tool_call_id} covered {record.file_count} item(s) "
+        f"(corpus {record.corpus_digest}, anchored {digest})",
     )

--- a/src/bernstein/core/quality/janitor.py
+++ b/src/bernstein/core/quality/janitor.py
@@ -119,6 +119,12 @@ _NONTRIVIAL_SIGNAL_TYPES = frozenset(
         # A grounded report proves the figures trace to signed sources - strong
         # evidence of real work, on par with a passing test (issue #2888).
         "figures_grounded",
+        # A verified absence proves a search actually covered a named corpus
+        # (issue #3650). It is the one signal that legitimately accompanies an
+        # empty diff - "nothing to change, and here is what was searched" - so
+        # a passing one must count as evidence rather than leave the task
+        # looking like a rubber stamp.
+        "absence_verified",
     }
 )
 
@@ -338,6 +344,20 @@ def evaluate_signal(
         case "llm_judge":
             # llm_judge requires async evaluation - use judge_task() instead.
             return False, "llm_judge requires async evaluation via judge_task()"
+        case "absence_verified":
+            # The absence-shaped signal (issue #3650): the value names the tool
+            # call that reported "nothing found", and the claim is only
+            # readable as verified when that call's own anchored coverage says
+            # what it covered. Fails closed on every missing or mismatched
+            # piece, so an unrecorded absence reads as unverified, never as a
+            # plain success.
+            from bernstein.core.quality.absence_coverage import verify_anchored_absence_claim
+
+            return verify_anchored_absence_claim(
+                tool_call_id=signal.value.strip(),
+                workdir=workdir,
+                lineage_store=lineage_store,
+            )
         case _ if signal.type in _ARTIFACT_SIGNAL_TYPES:
             # Artifact-mode criteria operate on the produced artifact's canonical
             # bytes (and, for figures_grounded, on lineage reads), not the

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -289,6 +289,16 @@ class CompletionSignal:
     record and every material number in the body to be declared in the sidecar.
     Its ``value`` is the severity - ``""``/``"strict"`` (an unanchored figure
     fails completion) or ``"warn"`` (downgrade for exploratory work).
+
+    ``absence_verified`` (issue #3650) is the only absence-shaped type: every
+    other one asserts that something is present, so a task whose real result is
+    "no occurrences found" had no way to state that as a checkable claim. Its
+    ``value`` is the ``tool_call_id`` of the call that reported the absence, and
+    it passes only when that call's recorded coverage payload (issue #3769)
+    hash-matches the lineage coverage entry anchored to the same
+    ``tool_call_id`` (issue #3770) and describes a complete, exit-checked walk.
+    Its evaluator is
+    :func:`bernstein.core.quality.absence_coverage.verify_anchored_absence_claim`.
     """
 
     type: Literal[
@@ -302,8 +312,11 @@ class CompletionSignal:
         "criteria_match",
         "hash_stable",
         "figures_grounded",
+        "absence_verified",
     ]
-    value: str  # path, glob pattern, test command, search string, review instruction, criterion payload, or severity
+    # path, glob, test command, search string, review instruction,
+    # criterion payload, severity, or tool_call_id
+    value: str
 
 
 @dataclass(frozen=True)

--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -323,6 +323,7 @@ type CompletionSignalType = Literal[
     "criteria_match",
     "hash_stable",
     "figures_grounded",
+    "absence_verified",
 ]
 
 _COMPLETION_SIGNAL_TYPES: tuple[CompletionSignalType, ...] = (
@@ -336,6 +337,7 @@ _COMPLETION_SIGNAL_TYPES: tuple[CompletionSignalType, ...] = (
     "criteria_match",
     "hash_stable",
     "figures_grounded",
+    "absence_verified",
 )
 
 

--- a/tests/unit/test_absence_verified_signal.py
+++ b/tests/unit/test_absence_verified_signal.py
@@ -1,0 +1,237 @@
+"""Unit tests for the ``absence_verified`` completion signal (issue #3650).
+
+The signal is the absence-shaped member of ``completion_signals``: its value is
+the ``tool_call_id`` of the call that reported "nothing found", and it passes
+only when that call's recorded coverage payload hash-matches the lineage
+coverage entry anchored to the *same* ``tool_call_id``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from bernstein.core.lineage.coverage import anchor_coverage_record
+from bernstein.core.lineage.identity import AgentCard, generate_keypair
+from bernstein.core.lineage.signed_write import SignedLineageLog
+from bernstein.core.lineage.store import LineageStore
+from bernstein.core.quality.absence_coverage import verify_anchored_absence_claim
+from bernstein.core.quality.janitor import evaluate_signal
+from bernstein.core.tasks.models import CompletionSignal
+from bernstein.core.tasks.task_store_core import _narrow_signal_type
+from bernstein.core.tools.coverage import ToolCoverageRecord, compute_corpus_digest
+
+_RUN_ID = "run-abs-1"
+_TASK_ID = "T-abs"
+_AGENT_ID = "agent-abs"
+
+
+def _complete_record() -> ToolCoverageRecord:
+    return ToolCoverageRecord(
+        file_count=2,
+        corpus_digest=compute_corpus_digest(["a.py", "b.py"]),
+        coverage="complete",
+        truncated=False,
+        truncation_reason=None,
+        exit_status=0,
+        exit_checked=True,
+    )
+
+
+def _write_tool_call(workdir: Path, call_id: str, coverage: dict[str, object] | None) -> Path:
+    """Append one tool-call record under the run's instrumentation tree."""
+    agent_dir = workdir / ".sdd" / "runs" / _RUN_ID / "tasks" / _TASK_ID / "agents" / _AGENT_ID
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    record: dict[str, object] = {
+        "call_id": call_id,
+        "ts_start": "2026-09-02T00:00:00Z",
+        "ts_end": "2026-09-02T00:00:01Z",
+        "tool": "grep",
+        "args": {"pattern": "TODO"},
+        "success": True,
+        "error": None,
+        "result": "",
+    }
+    if coverage is not None:
+        record["coverage"] = coverage
+    path = agent_dir / "tool-calls.jsonl"
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record) + "\n")
+    return path
+
+
+def _anchor(workdir: Path, call_id: str, record: ToolCoverageRecord) -> LineageStore:
+    lineage_root = workdir / ".sdd" / "lineage"
+    lineage_root.mkdir(parents=True, exist_ok=True)
+    priv_pem, pub_pem = generate_keypair()
+    card = AgentCard(agent_id="agent:cov", kid="k1", public_key_pem=pub_pem)
+    store = LineageStore(lineage_root)
+    recorder = SignedLineageLog(store=store, operator_hmac_key=b"0" * 64)
+    anchor_coverage_record(
+        recorder,
+        tool_name="grep",
+        tool_call_id=call_id,
+        coverage=record,
+        agent_id=card.agent_id,
+        agent_card=card,
+        private_key_pem=priv_pem,
+    )
+    return store
+
+
+# 1 ---------------------------------------------------------------------------
+def test_absence_claim_without_coverage_record_reads_unverified(tmp_path: Path) -> None:
+    """A tool call that recorded no coverage at all cannot back an absence claim."""
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    _write_tool_call(workdir, "tc-1", coverage=None)
+
+    passed, detail = verify_anchored_absence_claim(tool_call_id="tc-1", workdir=workdir)
+    assert passed is False
+    assert "unverified" in detail.lower()
+    assert "no coverage record" in detail.lower()
+
+
+# 2 ---------------------------------------------------------------------------
+def test_unanchored_coverage_record_reads_unverified(tmp_path: Path) -> None:
+    """A coverage payload nobody sealed into lineage is not a verified absence."""
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    _write_tool_call(workdir, "tc-2", coverage=_complete_record().to_dict())
+
+    passed, detail = verify_anchored_absence_claim(tool_call_id="tc-2", workdir=workdir)
+    assert passed is False
+    assert "unverified" in detail.lower()
+    assert "not anchored" in detail.lower()
+
+
+# 3 ---------------------------------------------------------------------------
+def test_coverage_payload_edited_after_anchoring_reads_unverified(tmp_path: Path) -> None:
+    """LOAD-BEARING: a truncated walk relabelled 'complete' after sealing is refused.
+
+    The anchored entry commits to ``sha256`` of the record that was actually
+    sealed; a payload rewritten afterwards no longer matches it, so the claim
+    degrades instead of reading as a verified absence.
+    """
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    truncated = ToolCoverageRecord(
+        file_count=1,
+        corpus_digest=compute_corpus_digest(["a.py"]),
+        coverage="partial",
+        truncated=True,
+        truncation_reason="timeout",
+        exit_status="timeout",
+        exit_checked=True,
+    )
+    _anchor(workdir, "tc-3", truncated)
+    # The record that reaches the janitor claims a complete walk.
+    _write_tool_call(workdir, "tc-3", coverage=_complete_record().to_dict())
+
+    passed, detail = verify_anchored_absence_claim(tool_call_id="tc-3", workdir=workdir)
+    assert passed is False
+    assert "unverified" in detail.lower()
+    assert "does not match" in detail.lower()
+
+
+# 4 ---------------------------------------------------------------------------
+def test_coverage_anchored_to_another_tool_call_cannot_back_this_claim(tmp_path: Path) -> None:
+    """Scope cannot be borrowed: another call's complete coverage verifies nothing here."""
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    _anchor(workdir, "tc-other", _complete_record())
+    _write_tool_call(workdir, "tc-other", coverage=_complete_record().to_dict())
+    _write_tool_call(workdir, "tc-4", coverage=_complete_record().to_dict())
+
+    passed, detail = verify_anchored_absence_claim(tool_call_id="tc-4", workdir=workdir)
+    assert passed is False
+    assert "unverified" in detail.lower()
+    assert "not anchored" in detail.lower()
+
+
+# 5 ---------------------------------------------------------------------------
+def test_truncated_anchored_coverage_reads_unverified(tmp_path: Path) -> None:
+    """An honestly-recorded truncated walk still cannot assert a verified absence."""
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    truncated = ToolCoverageRecord(
+        file_count=3,
+        corpus_digest=compute_corpus_digest(["a.py"]),
+        coverage="partial",
+        truncated=True,
+        truncation_reason="limit_reached",
+        exit_status=0,
+        exit_checked=True,
+    )
+    _anchor(workdir, "tc-5", truncated)
+    _write_tool_call(workdir, "tc-5", coverage=truncated.to_dict())
+
+    passed, detail = verify_anchored_absence_claim(tool_call_id="tc-5", workdir=workdir)
+    assert passed is False
+    assert "unverified" in detail.lower()
+    assert "limit_reached" in detail
+
+
+# 6 ---------------------------------------------------------------------------
+def test_unchecked_exit_status_reads_unverified(tmp_path: Path) -> None:
+    """A walk whose exit status was never checked is the #3573 shape and is refused."""
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    unchecked = ToolCoverageRecord(
+        file_count=2,
+        corpus_digest=compute_corpus_digest(["a.py", "b.py"]),
+        coverage="complete",
+        truncated=False,
+        truncation_reason=None,
+        exit_status=0,
+        exit_checked=False,
+    )
+    _anchor(workdir, "tc-6", unchecked)
+    _write_tool_call(workdir, "tc-6", coverage=unchecked.to_dict())
+
+    passed, detail = verify_anchored_absence_claim(tool_call_id="tc-6", workdir=workdir)
+    assert passed is False
+    assert "unverified" in detail.lower()
+    assert "exit status" in detail.lower()
+
+
+# 7 ---------------------------------------------------------------------------
+def test_complete_anchored_coverage_reads_verified(tmp_path: Path) -> None:
+    """A complete walk whose payload matches its anchor is a verified absence."""
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    record = _complete_record()
+    _anchor(workdir, "tc-7", record)
+    _write_tool_call(workdir, "tc-7", coverage=record.to_dict())
+
+    passed, detail = verify_anchored_absence_claim(tool_call_id="tc-7", workdir=workdir)
+    assert passed is True
+    assert "verified absence" in detail.lower()
+    assert record.corpus_digest in detail
+
+    # The anchored digest really is sha256 over the canonical payload bytes.
+    canonical = json.dumps(record.to_dict(), sort_keys=True, separators=(",", ":")).encode("utf-8")
+    assert "sha256:" + hashlib.sha256(canonical).hexdigest() in detail
+
+
+# 8 ---------------------------------------------------------------------------
+def test_absence_verified_signal_dispatches_through_evaluate_signal(tmp_path: Path) -> None:
+    """The signal is a first-class completion signal, not an unknown type."""
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    record = _complete_record()
+    _anchor(workdir, "tc-8", record)
+    _write_tool_call(workdir, "tc-8", coverage=record.to_dict())
+
+    assert _narrow_signal_type("absence_verified") == "absence_verified"
+
+    signal = CompletionSignal(type="absence_verified", value="tc-8")
+    passed, detail = evaluate_signal(signal, workdir)
+    assert passed is True
+    assert "verified absence" in detail.lower()
+
+    missing = CompletionSignal(type="absence_verified", value="tc-nope")
+    passed_missing, detail_missing = evaluate_signal(missing, workdir)
+    assert passed_missing is False
+    assert "unverified" in detail_missing.lower()


### PR DESCRIPTION
## What

Adds `absence_verified` to `completion_signals` — the first absence-shaped
member of the vocabulary. Its `value` is the `tool_call_id` of the call that
reported "nothing found"; it passes only when that call's recorded coverage
payload hash-matches the `coverage` lineage entry anchored to the *same*
`tool_call_id`, and that record describes a complete, exit-checked walk.

This PR does **not** change how tools emit coverage records, how those records
are anchored, or how a journal-backed absence is classified — all three already
exist on `main` (`src/bernstein/core/tools/coverage.py`,
`src/bernstein/core/lineage/coverage.py`,
`src/bernstein/core/quality/absence_coverage.py`). It adds the one missing
piece: a way for a *task* to declare that its result is an absence, so the
janitor can check it.

## Why

`completion_signals` had ten types and every one of them asserts that something
is present — a path exists, a glob matches, a command exits 0, a file contains a
pattern, an artifact hashes stably. A task whose honest result is "no
occurrences found" had no way to state that as a checkable claim, so it was
declared complete with no signal at all, or with a signal that describes
something other than what the task actually did.

That leaves the absence indistinguishable from a search that never ran. Two
defects on this repository had exactly that shape: a journal verifier loaded
with `strict=False` exited 0 over a corrupted journal (#3549 / #3636), and a
`curl -sL` that exited 0 on an HTTP error produced a digest that passed every
guard (#3573 / #3626). In both, a transport-level success was read as a
domain-level fact.

The janitor is also the place where an empty diff is normally treated as a
rubber stamp. `absence_verified` is the one signal that legitimately accompanies
an empty diff — "nothing to change, and here is what was searched" — so it joins
`_NONTRIVIAL_SIGNAL_TYPES`.

## How

`verify_anchored_absence_claim(tool_call_id, workdir, lineage_store=None)` in
`src/bernstein/core/quality/absence_coverage.py`:

1. Reads the coverage payload the instrumenter recorded for that call, from the
   per-agent `tool-calls.jsonl` ledgers under `.sdd/runs/*/tasks/*/agents/*/`
   (the layout `RunInstrumenter.log_tool_call` and `resolve_agent_dir` write).
   A torn or non-JSON ledger line is skipped rather than read as evidence — it
   is itself the "the search may not have run" case.
2. Looks up the `coverage` lineage entry anchored to the same `tool_call_id`
   via `find_coverage_for_tool_call`. Coverage anchored to a *different* call is
   another claim's scope and never stands in for this one.
3. Recomputes `sha256` over the recorded payload's canonical bytes (the same
   `sort_keys=True, separators=(",", ":")` encoding `anchor_coverage_record`
   seals) and requires it to equal the entry's `content_hash`, so the scope
   cannot be relabelled after sealing.
4. Requires `coverage == "complete"`, `truncated is False`, and
   `exit_checked is True`.

Every failure returns `(False, "unverified: …")` rather than raising, so a
caller evaluating a list of signals needs no guard at the call site.

**The open decision — mandatory or opt-in — is resolved as mandatory, with the
burden carried by the record rather than by the adapter.** The default for a
tool that records no coverage is `unverified`, not success: an adapter that
never adopts the coverage schema keeps working and simply never gets to assert a
verified absence. That is the correct outcome rather than a compromise, and once
the unverified path exists the opt-in variant produces the same degradation
behind a flag nobody sets.

`absence_verified` is registered in the three places the vocabulary lives
(`CompletionSignal` in `tasks/models.py`, `_COMPLETION_SIGNAL_TYPES` in
`tasks/task_store_core.py`, `COMPLETION_SIGNAL_TYPES` in
`planning/plan_schema.py`) so a plan can declare one and it round-trips through
the task store.

## Tests

`tests/unit/test_absence_verified_signal.py`, eight cases. All eight fail on the
unmodified tree — `verify_anchored_absence_claim` does not exist and
`absence_verified` is not a member of the signal vocabulary, so the module fails
at import.

1. `test_absence_claim_without_coverage_record_reads_unverified` — a tool call
   that recorded no coverage at all cannot back an absence claim.
2. `test_unanchored_coverage_record_reads_unverified` — a coverage payload
   nobody sealed into lineage is not a verified absence.
3. `test_coverage_payload_edited_after_anchoring_reads_unverified` —
   **load-bearing.** A walk sealed as `partial`/`truncated` and then relabelled
   `complete` in the ledger no longer matches its anchor's `content_hash`, so
   the claim degrades. This is the property that makes the whole signal worth
   having: without it the record is a comment, not a commitment.
4. `test_coverage_anchored_to_another_tool_call_cannot_back_this_claim` — scope
   cannot be borrowed from a neighbouring call's complete coverage.
5. `test_truncated_anchored_coverage_reads_unverified` — an honestly recorded
   truncated walk still cannot assert a verified absence, and the detail names
   the truncation reason.
6. `test_unchecked_exit_status_reads_unverified` — the #3573 shape: an exit
   status that was never checked is refused even when the walk says complete.
7. `test_complete_anchored_coverage_reads_verified` — the positive case, and it
   pins that the anchored digest really is `sha256` over the canonical payload
   bytes.
8. `test_absence_verified_signal_dispatches_through_evaluate_signal` — the
   signal is a first-class type end to end: `_narrow_signal_type` accepts it and
   `evaluate_signal` routes it to the evaluator rather than falling through to
   "unknown signal type".

Also run green, unchanged: `test_completion_absence_coverage.py`,
`test_janitor.py`, `test_janitor_alive_exit.py`,
`test_janitor_orphan_autocompletion.py`, `test_janitor_test_path_resolution.py`,
`test_plan_schema.py`, `tasks/test_models_serialization.py`,
`tasks/test_artifact_completion.py`, `tasks/test_artifact_spec_declaration.py`,
`tasks/test_lifecycle_helpers.py`, `test_task_lifecycle.py`, `test_planner.py`,
`test_invariants.py`, `test_docs_capability_reachability.py`,
`test_adversary_role.py`, `test_merge_preview_gate.py`,
`mcp/test_tool_timeout_enforcement.py`,
`security/test_lineage_toolcall_gate.py`, `test_spec_pipeline.py`,
`test_data_generators.py`.

`--affected origin/main` did not finish inside the local time budget on a shared
machine, so the set above was selected as the touched modules plus every test
that imports them. CI runs the full suite.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` — repo-wide pyright is advisory. On the files this PR
  touches: `absence_coverage.py` reports the same 3 pre-existing errors before
  and after; `janitor.py` goes 326 → 329, all three the `signal.value` unknown
  shape the neighbouring `file_contains` arm already produces. No file here is
  in the blocking `pyrightconfig.strict.json` zone.
- [x] `uv run python scripts/run_tests.py -x` passes — on the selection above,
  not the whole suite (see Tests).
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated — N/A, no README surface changes.
- [x] `docs/operations/<area>.md` updated — N/A; the signal is not
  artifact-mode, so `docs/operations/artifacts.md` is not its home. The two
  tables that enumerate the janitor's and the plan schema's signal types are
  updated: `docs/architecture/quality-pipeline.md` and
  `docs/architecture/plans.md`.
- [x] `docs/api/` schema regenerated if a public surface changed — N/A. The
  HTTP-level `CompletionSignalSchema` in `docs/reference/openapi.json` is a
  narrower, separately generated enum and is untouched.
- [x] `uv run bernstein agents-md sync` run — produced no changes (no new
  module).
- [x] Tests cover the documented behaviour

Closes #3650
