### PR TITLE
Partial implementation of #3112: source fetcher protocol and recorded corpus

### DIFF
--- a/src/bernstein/core/orchestration/source_fetcher.py
+++ b/src/bernstein/core/orchestration/source_fetcher.py
@@ -1,0 +1,98 @@
+"""Fetcher interface for research activities: a `fetch(ref) -> bytes` verb (#3112).
+
+:meth:`~bernstein.core.orchestration.research_worker.ResearchWorker.run` takes
+``fetch_fn: Callable[[str], bytes]`` and documents it as "the only place the run
+touches the outside world" -- every blob it returns is content-addressed at fetch
+time. Until this module, no concrete implementation shipped: the only callers in
+the tree were tests passing a raw dict-lookup lambda.
+
+This mirrors the shape :class:`~bernstein.core.orchestration.browser_driver.BrowserDriver`
+already established for the browser modality: a small protocol the worker never
+imports a concrete implementation of, plus a recorded implementation that serves
+fixed bytes with no network, so a second fetcher is a new implementation and not
+a change to the worker, and the whole research determinism suite can run offline
+against a fixed corpus.
+
+Note: :mod:`bernstein.core.devops.trend_scan` already defines an unrelated
+``SourceFetcher`` type alias over its own ``SourceSpec``/``RawItem`` types. That
+name is a scan-pipeline callable shape with no relation to this protocol; import
+this one by module path (``from bernstein.core.orchestration.source_fetcher import
+SourceFetcher``) rather than assuming a bare ``SourceFetcher`` import resolves
+here.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+__all__ = [
+    "RecordedSourceFetcher",
+    "SourceFetcher",
+    "SourceNotRecorded",
+]
+
+
+class SourceNotRecorded(KeyError):
+    """A :class:`RecordedSourceFetcher` was asked to fetch a ref outside its corpus.
+
+    Raised instead of a bare ``KeyError`` so the refusal is typed and names the
+    ref that was missing, the way :class:`~bernstein.core.orchestration.browser_driver.BrowserDriverError`
+    names what a browser driver could not do.
+    """
+
+    def __init__(self, source_ref: str) -> None:
+        self.source_ref = source_ref
+        super().__init__(f"source {source_ref!r} is not in the recorded corpus")
+
+
+@runtime_checkable
+class SourceFetcher(Protocol):
+    """The one-verb surface a research activity fetches sources through.
+
+    Deliberately a single method: :meth:`~bernstein.core.orchestration.research_worker.ResearchWorker.run`
+    only ever needs the exact bytes behind a source reference, and every fetcher
+    implementation (recorded corpus, live stdlib, a future backend) binds to this
+    one verb so the worker never depends on which one is in use.
+    """
+
+    def fetch(self, source_ref: str) -> bytes:
+        """Return the exact bytes behind *source_ref*.
+
+        Args:
+            source_ref: The source reference (URL / label) to fetch.
+
+        Returns:
+            The exact bytes fetched, before any decoding or normalisation --
+            these are the bytes the worker content-addresses.
+        """
+
+
+class RecordedSourceFetcher:
+    """A fetcher over a fixed ``{source_ref: bytes}`` corpus, no network involved.
+
+    This is what makes the research determinism suite runnable offline: a run
+    driven against a fixed corpus is a pure function of the query and the corpus,
+    so "the same query over the same recorded corpus produces a byte-identical
+    report" is a testable property rather than a claim. It is also the offline
+    replay path -- a corpus recorded once from a live fetcher replays with no
+    network access.
+
+    Args:
+        corpus: The fixed ``{source_ref: bytes}`` mapping served. Copied on
+            construction so a caller mutating their own dict afterwards cannot
+            change what the fetcher serves.
+    """
+
+    def __init__(self, corpus: dict[str, bytes]) -> None:
+        self._corpus = dict(corpus)
+
+    def fetch(self, source_ref: str) -> bytes:
+        """Return the recorded bytes for *source_ref*.
+
+        Raises:
+            SourceNotRecorded: When *source_ref* is not in the corpus.
+        """
+        try:
+            return self._corpus[source_ref]
+        except KeyError:
+            raise SourceNotRecorded(source_ref) from None

--- a/tests/unit/test_research_worker.py
+++ b/tests/unit/test_research_worker.py
@@ -44,6 +44,7 @@ from bernstein.core.orchestration.research_worker import (
     ResearchWorker,
     SpanRef,
 )
+from bernstein.core.orchestration.source_fetcher import RecordedSourceFetcher, SourceNotRecorded
 from bernstein.core.replay.journal import EventJournal
 from bernstein.core.security.audit_chain import EVENT_ACTIVITY_RESULT, AuditChainStore
 
@@ -320,6 +321,40 @@ def test_recorded_half_produces_identical_canonical_bytes_and_artifact_hash(tmp_
     # The artifact hashes are content-addressed keys in their respective stores.
     assert store.get(artifact1)
     assert store2.get(artifact2)
+
+
+def test_same_corpus_twice_yields_identical_report_and_hashes(tmp_path: Path) -> None:
+    """A run driven by RecordedSourceFetcher over a fixed corpus is a pure function
+    of the query and the corpus: run it twice into two separate `.sdd` roots and
+    the canonical report bytes, the artifact_hash, and the evidence_set_hash all
+    match (AC2)."""
+    corpus = {
+        "https://a": _PAGES["https://a"],
+        "https://b": _PAGES["https://b"],
+    }
+
+    def run_once(root: Path) -> tuple[bytes, str, str]:
+        store = ContentStore(root / ".sdd" / "cas")
+        worker = ResearchWorker(store=store, budget=ResearchBudget(max_fetches=5))
+        fetcher = RecordedSourceFetcher(corpus)
+        run = worker.run(query="q", sources=list(corpus), fetch_fn=fetcher.fetch, synthesise=_synth_two)
+        from bernstein.core.orchestration.research_report import report_to_canonical_bytes
+
+        return report_to_canonical_bytes(run.report), run.result.artifact_hash, run.result.evidence_set_hash
+
+    canonical1, artifact1, evidence1 = run_once(tmp_path / "run1")
+    canonical2, artifact2, evidence2 = run_once(tmp_path / "run2")
+
+    assert canonical1 == canonical2
+    assert artifact1 == artifact2
+    assert evidence1 == evidence2
+
+
+def test_recorded_source_fetcher_refuses_ref_outside_corpus() -> None:
+    fetcher = RecordedSourceFetcher({"https://a": b"known bytes"})
+    with pytest.raises(SourceNotRecorded) as excinfo:
+        fetcher.fetch("https://unknown")
+    assert excinfo.value.source_ref == "https://unknown"
 
 
 def test_research_runs_dispatch_next_to_coding_tasks_with_cost_caps(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

Adds a `SourceFetcher` protocol for research activities and a recorded-corpus
implementation, mirroring the shape `BrowserDriver` already established for
the browser modality:

- `src/bernstein/core/orchestration/source_fetcher.py`
  - `SourceFetcher`: a `@runtime_checkable` `Protocol` with one verb,
    `fetch(source_ref: str) -> bytes`.
  - `RecordedSourceFetcher`: serves bytes from a fixed `{source_ref: bytes}`
    corpus, no network involved.
  - `SourceNotRecorded`: typed refusal (names the missing ref) for a ref
    outside the corpus.

This does **not** change `ResearchWorker.run` — it already takes
`fetch_fn: Callable[[str], bytes]`, so a bound `RecordedSourceFetcher(...).fetch`
drops straight in with no worker-side change.

## What this does not do

This is the first slice of a larger issue. It does not add:

- A live fetcher over the standard library (AC6).
- The `bernstein activity research run` / `research verify` CLI group or its
  exit-code discipline (AC3, AC5 through the CLI).
- A socket-guard test proving the recorded path opens no network connection
  (AC1's "asserted by a test that fails if a socket is opened" clause).
- The `docs/orchestration/research-activity.md` update for the new CLI verb.

Those are left for follow-up PRs against the same issue.

## Why

`ResearchWorker.run` takes `fetch_fn` and `synthesise` as required callables.
`fetch_fn` is documented as the only place a research run touches the outside
world, and every blob it returns is content-addressed at fetch time — but no
concrete implementation shipped. The only callers in the tree were tests
passing a raw dict-lookup lambda, so the fetch half of the research path had
no reusable implementation and no way to run the determinism suite against a
fixed, offline corpus.

## How

`SourceFetcher` is a one-method protocol so a second implementation (a live
backend, a future cache) is a new class rather than a change to the worker,
the same decoupling `BrowserDriver` gives the browser modality.
`RecordedSourceFetcher` copies its corpus on construction (so a caller
mutating their own dict afterward cannot change what gets served) and raises
`SourceNotRecorded` — a typed `KeyError` subclass naming the missing ref —
for anything outside the corpus, instead of a bare `KeyError`.

One naming note: `bernstein.core.devops.trend_scan` already defines an
unrelated `SourceFetcher` type alias over its own `SourceSpec`/`RawItem`
types. That's a scan-pipeline callable shape with no relation to this
protocol; this module is not re-exported from a shared package, and callers
should import it by module path.

## Tests

1. `test_same_corpus_twice_yields_identical_report_and_hashes` — **load-bearing**.
   Runs `ResearchWorker.run` twice, each time through a
   `RecordedSourceFetcher` bound over the same corpus, into two separate
   `tmp_path` `.sdd` roots, and asserts the canonical report bytes, the
   `artifact_hash`, and the `evidence_set_hash` are identical across both
   runs. This is the determinism half of AC2, exercised through the new
   fetcher rather than a bare lambda. Confirmed failing on the unmodified
   tree (collection error: `source_fetcher` module does not exist) before
   the implementation was added.
2. `test_recorded_source_fetcher_refuses_ref_outside_corpus` — asserts
   `RecordedSourceFetcher.fetch` raises `SourceNotRecorded` naming the
   requested ref when the ref is not in the corpus.

Both added to `tests/unit/test_research_worker.py` alongside the existing
research-worker suite (22 tests total in that file, all passing).

Ran:

```
uv run python scripts/run_tests.py --parallel 2 -x tests/unit/test_research_worker.py
uv run ruff check src/ && uv run ruff format --check src/
```

`scripts/run_tests.py --affected origin/main` returned "No affected tests
found" for this diff (the dependency-map selector does not pick up the new
module as an import edge); ran the specific test file directly instead. CI
runs the full suite.

## Checklist

- [x] `uv run ruff check src/`
- [x] `uv run ruff format --check src/`
- [ ] `uv run pyright src/` — repo-wide pyright is advisory only (gates
      nothing per `.github/workflows/ci.yml`). One advisory
      `reportReturnType` finding on `SourceFetcher.fetch`'s docstring-only
      Protocol body; the identical pattern already exists on `origin/main`
      for `BrowserDriver`'s Protocol methods in `browser_driver.py`. Neither
      file is in `pyrightconfig.strict.json`.
- [x] `uv run python scripts/run_tests.py -x tests/unit/test_research_worker.py`
- [x] Type hints on all new public functions/classes
- [x] Docstrings on all new public functions/classes
- N/A `docs/orchestration/research-activity.md` — left for the CLI-slice PR
      that adds the `research run` / `research verify` verbs it documents
- N/A README.md — no change
- N/A translations — no change

## Remaining

- AC6: live stdlib fetcher, with a test asserting the stored bytes equal the
  bytes served before any decoding.
- AC3, AC5 (through the CLI): `bernstein activity research run` /
  `research verify` in `activity_cmd.py`, with the same 0/2/3 exit-code
  discipline `browser run` uses; re-assert the uncited-claim and budget
  refusals reachable from the CLI (both already covered at library level by
  `test_run_refuses_claim_citing_unfetched_source` and
  `test_max_fetches_cap_refuses_before_overspending`).
- AC1's socket-guard clause: a test that fails if the recorded-corpus path
  opens a socket.
- AC4: whether `activity research verify` is a thin alias over the existing
  generic `activity verify` (which already reaches the citation-lineage
  verdict for a research stage), or whether the generic verb is sufficient
  and `research verify` should not exist as separate CLI surface. Still an
  open call, left for that PR.
- `docs/orchestration/research-activity.md` update for the new CLI verb.

Part of #3112
