### PR TITLE
fix(teams): refuse a role modality no worker in this tree runs (#3111)

### DIFF
--- a/docs/operations/activity-boundary.md
+++ b/docs/operations/activity-boundary.md
@@ -97,10 +97,16 @@ role = "scout"
 ```
 
 <!-- scope:activity-boundary-reachability start - delete this note when the scheduler reads agent_kind -->
-The key is parsed, validated against the known modalities, and round-tripped
-into the canonical manifest. It is not yet read on the execution path: a role
-that declares `agent_kind = "research"` runs exactly as it would without the
-key. Treat it as a forward-compatible declaration, not a dispatch switch.
+The accepted values are `coding`, `research` and `browser` -- the modalities
+something in this tree runs. `data` and `ops` are activity kinds on the
+boundary but ship no worker driving them, so declaring one is refused at
+manifest load naming the kind and the role, rather than accepted and quietly
+run as `coding`.
+
+An accepted value is parsed and round-tripped into the canonical manifest, but
+is not yet read on the execution path: a role that declares
+`agent_kind = "research"` runs exactly as it would without the key. Treat it as
+a forward-compatible declaration, not a dispatch switch.
 <!-- scope:activity-boundary-reachability end -->
 
 ## How verify reconstructs a run

--- a/src/bernstein/core/orchestration/activity_modalities.py
+++ b/src/bernstein/core/orchestration/activity_modalities.py
@@ -53,11 +53,13 @@ merely stops logging.
 from __future__ import annotations
 
 import hashlib
+import importlib
 import json
 import logging
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, Final, cast
 
 from bernstein.core.orchestration.activity import (
     ACTIVITY_RESULT_EVENT,
@@ -82,12 +84,13 @@ from bernstein.core.replay.journal import JournalPathError, load_events, run_jou
 from bernstein.core.skills.catalog.signature import sign_payload, verify_payload
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
+    from collections.abc import Iterable, Mapping, Sequence
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "RUNNABLE_ACTIVITY_KINDS",
     "ActivityVerifyResult",
     "BrowserActivity",
     "ContentStore",
@@ -100,6 +103,7 @@ __all__ = [
     "ResearchActivity",
     "SignedArtifact",
     "StageVerdict",
+    "activity_worker_for_kind",
     "replay_reattach",
     "verify_data_ops_receipt",
     "verify_run_activities",
@@ -684,6 +688,60 @@ class OpsActivity(_SignedArtifactActivity):
     """
 
     kind = ActivityKind.OPS
+
+
+# ---------------------------------------------------------------------------
+# Which modality this tree can actually run
+# ---------------------------------------------------------------------------
+
+#: The in-tree worker driving each modality end to end, keyed by modality.
+#:
+#: Values are ``"module:attribute"`` targets rather than imported classes
+#: because both workers import *this* module, so a module-level import here
+#: would close a cycle. :func:`activity_worker_for_kind` resolves a target on
+#: demand.
+#:
+#: Absent members are deliberate, not oversights.
+#: :attr:`~bernstein.core.orchestration.activity.ActivityKind.CODING` is the
+#: ordinary coding spawn and has no activity worker at all. ``DATA`` and ``OPS``
+#: ship only the :class:`DataActivity` / :class:`OpsActivity` collectors above:
+#: those build an ``ActivityResult`` when something drives them, and nothing in
+#: this tree does.
+_ACTIVITY_WORKER_TARGETS: Final[Mapping[ActivityKind, str]] = MappingProxyType(
+    {
+        ActivityKind.RESEARCH: "bernstein.core.orchestration.research_worker:ResearchWorker",
+        ActivityKind.BROWSER: "bernstein.core.orchestration.browser_worker:BrowserWorker",
+    }
+)
+
+#: The modalities a run may declare, because something here runs them: the
+#: ordinary coding spawn plus every modality with an activity worker.
+#:
+#: A modality outside this set is a valid ``ActivityKind`` member that no code
+#: path executes. Accepting such a declaration and then running a coding spawn
+#: presents an unimplemented modality as a supported configuration, so the
+#: declaration surfaces refuse it instead.
+RUNNABLE_ACTIVITY_KINDS: Final[frozenset[ActivityKind]] = frozenset({ActivityKind.CODING, *_ACTIVITY_WORKER_TARGETS})
+
+
+def activity_worker_for_kind(kind: ActivityKind) -> type[Any] | None:
+    """Return the activity worker that runs *kind*, or ``None`` when it has none.
+
+    ``None`` covers two distinct cases the caller already knows apart from
+    :data:`RUNNABLE_ACTIVITY_KINDS`: ``CODING`` is runnable but not as an
+    activity, while a modality outside that set has no runner at all.
+
+    Args:
+        kind: The modality to resolve.
+
+    Returns:
+        The worker class, or ``None`` if no activity worker drives *kind*.
+    """
+    target = _ACTIVITY_WORKER_TARGETS.get(kind)
+    if target is None:
+        return None
+    module_name, _, attribute = target.partition(":")
+    return cast("type[Any]", getattr(importlib.import_module(module_name), attribute))
 
 
 def replay_reattach(journal_path: Path, *, store: ContentStore, stage_id: str) -> list[bytes]:

--- a/src/bernstein/core/teams/manifest.py
+++ b/src/bernstein/core/teams/manifest.py
@@ -51,6 +51,7 @@ from typing import TYPE_CHECKING, cast
 from bernstein import _BUNDLED_TEMPLATES_DIR  # type: ignore[reportPrivateUsage]
 from bernstein.core.config.seed_config import SeedError
 from bernstein.core.orchestration.activity import ActivityKind
+from bernstein.core.orchestration.activity_modalities import RUNNABLE_ACTIVITY_KINDS
 from bernstein.core.skills.catalog.signature import (
     ManifestSignatureError,
     VerificationOutcome,
@@ -126,12 +127,16 @@ class TeamRoleSpec:
             :attr:`~bernstein.core.orchestration.activity.ActivityKind.CODING`,
             the modality the deterministic scheduler is already validated for.
 
-            The key is parsed, validated against the known modalities, and
-            round-tripped into the canonical manifest. It is **not read on the
-            execution path**: a role declaring ``research`` runs exactly as it
-            would without the key. Dispatching on it is tracked in #2996 and
-            #3110; see "Reachability today" in
-            ``docs/operations/activity-boundary.md``.
+            The key is parsed, validated against
+            :data:`~bernstein.core.orchestration.activity_modalities.RUNNABLE_ACTIVITY_KINDS`
+            -- the modalities something in this tree actually runs -- and
+            round-tripped into the canonical manifest. A modality with no
+            worker is refused at load rather than accepted and downgraded.
+
+            The accepted value is still **not read on the execution path**: a
+            role declaring ``research`` runs exactly as it would without the
+            key. Dispatching on it is tracked in #2996 and #3110; see
+            "Reachability today" in ``docs/operations/activity-boundary.md``.
     """
 
     role: str
@@ -281,13 +286,18 @@ def _parse_role_entry(index: int, raw: object, *, context: str) -> TeamRoleSpec:
     if raw_kind is not None:
         if not isinstance(raw_kind, str):
             raise TeamManifestValidationError(f"{context}: roles[{index}].agent_kind must be a string")
+        valid = ", ".join(sorted(k.value for k in RUNNABLE_ACTIVITY_KINDS))
         try:
             agent_kind = ActivityKind(raw_kind)
         except ValueError as exc:
-            valid = ", ".join(sorted(k.value for k in ActivityKind))
             raise TeamManifestValidationError(
                 f"{context}: roles[{index}].agent_kind {raw_kind!r} is not one of: {valid}"
             ) from exc
+        if agent_kind not in RUNNABLE_ACTIVITY_KINDS:
+            raise TeamManifestValidationError(
+                f"{context}: roles[{index}] (role {role!r}) declares agent_kind {agent_kind.value!r}, "
+                f"which no worker in this tree runs; accepted modalities are: {valid}"
+            )
 
     return TeamRoleSpec(
         role=role,

--- a/tests/unit/test_runnable_activity_modalities.py
+++ b/tests/unit/test_runnable_activity_modalities.py
@@ -1,0 +1,158 @@
+"""A declared role modality must be one something in this tree actually runs.
+
+The team manifest accepts a per-role modality declaration and validates it
+against the :class:`~bernstein.core.orchestration.activity.ActivityKind` enum.
+Enum membership is the wrong gate: ``data`` and ``ops`` are enum members that
+ship only collector classes, with no worker driving them, so a manifest
+declaring one parses cleanly and then runs an ordinary coding spawn. A
+declaration that is parsed, validated and then silently downgraded reads as a
+supported configuration.
+
+These tests pin the narrower gate: a modality is accepted only when the
+registry in :mod:`bernstein.core.orchestration.activity_modalities` names
+something that runs it, and the registry is held honest by resolving every
+entry it claims.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.orchestration.activity import ActivityKind
+from bernstein.core.orchestration.activity_modalities import (
+    RUNNABLE_ACTIVITY_KINDS,
+    activity_worker_for_kind,
+)
+from bernstein.core.teams.manifest import TeamManifestValidationError, load_team_manifest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_MANIFEST = """\
+name = "crew"
+version = "1.0.0"
+
+[coordination]
+parallelism = 1
+review_chain = false
+
+[[roles]]
+agent_kind = "{kind}"
+role = "scout"
+"""
+
+#: A manifest whose first role declares an unrunnable modality and whose second
+#: role is an ordinary coding role. Used to pin that the refusal takes the whole
+#: load down rather than letting the bad role degrade to the good one's spawn.
+_MIXED = """\
+name = "crew"
+version = "1.0.0"
+
+[coordination]
+parallelism = 2
+review_chain = false
+
+[[roles]]
+agent_kind = "data"
+role = "loader"
+
+[[roles]]
+role = "backend"
+"""
+
+
+def _write(tmp_path: Path, name: str, body: str) -> Path:
+    teams_dir = tmp_path / "templates" / "teams"
+    teams_dir.mkdir(parents=True, exist_ok=True)
+    path = teams_dir / f"{name}.toml"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# The registry: what this tree can run
+# ---------------------------------------------------------------------------
+
+
+def test_every_registered_modality_resolves_to_an_importable_worker() -> None:
+    """Load-bearing: the accept-list is only honest if its workers exist.
+
+    ``RUNNABLE_ACTIVITY_KINDS`` is what the manifest lets an operator declare.
+    If an entry named a class that had been renamed or removed, the manifest
+    would keep accepting a modality nothing could run -- exactly the defect this
+    change closes, reintroduced one rename later.
+    """
+    registered = RUNNABLE_ACTIVITY_KINDS - {ActivityKind.CODING}
+    assert registered, "the registry must name at least one activity worker"
+    for kind in registered:
+        worker = activity_worker_for_kind(kind)
+        assert worker is not None, f"{kind.value} is accepted but resolves to no worker"
+        assert isinstance(worker, type)
+
+
+def test_coding_has_no_activity_worker() -> None:
+    """``coding`` is runnable, but as the ordinary spawn rather than an activity."""
+    assert ActivityKind.CODING in RUNNABLE_ACTIVITY_KINDS
+    assert activity_worker_for_kind(ActivityKind.CODING) is None
+
+
+@pytest.mark.parametrize("kind", [ActivityKind.DATA, ActivityKind.OPS])
+def test_collector_only_modality_is_not_runnable(kind: ActivityKind) -> None:
+    """``data`` and ``ops`` ship collectors only: no worker, so not declarable."""
+    assert kind not in RUNNABLE_ACTIVITY_KINDS
+    assert activity_worker_for_kind(kind) is None
+
+
+# ---------------------------------------------------------------------------
+# The manifest gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kind", ["data", "ops"])
+def test_modality_with_no_worker_is_refused_at_manifest_load(tmp_path: Path, kind: str) -> None:
+    with pytest.raises(TeamManifestValidationError):
+        load_team_manifest(_write(tmp_path, kind, _MANIFEST.format(kind=kind)))
+
+
+@pytest.mark.parametrize("kind", ["data", "ops"])
+def test_refusal_names_the_kind_and_the_role(tmp_path: Path, kind: str) -> None:
+    """The message has to be actionable without opening the source."""
+    with pytest.raises(TeamManifestValidationError) as excinfo:
+        load_team_manifest(_write(tmp_path, kind, _MANIFEST.format(kind=kind)))
+    message = str(excinfo.value)
+    assert kind in message
+    assert "scout" in message
+
+
+def test_refused_role_does_not_fall_back_to_a_coding_spawn(tmp_path: Path) -> None:
+    """The whole load fails; no role is quietly downgraded to coding."""
+    with pytest.raises(TeamManifestValidationError) as excinfo:
+        load_team_manifest(_write(tmp_path, "mixed", _MIXED))
+    assert "loader" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("kind", ["research", "browser"])
+def test_runnable_modality_still_parses(tmp_path: Path, kind: str) -> None:
+    manifest = load_team_manifest(_write(tmp_path, kind, _MANIFEST.format(kind=kind)))
+    assert manifest.roles[0].agent_kind is ActivityKind(kind)
+
+
+def test_role_omitting_the_key_still_defaults_to_coding(tmp_path: Path) -> None:
+    body = _MANIFEST.format(kind="research").replace('agent_kind = "research"\n', "")
+    manifest = load_team_manifest(_write(tmp_path, "legacy", body))
+    assert manifest.roles[0].agent_kind is ActivityKind.CODING
+
+
+def test_unknown_modality_message_lists_only_runnable_kinds(tmp_path: Path) -> None:
+    """A rejection must not advertise a modality the next load would refuse.
+
+    Listing every enum member sends an operator straight from ``telepathy`` to
+    ``data``, which is refused in turn.
+    """
+    with pytest.raises(TeamManifestValidationError) as excinfo:
+        load_team_manifest(_write(tmp_path, "bad", _MANIFEST.format(kind="telepathy")))
+    _, separator, listed = str(excinfo.value).partition("is not one of: ")
+    assert separator, "the rejection must still enumerate the accepted modalities"
+    assert {item.strip() for item in listed.split(",")} == {kind.value for kind in RUNNABLE_ACTIVITY_KINDS}


### PR DESCRIPTION
## What

Partial implementation of #3111 — the first slice only: **a role may no longer declare a modality that nothing in this tree runs.**

Two changes:

1. `activity_modalities.py` gains the single lookup from `ActivityKind` to the worker that drives it, plus the derived set of modalities that are runnable at all.
2. `_parse_role_entry` in `core/teams/manifest.py` gates the role modality key on that set instead of on bare enum membership.

**Explicitly not in this PR:** the dispatch. `expand_manifest` still drops the key, `ExpandedTeam` gains no field, and the scheduler still runs an ordinary coding spawn for every role. No new CLI surface, no scheduler change, no journal change. `tests/unit/test_docs_capability_reachability.py` is deliberately untouched — its entry asserts the key is still inert, and it still is.

## Why

`ActivityKind` has five members, but only two of them have anything in the tree that drives them to an `ActivityResult`:

| Kind | What runs it |
|---|---|
| `coding` | the ordinary coding spawn |
| `research` | `ResearchWorker` (`core/orchestration/research_worker.py:204`) |
| `browser` | `BrowserWorker` (`core/orchestration/browser_worker.py:198`) |
| `data` | nothing — `DataActivity` is a collector with no caller outside the package |
| `ops` | nothing — `OpsActivity`, same |

The manifest validated the key by constructing `ActivityKind(raw_kind)`, so all five passed. A manifest declaring `agent_kind = "data"` parsed, validated, round-tripped through the canonical serialisation with a stable digest — and then ran a coding spawn. The operator gets no signal at any point that the declaration did nothing.

That is worse than not offering the key: a value that survives parsing, validation and serialisation reads as a supported configuration. The failure is also silent in the direction that costs most — the run completes, so there is no error to trace back to the declaration.

The rejection message had the same defect from the other side. `agent_kind = "telepathy"` was refused with `is not one of: browser, coding, data, ops, research`, which walks the operator straight to `data` — a value the next load also fails to honour.

## How

`_ACTIVITY_WORKER_TARGETS` maps a kind to its worker; `RUNNABLE_ACTIVITY_KINDS` is that mapping's keys plus `CODING`. `_parse_role_entry` refuses anything outside the set, naming both the kind and the role. The unknown-string branch now enumerates the runnable set, so the two messages agree.

**The one open decision, and why it went this way.** The issue leaves open whether `data` / `ops` should be refused or accepted-and-inert. They are **refused**. Accepting them would preserve exactly the defect being closed — a declaration that validates and then does not happen — and refusal is the cheaper direction to reverse: when a data or ops worker lands, adding a row to the mapping makes the declaration legal again, and no manifest written in the meantime encodes an expectation that was never met.

Worker targets are stored as `"module:attribute"` strings resolved on demand rather than imported at module level. Both worker modules import `activity_modalities`, so a direct import would close a cycle. `activity_worker_for_kind` does the resolution, which also makes the mapping falsifiable — see test 1.

`data` and `ops` are unreachable from any manifest on `main` today, so nothing that loads now stops loading. This narrows an input surface rather than a public API.

## Tests

`tests/unit/test_runnable_activity_modalities.py` (13 cases). Every one failed before the change; the manifest cases failed with `DID NOT RAISE`, the message case with the listing containing `data` and `ops`.

1. `test_every_registered_modality_resolves_to_an_importable_worker` — **load-bearing.** The accept-list is only honest if each entry names a class that exists; it resolves every registered kind and asserts a class comes back. Without it the registry is unvalidated strings, and one rename would silently restore the original defect — a manifest accepting a modality nothing can run.
2. `test_coding_has_no_activity_worker` — `coding` is runnable but resolves to no *activity* worker; pins that the two concepts stay distinct.
3. `test_collector_only_modality_is_not_runnable[data]` — `data` is absent from the runnable set and resolves to nothing.
4. `test_collector_only_modality_is_not_runnable[ops]` — same for `ops`.
5. `test_modality_with_no_worker_is_refused_at_manifest_load[data]` — refused at load, not at dispatch.
6. `test_modality_with_no_worker_is_refused_at_manifest_load[ops]` — same for `ops`.
7. `test_refusal_names_the_kind_and_the_role[data]` — the message carries both, so it is actionable without opening the source.
8. `test_refusal_names_the_kind_and_the_role[ops]` — same for `ops`.
9. `test_refused_role_does_not_fall_back_to_a_coding_spawn` — a manifest mixing an unrunnable role with a valid coding role fails as a whole; no role is quietly downgraded.
10. `test_runnable_modality_still_parses[research]` — no regression on the modality that has a worker.
11. `test_runnable_modality_still_parses[browser]` — same for `browser`.
12. `test_role_omitting_the_key_still_defaults_to_coding` — legacy manifests are untouched.
13. `test_unknown_modality_message_lists_only_runnable_kinds` — the enumeration equals the runnable set exactly, so a rejection cannot advertise a value the next load would refuse.

Also run green, unchanged: `tests/unit/test_team_manifest_agent_kind.py` (8), `tests/unit/test_docs_capability_reachability.py` (8).

**Test selection.** `run_tests.py --affected origin/main` selects 816 files (`activity_modalities` sits under most of the orchestration tree), over the threshold for a local run. Ran instead the tests of both touched modules plus the tests of their importers — `activity`, `research_worker`, `browser_worker`, `browser_check`, `research_report`, `activity_cmd`, `query_driver`, `seed_parser`, `team_cmd`, `teams.audit`, `teams.drift` — 35 files, all passing. CI runs the full suite.

## Checklist

- [x] `uv run ruff check src/` — clean
- [x] `uv run ruff format --check src/` — clean (formatted only the files changed here)
- [x] `uv run pyright src/` — zero new diagnostics; the two touched files report the same 24 isolated-file diagnostics before and after, none on a changed line
- [x] `uv run python scripts/run_tests.py --parallel 2 -x <files>` — 35 files green
- [x] Type hints on all new code (`Final`, `Mapping[ActivityKind, str]`, `type[Any] | None`)
- [x] Documentation duty: `docs/operations/activity-boundary.md` named "the known modalities" as the accepted set, which now overstates it; it names `coding` / `research` / `browser` and the refusal instead
- [x] `uv run bernstein agents-md sync` — run, no changes produced
- [N/A] README / translations — untouched, per the issue's note that this slice does not make the key reachable
- [N/A] Schema or data migration — none; this narrows an input surface, no stored shape changes

Part of #3111

## Remaining

The dispatch itself, in the issue's order:

- AC1 — map the declared modality to the worker at the scheduler, as the only path. Needs `expand_manifest` to stop dropping the key and `ExpandedTeam` to carry it.
- AC3 — coding roles unaffected (holds today, must be re-asserted once the scheduler branches).
- AC4 — the resolved kind on the journal entry. `dispatch_activity` (`core/orchestration/activity.py:389`) already stamps `kind=`, so this falls out once a result actually flows through it; nothing flows yet.
- AC5 — determinism of the dispatch decision sequence across two loads.

AC2 is the half this PR lands: a kind with no registered worker is refused at load, with the kind and the role in the message, and no fallback to a coding spawn.
