### PR TITLE
docs+feat(volunteer): close protocol.md and manifest-projection gaps (#3883)

### DIFF
--- a/docs/volunteer/README.md
+++ b/docs/volunteer/README.md
@@ -16,6 +16,9 @@ receipt bundle that a maintainer can verify offline.
   boundary derived from the manifest and the donor's limits.
 - [Volunteer donor budgets](reference/volunteer-budget.md) — persistent task,
   wall-clock, token, size, and local-model limits.
+- [Volunteer protocol documents](protocol.md) — the five signed, transport-neutral
+  documents (project card, worker card, claim, submission, verification
+  verdict) that carry the cycle across GitHub and a self-hosted hub alike.
 
 ## For donors
 

--- a/docs/volunteer/protocol.md
+++ b/docs/volunteer/protocol.md
@@ -1,0 +1,216 @@
+# Volunteer protocol documents
+
+The volunteer cycle exchanges five kinds of message: a project advertises what
+it offers, a donor advertises what they offer, a worker claims a task, a
+worker submits a result, and a verifier records the outcome. Each is a small,
+versioned, signed JSON document, defined once in
+`src/bernstein/core/protocols/volunteer/` and independent of how it travels.
+
+GitHub is one transport for these documents today (the manifest file, an
+issue comment, a PR body). A self-hosted hub is another (plain JSON over
+HTTP). Both read and write the *same* document and the *same* hash — the
+transport is a rendering choice, not part of the document's identity.
+
+## Shared substrate
+
+Every document in this layer is wrapped in the same DSSE / in-toto v1
+envelope, built by `documents.py`:
+
+- **Canonical bytes** — `canonical_bytes()` serialises a document's dict as
+  compact, recursively key-sorted, UTF-8 JSON. Two documents with the same
+  field values always produce the same bytes, regardless of construction
+  order.
+- **Digest** — `canonical_hash()` is the SHA-256 hex digest of those bytes.
+  This is a document's stable identity: unchanged by re-serialisation,
+  changed by any field.
+- **Sign / verify** — `sign_document()` / `verify_document()` wrap a
+  canonical dict in an `Envelope` (reusing
+  `bernstein.core.security.audit_dsse` wholesale — no reimplemented DSSE
+  types) and check it back. Ed25519 is deterministic (RFC 8032 §5.1.6), so
+  the same document plus the same key always produces the same signature.
+- **Predicate type** — every document shares one base predicate type,
+  `https://bernstein.run/attestations/volunteer/v1`; each document kind below
+  also defines its own more specific predicate type (for example
+  `.../claim/v1`) so a verifier can filter by kind without parsing the full
+  payload first.
+
+Each document module (`claim.py`, `project_card.py`, `worker_card.py`,
+`submission.py`, `verdict.py`) builds its own envelope with its own predicate
+type and its own `document_kind` string, using the same DSSE primitives
+`documents.py` exposes rather than a fifth copy of the canonicalisation
+logic.
+
+### Schema version policy
+
+`VOLUNTEER_DOCUMENT_SCHEMA_VERSION` (currently `"1.0.0"`) and each document's
+own `*_SCHEMA_VERSION` constant are bumped only when a predicate or document
+field set changes in a backward-incompatible way. An additive field that an
+older verifier can carry-and-ignore does not require a bump — the field
+already lives inside the predicate body and participates in the canonical
+hash, so it is detectable without a version change.
+
+## The five documents
+
+### Project card
+
+*What a project offers.* Built from a project's committed
+`.bernstein/volunteer.json` (see
+[the manifest reference](../reference/volunteer-manifest.md)) via
+`ProjectCard.from_manifest(manifest, *, task_types, demand, submitted_at)`.
+
+The dependency runs one way — `project_card.py` imports
+`bernstein.core.volunteer.manifest`, never the reverse — so the manifest
+loader gained no new dependency to make this projection possible.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `schema_version` | `str` | Defaults to `PROJECT_CARD_SCHEMA_VERSION`. |
+| `demand` | `str` | Human-readable current demand (`"high"`, `"low"`, ...). Caller-supplied — the manifest has no demand field. |
+| `task_types` | `list[str]` | Task type identifiers this project currently offers. Caller-supplied. |
+| `requirements` | `str` | Human-readable summary derived from the manifest (license, sandbox tier, wall-clock ceiling, local-model eligibility). |
+| `demand_snapshot` | `dict` | Structured snapshot: `manifest_digest` (the manifest's own digest, so a verifier can confirm which policy the card was built from), `gates_count`, `allowed_paths_count`, `task_label`. |
+| `status` | `str` | `"active"` or `"paused"` — copied from the manifest's own `status`. |
+| `submitted_at` | `str` | ISO-8601 timestamp, timezone-aware. |
+| `notes` | `str \| None` | Optional. |
+
+The manifest's `gates` are acceptance commands, not an advertisement — only
+their **count** crosses into `demand_snapshot`. A gate's argv (for example
+the exact pytest invocation) never appears on a project card.
+
+Every string field is checked against a credential-name denylist
+(case-insensitive `key`, `token`, `secret`, `password`, `credential`
+substrings) before construction succeeds.
+
+### Worker card
+
+*What a donor offers.* A closed schema: every field has a fixed, explicit
+type, and none is `dict[str, Any]` or otherwise open-ended. Unlike every
+other document in this layer, a worker card cannot carry an unknown-field
+extension bag — "preserve unknown fields verbatim" and "no free-form
+secret-bearing field" are contradictory, and this document resolves that in
+favour of being structurally incapable of carrying a credential.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `schema_version` | `str` | Defaults to `WORKER_CARD_SCHEMA_VERSION`. |
+| `task_types` | `list[str]` | Must be drawn from a fixed vocabulary (`compute`, `data-processing`, `analysis`, `documentation`, `support`). |
+| `capabilities` | `str` | Human-readable capability summary. |
+| `cpu_ceiling`, `ram_ceiling`, `gpu_ceiling` | `str` | Each one of a fixed tier vocabulary (`micro`, `small`, `medium`, `large`, `xlarge`). |
+| `sandbox_tier` | `str` | One of `microvm`, `container`, `baremetal`. |
+| `availability_window` | `str` | Human-readable (`"weekdays 9am-5pm"`, `"full-time"`, ...). |
+| `budget_posture` | `str` | One of `generous`, `modest`, `tight`, `free`. |
+| `submitted_at` | `str` | ISO-8601 timestamp, timezone-aware. |
+| `notes` | `str \| None` | Optional. |
+
+Every string field value is rejected if it contains a credential-like
+substring (`key`, `token`, `secret`, `password`, `credential`,
+case-insensitive) — a second line of defense on top of the closed field set,
+since a legitimately-typed string field could otherwise smuggle a value that
+merely looks like a capability description.
+
+A worker card is never emitted through the GitHub projection: the GitHub
+comment renderer (`github.py`) only knows claim, submission, verdict, and
+merge-receipt documents. Worker cards are published only where a donor
+explicitly enrolls with a hub — the forge (GitHub-native) path never
+publishes one, so a donor's availability and capacity stay private by
+default.
+
+### Claim
+
+*Worker X takes task Y at time T.* The simplest document in the layer, and
+the one the shared substrate and conformance harness were built and proved
+against first.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `schema_version` | `str` | Defaults to `CLAIM_SCHEMA_VERSION`. |
+| `worker_id` | `str` | Opaque identifier for the claiming worker. Non-empty. |
+| `task_id` | `str` | Opaque identifier for the task. Non-empty. |
+| `claimed_at` | `str` | ISO-8601 timestamp, timezone-aware. |
+
+`protocols/volunteer/claim.py` is distinct from
+`bernstein.core.volunteer.claim`, which implements the best-effort
+GitHub-comment etiquette for coordinator-free claim signalling. The two
+serve different roles: this module is cryptographically verifiable evidence,
+the other is a human-observable signal.
+
+### Submission
+
+*A patch reference plus a receipt bundle reference.* A submission is
+deliberately thin: everything else — the patch, the gate logs, the
+manifest digest the gates ran against — already lives inside the signed
+[result-receipt bundle](../../src/bernstein/core/security/result_receipt_bundle.py)
+it points at. A submission does not recompute or re-attest anything the
+bundle already carries; it only routes a verifier to it.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `schema_version` | `str` | Defaults to `SUBMISSION_SCHEMA_VERSION`. |
+| `receipt_bundle_digest` | `str` | The bundle's own `.digest` — a 64-char sha256 hex string, carried verbatim, never recomputed here. |
+| `receipt_bundle_location` | `str` | Where a verifier fetches the bundle: a URL, a PR artifact reference, or a hub path. |
+| `task_ref` | `dict` | `repo`, `commit_sha`, `issue_number` — field-for-field the same shape as the receipt bundle's own `TaskRef`, duplicated on purpose so a verifier can route without fetching the bundle first. The two copies are allowed to disagree; that disagreement is itself a signal worth surfacing, not something to prevent by only keeping one copy. |
+| `submitted_at` | `str` | ISO-8601 timestamp, timezone-aware. Optional (defaults to unset). |
+
+### Verification verdict
+
+*The gate re-run outcome.* A maintainer-facing pass/fail summary, not a
+second copy of the bundle's full logs — those stay in the receipt bundle,
+which already tamper-protects them field-by-field.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `schema_version` | `str` | Defaults to `VERDICT_SCHEMA_VERSION`. |
+| `submission_digest` | `str` | Which submission this verdict is about — chains verdict → submission → bundle, rather than pointing at a task id directly (which would let a verdict be replayed against a different submission for the same task). |
+| `gate_results` | `list[dict]` | One `{"command": str, "passed": bool}` entry per gate. No log text. |
+| `verifier_keyid` | `str` | keyid of the verifier who signed this verdict. |
+| `recommendation` | `str` | One of `accept`, `request-changes`, `reject`, `no-gates` — a closed enum, not free text, so a maintainer-facing UI can filter and sort by outcome. |
+| `verified_at` | `str` | ISO-8601 timestamp, timezone-aware. |
+| `notes` | `str \| None` | Optional. |
+
+## Two conformance projections
+
+`conformance.py` proves the property that makes GitHub one transport among
+several rather than a structural dependency:
+
+```
+canonical_hash(original_dict)
+    == canonical_hash(from_github_projection(to_github_projection(original_dict)))
+    == canonical_hash(from_hub_projection(to_hub_projection(original_dict)))
+```
+
+- **Hub projection** — the canonical dict serialised as plain JSON. The
+  simplest possible projection; what a hub or webhook payload carries.
+- **GitHub projection** — the document embedded in a fenced JSON block
+  inside an issue comment or PR body, wrapped in a `<!-- bernstein-volunteer-doc -->`
+  marker so it can be reliably stripped on read-back. Readable by a human
+  looking at the comment, parseable by a machine reading the same string.
+
+Both projections are lossless. `ConformanceHarness` is generic — a document
+type plugs in by registering a `to_canonical_dict` / `from_canonical_dict`
+pair, not by subclassing. `github.py` builds the per-document-kind GitHub
+projection helpers (`to_github_claim`, `to_github_submission`,
+`to_github_verdict`, plus a universal `to_github_projection` /
+`from_github_projection` dispatcher) on top of the same harness for claim,
+submission, verdict, and merge-receipt documents. Project cards and worker
+cards are not part of the GitHub-comment surface: a project card already has
+a native GitHub-native transport (the manifest file itself), and a worker
+card is deliberately never rendered through the forge path at all (see
+above).
+
+## Related: merge receipt
+
+Beyond the five documents above, `receipt.py` defines a `MergeReceipt` — the
+record that a submission was merged and any reward decision made. It closes
+the cycle (claim → submission → verdict → merge receipt) using the same DSSE
+substrate and predicate-type discipline as every other document here.
+
+## Verifying a document offline
+
+Any party holding the signer's Ed25519 public key can verify a document
+without importing bernstein code: parse the DSSE envelope, check the
+signature over the PAE-encoded payload, confirm the predicate type matches
+the document kind, and recompute the embedded document's canonical hash
+against the envelope's attested subject digest. Each module's
+`build_*_envelope` / `verify_*_envelope` pair (`build_claim_envelope` /
+`verify_claim_envelope`, and the equivalent pair for every other document
+kind) is the reference implementation of that check.

--- a/src/bernstein/core/protocols/volunteer/project_card.py
+++ b/src/bernstein/core/protocols/volunteer/project_card.py
@@ -66,6 +66,8 @@ if TYPE_CHECKING:
         Ed25519PublicKey,
     )
 
+    from bernstein.core.volunteer.manifest import VolunteerManifest
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -219,6 +221,75 @@ class ProjectCard:
     def digest(self) -> str:
         """SHA-256 hex digest of the canonical bytes (stable identity)."""
         return canonical_hash(self.to_canonical_dict())
+
+    # ---------------------------------------------------------------------------
+    # Manifest projection
+    # ---------------------------------------------------------------------------
+
+    @classmethod
+    def from_manifest(
+        cls,
+        manifest: VolunteerManifest,
+        *,
+        task_types: list[str],
+        demand: str,
+        submitted_at: str,
+        notes: str | None = None,
+    ) -> ProjectCard:
+        """Build a :class:`ProjectCard` from a project's committed manifest.
+
+        This is the manifest-loader emission path: the manifest is the
+        project's committed acceptance policy (gates, allowed paths,
+        sandbox tier); the card is a public advertisement of what the
+        project offers, built *from* that policy without ever importing it
+        back (``protocols/volunteer`` depends on ``core/volunteer``, never
+        the reverse).
+
+        ``task_types`` and ``demand`` have no source on
+        :class:`VolunteerManifest` today (task-type taxonomy and live
+        demand are hub/index concerns, not manifest fields) so the caller
+        supplies them rather than this method inventing a data source.
+
+        The manifest's ``gates`` are acceptance commands, not something to
+        publish: only their count crosses into ``demand_snapshot``, never
+        their argv content. The manifest's own digest is included so a
+        verifier can confirm the card was built from a specific, checkable
+        policy without re-deriving it.
+
+        Args:
+            manifest: The project's loaded, validated manifest.
+            task_types: Task type identifiers this project currently offers.
+                Caller-supplied; not derived from the manifest.
+            demand: Human-readable current demand description.
+                Caller-supplied; not derived from the manifest.
+            submitted_at: ISO-8601 timestamp (with timezone) for this
+                snapshot.
+            notes: Optional human-readable notes.
+
+        Returns:
+            A :class:`ProjectCard` built from the manifest's policy fields
+            plus the caller-supplied task types and demand.
+        """
+        requirements = (
+            f"license={manifest.license}; sandbox={manifest.sandbox}; "
+            f"max_wall_clock_minutes={manifest.max_wall_clock_minutes}; "
+            f"local_ok={manifest.local_ok}"
+        )
+        demand_snapshot: dict[str, Any] = {
+            "manifest_digest": manifest.digest,
+            "gates_count": len(manifest.gates),
+            "allowed_paths_count": len(manifest.allowed_paths),
+            "task_label": manifest.task_label,
+        }
+        return cls(
+            demand=demand,
+            task_types=list(task_types),
+            requirements=requirements,
+            demand_snapshot=demand_snapshot,
+            status=manifest.status,
+            submitted_at=submitted_at,
+            notes=notes,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/volunteer/test_project_card.py
+++ b/tests/unit/volunteer/test_project_card.py
@@ -7,6 +7,7 @@ guards against smuggling a credential into a string field.
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -20,12 +21,35 @@ from bernstein.core.protocols.volunteer.project_card import (
     verify_project_card_envelope,
 )
 from bernstein.core.security.audit_dsse import parse_envelope
+from bernstein.core.volunteer.manifest import GateCommand, VolunteerManifest
 
 
 def _keypair() -> tuple[Ed25519PrivateKey, Any]:
     """Generate a fresh Ed25519 keypair for testing."""
     key = Ed25519PrivateKey.generate()
     return key, key.public_key()
+
+
+def _make_manifest(**overrides: Any) -> VolunteerManifest:
+    """Build a valid VolunteerManifest for testing ``ProjectCard.from_manifest``."""
+    defaults: dict[str, Any] = {
+        "version": 1,
+        "license": "Apache-2.0",
+        "gates": (
+            GateCommand(argv=("uv", "run", "pytest", "-q")),
+            GateCommand(argv=("uv", "run", "ruff", "check", ".")),
+        ),
+        "allowed_paths": ("src/**", "tests/**"),
+        "egress_allowlist": ("pypi.org",),
+        "sandbox": "microvm",
+        "max_wall_clock_minutes": 30,
+        "task_label": "volunteer-ok",
+        "local_ok": True,
+        "status": "active",
+        "extensions": {},
+    }
+    defaults.update(overrides)
+    return VolunteerManifest(**defaults)
 
 
 def _make_project_card(**overrides: Any) -> ProjectCard:
@@ -241,3 +265,86 @@ class TestVerifyProjectCardEnvelope:
         result = verify_project_card_envelope(envelope, other_public)
         assert not result.ok
         assert result.errors != ()
+
+
+# ---------------------------------------------------------------------------
+# from_manifest projection
+# ---------------------------------------------------------------------------
+
+
+class TestProjectCardFromManifest:
+    """``ProjectCard.from_manifest`` is the manifest-loader emission path.
+
+    #3883's own acceptance criteria say the manifest loader "emits/consumes
+    the project card" -- this is that emission side. The manifest is the
+    project's committed acceptance policy (gates, paths, sandbox); the card
+    is a public advertisement of what the project offers. The two must never
+    carry the same bytes: a gate's argv is an acceptance script, not
+    something to publish, so the card carries only a count of it.
+    """
+
+    def test_project_card_from_manifest_carries_the_manifests_own_digest(self) -> None:
+        manifest = _make_manifest()
+        card = ProjectCard.from_manifest(
+            manifest,
+            task_types=["compute"],
+            demand="high",
+            submitted_at="2026-08-21T12:00:00Z",
+        )
+        assert card.demand_snapshot["manifest_digest"] == manifest.digest
+
+    def test_project_card_never_includes_gate_command_contents_only_their_count_or_names(
+        self,
+    ) -> None:
+        manifest = _make_manifest(
+            gates=(GateCommand(argv=("uv", "run", "pytest", "-q", "--secret-flag=xyz")),),
+        )
+        card = ProjectCard.from_manifest(
+            manifest,
+            task_types=["compute"],
+            demand="high",
+            submitted_at="2026-08-21T12:00:00Z",
+        )
+        canonical = json.dumps(card.to_canonical_dict())
+        assert "--secret-flag=xyz" not in canonical
+        assert "pytest" not in canonical
+        assert card.demand_snapshot["gates_count"] == 1
+
+    def test_two_project_cards_from_the_same_manifest_and_demand_hash_identically(self) -> None:
+        manifest = _make_manifest()
+        card_a = ProjectCard.from_manifest(
+            manifest,
+            task_types=["compute"],
+            demand="high",
+            submitted_at="2026-08-21T12:00:00Z",
+        )
+        card_b = ProjectCard.from_manifest(
+            manifest,
+            task_types=["compute"],
+            demand="high",
+            submitted_at="2026-08-21T12:00:00Z",
+        )
+        assert card_a.digest() == card_b.digest()
+
+    def test_project_card_from_manifest_status_matches_manifest_status(self) -> None:
+        manifest = _make_manifest(status="paused")
+        card = ProjectCard.from_manifest(
+            manifest,
+            task_types=["compute"],
+            demand="low",
+            submitted_at="2026-08-21T12:00:00Z",
+        )
+        assert card.status == "paused"
+
+    def test_project_card_from_manifest_can_be_signed_and_verified(self) -> None:
+        manifest = _make_manifest()
+        card = ProjectCard.from_manifest(
+            manifest,
+            task_types=["compute"],
+            demand="high",
+            submitted_at="2026-08-21T12:00:00Z",
+        )
+        key, public = _keypair()
+        envelope = build_project_card_envelope(card, key)
+        result = verify_project_card_envelope(envelope, public)
+        assert result.ok


### PR DESCRIPTION
## What

Closes the two acceptance-criteria gaps left open on #3883 (a rollup/tracking
issue) after its three sub-issues (#4040, #4041, #4042) merged:

1. `ProjectCard.from_manifest(manifest, *, task_types, demand, submitted_at)`
   — the manifest-loader-emits-the-project-card projection #3883's own
   acceptance criteria and #4041's brief both call for, which was missing
   from the shipped code.
2. `docs/volunteer/protocol.md` — the field-by-field description of the
   five signed volunteer protocol documents, which #4042's brief proposed
   writing but which never landed.

This PR does not add a sixth document type, does not touch the GitHub or
hub projection layer, and does not change `VolunteerManifest` itself — the
dependency stays one-way (`protocols/volunteer` imports
`core/volunteer/manifest`, never the reverse).

## Why

#3883 tracks the volunteer protocol document layer (project card, worker
card, claim, submission, verification verdict) and stays open, by its own
text, only until its checklist is confirmed against the shipped code. Two
items on that checklist were not actually satisfied at HEAD despite the
three sub-issues that were meant to deliver them being closed:

- `ProjectCard` had no constructor that builds a card from a project's
  committed manifest, so nothing in the codebase actually wired "the
  manifest loader emits... the project card."
- `docs/volunteer/protocol.md` did not exist, so the document layer had no
  single page describing what a project or a hub integrator actually reads
  or writes.

## How

- Added `ProjectCard.from_manifest` as a classmethod on `ProjectCard`. It
  derives `requirements` and `demand_snapshot` (including the manifest's own
  digest, so a verifier can confirm which policy a card was built from) from
  the manifest's already-validated fields. `task_types` and `demand` are
  caller-supplied, since neither exists on `VolunteerManifest` today. A
  manifest's gate commands never cross into the card — only their count
  does, so an acceptance script is never advertised.
- Added `docs/volunteer/protocol.md`, describing the shared DSSE substrate,
  each of the five documents' fields, the two conformance projections
  (GitHub comment / plain hub JSON), and the schema-version policy. Every
  field name in the doc's tables is checked against the shipped
  dataclasses' actual fields (a throwaway verification script; see Tests).
  Linked it from `docs/volunteer/README.md`'s "Start here" list.

## Tests

1. `test_project_card_from_manifest_carries_the_manifests_own_digest` —
   **load-bearing**. Failed before this change with
   `AttributeError: type object 'ProjectCard' has no attribute
   'from_manifest'`; confirms the card's `demand_snapshot` carries the
   manifest's own digest.
2. `test_project_card_never_includes_gate_command_contents_only_their_count_or_names`
   — a gate's argv never appears in the card's canonical JSON; only
   `gates_count` does.
3. `test_two_project_cards_from_the_same_manifest_and_demand_hash_identically`
   — determinism of the projection.
4. `test_project_card_from_manifest_status_matches_manifest_status` — a
   paused manifest produces a paused card.
5. `test_project_card_from_manifest_can_be_signed_and_verified` — the
   projected card signs and verifies through the existing DSSE envelope
   helpers unchanged.

All five in `tests/unit/volunteer/test_project_card.py`
(`TestProjectCardFromManifest`), alongside the file's existing 21 tests
(26 total, all passing).

`docs/volunteer/protocol.md`'s field tables were checked with a throwaway
script asserting every documented field name matches
`dataclasses.fields(...)` for `Claim`, `ProjectCard`, `WorkerCard`,
`Submission`, and `VerificationVerdict` — no gaps.

Ran `tests/unit/volunteer/`, `tests/unit/protocols/volunteer/`, and the
top-level `test_volunteer_claim.py` / `test_volunteer_documents.py` /
`test_volunteer_conformance.py` files (the modules this change touches or
that touch the same package) locally. `--affected origin/main` did not
complete in reasonable time on this shared machine; CI runs the full
suite.

## Checklist

- [x] `uv run ruff check src/` — clean on changed files.
- [x] `uv run ruff format --check src/` — clean on changed files.
- [x] `scripts/run_tests.py -x` on the touched and package-adjacent test
      files — all passing.
- [x] Type hints on the new `from_manifest` classmethod.
- [x] Documentation: `docs/volunteer/protocol.md` added,
      `docs/volunteer/README.md` links it. N/A: no CLI surface changed, no
      README.md/translation touched.

Part of #3883

## Remaining

Nothing outstanding against #3883's own acceptance checklist as far as this
PR's scope goes; the parent issue's rollup text says it should be closed
once a maintainer confirms the checklist against shipped code, which this
PR does not do on its own authority.
