### PR TITLE
resume: write a checkpoint before every automatic stall kill (#3376)

### DIFF
--- a/src/bernstein/cli/commands/resume_cmd.py
+++ b/src/bernstein/cli/commands/resume_cmd.py
@@ -1,9 +1,12 @@
 """``bernstein resume <task-id>`` - pick up a task from its last checkpoint.
 
 Loads the per-task checkpoint written by the orchestrator after every
-successful step transition, validates it, bumps ``resume_count``, fires
-the ``task.resume`` lifecycle event, and hands control back so the
-orchestrator can re-spawn the task from the next step boundary.
+successful step transition, or before an automatic stall kill (heartbeat
+staleness or identical-progress detection; issue #3376) discards the
+worker's state, validates it, bumps ``resume_count``, fires the
+``task.resume`` lifecycle event, and hands control back so the
+orchestrator can re-spawn the task from the next step boundary. A
+checkpoint written at a stall kill carries its ``stall_reason``.
 
 See ``feat-resume-from-checkpoint`` spec for the full contract. v1 scope
 is local-only - cross-machine resume, distributed checkpoint storage,

--- a/src/bernstein/core/agents/heartbeat.py
+++ b/src/bernstein/core/agents/heartbeat.py
@@ -536,9 +536,9 @@ def _write_stall_checkpoint(
         from bernstein.core.tasks.task_lifecycle import _write_task_resume_checkpoint
 
         worktree_path = orch._spawner.get_worktree_path(session.id)
-        adapter_name = adapter_name_for_provider(
-            session.provider, session.model_config.model
-        ) or getattr(orch._spawner, "default_adapter_name", None)
+        adapter_name = adapter_name_for_provider(session.provider, session.model_config.model) or getattr(
+            orch._spawner, "default_adapter_name", None
+        )
         for task_id in task_ids:
             _write_task_resume_checkpoint(
                 workdir,

--- a/src/bernstein/core/agents/heartbeat.py
+++ b/src/bernstein/core/agents/heartbeat.py
@@ -501,6 +501,63 @@ def _emit_stall_verdict(
         )
 
 
+def _write_stall_checkpoint(
+    orch: Any,
+    session: Any,
+    *,
+    stall_reason: StallReason,
+    detector: str,
+) -> None:
+    """Persist a resume checkpoint before a stall kill discards the agent's state (#3376).
+
+    A stall kill throws away everything the worker knew unless something
+    captures it first. This writes the same on-disk checkpoint
+    ``bernstein resume`` already reads (``task_lifecycle._write_task_resume_checkpoint``,
+    otherwise fired only after a normal step completion) so a killed worker
+    is resumable instead of a dead end -- with ``stall_reason`` set so the
+    checkpoint records *why* the prior attempt stopped.
+
+    Called at the moment the kill verdict is reached, before the kill signal
+    goes out, mirroring ``_emit_stall_verdict``'s ordering.
+
+    Fail-open by design, like the verdict and receipt emitters beside it: a
+    stuck worker must still die even when the checkpoint cannot be written.
+    Failure is logged as a warning naming the session so a missing
+    checkpoint stays observable rather than silent.
+    """
+    workdir = getattr(orch, "_workdir", None)
+    if not isinstance(workdir, Path):
+        return
+    task_ids = list(getattr(session, "task_ids", None) or [])
+    if not task_ids:
+        return
+    try:
+        from bernstein.adapters.registry import adapter_name_for_provider
+        from bernstein.core.tasks.task_lifecycle import _write_task_resume_checkpoint
+
+        worktree_path = orch._spawner.get_worktree_path(session.id)
+        adapter_name = adapter_name_for_provider(
+            session.provider, session.model_config.model
+        ) or getattr(orch._spawner, "default_adapter_name", None)
+        for task_id in task_ids:
+            _write_task_resume_checkpoint(
+                workdir,
+                task_id,
+                session=session,
+                worktree_path=worktree_path,
+                adapter_name=adapter_name,
+                stall_reason=stall_reason.value,
+            )
+    except Exception as exc:  # a stuck worker must still die without a checkpoint
+        logger.warning(
+            "Could not write stall checkpoint for session %s (%s detector): %s: %s",
+            session.id,
+            detector,
+            type(exc).__name__,
+            exc,
+        )
+
+
 def _emit_escalation_receipt(
     orch: Any,
     session: Any,
@@ -659,6 +716,12 @@ def _escalate_heartbeat(
                 detector="heartbeat",
                 heartbeat_age_s=age,
                 threshold=kill_threshold,
+            )
+            _write_stall_checkpoint(
+                orch,
+                session,
+                stall_reason=StallReason.HEARTBEAT_STALE,
+                detector="heartbeat",
             )
             _terminate_stuck_agent(orch, session, age)
             if session.pid is None or not action.action_taken:
@@ -829,6 +892,12 @@ def _escalate_stall_simple(
             identical_snapshot_count=count,
             threshold=AGENT.escalation_kill_count,
         )
+        _write_stall_checkpoint(
+            orch,
+            session,
+            stall_reason=StallReason.NO_PROGRESS,
+            detector="stall_simple",
+        )
         with contextlib.suppress(Exception):
             orch._spawner.kill(session)
         _emit_escalation_receipt(
@@ -876,6 +945,12 @@ def _escalate_stall_profiled(
             task_id,
             count,
             profile.reason,
+        )
+        _write_stall_checkpoint(
+            orch,
+            session,
+            stall_reason=StallReason.NO_PROGRESS,
+            detector="stall_profiled",
         )
         with contextlib.suppress(Exception):
             orch._spawner.kill(session)

--- a/src/bernstein/core/persistence/task_resume.py
+++ b/src/bernstein/core/persistence/task_resume.py
@@ -24,6 +24,11 @@ Schema (versioned via :data:`SCHEMA_VERSION`):
   scope is local-only, so this is intentionally a literal path).
 * ``resume_count`` - how many times this task has been resumed; the CLI
   bumps it before re-spawning so flaky tasks are visible in the dashboard.
+* ``stall_reason`` - *optional*. Set when the checkpoint was written at an
+  automatic stall-kill boundary (heartbeat staleness or identical-progress
+  detection) rather than after a normal step completion; ``None`` for the
+  latter. Value is a :class:`~bernstein.core.orchestration.supervisor_receipt.StallReason`
+  string.
 * ``merge_cursor`` - *optional* streaming-merge cursor handed in by
   :mod:`bernstein.core.streaming_merge`. Coordination with the merge
   pipeline is a follow-up; we capture the shape now so adopters do not
@@ -109,6 +114,7 @@ class TaskResumeCheckpoint(BaseModel):
     adapter_session_id: str = ""
     worktree_path: str | None = None
     resume_count: int = Field(default=0, ge=0)
+    stall_reason: str | None = None
     merge_cursor: dict[str, Any] | None = None
     meta: dict[str, Any] = Field(default_factory=dict)
     created_at: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -3686,8 +3686,9 @@ def _write_task_resume_checkpoint(
     session: AgentSession | None,
     worktree_path: Path | None,
     adapter_name: str | None = None,
+    stall_reason: str | None = None,
 ) -> None:
-    """Write a task resume checkpoint for a completed task.
+    """Write a task resume checkpoint for a completed or stall-killed task.
 
     This checkpoint captures the state after a successful step transition
     (agent spawn -> task completion) so the task can be resumed later if
@@ -3705,6 +3706,10 @@ def _write_task_resume_checkpoint(
         adapter_name: Adapter that ran the session. ``bernstein resume`` reads
             its resume strategy off this name (``resume_cmd.py``), so a
             checkpoint written without one is readable but not resumable.
+        stall_reason: When set, this checkpoint was written at an automatic
+            stall-kill boundary (issue #3376) rather than after a normal step
+            completion. Passed straight through onto the checkpoint's own
+            ``stall_reason`` field.
     """
     adapter = adapter_name or ""
     adapter_session_id = session.id if session is not None else ""
@@ -3737,6 +3742,7 @@ def _write_task_resume_checkpoint(
         worktree_path=str(worktree_path) if worktree_path is not None else None,
         scratchpad_path=scratchpad_path,
         scratchpad_sha256=scratchpad_sha,
+        stall_reason=stall_reason,
         meta=({"adapter_name": adapter} if adapter else {}),
     )
     save_checkpoint(workdir, checkpoint)

--- a/tests/chaos/test_worktree_locked.py
+++ b/tests/chaos/test_worktree_locked.py
@@ -26,7 +26,7 @@ async def test_worktree_locked(test_client: TestClient, orchestrator_factory, in
         "subprocess.run(['git', 'add', 'chaos.txt'], check=True)\n"
         "subprocess.run(['git', 'commit', '-m', 'chaos'], check=True)\n"
         "runtime_dir = Path(__file__).parent\n"
-        "(runtime_dir / 'DONE_chaos').write_text('done')\n"
+        "(runtime_dir / 'DONE_chaos-task').write_text('done')\n"
         "import time\n"
         "time.sleep(2)\n"
         "```"

--- a/tests/chaos/test_zombie_agent_process.py
+++ b/tests/chaos/test_zombie_agent_process.py
@@ -30,9 +30,9 @@ async def test_zombie_agent_process(test_client: TestClient, orchestrator_factor
     orch._incident_manager.auto_pause = False
 
     # Speed up recycling
-    import bernstein.core.agent_lifecycle
+    import bernstein.core.agents.agent_recycling
 
-    monkeypatch.setattr(bernstein.core.agent_lifecycle, "_IDLE_GRACE_S", 1.0)
+    monkeypatch.setattr(bernstein.core.agents.agent_recycling, "_IDLE_GRACE_S", 1.0)
 
     # WORKAROUND: Monkeypatch adapter.kill to avoid killing the test process group
     from bernstein.adapters.registry import get_adapter

--- a/tests/unit/test_heartbeat_stall_checkpoint.py
+++ b/tests/unit/test_heartbeat_stall_checkpoint.py
@@ -21,8 +21,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from bernstein.core.tasks.models import AgentSession, ModelConfig
-
+from bernstein.cli.commands.resume_cmd import prepare_resume
 from bernstein.core.agents.heartbeat import (
     AGENT,
     StallProfile,
@@ -32,7 +31,7 @@ from bernstein.core.agents.heartbeat import (
 )
 from bernstein.core.orchestration.supervisor_receipt import StallReason
 from bernstein.core.persistence.task_resume import load_checkpoint
-from bernstein.cli.commands.resume_cmd import prepare_resume
+from bernstein.core.tasks.models import AgentSession, ModelConfig
 
 RUN_ID = "run-stall-checkpoint-1"
 

--- a/tests/unit/test_heartbeat_stall_checkpoint.py
+++ b/tests/unit/test_heartbeat_stall_checkpoint.py
@@ -1,0 +1,203 @@
+"""Invariant: every automatic stall kill writes a resumable checkpoint first.
+
+Issue #3376: a worker stalled and killed by any of the three escalation paths
+in ``heartbeat`` (``_escalate_heartbeat``, ``_escalate_stall_simple``,
+``_escalate_stall_profiled``) used to lose all of its state -- the only
+artifacts were a signal file and a log line. ``bernstein resume`` already
+reads a per-task checkpoint written after a normal step completion, but
+nothing wrote one at the kill boundary, so a stalled task could never be
+resumed.
+
+These tests drive the real kill paths (never mocking the write itself, except
+where the test is specifically about the fail-open contract) and assert on
+the checkpoint that lands on disk -- the same file ``bernstein resume``
+reads -- proving the write happens before the kill, carries the stall
+reason, and never blocks the kill when it fails.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from bernstein.core.tasks.models import AgentSession, ModelConfig
+
+from bernstein.core.agents.heartbeat import (
+    AGENT,
+    StallProfile,
+    _escalate_heartbeat,
+    _escalate_stall_profiled,
+    _escalate_stall_simple,
+)
+from bernstein.core.orchestration.supervisor_receipt import StallReason
+from bernstein.core.persistence.task_resume import load_checkpoint
+from bernstein.cli.commands.resume_cmd import prepare_resume
+
+RUN_ID = "run-stall-checkpoint-1"
+
+
+def _session(sid: str = "A-1", task_id: str = "T-1", *, pid: int | None = 4321) -> AgentSession:
+    return AgentSession(
+        id=sid,
+        role="backend",
+        task_ids=[task_id],
+        status="working",
+        spawn_ts=100.0,
+        pid=pid,
+        model_config=ModelConfig("sonnet", "high"),
+    )
+
+
+def _orch(workdir: Path, session: AgentSession) -> SimpleNamespace:
+    worktree = workdir / "worktree"
+    worktree.mkdir(parents=True, exist_ok=True)
+    spawner = MagicMock()
+    spawner.get_worktree_path.return_value = worktree
+    spawner.default_adapter_name = "claude"
+    return SimpleNamespace(
+        _agents={session.id: session},
+        _workdir=workdir,
+        _run_id=RUN_ID,
+        _signal_mgr=MagicMock(),
+        _spawner=spawner,
+        _stall_counts={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Every detector writes a checkpoint that parses
+# ---------------------------------------------------------------------------
+
+
+def test_heartbeat_kill_writes_a_resumable_checkpoint(tmp_path: Path) -> None:
+    """A heartbeat-stale kill writes a checkpoint naming HEARTBEAT_STALE."""
+    session = _session()
+    orch = _orch(tmp_path, session)
+    with patch("bernstein.core.platform_compat.kill_process_group"):
+        _escalate_heartbeat(
+            orch,
+            session,
+            age=950.0,
+            elapsed=850.0,
+            shutdown_threshold=60.0,
+            wakeup_threshold=30.0,
+            shutdown_reason="no_heartbeat",
+            kill_threshold=90.0,
+        )
+
+    cp = load_checkpoint(tmp_path, "T-1")
+    assert cp.stall_reason == StallReason.HEARTBEAT_STALE.value
+    assert cp.adapter == "claude"
+    assert cp.worktree_path == str(tmp_path / "worktree")
+
+
+def test_stall_simple_kill_writes_a_resumable_checkpoint(tmp_path: Path) -> None:
+    """An identical-progress kill (no-workdir detector) writes a checkpoint."""
+    session = _session(sid="B-1", task_id="T-2")
+    orch = _orch(tmp_path, session)
+    _escalate_stall_simple(orch, session, "T-2", count=AGENT.escalation_kill_count)
+
+    cp = load_checkpoint(tmp_path, "T-2")
+    assert cp.stall_reason == StallReason.NO_PROGRESS.value
+    assert cp.adapter == "claude"
+
+
+def test_stall_profiled_kill_writes_a_resumable_checkpoint(tmp_path: Path) -> None:
+    """An identical-progress kill (profiled detector) writes a checkpoint."""
+    session = _session(sid="C-1", task_id="T-3")
+    orch = _orch(tmp_path, session)
+    profile = StallProfile(wakeup_threshold=3, shutdown_threshold=5, kill_threshold=7, reason="default profile")
+    _escalate_stall_profiled(orch, session, "T-3", count=7, profile=profile)
+
+    cp = load_checkpoint(tmp_path, "T-3")
+    assert cp.stall_reason == StallReason.NO_PROGRESS.value
+
+
+# ---------------------------------------------------------------------------
+# Ordering: checkpoint is written before the kill signal
+# ---------------------------------------------------------------------------
+
+
+def test_checkpoint_exists_before_the_kill_signal(tmp_path: Path) -> None:
+    """At the moment the kill runs the checkpoint is already on disk."""
+    session = _session(sid="D-1", task_id="T-4")
+    orch = _orch(tmp_path, session)
+
+    seen: dict[str, bool] = {}
+
+    def fake_kill(_session: object) -> None:
+        try:
+            load_checkpoint(tmp_path, "T-4")
+            seen["checkpoint_present_at_kill"] = True
+        except Exception:
+            seen["checkpoint_present_at_kill"] = False
+
+    orch._spawner.kill.side_effect = fake_kill
+    _escalate_stall_simple(orch, session, "T-4", count=AGENT.escalation_kill_count)
+
+    assert seen["checkpoint_present_at_kill"] is True
+    assert orch._spawner.kill.called
+
+
+# ---------------------------------------------------------------------------
+# Fail-open: a checkpoint write failure never blocks the kill
+# ---------------------------------------------------------------------------
+
+
+def test_checkpoint_write_failure_never_blocks_the_kill(tmp_path: Path) -> None:
+    """A raising checkpoint write leaves the kill issued and warns loudly."""
+    session = _session(sid="E-1", task_id="T-5")
+    orch = _orch(tmp_path, session)
+
+    with (
+        patch(
+            "bernstein.core.tasks.task_lifecycle._write_task_resume_checkpoint",
+            side_effect=RuntimeError("disk full"),
+        ),
+        patch("bernstein.core.agents.heartbeat.logger") as log,
+    ):
+        _escalate_stall_simple(orch, session, "T-5", count=AGENT.escalation_kill_count)
+
+    assert orch._spawner.kill.called
+    warnings = [c for c in log.warning.call_args_list if "Could not write stall checkpoint" in str(c.args[0])]
+    assert warnings, "checkpoint write failure must be logged, not silent"
+    assert "E-1" in warnings[0].args
+
+
+def test_no_workdir_skips_checkpoint_without_blocking_kill(tmp_path: Path) -> None:
+    """No workdir on the orchestrator -> checkpoint write is a silent no-op."""
+    session = _session(sid="F-1", task_id="T-6")
+    orch = _orch(tmp_path, session)
+    orch._workdir = None  # simulates the no-workdir simple-mode caller
+
+    _escalate_stall_simple(orch, session, "T-6", count=AGENT.escalation_kill_count)
+
+    assert orch._spawner.kill.called
+    assert not (tmp_path / ".sdd" / "runtime" / "checkpoints" / "T-6").exists()
+
+
+# ---------------------------------------------------------------------------
+# The load-bearing test: `bernstein resume` actually succeeds afterwards
+# ---------------------------------------------------------------------------
+
+
+def test_resume_succeeds_against_a_stall_kill_checkpoint(tmp_path: Path) -> None:
+    """Before this change, `bernstein resume` could never succeed against a
+    stalled task: nothing wrote its checkpoint. It now does."""
+    session = _session(sid="G-1", task_id="T-7")
+    orch = _orch(tmp_path, session)
+    _escalate_stall_profiled(
+        orch,
+        session,
+        "T-7",
+        count=7,
+        profile=StallProfile(wakeup_threshold=3, shutdown_threshold=5, kill_threshold=7, reason="stuck"),
+    )
+
+    plan = prepare_resume(tmp_path, "T-7")
+
+    assert plan.checkpoint.task_id == "T-7"
+    assert plan.checkpoint.stall_reason == StallReason.NO_PROGRESS.value
+    assert plan.checkpoint.resume_count == 1
+    assert "Resume context" in plan.resume_context


### PR DESCRIPTION
## What

Writes a resume checkpoint before every automatic stall kill in `heartbeat.py`'s three detectors (heartbeat staleness, identical-progress "simple", identical-progress "profiled"). `bernstein resume <task-id>` already loads a per-task checkpoint, but nothing produced one at a stall-kill boundary, so a stalled task could never be resumed.

Not included in this slice (see Remaining):
- The fourth stall path, `run_stall.py`'s zero-terminal-quiescence detector, which fails a batch of stuck tasks with no single live session to snapshot per task.
- The human-editable `corrective_context` field and hash-linking a resumed attempt's journal entry back to the capsule it started from.
- Wiring `record_snapshot_event` at the kill boundary so escalation receipts carry a real fork reference.

## Why

The checkpoint-resume loop already ships on the consumption side (`bernstein resume`, `TaskResumeCheckpoint`, `build_resume_context`), and a checkpoint is already written after a normal step completion. The one place a checkpoint was never written is the one place a worker's state is about to be discarded: the moment a stall detector decides to kill it. That gap makes `bernstein resume` a reader with no writer for the exact case an operator most needs it -- a worker that stalled mid-task, not one that finished cleanly.

## How

- `TaskResumeCheckpoint` (`task_resume.py`) gains an optional `stall_reason` field, `None` for a normal completion checkpoint, set to the detector's `StallReason` value when the checkpoint was written at a kill boundary.
- `task_lifecycle._write_task_resume_checkpoint` takes an optional `stall_reason` parameter and threads it onto the checkpoint it builds; unchanged for its existing normal-completion caller.
- `heartbeat.py` adds `_write_stall_checkpoint`, called at the moment the kill verdict is reached in all three detector functions (`_escalate_heartbeat`, `_escalate_stall_simple`, `_escalate_stall_profiled`), mirroring where `_emit_stall_verdict` already fires -- before the kill signal goes out (order: verdict -> checkpoint -> kill -> receipt). It resolves the worktree path and adapter name the same way the normal-completion path does and reuses `_write_task_resume_checkpoint` rather than duplicating the write.
- Fail-open by design, matching `_emit_stall_verdict` and `_emit_escalation_receipt` beside it: a checkpoint write failure is caught, logged as a warning naming the session, and never blocks the kill. A stuck worker has to die whether or not its state could be captured.
- `resume_cmd.py`'s module docstring, which claimed a checkpoint is written "after every successful step transition" only, now also names the stall-kill boundary.

## Tests

1. `test_heartbeat_kill_writes_a_resumable_checkpoint` -- a heartbeat-stale kill writes a checkpoint with `stall_reason == HEARTBEAT_STALE`.
2. `test_stall_simple_kill_writes_a_resumable_checkpoint` -- the no-workdir identical-progress detector writes a checkpoint with `stall_reason == NO_PROGRESS`.
3. `test_stall_profiled_kill_writes_a_resumable_checkpoint` -- the profiled identical-progress detector writes the same.
4. `test_checkpoint_exists_before_the_kill_signal` -- at the instant `spawner.kill` runs, the checkpoint is already readable on disk (ordering).
5. `test_checkpoint_write_failure_never_blocks_the_kill` -- a raising checkpoint write still lets the kill happen and logs a warning naming the session (fail-open contract).
6. `test_no_workdir_skips_checkpoint_without_blocking_kill` -- no workdir on the orchestrator is a silent no-op, kill still happens.
7. `test_resume_succeeds_against_a_stall_kill_checkpoint` -- **load-bearing**. Drives a real stall-profiled kill, then calls `prepare_resume` (the function behind `bernstein resume`) against the resulting checkpoint and asserts it succeeds, returning the right task id, `stall_reason`, and a bumped `resume_count`. Before this change `prepare_resume` always raised `CheckpointMissingError` for a stalled task; there was no checkpoint to find.

All 7 were run against the unmodified tree first (`git stash` the implementation, keep the tests) and failed with `CheckpointMissingError` for the stated reason, then passed after restoring the implementation.

Regression: `test_heartbeat_escalation_receipt.py`, `test_heartbeat_stall_verdict_audit.py`, `test_task_lifecycle_checkpoint.py`, `test_resume_cmd.py`, `test_task_suspension.py`, plus every other `test_heartbeat_*` / `test_worker_*heartbeat*` file, `test_stalled_manager.py`, and `agents/test_spawner_core_helpers.py` -- 23 files total, all green.

`--affected origin/main` did not return a bounded selection within the time available under heavy shared-machine load; ran the touched modules' own tests plus their known importers' tests instead (list above). CI runs the full suite.

## Checklist

- [x] `uv run ruff check src/` -- clean on the touched files
- [x] `uv run ruff format --check src/` -- clean on the touched files
- [x] `uv run python scripts/run_tests.py -x <touched test files>` -- green
- [x] Type hints on all new/changed signatures
- [x] `pyright` (advisory, non-blocking per this repo's CI split) -- no new errors from this diff beyond one `reportPrivateUsage` on the new cross-module private-function import, which matches an existing import of the same shape 90 lines above it in the same file
- [x] Documentation: `resume_cmd.py` module docstring updated; `task_resume.py`'s schema docstring updated for the new field
- N/A: no CLI flag or public API surface added; `bernstein agents-md sync` produced no diff

## Remaining

- [ ] Write a stall capsule at `run_stall.py`'s zero-terminal-quiescence kill boundary (a batch of stuck tasks with no single live session)
- [ ] `corrective_context` human-editable field on the checkpoint, folded into the resume prompt
- [ ] Resume records the capsule hash it started from in the run journal
- [ ] Wire `record_snapshot_event` at the kill boundary so `assemble_escalation_receipt` gets a real `ForkRef`

Part of #3376
