### PR TITLE
feat(checkpoint): make a resume onto moved observations a discard candidate (#3649)

### DIFF
--- a/docs/release-notes/fragments/5206-observations-bind.md
+++ b/docs/release-notes/fragments/5206-observations-bind.md
@@ -1,0 +1,7 @@
+## Checkpoints bind to the observations they were derived from
+
+A checkpoint captured the grant it was written under but not the actual bytes its suspended work was derived from. If those files moved while the checkpoint sat, the resume would continue on a stale world model that no permission comparison could detect.
+
+`park_task` now content-hashes uncommitted files in the worktree and records the hash on the checkpoint. `evaluate_observations` re-derives those hashes at resume and returns a discard verdict naming what moved; `bernstein resume` stops before the resume_count bump, points at `--discard`, and accepts `--override-observations`. The continuation row records the observations hash and whether the resume was overridden, so later readers can distinguish an overridden resume from a clean one.
+
+(#5206)

--- a/src/bernstein/cli/commands/resume_cmd.py
+++ b/src/bernstein/cli/commands/resume_cmd.py
@@ -24,6 +24,8 @@ from bernstein.adapters._contract import resume_capability, strategy_for
 from bernstein.cli.helpers import console
 from bernstein.core.lifecycle.hooks import HookRegistry, LifecycleContext, LifecycleEvent
 from bernstein.core.persistence.agent_checkpoint import (
+    discard_checkpoint,
+    evaluate_observations,
     find_checkpoint_for_task,
     is_checkpoint_recoverable,
 )
@@ -44,6 +46,7 @@ EXIT_NO_CHECKPOINT: int = 2
 EXIT_CORRUPT: int = 3
 EXIT_HOOK_FAILED: int = 4
 EXIT_GRANT_REFUSED: int = 5
+EXIT_OBSERVATIONS_MOVED: int = 6
 
 
 class GrantRefusedError(RuntimeError):
@@ -53,6 +56,31 @@ class GrantRefusedError(RuntimeError):
     permissions, task, parent run, chain head) so the operator can act
     without reading source.
     """
+
+
+class ObservationsMovedError(RuntimeError):
+    """Raised when the bytes the suspended work was derived from have moved.
+
+    Distinct from :class:`GrantRefusedError` on purpose: the grant refusal
+    says the run may no longer act, while this says the run would act on a
+    world model that is no longer true. Discarding the checkpoint and
+    respawning is the expected answer; ``--override-observations`` resumes
+    anyway and records that it did.
+    """
+
+
+def discard_agent_checkpoint(workdir: Path, task_id: str) -> bool:
+    """Drop the agent checkpoint for ``task_id``; return whether one existed.
+
+    Exposed so the dashboard and the API can take the discard path without
+    parsing CLI output. After the drop the next run of the task carries no
+    continuation entry, so the chain reads it as a new run.
+    """
+    runtime_dir = workdir / ".sdd" / "runtime"
+    checkpoint = find_checkpoint_for_task(task_id, runtime_dir)
+    if checkpoint is None:
+        return False
+    return discard_checkpoint(checkpoint.agent_id, runtime_dir)
 
 
 @dataclass(frozen=True)
@@ -78,6 +106,7 @@ def prepare_resume(
     *,
     hooks: HookRegistry | None = None,
     override_interpreter: bool = False,
+    override_observations: bool = False,
 ) -> ResumePlan:
     """Load + validate the checkpoint, bump ``resume_count``, fire the hook.
 
@@ -88,6 +117,9 @@ def prepare_resume(
         override_interpreter: When ``True``, bypass the interpreter mismatch
             check (``--override-interpreter``) so a resume proceeds even
             though the adapter or resolved model moved.
+        override_observations: When ``True``, resume even though the bytes the
+            suspended work was derived from moved, instead of discarding the
+            checkpoint and respawning.
 
     Returns:
         A :class:`ResumePlan` ready for the orchestrator.
@@ -95,6 +127,8 @@ def prepare_resume(
     Raises:
         CheckpointMissingError: No checkpoint on disk.
         CheckpointCorruptError: File exists but is invalid.
+        GrantRefusedError: The grant the checkpoint was written under moved.
+        ObservationsMovedError: The observations the checkpoint bound moved.
         HookFailure: The ``task.resume`` hook rejected the resume.
     """
     # Reading once before the bump gives us a clear error path: if the
@@ -122,6 +156,13 @@ def prepare_resume(
         )
         if not _ok:
             raise GrantRefusedError(_reason)
+        # The authority question is settled; the world-model question is not.
+        # Both are asked before the first side effect, and in this order: a
+        # run that may not act at all is never offered the discard choice.
+        if not override_observations:
+            _verdict = evaluate_observations(_agent_checkpoint)
+            if _verdict.discard_candidate:
+                raise ObservationsMovedError(_verdict.reason)
 
     checkpoint = bump_resume_count(workdir, task_id)
     adapter_name = checkpoint.adapter or ""
@@ -223,12 +264,26 @@ def _render_plan(workdir: Path, plan: ResumePlan, *, output_json: bool) -> None:
     default=False,
     help="Resume even though the adapter or resolved model moved since suspend.",
 )
+@click.option(
+    "--override-observations",
+    is_flag=True,
+    default=False,
+    help="Resume even though the bytes the suspended work was derived from moved.",
+)
+@click.option(
+    "--discard",
+    is_flag=True,
+    default=False,
+    help="Drop the checkpoint first, so the task runs fresh instead of continuing.",
+)
 def resume_cmd(
     task_id: str,
     workdir: Path | None,
     output_json: bool,
     dry_run: bool,
     override_interpreter: bool,
+    override_observations: bool,
+    discard: bool,
 ) -> None:
     """Pick up a paused/killed/crashed task from its last checkpoint.
 
@@ -239,10 +294,24 @@ def resume_cmd(
         3  checkpoint corrupt / failed schema validation
         4  task.resume lifecycle hook failed
         5  grant mismatch — role narrowed, task reassigned, or parent cancelled
+        6  observations moved — discard and respawn, or --override-observations
     """
     project_root = workdir or Path.cwd()
+    if discard:
+        dropped = discard_agent_checkpoint(project_root, task_id)
+        console.print(
+            f"[yellow]Checkpoint discarded for {task_id!r}.[/yellow] The task runs fresh; "
+            "the chain records a new run, not a continuation."
+            if dropped
+            else f"[dim]No agent checkpoint to discard for {task_id!r}.[/dim]"
+        )
     try:
-        plan = prepare_resume(project_root, task_id, override_interpreter=override_interpreter)
+        plan = prepare_resume(
+            project_root,
+            task_id,
+            override_interpreter=override_interpreter,
+            override_observations=override_observations,
+        )
     except CheckpointMissingError as exc:
         console.print(f"[red]No checkpoint:[/red] {exc}")
         _hint_work_ledger(project_root, task_id)
@@ -260,6 +329,14 @@ def resume_cmd(
             " checkpoint was written. Re-run the task from scratch or restore the original grant.[/dim]"
         )
         raise SystemExit(EXIT_GRANT_REFUSED) from None
+    except ObservationsMovedError as exc:
+        console.print(f"[red]Observations moved — resume is not a continuation:[/red] {exc}")
+        console.print(
+            "[dim]Respawn the task from scratch with 'bernstein resume"
+            f" {task_id} --discard', or resume onto the changed bytes with"
+            " --override-observations (recorded in the chain).[/dim]"
+        )
+        raise SystemExit(EXIT_OBSERVATIONS_MOVED) from None
 
     _render_plan(project_root, plan, output_json=output_json)
 

--- a/src/bernstein/core/persistence/agent_checkpoint.py
+++ b/src/bernstein/core/persistence/agent_checkpoint.py
@@ -22,6 +22,16 @@ binding ``(checkpoint_hash, grant_hash, chain_head_at_suspend,
 chain_head_at_resume)`` so a verifier can chain suspend → resume with no
 filesystem access.  Absence of the entry means the resume never completed; the
 verifier treats absence as a new run, never as evidence of continuity.
+
+The grant answers whether the run may still act.  It says nothing about the
+bytes the suspended work was derived from, which can move while a checkpoint
+sits without any grant field changing.  :func:`capture_worktree_observations`
+binds those bytes at suspend and :func:`evaluate_observations` re-derives them
+at resume.  The outcome there is deliberately not a refusal: a moved
+observation makes the checkpoint a *discard candidate*, and
+:func:`discard_checkpoint` is the expected answer -- respawning re-reads the
+tree, while resuming onto changed bytes and recording it as continuity does
+not.
 """
 
 from __future__ import annotations
@@ -170,6 +180,11 @@ class ContinuationEntry:
         interpreter_overridden: Whether the operator forced the resume past an
             interpreter mismatch (``--override-interpreter``). A later reader
             can distinguish an overridden resume from a clean one.
+        observations_hash: SHA-256 of the observations the suspended work was
+            derived from, or ``""`` when the checkpoint bound none.
+        observations_overridden: Whether the operator resumed past moved
+            observations (``--override-observations``) instead of discarding
+            the checkpoint and respawning.
         resumed_at: Unix timestamp of resumption.
     """
 
@@ -179,6 +194,8 @@ class ContinuationEntry:
     chain_head_at_resume: str
     interpreter_hash: str = ""
     interpreter_overridden: bool = False
+    observations_hash: str = ""
+    observations_overridden: bool = False
     resumed_at: float = field(default_factory=time.time)
 
 
@@ -257,6 +274,22 @@ def load_checkpoint(agent_id: str, runtime_dir: Path) -> AgentCheckpoint | None:
     if not path.exists():
         return None
     return AgentCheckpoint(**json.loads(path.read_text()))
+
+
+def discard_checkpoint(agent_id: str, runtime_dir: Path) -> bool:
+    """Remove the checkpoint for ``agent_id``; return whether one was removed.
+
+    Discarding is the answer to a checkpoint whose observations moved. Once
+    the file is gone the resume has nothing to continue from, so no
+    continuation entry is appended and the chain reads the next run as a new
+    run rather than as a continuation.
+    """
+    path = runtime_dir / "agents" / agent_id / _CHECKPOINT_FILENAME
+    try:
+        path.unlink()
+    except OSError:
+        return False
+    return True
 
 
 def find_checkpoint_for_task(task_id: str, runtime_dir: Path) -> AgentCheckpoint | None:
@@ -510,11 +543,178 @@ def _git_status(worktree: Path) -> str | None:
         return None
 
 
+# ---------------------------------------------------------------------------
+# Observations — the bytes the suspended work was derived from
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ObservationVerdict:
+    """Outcome of comparing a checkpoint's observations against the worktree.
+
+    The outcome is deliberately *not* a refusal. A moved grant means the run
+    may no longer act and must stop. A moved observation means the suspended
+    work was derived from bytes that are no longer on disk, so resuming would
+    build on a world model that is wrong -- discarding the checkpoint and
+    respawning is the expected answer, and it is a legitimate one.
+
+    Attributes:
+        discard_candidate: Whether any bound observation moved or vanished.
+        moved: Repo-relative paths whose content hash changed.
+        missing: Repo-relative paths that no longer exist.
+        reason: Operator-facing sentence naming what moved; ``""`` when
+            nothing did.
+    """
+
+    discard_candidate: bool
+    moved: tuple[str, ...] = ()
+    missing: tuple[str, ...] = ()
+    reason: str = ""
+
+
+def _dirty_paths(worktree: Path) -> list[str]:
+    """Repo-relative paths git reports as changed in ``worktree``.
+
+    Uses ``--porcelain -z`` so paths are NUL-separated and never quoted or
+    escaped, and ``--untracked-files=all`` so a new directory is expanded to
+    the files inside it rather than reported as one directory entry that
+    cannot be hashed. Returns ``[]`` when git cannot describe the directory.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain", "-z", "--untracked-files=all"],
+            cwd=worktree,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return []
+    if result.returncode != 0:
+        return []
+    fields = [f for f in result.stdout.split("\0") if f]
+    paths: list[str] = []
+    index = 0
+    while index < len(fields):
+        record = fields[index]
+        index += 1
+        if len(record) < 4:
+            continue
+        status, path = record[:2], record[3:]
+        # A rename or copy is followed by its source path in its own field;
+        # consume it so it is not mistaken for the next status record.
+        if "R" in status or "C" in status:
+            index += 1
+        paths.append(path)
+    return paths
+
+
+def capture_worktree_observations(worktree: Path) -> dict[str, str]:
+    """Content-hash the uncommitted files in ``worktree``.
+
+    What a checkpoint can bind without inferring a dependency set is the work
+    it is carrying: the files git reports as changed. Those are exactly the
+    bytes a resume picks up and continues from, so they are the bytes whose
+    movement makes the resume unsound.
+
+    Files the suspended agent *read* but did not change are **not** bound --
+    identifying them needs dependency inference, which no part of the
+    checkpoint records today.
+
+    Keyed by repo-relative POSIX path, valued by the ``sha256:``-prefixed
+    content hash, so a file deleted and recreated with identical bytes is
+    identical here. Paths that no longer exist (deletions, and files removed
+    between the status call and the read) are skipped: there is nothing to
+    hash, and a deletion is already visible as an absent key.
+
+    Args:
+        worktree: The agent's worktree.
+
+    Returns:
+        Mapping of repo-relative path to content hash; empty when git cannot
+        describe the directory.
+    """
+    from bernstein.core.lineage.spine import content_hash_of
+
+    root = Path(worktree)
+    observations: dict[str, str] = {}
+    for relative in _dirty_paths(root):
+        candidate = root / relative
+        try:
+            if candidate.is_symlink() or not candidate.is_file():
+                continue
+            observations[relative] = content_hash_of(candidate.read_bytes())
+        except OSError:
+            continue
+    return observations
+
+
+def evaluate_observations(
+    checkpoint: AgentCheckpoint,
+    *,
+    worktree: Path | None = None,
+) -> ObservationVerdict:
+    """Compare a checkpoint's bound observations against the live worktree.
+
+    Call after :func:`is_checkpoint_recoverable` says the grant still holds.
+    A checkpoint that bound nothing is never a discard candidate: absence of
+    a binding is not evidence that something moved.
+
+    Args:
+        checkpoint: The checkpoint whose observations to re-derive.
+        worktree: Override for the worktree to read; defaults to the path the
+            checkpoint recorded.
+
+    Returns:
+        An :class:`ObservationVerdict`.
+    """
+    from bernstein.core.lineage.spine import content_hash_of
+
+    if not checkpoint.observations:
+        return ObservationVerdict(discard_candidate=False)
+
+    root = Path(worktree) if worktree is not None else Path(checkpoint.worktree_path)
+    moved: list[str] = []
+    missing: list[str] = []
+    for relative, recorded_hash in sorted(checkpoint.observations.items()):
+        candidate = root / relative
+        try:
+            content = candidate.read_bytes()
+        except OSError:
+            missing.append(relative)
+            continue
+        if content_hash_of(content) != recorded_hash:
+            moved.append(relative)
+
+    if not moved and not missing:
+        return ObservationVerdict(discard_candidate=False)
+
+    parts: list[str] = []
+    if moved:
+        parts.append("changed: " + ", ".join(moved))
+    if missing:
+        parts.append("gone: " + ", ".join(missing))
+    reason = (
+        "observations moved since suspend (" + "; ".join(parts) + ") — "
+        "the suspended work was derived from bytes that are no longer on disk, "
+        "so this checkpoint is a discard candidate: respawn the task from "
+        "scratch rather than continue on a stale world model"
+    )
+    return ObservationVerdict(
+        discard_candidate=True,
+        moved=tuple(moved),
+        missing=tuple(missing),
+        reason=reason,
+    )
+
+
 def build_continuation_entry(
     checkpoint: AgentCheckpoint,
     *,
     chain_head_at_resume: str = "",
     interpreter_overridden: bool = False,
+    observations_overridden: bool = False,
 ) -> ContinuationEntry:
     """Build the authenticated journal entry for a successful resume.
 
@@ -532,6 +732,9 @@ def build_continuation_entry(
         interpreter_overridden: Whether the operator forced the resume past an
             interpreter mismatch (``--override-interpreter``). Recorded so a
             later reader can tell an overridden resume from a clean one.
+        observations_overridden: Whether the operator resumed past moved
+            observations instead of discarding the checkpoint. Recorded for
+            the same reason.
 
     Returns:
         A :class:`ContinuationEntry` ready to append to the journal.
@@ -543,6 +746,10 @@ def build_continuation_entry(
         chain_head_at_resume=chain_head_at_resume,
         interpreter_hash=checkpoint.interpreter_hash,
         interpreter_overridden=interpreter_overridden,
+        # An empty mapping bound nothing; an empty hash says so, rather than
+        # publishing the digest of ``{}`` as if something had been bound.
+        observations_hash=(compute_observations_hash(checkpoint.observations) if checkpoint.observations else ""),
+        observations_overridden=observations_overridden,
     )
 
 

--- a/src/bernstein/core/tasks/suspension.py
+++ b/src/bernstein/core/tasks/suspension.py
@@ -1061,6 +1061,7 @@ def park_task(
     from bernstein.core.cost.budget_actions import compute_released_headroom
     from bernstein.core.persistence.agent_checkpoint import (
         AgentCheckpoint,
+        capture_worktree_observations,
         compute_grant_hash,
         compute_interpreter_hash,
         save_checkpoint,
@@ -1128,6 +1129,9 @@ def park_task(
         adapter=adapter,
         model=model,
         interpreter_hash=compute_interpreter_hash(adapter, model) if adapter else "",
+        # The bytes the parked work is carrying, hashed here so a resume can
+        # tell whether it would continue onto the same bytes it left behind.
+        observations=capture_worktree_observations(Path(worktree_path)),
     )
     save_checkpoint(checkpoint, sdd_dir / "runtime")
 
@@ -1235,6 +1239,7 @@ def resume_task(
     ledger: WorkLedger | None = None,
     approval_ref: str = "",
     override_interpreter: bool = False,
+    override_observations: bool = False,
 ) -> ResumeResult:
     """Durably resume a parked task from its suspend row.
 
@@ -1256,6 +1261,10 @@ def resume_task(
             interpreter mismatch (``--override-interpreter``); recorded in the
             continuation row so a later reader can tell an overridden resume
             from a clean one.
+        override_observations: Whether the operator resumed past moved
+            observations (``--override-observations``) instead of discarding
+            the checkpoint; recorded in the continuation row for the same
+            reason.
 
     Returns:
         A :class:`ResumeResult` with the decision and both continuity anchors.
@@ -1359,6 +1368,7 @@ def resume_task(
             _cp_for_cont,
             chain_head_at_resume=resume_event_hash,
             interpreter_overridden=override_interpreter,
+            observations_overridden=override_observations,
         )
         journal.record(
             JOURNAL_EVENT_GRANT_CONTINUATION,
@@ -1369,6 +1379,8 @@ def resume_task(
             chain_head_at_resume=_entry.chain_head_at_resume,
             interpreter_hash=_entry.interpreter_hash,
             interpreter_overridden=_entry.interpreter_overridden,
+            observations_hash=_entry.observations_hash,
+            observations_overridden=_entry.observations_overridden,
         )
 
     receipt = record_task_resume(

--- a/tests/unit/test_checkpoint_observations.py
+++ b/tests/unit/test_checkpoint_observations.py
@@ -1,0 +1,433 @@
+"""Tests for issue #3649 — a checkpoint binds the observations it depended on.
+
+The grant binding (already shipped) answers "may this run continue?". These
+tests cover the second question a checkpoint could not answer: "are the bytes
+the suspended work was derived from still the bytes on disk?".
+
+The outcome differs from the grant case on purpose. A moved grant *refuses* the
+resume. A moved observation makes the checkpoint a **discard candidate**:
+respawning from scratch is the expected answer, and resuming onto changed bytes
+while recording it as continuity is the thing that must not happen.
+
+Numbered properties:
+     1. capture binds content, not path identity
+     2. capture is bounded to the uncommitted set (states what is not bound)
+     3. unchanged observations are not a discard candidate
+     4. a changed artifact is a discard candidate naming the artifact
+     5. a deleted artifact is a discard candidate naming the artifact
+     6. delete-then-recreate with identical bytes is NOT a discard candidate
+     7. the verdict says respawning is the expected answer
+     8. a moved observation is not turned into a grant refusal
+     9. a moved observation stops the resume before any side effect
+    10. --override-observations lets the resume proceed
+    11. the override is recorded on the continuation entry
+    12. discarding drops the checkpoint so the run is not a continuation
+    13. park_task binds the uncommitted worktree bytes in production
+    14. a checkpoint carrying no observations is not a discard candidate
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from bernstein.cli.commands.resume_cmd import (
+    EXIT_OBSERVATIONS_MOVED,
+    ObservationsMovedError,
+    discard_agent_checkpoint,
+    prepare_resume,
+    resume_cmd,
+)
+from bernstein.core.persistence.agent_checkpoint import (
+    AgentCheckpoint,
+    build_continuation_entry,
+    capture_worktree_observations,
+    evaluate_observations,
+    is_checkpoint_recoverable,
+)
+from bernstein.core.persistence.agent_checkpoint import (
+    save_checkpoint as save_agent_checkpoint,
+)
+from bernstein.core.persistence.task_resume import (
+    TaskResumeCheckpoint,
+    load_checkpoint,
+    save_checkpoint,
+)
+from bernstein.core.replay.journal import load_events
+from bernstein.core.security.audit_chain import AuditChainStore
+from bernstein.core.tasks.checkpoint_retry import task_run_id
+from bernstein.core.tasks.suspension import (
+    JOURNAL_EVENT_GRANT_CONTINUATION,
+    park_task,
+    resume_task,
+)
+
+_KEY = b"test-key-32-bytes-exactly-------"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _git(worktree: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=worktree, check=True, capture_output=True)
+
+
+def _init_worktree(path: Path) -> Path:
+    """A git worktree with one committed file and one uncommitted edit."""
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-b", "main")
+    _git(path, "config", "gc.auto", "0")
+    _git(path, "config", "maintenance.auto", "false")
+    _git(path, "config", "user.email", "test@example.com")
+    _git(path, "config", "user.name", "Test")
+    (path / "schema.sql").write_text("CREATE TABLE t (id INT);\n", encoding="utf-8")
+    _git(path, "add", ".")
+    _git(path, "commit", "-m", "init")
+    (path / "work.py").write_text("# in progress\n", encoding="utf-8")
+    return path
+
+
+def _agent_checkpoint(worktree: Path, *, task_id: str = "t-obs") -> AgentCheckpoint:
+    return AgentCheckpoint(
+        agent_id=f"agent-{task_id}",
+        task_id=task_id,
+        worktree_path=str(worktree),
+        observations=capture_worktree_observations(worktree),
+    )
+
+
+def _task_checkpoint(task_id: str) -> TaskResumeCheckpoint:
+    return TaskResumeCheckpoint(
+        task_id=task_id,
+        last_completed_step_id="step-1",
+        trace_cursor=0,
+        scratchpad_path=None,
+        adapter="claude",
+        adapter_session_id="sess-1",
+        worktree_path="/tmp/wt",
+    )
+
+
+def _seed_resume(workdir: Path, task_id: str, worktree: Path) -> AgentCheckpoint:
+    """Both checkpoints ``bernstein resume`` reads, on disk."""
+    save_checkpoint(workdir, _task_checkpoint(task_id))
+    cp = _agent_checkpoint(worktree, task_id=task_id)
+    save_agent_checkpoint(cp, workdir / ".sdd" / "runtime")
+    return cp
+
+
+def _chain(tmp_path: Path) -> AuditChainStore:
+    return AuditChainStore(tmp_path / "audit", key=_KEY)
+
+
+# ---------------------------------------------------------------------------
+# 1-2  capture_worktree_observations
+# ---------------------------------------------------------------------------
+
+
+class TestCapture:
+    def test_capture_binds_content_not_path_identity(self, tmp_path: Path) -> None:
+        """1. The same bytes hash the same however the file got there."""
+        wt = _init_worktree(tmp_path / "wt")
+        before = capture_worktree_observations(wt)
+
+        (wt / "work.py").unlink()
+        (wt / "work.py").write_text("# in progress\n", encoding="utf-8")
+        after = capture_worktree_observations(wt)
+
+        assert before == after
+        assert before["work.py"].startswith("sha256:")
+
+    def test_capture_is_bounded_to_the_uncommitted_set(self, tmp_path: Path) -> None:
+        """2. Committed, untouched files are not bound.
+
+        What a checkpoint can bind without inferring a dependency set is the
+        work it is carrying. ``schema.sql`` is committed and unmodified, so it
+        is deliberately outside the binding.
+        """
+        wt = _init_worktree(tmp_path / "wt")
+        observations = capture_worktree_observations(wt)
+
+        assert "work.py" in observations
+        assert "schema.sql" not in observations
+
+    def test_capture_on_a_non_git_directory_binds_nothing(self, tmp_path: Path) -> None:
+        """A directory git cannot describe yields no false observations."""
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        (plain / "a.txt").write_text("a\n", encoding="utf-8")
+        assert capture_worktree_observations(plain) == {}
+
+
+# ---------------------------------------------------------------------------
+# 3-7, 14  evaluate_observations
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateObservations:
+    def test_unchanged_observations_are_not_a_discard_candidate(self, tmp_path: Path) -> None:
+        """3."""
+        wt = _init_worktree(tmp_path / "wt")
+        verdict = evaluate_observations(_agent_checkpoint(wt))
+
+        assert verdict.discard_candidate is False
+        assert verdict.moved == ()
+        assert verdict.missing == ()
+
+    def test_changed_artifact_is_a_discard_candidate_naming_it(self, tmp_path: Path) -> None:
+        """4."""
+        wt = _init_worktree(tmp_path / "wt")
+        cp = _agent_checkpoint(wt)
+        (wt / "work.py").write_text("# somebody else edited this\n", encoding="utf-8")
+
+        verdict = evaluate_observations(cp)
+
+        assert verdict.discard_candidate is True
+        assert verdict.moved == ("work.py",)
+        assert "work.py" in verdict.reason
+
+    def test_deleted_artifact_is_a_discard_candidate_naming_it(self, tmp_path: Path) -> None:
+        """5."""
+        wt = _init_worktree(tmp_path / "wt")
+        cp = _agent_checkpoint(wt)
+        (wt / "work.py").unlink()
+
+        verdict = evaluate_observations(cp)
+
+        assert verdict.discard_candidate is True
+        assert verdict.missing == ("work.py",)
+        assert "work.py" in verdict.reason
+
+    def test_deleted_and_recreated_identical_content_is_not_a_discard_candidate(self, tmp_path: Path) -> None:
+        """6. Load-bearing: separates a content hash from a stat check.
+
+        A worktree rebuilt from scratch changes every inode and mtime while
+        the bytes stay identical. An implementation keyed on either would
+        discard every checkpoint on such a host.
+        """
+        wt = _init_worktree(tmp_path / "wt")
+        cp = _agent_checkpoint(wt)
+        original = (wt / "work.py").read_bytes()
+        (wt / "work.py").unlink()
+        (wt / "work.py").write_bytes(original)
+
+        verdict = evaluate_observations(cp)
+
+        assert verdict.discard_candidate is False, verdict.reason
+
+    def test_verdict_says_respawning_is_the_expected_answer(self, tmp_path: Path) -> None:
+        """7. The message must not read as a permission refusal."""
+        wt = _init_worktree(tmp_path / "wt")
+        cp = _agent_checkpoint(wt)
+        (wt / "work.py").write_text("# moved\n", encoding="utf-8")
+
+        reason = evaluate_observations(cp).reason
+
+        assert "discard" in reason
+        assert "respawn" in reason
+        assert "grant" not in reason
+
+    def test_checkpoint_without_observations_is_not_a_discard_candidate(self, tmp_path: Path) -> None:
+        """14. Nothing bound is not evidence that something moved."""
+        wt = _init_worktree(tmp_path / "wt")
+        cp = AgentCheckpoint(agent_id="a", task_id="t", worktree_path=str(wt))
+
+        verdict = evaluate_observations(cp)
+
+        assert verdict.discard_candidate is False
+
+    def test_moved_observation_is_not_a_grant_refusal(self, tmp_path: Path) -> None:
+        """8. The authority check keeps its own outcome."""
+        wt = _init_worktree(tmp_path / "wt")
+        cp = _agent_checkpoint(wt)
+        (wt / "work.py").write_text("# moved\n", encoding="utf-8")
+
+        ok, reason = is_checkpoint_recoverable(cp)
+
+        assert ok is True, reason
+        assert "discard" not in reason
+
+
+# ---------------------------------------------------------------------------
+# 9-12  the operator-facing resume path
+# ---------------------------------------------------------------------------
+
+
+class TestResumeCommand:
+    def test_moved_observation_stops_resume_before_any_side_effect(self, tmp_path: Path) -> None:
+        """9. No resume_count bump, no resume signal, no hook."""
+        workdir = tmp_path / "proj"
+        workdir.mkdir()
+        wt = _init_worktree(tmp_path / "wt")
+        _seed_resume(workdir, "t-side", wt)
+        (wt / "work.py").write_text("# moved underneath\n", encoding="utf-8")
+
+        with pytest.raises(ObservationsMovedError) as excinfo:
+            prepare_resume(workdir, "t-side")
+
+        assert "work.py" in str(excinfo.value)
+        assert load_checkpoint(workdir, "t-side").resume_count == 0
+        assert not (workdir / ".sdd" / "runtime" / "resume").exists()
+
+    def test_override_observations_allows_the_resume(self, tmp_path: Path) -> None:
+        """10."""
+        workdir = tmp_path / "proj"
+        workdir.mkdir()
+        wt = _init_worktree(tmp_path / "wt")
+        _seed_resume(workdir, "t-override", wt)
+        (wt / "work.py").write_text("# moved underneath\n", encoding="utf-8")
+
+        plan = prepare_resume(workdir, "t-override", override_observations=True)
+
+        assert plan.checkpoint.resume_count == 1
+
+    def test_cli_exits_with_the_observations_code(self, tmp_path: Path) -> None:
+        """9 (CLI surface)."""
+        from click.testing import CliRunner
+
+        workdir = tmp_path / "proj"
+        workdir.mkdir()
+        wt = _init_worktree(tmp_path / "wt")
+        _seed_resume(workdir, "t-cli", wt)
+        (wt / "work.py").write_text("# moved underneath\n", encoding="utf-8")
+
+        result = CliRunner().invoke(resume_cmd, ["t-cli", "--workdir", str(workdir)])
+
+        assert result.exit_code == EXIT_OBSERVATIONS_MOVED
+        assert "work.py" in result.output
+
+    def test_discard_drops_the_checkpoint(self, tmp_path: Path) -> None:
+        """12 (first half): the discard path really removes the checkpoint."""
+        workdir = tmp_path / "proj"
+        workdir.mkdir()
+        wt = _init_worktree(tmp_path / "wt")
+        _seed_resume(workdir, "t-discard", wt)
+
+        assert discard_agent_checkpoint(workdir, "t-discard") is True
+        assert discard_agent_checkpoint(workdir, "t-discard") is False
+
+        plan = prepare_resume(workdir, "t-discard")
+        assert plan.checkpoint.resume_count == 1
+
+
+# ---------------------------------------------------------------------------
+# 11  the override is recorded
+# ---------------------------------------------------------------------------
+
+
+class TestContinuationEntryRecordsObservations:
+    def test_entry_binds_the_observations_hash(self, tmp_path: Path) -> None:
+        wt = _init_worktree(tmp_path / "wt")
+        entry = build_continuation_entry(_agent_checkpoint(wt))
+
+        assert entry.observations_hash != ""
+        assert entry.observations_overridden is False
+
+    def test_entry_without_observations_binds_nothing(self, tmp_path: Path) -> None:
+        cp = AgentCheckpoint(agent_id="a", task_id="t", worktree_path=str(tmp_path))
+        assert build_continuation_entry(cp).observations_hash == ""
+
+    def test_override_is_recorded_on_the_entry(self, tmp_path: Path) -> None:
+        """11. A later reader tells an overridden resume from a clean one."""
+        wt = _init_worktree(tmp_path / "wt")
+        entry = build_continuation_entry(_agent_checkpoint(wt), observations_overridden=True)
+
+        assert entry.observations_overridden is True
+
+
+# ---------------------------------------------------------------------------
+# 12-13  suspend/resume in production
+# ---------------------------------------------------------------------------
+
+
+class TestSuspensionWiring:
+    def test_park_binds_the_uncommitted_worktree_bytes(self, tmp_path: Path) -> None:
+        """13. The capture activates on a real park, not only in tests."""
+        from bernstein.core.persistence.agent_checkpoint import find_checkpoint_for_task
+
+        wt = _init_worktree(tmp_path / "wt")
+        park_task(
+            sdd_dir=tmp_path / ".sdd",
+            task_id="T-park-obs",
+            adapter="claude",
+            session_id="s",
+            worktree_path=wt,
+            envelope="subscription",
+            reserved_usd=5.0,
+            spent_usd=1.0,
+            chain=_chain(tmp_path),
+            role="backend",
+            parent_run_id="run-1",
+        )
+
+        written = find_checkpoint_for_task("T-park-obs", tmp_path / ".sdd" / "runtime")
+        assert written is not None
+        assert "work.py" in written.observations
+        assert written.observations["work.py"].startswith("sha256:")
+
+    def test_continuation_row_carries_the_observation_fields(self, tmp_path: Path) -> None:
+        """11 (chain surface)."""
+        wt = _init_worktree(tmp_path / "wt")
+        chain = _chain(tmp_path)
+        parked = park_task(
+            sdd_dir=tmp_path / ".sdd",
+            task_id="T-cont-obs",
+            adapter="claude",
+            session_id="s",
+            worktree_path=wt,
+            envelope="subscription",
+            reserved_usd=5.0,
+            spent_usd=1.0,
+            chain=chain,
+            role="backend",
+            parent_run_id="run-1",
+        )
+        resume_task(
+            sdd_dir=tmp_path / ".sdd",
+            suspend_row=parked.suspend_row,
+            new_worktree_path=wt,
+            chain=chain,
+            suspend_receipt_hash=parked.suspend_receipt_hash,
+            override_observations=True,
+        )
+
+        journal_path = tmp_path / ".sdd" / "runs" / task_run_id("T-cont-obs") / "journal.jsonl"
+        row = next(e for e in load_events(journal_path).events if e.get("event") == JOURNAL_EVENT_GRANT_CONTINUATION)
+
+        assert row["observations_hash"] != ""
+        assert row["observations_overridden"] is True
+
+    def test_discarded_checkpoint_produces_no_continuation_row(self, tmp_path: Path) -> None:
+        """12 (second half): the chain reads the resume as a new run."""
+        wt = _init_worktree(tmp_path / "wt")
+        chain = _chain(tmp_path)
+        parked = park_task(
+            sdd_dir=tmp_path / ".sdd",
+            task_id="T-discard-obs",
+            adapter="claude",
+            session_id="s",
+            worktree_path=wt,
+            envelope="subscription",
+            reserved_usd=5.0,
+            spent_usd=1.0,
+            chain=chain,
+            role="backend",
+            parent_run_id="run-1",
+        )
+        assert discard_agent_checkpoint(tmp_path, "T-discard-obs") is True
+
+        resume_task(
+            sdd_dir=tmp_path / ".sdd",
+            suspend_row=parked.suspend_row,
+            new_worktree_path=wt,
+            chain=chain,
+            suspend_receipt_hash=parked.suspend_receipt_hash,
+        )
+
+        journal_path = tmp_path / ".sdd" / "runs" / task_run_id("T-discard-obs") / "journal.jsonl"
+        rows = [e for e in load_events(journal_path).events if e.get("event") == JOURNAL_EVENT_GRANT_CONTINUATION]
+        assert rows == []


### PR DESCRIPTION
## What

Binds the observations a checkpoint's suspended work was derived from, and makes a resume onto moved bytes a **discard candidate** instead of a silent continuation.

Concretely:

- `capture_worktree_observations(worktree)` content-hashes the uncommitted files in a worktree (`sha256:`-prefixed, via `content_hash_of`).
- `park_task` calls it and stores the mapping on the `AgentCheckpoint`, so the binding activates on a real park rather than only in tests.
- `evaluate_observations(checkpoint)` re-derives those hashes at resume and returns an `ObservationVerdict` naming what changed and what is gone.
- `bernstein resume` stops before the `resume_count` bump when the verdict is a discard candidate, with exit code `6` and a message that names the artifacts and points at the discard path.
- `bernstein resume --discard` drops the checkpoint (`discard_checkpoint`), so the following run appends no continuation row and the chain reads it as a new run.
- `bernstein resume --override-observations` resumes anyway; `resume_task(override_observations=True)` records `observations_hash` and `observations_overridden` on the `task.grant_continuation` row, so a later reader can tell an overridden resume from a clean one.

What this PR explicitly does **not** do:

- It does not turn a moved observation into a refusal. That outcome belongs to the grant check, which is unchanged and still runs first.
- It does not infer a dependency set. Files the suspended agent *read* but did not change are not bound; nothing in the checkpoint records them today, and guessing them is a separate problem. The docstring says so at the binding site.
- It does not make the binding immutable or add per-artifact chain entries beyond the two fields on the existing continuation row.
- It does not touch the grant hash, the interpreter check, or `is_checkpoint_recoverable`'s refusal behaviour.

## Why

A checkpoint already binds the authority it was written under — role, resolved paths, task, parent run, chain head — and refuses a resume whose grant moved. That answers "may this run still act?". It does not answer "are the bytes this work was built on still the bytes on disk?".

Those two can diverge without touching each other. A worktree gets rebuilt, a rebase lands, another process edits the parked files: no grant field moves, the authority check passes, and the resume picks up work derived from bytes that no longer exist. The run then continues confidently on a wrong world model, which is worse than stopping — a from-scratch respawn would at least have re-read the tree. Until now nothing in the checkpoint could see that, and the resulting run was recorded on the chain as a clean continuation.

The whole-worktree `workspace_hash` on the suspend row does not close this: it downgrades warm to cold and never names a file, and it does not participate in the checkpoint's recoverability decision at all.

## How

`capture_worktree_observations` asks git for the changed set (`--porcelain -z --untracked-files=all`, so paths are never quoted and a new directory is expanded to its files) and hashes each existing regular file. A directory git cannot describe yields `{}`, which is never a discard candidate — absence of a binding is not evidence that something moved.

`evaluate_observations` re-reads each bound path and classifies it as `moved` (hash differs) or `missing` (unreadable). Because the comparison is over content, a file deleted and recreated with identical bytes compares equal; nothing keys on inode, size, or mtime.

In `prepare_resume` the check sits directly after the grant check and before `bump_resume_count`, so the order is: authority first, then world model, then side effects. A run that may not act at all is never offered the discard choice.

**The one decision the issue left open** — what the default is for an unattended resume that finds moved observations. This ships **stop, do not continue**: the resume raises rather than proceeding. Continuing would propagate a wrong world model into work that then looks like verified continuity, and that state is not recoverable by inspection afterwards. Discarding at worst loses uncommitted work that would have been fine, and that work is still on disk for an operator who disagrees — `--override-observations` resumes onto it and the override is written into the continuation row, so a postmortem can always tell which branch fired.

## Tests

`tests/unit/test_checkpoint_observations.py` (20 tests). The whole file fails to collect on `origin/main`: none of `capture_worktree_observations`, `evaluate_observations`, `ObservationsMovedError`, `EXIT_OBSERVATIONS_MOVED`, or `discard_agent_checkpoint` exists there.

1. `test_capture_binds_content_not_path_identity` — the same bytes hash the same however the file got there.
2. `test_capture_is_bounded_to_the_uncommitted_set` — a committed, untouched file is deliberately not bound; pins what this PR does not claim to cover.
3. `test_capture_on_a_non_git_directory_binds_nothing` — no false observations where git cannot answer.
4. `test_unchanged_observations_are_not_a_discard_candidate`
5. `test_changed_artifact_is_a_discard_candidate_naming_it`
6. `test_deleted_artifact_is_a_discard_candidate_naming_it`
7. `test_deleted_and_recreated_identical_content_is_not_a_discard_candidate` — **load-bearing**. It is what separates a content hash from a stat check: an implementation keyed on inode or mtime discards every checkpoint on a host that rebuilt its worktree. Verified by mutation: replacing the content comparison with `st_mtime_ns` turns this test and #4 red while the rest of the file stays green.
8. `test_verdict_says_respawning_is_the_expected_answer` — the message must not read as a permission refusal.
9. `test_checkpoint_without_observations_is_not_a_discard_candidate` — absence is not evidence.
10. `test_moved_observation_is_not_a_grant_refusal` — `is_checkpoint_recoverable` keeps its own outcome.
11. `test_moved_observation_stops_resume_before_any_side_effect` — no `resume_count` bump, no resume signal directory.
12. `test_override_observations_allows_the_resume`
13. `test_cli_exits_with_the_observations_code` — exit `6`, artifact named in the output.
14. `test_discard_drops_the_checkpoint` — discard is idempotent and unblocks the resume.
15. `test_entry_binds_the_observations_hash`
16. `test_entry_without_observations_binds_nothing` — an empty binding publishes `""`, not the digest of `{}`.
17. `test_override_is_recorded_on_the_entry`
18. `test_park_binds_the_uncommitted_worktree_bytes` — the capture activates on a real park, not only through the helper.
19. `test_continuation_row_carries_the_observation_fields` — the override reaches the chain.
20. `test_discarded_checkpoint_produces_no_continuation_row` — after a discard the chain shows a new run, not a continuation.

Every one of them failed on the unmodified tree (collection error: the API did not exist), and #7 additionally fails against a stat-keyed implementation of the new API.

Verified locally with `--parallel 2` on the touched modules and their importers, since `--affected origin/main` did not finish inside the time budget on this machine; CI runs the full suite:

```
tests/unit/test_checkpoint_observations.py        20 passed
tests/unit/test_agent_checkpoint.py               41 passed
tests/unit/test_grant_bound_checkpoint.py         38 passed
tests/unit/test_grant_bound_suspension.py         10 passed
tests/unit/test_resume_cmd.py                     26 passed
tests/unit/test_task_suspension.py                84 passed
tests/unit/test_suspension_downgrade_reason.py     9 passed
tests/unit/test_ledger_cmd.py                     15 passed
tests/unit/test_path_containment.py              177 passed
tests/integration/test_resume_lifecycle.py         8 passed
```

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes — the three touched modules report the same 10 pre-existing findings before and after this change; no new ones
- [x] `uv run python scripts/run_tests.py -x` passes (targeted set above; full suite on CI)
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated — N/A (no README surface for `bernstein resume` flags)
- [x] `docs/operations/<area>.md` updated — N/A (no operations page covers the resume flags; `--override-interpreter` has none either)
- [x] `docs/api/` schema regenerated if a public surface changed — N/A (no HTTP surface changed)
- [x] `uv run bernstein agents-md sync` run — ran, produced no tracked changes (no new module)
- [x] Tests cover the documented behaviour

Part of #3649

## Remaining

- Binding artifacts the suspended agent *read* rather than wrote. Needs a dependency-set source the checkpoint does not have today.
- Surfacing the discard verdict on the `bernstein task resume` path as well; it currently reaches only `bernstein resume`, which is also where the grant refusal surfaces.
- An offline verifier that reads `observations_hash` off the continuation row, matching the one the grant fields already have.
