### PR TITLE
feat: project journal steps onto a schema-stable trajectory row (#2926)

### DIFF
--- a/src/bernstein/core/replay/trajectory.py
+++ b/src/bernstein/core/replay/trajectory.py
@@ -1,0 +1,178 @@
+"""Step-granular trajectory rows projected from the per-step journal (#2926).
+
+The per-step journal (``bernstein.core.persistence.journal``, #1799) already
+hash-chains every step of an agent run. What it does not offer is a
+**schema-stable row** a downstream consumer can read without knowing journal
+internals: today a consumer either takes run-level aggregates, which have no
+notion of individual steps, or reaches into the journal's own record shape.
+
+This module is that row. :class:`TrajectoryStep` is one executed step in
+consumer vocabulary - ``observation`` / ``action`` / ``outcome`` - carrying
+the chain fields (``index``, ``prev_step_hash``, ``step_hash``) that let a
+verifier walk the trajectory offline.
+
+Re-emit, never recompute (load-bearing)
+---------------------------------------
+The projection **copies** ``step_hash`` from the journal entry. It never
+calls :func:`~bernstein.core.persistence.journal.compute_step_hash`. That is
+the whole point of the row: the hash it carries is the hash the run
+committed, so a row whose ``observation`` was edited after the fact still
+carries the original digest and the edit stays detectable. If the projection
+re-derived the hash, an edited row would carry a hash that agrees with the
+edit, and the export would attest only to itself.
+
+Canonical encoding contract
+---------------------------
+:meth:`TrajectoryStep.canonical_bytes` follows the same discipline as
+``canonical_step_payload`` in the journal - ``json.dumps(..., sort_keys=True,
+separators=(",", ":"))``, UTF-8 - so two exports of one recorded run produce
+byte-identical rows. Wall-clock (``ts``) is excluded, exactly as it is
+excluded from the step hash, so nothing about *when* the export ran enters
+the bytes.
+
+``effort`` keeps the journal's back-compat rule of versioning by omission: an
+unrecorded (``None``) effort leaves the key out of the document entirely, so
+a row that predates the effort dimension canonicalises exactly as it did
+before that dimension existed.
+
+Scope: library-only. The signed manifest that binds a dataset to the replay
+head, the lineage spine and the audit chain, the redaction projection, and
+the ``bernstein trajectory`` CLI are separate, later work.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from bernstein.core.persistence.journal import JournalEntry, JournalReader
+
+__all__ = [
+    "TRAJECTORY_SCHEMA_VERSION",
+    "TrajectoryStep",
+    "project_trajectory",
+    "trajectory_step_from_entry",
+]
+
+#: Trajectory row schema version. This is a public contract read by consumers
+#: outside bernstein; bump it on any change to the field set or the canonical
+#: encoding, and document the migration alongside the journal's own contract.
+TRAJECTORY_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class TrajectoryStep:
+    """One executed step of an agent run, in consumer vocabulary.
+
+    Attributes:
+        index: Position in the run, from the journal entry's ``seq``.
+        prev_step_hash: ``step_hash`` of the preceding step, or the journal's
+            genesis hash for the first step. Lets a consumer walk the chain
+            without reading the journal.
+        step_hash: The hash the run committed for this step, copied verbatim
+            from the journal. Never recomputed here.
+        input_hash: SHA-256 hex of the input blob the step was driven by. Part
+            of the hashed document, so it is carried as its own column - a
+            verifier needs it to re-derive ``step_hash`` by hand.
+        observation: The prompt the adapter received, or ``None``.
+        action: The serialised tool invocation, or ``None``.
+        outcome: The serialised tool result, or ``None``.
+        model: Model id the step was routed to, or ``None``.
+        effort: Reasoning effort the step was routed at, or ``None`` for a row
+            recorded before the effort dimension existed. Omitted from
+            :meth:`canonical_bytes` when ``None`` (see the module docstring).
+        schema_version: Row schema version; see
+            :data:`TRAJECTORY_SCHEMA_VERSION`.
+    """
+
+    index: int
+    prev_step_hash: str
+    step_hash: str
+    input_hash: str
+    observation: str | None
+    action: Any
+    outcome: Any
+    model: str | None
+    effort: str | None = None
+    schema_version: int = TRAJECTORY_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON-friendly wire shape of the row."""
+        row: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "index": self.index,
+            "prev_step_hash": self.prev_step_hash,
+            "step_hash": self.step_hash,
+            "input_hash": self.input_hash,
+            "observation": self.observation,
+            "action": self.action,
+            "outcome": self.outcome,
+            "model": self.model,
+        }
+        # Sentinel-by-omission, mirroring ``canonical_step_payload``: only a
+        # recorded effort is serialised, so a legacy row keeps its old shape.
+        if self.effort is not None:
+            row["effort"] = self.effort
+        return row
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> TrajectoryStep:
+        """Build a row from its wire shape.
+
+        A document with no ``effort`` key reads back as ``effort=None``, the
+        sentinel for an unrecorded effort.
+        """
+        return cls(
+            index=int(raw["index"]),
+            prev_step_hash=str(raw["prev_step_hash"]),
+            step_hash=str(raw["step_hash"]),
+            input_hash=str(raw["input_hash"]),
+            observation=raw.get("observation"),
+            action=raw.get("action"),
+            outcome=raw.get("outcome"),
+            model=raw.get("model"),
+            effort=raw.get("effort"),
+            schema_version=int(raw.get("schema_version", TRAJECTORY_SCHEMA_VERSION)),
+        )
+
+    def canonical_bytes(self) -> bytes:
+        """Return the canonical UTF-8 bytes of this row.
+
+        Sorted keys, compact separators, no wall-clock - so two exports of the
+        same recorded run produce byte-identical rows.
+        """
+        return json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def trajectory_step_from_entry(entry: JournalEntry) -> TrajectoryStep:
+    """Project one journal entry onto a trajectory row.
+
+    ``step_hash`` and ``prev_step_hash`` are copied from the entry; this
+    function never computes a hash. ``ts``, ``blob_refs`` and the journal's
+    own ``schema_version`` stay behind: none of them is part of the step
+    hash, and the row's version tracks the trajectory contract, not the
+    journal's storage format.
+    """
+    return TrajectoryStep(
+        index=entry.seq,
+        prev_step_hash=entry.prev_hash,
+        step_hash=entry.step_hash,
+        input_hash=entry.input_hash,
+        observation=entry.prompt,
+        action=entry.tool_call,
+        outcome=entry.tool_result,
+        model=entry.model,
+        effort=entry.effort,
+    )
+
+
+def project_trajectory(reader: JournalReader) -> list[TrajectoryStep]:
+    """Return every step of the journal behind *reader* as trajectory rows.
+
+    Rows come back in ``seq`` order. A journal that was never written yields
+    an empty list - a run that never stepped has an empty trajectory, which is
+    a fact about the run rather than an error.
+    """
+    return [trajectory_step_from_entry(entry) for entry in reader.entries()]

--- a/tests/unit/core/replay/test_trajectory_row_fidelity.py
+++ b/tests/unit/core/replay/test_trajectory_row_fidelity.py
@@ -1,0 +1,202 @@
+"""The trajectory exporter re-emits the committed step hash, never mints one (#2926).
+
+A trajectory row is only usable as governed learning data if the hash it
+carries is the hash the run committed. If the projection recomputed the
+digest, a row whose ``prompt`` had been edited after the fact would still
+carry a self-consistent hash and pass any downstream check - the export
+would attest to itself rather than to the run.
+
+These tests pin that property at the row layer:
+
+* every projected row's ``step_hash`` is byte-identical to
+  ``compute_step_hash()`` over the same journal inputs;
+* an edited row is caught, because the projection copies the stored hash
+  instead of re-deriving one that would agree with the edit;
+* projecting the same journal twice yields byte-identical canonical rows;
+* a legacy ``effort=None`` row keeps the sentinel-by-omission shape, so it
+  canonicalises exactly as it did before the effort dimension existed.
+"""
+
+from __future__ import annotations
+
+import json
+from itertools import pairwise
+
+from bernstein.core.persistence.journal import (
+    GENESIS_HASH,
+    Journal,
+    JournalEntry,
+    JournalReader,
+    compute_step_hash,
+)
+from bernstein.core.replay.trajectory import (
+    TRAJECTORY_SCHEMA_VERSION,
+    TrajectoryStep,
+    project_trajectory,
+    trajectory_step_from_entry,
+)
+
+
+def _seed_journal(agent_dir):
+    """Write a three-step chain: two effort-bearing rows and one legacy row."""
+    with Journal.open(agent_dir) as journal:
+        journal.append(
+            input_hash="a" * 64,
+            model="claude-3-7-sonnet-20250219",
+            prompt="list the failing tests",
+            tool_call={"name": "bash", "args": {"cmd": "pytest -q"}},
+            tool_result={"exit_code": 1, "stdout": "1 failed"},
+            effort="high",
+        )
+        journal.append(
+            input_hash="b" * 64,
+            model="claude-3-7-sonnet-20250219",
+            prompt="fix the assertion",
+            tool_call={"name": "edit", "args": {"path": "x.py"}},
+            tool_result={"ok": True},
+            effort="low",
+        )
+        # A legacy row: no recorded effort, so the effort key is omitted
+        # from both the hashed document and the projected row.
+        journal.append(
+            input_hash="c" * 64,
+            model=None,
+            prompt=None,
+            tool_call=None,
+            tool_result=None,
+        )
+    return JournalReader(agent_dir)
+
+
+def test_projected_step_hash_equals_the_committed_journal_hash(tmp_path) -> None:
+    """Every row carries the hash the journal wrote, re-derivable by hand."""
+    reader = _seed_journal(tmp_path / "agent-1")
+    entries = list(reader.entries())
+    rows = project_trajectory(reader)
+
+    assert len(rows) == len(entries) == 3
+    for entry, row in zip(entries, rows, strict=True):
+        expected = compute_step_hash(
+            prev_hash=entry.prev_hash,
+            input_hash=entry.input_hash,
+            model=entry.model,
+            prompt=entry.prompt,
+            tool_call=entry.tool_call,
+            tool_result=entry.tool_result,
+            effort=entry.effort,
+        )
+        assert row.step_hash == entry.step_hash == expected
+
+
+def test_row_chain_links_through_prev_step_hash(tmp_path) -> None:
+    """The rows carry the chain, so a consumer can walk it without the journal."""
+    reader = _seed_journal(tmp_path / "agent-1")
+    rows = project_trajectory(reader)
+
+    assert rows[0].prev_step_hash == GENESIS_HASH
+    assert [row.index for row in rows] == [0, 1, 2]
+    for previous, current in pairwise(rows):
+        assert current.prev_step_hash == previous.step_hash
+
+
+def test_projection_re_emits_and_never_recomputes_an_edited_row() -> None:
+    """A tampered field does not get a fresh hash minted for it.
+
+    This is the load-bearing property. The entry below claims a hash for one
+    prompt while carrying another; the projection must surface the claimed
+    hash unchanged so the divergence stays detectable downstream.
+    """
+    committed_hash = compute_step_hash(
+        prev_hash=GENESIS_HASH,
+        input_hash="a" * 64,
+        model="m",
+        prompt="the prompt the run actually sent",
+        tool_call=None,
+        tool_result=None,
+        effort="high",
+    )
+    tampered = JournalEntry(
+        seq=0,
+        prev_hash=GENESIS_HASH,
+        input_hash="a" * 64,
+        model="m",
+        prompt="a prompt substituted after the run",
+        tool_call=None,
+        tool_result=None,
+        step_hash=committed_hash,
+        ts=0.0,
+        effort="high",
+    )
+
+    row = trajectory_step_from_entry(tampered)
+
+    assert row.step_hash == committed_hash
+    recomputed = compute_step_hash(
+        prev_hash=row.prev_step_hash,
+        input_hash=row.input_hash,
+        model=row.model,
+        prompt=row.observation,
+        tool_call=row.action,
+        tool_result=row.outcome,
+        effort=row.effort,
+    )
+    assert row.step_hash != recomputed
+
+
+def test_projecting_the_same_journal_twice_is_byte_identical(tmp_path) -> None:
+    """Determinism at the row layer: same journal in, same bytes out."""
+    reader = _seed_journal(tmp_path / "agent-1")
+
+    first = [row.canonical_bytes() for row in project_trajectory(reader)]
+    second = [row.canonical_bytes() for row in project_trajectory(reader)]
+
+    assert first == second
+    # And the bytes carry no wall-clock: ``ts`` never enters the document.
+    for blob in first:
+        assert "ts" not in json.loads(blob.decode("utf-8"))
+
+
+def test_legacy_row_omits_effort_from_its_canonical_bytes(tmp_path) -> None:
+    """Sentinel-by-omission: an unrecorded effort leaves no key behind.
+
+    The journal hashes a legacy row without an ``effort`` key so it stays
+    byte-identical to a pre-effort record. The trajectory row mirrors that
+    contract, so adding the effort dimension did not change the bytes of any
+    row that predates it.
+    """
+    reader = _seed_journal(tmp_path / "agent-1")
+    rows = project_trajectory(reader)
+
+    legacy = rows[2]
+    assert legacy.effort is None
+    assert "effort" not in json.loads(legacy.canonical_bytes().decode("utf-8"))
+
+    recorded = rows[0]
+    assert recorded.effort == "high"
+    assert json.loads(recorded.canonical_bytes().decode("utf-8"))["effort"] == "high"
+
+
+def test_row_projects_observation_action_and_outcome(tmp_path) -> None:
+    """The consumer-facing column names map onto the journal fields."""
+    reader = _seed_journal(tmp_path / "agent-1")
+    row = project_trajectory(reader)[0]
+
+    assert row.observation == "list the failing tests"
+    assert row.input_hash == "a" * 64
+    assert row.action == {"name": "bash", "args": {"cmd": "pytest -q"}}
+    assert row.outcome == {"exit_code": 1, "stdout": "1 failed"}
+    assert row.model == "claude-3-7-sonnet-20250219"
+    assert row.effort == "high"
+    assert row.schema_version == TRAJECTORY_SCHEMA_VERSION
+
+
+def test_row_round_trips_through_dict(tmp_path) -> None:
+    """The dict form is the wire shape a consumer reads; it must round-trip."""
+    reader = _seed_journal(tmp_path / "agent-1")
+    for row in project_trajectory(reader):
+        assert TrajectoryStep.from_dict(row.to_dict()) == row
+
+
+def test_empty_journal_projects_no_rows(tmp_path) -> None:
+    """A run that never stepped exports an empty trajectory, not an error."""
+    assert project_trajectory(JournalReader(tmp_path / "never-ran")) == []


### PR DESCRIPTION
## What

Adds `src/bernstein/core/replay/trajectory.py`: a schema-stable, per-step row projected from the per-step journal, plus the projection over `JournalReader.entries()`.

- `TrajectoryStep` — one executed step as a frozen, versioned row: `index`, `prev_step_hash`, `step_hash`, `input_hash`, `observation`, `action`, `outcome`, `model`, `effort`, `schema_version`.
- `trajectory_step_from_entry()` — projects one `JournalEntry` onto a row.
- `project_trajectory()` — projects a whole journal, in `seq` order.
- `TrajectoryStep.canonical_bytes()` / `to_dict()` / `from_dict()` — the wire shape and its canonical encoding.

This is step 1 of the issue ("Start here"), library-only. It explicitly does **not**:

- add a `TrajectoryManifest` or any of its three anchors (replay head, lineage-spine entry, HMAC audit-chain receipt + Ed25519 signature);
- add the `gate_passed` label, `--redact`, or `redaction_digest`;
- add a `bernstein trajectory` CLI group;
- rewire `core/tokens/auto_distillation.py` or `eval/harness.py`;
- modify `core/persistence/journal.py` or `journal_export.py` — it reads them, nothing more.

`src/bernstein/eval/trajectory_receipt.py` is a different, unrelated surface (benchmark scores) and is untouched.

**Open decision, decided here: the row keeps the journal's sentinel-by-omission rule for `effort`.** A recorded effort serialises as an `"effort"` key; an unrecorded one (`None`) leaves the key out of the document entirely. The alternative — always emitting `"effort": null` for a fixed column set — is friendlier to a naive reader, but it would give a row that predates the effort dimension different canonical bytes than the record it projects, for no gain: the journal already hashes those rows by omission, so mirroring the rule keeps one contract instead of two. `from_dict()` reads a missing key back as `None`, so a consumer never has to know the difference.

Second decision: the module is **not** re-exported from `bernstein/core/replay/__init__.py`. That package is imported very widely, and step 1 has no consumer yet; consumers import `bernstein.core.replay.trajectory` directly. Re-exporting is cheap to add in the slice that lands the first consumer.

## Why

A finished run is already hash-chained per step: `compute_step_hash()` in `src/bernstein/core/persistence/journal.py` gives every step a stable, independently re-derivable digest, and `journal_export.py` bundles the chain into a portable receipt. What is missing is on the reading side. A consumer that wants the run *as steps* has two options today, and neither is a contract: run-level aggregates (`src/bernstein/eval/telemetry.py`) collapse a whole task to counters and have no notion of an individual step, or the consumer reads the journal's own storage record and takes a dependency on internals — which is what `src/bernstein/core/tokens/auto_distillation.py` and `src/bernstein/eval/harness.py` do now.

The row this PR adds is the missing contract, and its load-bearing property is that it **re-emits** the committed hash rather than recomputing one. That distinction is the whole reason the row is worth having: if the projection derived `step_hash` from the fields it is emitting, a row whose `observation` had been edited after the run would carry a hash that agrees with the edit, and the export would attest only to itself. By copying the hash the run committed, an edited row stays detectably divergent from its own contents — which is the property that has to hold before any of the later binding, labelling or redaction work means anything.

## How

`trajectory_step_from_entry()` copies `step_hash` and `prev_hash` straight off the `JournalEntry` and never calls `compute_step_hash()`. The rename to `observation` / `action` / `outcome` is a projection of `prompt` / `tool_call` / `tool_result`; `input_hash` stays its own column because it is part of the hashed document and a verifier needs it to re-derive the digest by hand.

`ts`, `blob_refs` and the journal's storage `schema_version` are deliberately left behind. None of them is part of the step hash, and the row's `schema_version` tracks the trajectory contract rather than the journal's on-disk format, so the two can version independently.

`canonical_bytes()` uses the same encoding discipline as `canonical_step_payload()` — `json.dumps(..., sort_keys=True, separators=(",", ":"))`, UTF-8 — with no wall-clock in the document, so two exports of one recorded run produce byte-identical rows.

## Tests

`tests/unit/core/replay/test_trajectory_row_fidelity.py`, 8 tests. All 8 failed before the change, at collection, on `ModuleNotFoundError: No module named 'bernstein.core.replay.trajectory'` — the module did not exist.

1. `test_projected_step_hash_equals_the_committed_journal_hash` — every row's `step_hash` is byte-identical to the journal entry's and to `compute_step_hash()` over the same inputs.
2. `test_row_chain_links_through_prev_step_hash` — the first row starts at `GENESIS_HASH` and each row's `prev_step_hash` is the previous row's `step_hash`, so a consumer can walk the chain without the journal.
3. `test_projection_re_emits_and_never_recomputes_an_edited_row` — **load-bearing.** An entry that claims one hash while carrying a substituted prompt keeps its claimed hash through the projection, and that hash does not equal a re-derivation over the row's own fields. Verified as a mutation kill: replacing the copy with a `compute_step_hash()` call makes this test — and only this test — fail.
4. `test_projecting_the_same_journal_twice_is_byte_identical` — determinism at the row layer, and no `ts` in the canonical document.
5. `test_legacy_row_omits_effort_from_its_canonical_bytes` — an unrecorded effort leaves no key in the bytes; a recorded one does.
6. `test_row_projects_observation_action_and_outcome` — the consumer-facing column names map onto the journal fields.
7. `test_row_round_trips_through_dict` — the wire shape round-trips, including the omitted-effort row.
8. `test_empty_journal_projects_no_rows` — a run that never stepped exports an empty trajectory, not an error.

`--affected origin/main` selected 53 test files; all were run and are green. CI runs the full suite.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run ruff format --check` passes on the changed files
- [x] `uv run pyright src/bernstein/core/replay/trajectory.py` — 0 errors, 0 warnings
- [x] `uv run python scripts/run_tests.py --parallel 2 -x tests/unit/core/replay/test_trajectory_row_fidelity.py` — 8 passed
- [x] New code has type hints

### Documentation duty

- [ ] User-visible README section updated — N/A, no user-visible surface ships in this slice
- [ ] `docs/operations/<area>.md` updated — N/A, the schema is documented in the module docstring and the replay/lineage docs land with the CLI slice
- [ ] `docs/api/` schema regenerated — N/A, no HTTP or CLI surface changed
- [x] `uv run bernstein agents-md sync` run — produced no changes
- [x] Tests cover the documented behaviour

Part of #2926

## Remaining

- `TrajectoryDataset` + `TrajectoryManifest`, bound to the replay head (`EventJournal.head()`), the lineage-spine entry from `seal_journal_into_spine()`, and an HMAC audit-chain receipt plus an Ed25519 signature over the canonical manifest bytes.
- The `gate_passed` label read from `core/quality/janitor.py`, signed into the same bytes.
- `--redact` and a deterministic `redaction_digest` reusing `journal_publish.RedactionPolicy` and `core/security/dlp_scanner.py`.
- `bernstein trajectory export` / `verify`, with the verifier failing closed when the spine or audit-chain anchor is absent, and reporting the first divergent index.
- Rewiring `core/tokens/auto_distillation.py` and `eval/harness.py` onto the schema, and the docs for the offline verify recipe.
