### PR TITLE
feat(cluster): govern agent workloads by declaration, without editing their manifests (#4988)

### DIFF
--- a/docs/operations/cluster-mode.md
+++ b/docs/operations/cluster-mode.md
@@ -357,6 +357,50 @@ standard audit log (`core/security/audit.py`); see
 [Security and identity](security-and-identity.md) for the integrity
 guarantees and how to export them.
 
+## Governing workloads that are not ours
+
+`bernstein cluster` and the Helm chart govern the orchestrator's own workload.
+Agent workloads that run next to it on the same cluster are governed by
+declaration instead: a workload carries the label `bernstein.io/govern` and is
+inventoried, routed, and diffed without its manifest being edited by Bernstein.
+
+```bash
+kubectl get deploy,sts -A -o json > workloads.json
+bernstein cluster govern-inventory --manifests workloads.json --json > inventory.json
+```
+
+The inventory holds one record per workload, not one per *governed* workload:
+
+| Label                          | State        | Meaning                                              |
+| ------------------------------ | ------------ | ---------------------------------------------------- |
+| `bernstein.io/govern: enabled` | `governed`   | Telemetry is routed to the ingest boundary.          |
+| `bernstein.io/govern: disabled`| `opted_out`  | Declined governance, still listed.                   |
+| (no label)                     | `ungoverned` | Nobody enrolled it. Listed, so it can be found.      |
+
+A label value that is neither spelling is refused rather than resolved to a
+posture nobody declared, so a typo fails loudly instead of reading as "not
+governed".
+
+Pass a previous inventory to see what changed:
+
+```bash
+bernstein cluster govern-inventory --manifests workloads.json --previous inventory.json
+```
+
+A workload that drops the label reports `opted_out`; a workload that is gone from
+the cluster reports `withdrawn`. The two are distinct, and neither is a row that
+quietly stops appearing.
+
+The inventory document is in the shape `bernstein governance plan` consumes, so
+the same file feeds the posture diff without a second format. `inventory_hash`
+is a pure function of the listing's contents, not its order: two operators
+running against the same cluster get the same hash.
+
+Governed workloads' OTLP spans reach the ingest boundary under the source label
+`k8s:<namespace>/<kind>/<name>`, so the signed receipt names the workload the
+spans came from. Nothing here sits in a workload's data path, and there is no
+admission webhook: a workload is never blocked from starting.
+
 ## Code pointers
 
 | Concern                          | File                                                                            |
@@ -370,4 +414,5 @@ guarantees and how to export them.
 | Heartbeat client (library)       | `src/bernstein/core/protocols/cluster/cluster.py:396-...`                       |
 | Cluster autoscaler (optional)    | `src/bernstein/core/protocols/cluster/cluster_autoscaler.py`                    |
 | Fleet aggregator                 | `src/bernstein/core/fleet/aggregator.py`                                        |
+| Workload governance inventory    | `src/bernstein/core/govern/cluster_inventory.py`                                |
 | Models / data classes            | `src/bernstein/core/models.py` - `NodeInfo`, `NodeCapacity`, `NodeStatus`, `ClusterConfig` |

--- a/docs/release-notes/fragments/4988-cluster-govern-by-declaration.md
+++ b/docs/release-notes/fragments/4988-cluster-govern-by-declaration.md
@@ -1,0 +1,25 @@
+## `bernstein cluster govern-inventory` (Issue #4988)
+
+Governance that has to be wired per workload covers the workloads someone
+remembered. `bernstein cluster govern-inventory` reads a workload listing and
+derives each workload's posture from the `bernstein.io/govern` label it already
+carries. Nothing is written back: enrolling a workload is labelling it, not
+having its manifest edited.
+
+Every workload in the listing produces a record. An unlabelled workload is
+reported as `ungoverned` rather than skipped, an explicit opt-out as
+`opted_out`, and a label value that is neither spelling is refused instead of
+resolving to a posture nobody declared.
+
+Given an earlier inventory, the command reports what changed. A workload that
+drops the label is an `opted_out` event and a workload that has left the cluster
+is a `withdrawn` event; neither is a row that stops appearing.
+
+The inventory is the same artifact `bernstein governance plan` diffs against a
+playbook, so the posture check needs no second format, and its content hash is a
+pure function of the listing's contents rather than its order.
+
+A governed workload's OTLP spans reach the ingest boundary under the source
+label `k8s:<namespace>/<kind>/<name>`, so the signed, chain-anchored receipt
+names the workload the activity came from. The route stays out of the data path:
+there is no admission webhook and no workload is blocked from starting.

--- a/src/bernstein/cli/commands/cluster_cmd.py
+++ b/src/bernstein/cli/commands/cluster_cmd.py
@@ -30,7 +30,8 @@ def cluster_group() -> None:
     """Cluster lifecycle helpers.
 
     \b
-      bernstein cluster bootstrap-ca   # generate self-signed CA + server/node certs
+      bernstein cluster bootstrap-ca      # generate self-signed CA + server/node certs
+      bernstein cluster govern-inventory  # inventory workloads by their governance label
     """
 
 
@@ -582,3 +583,124 @@ def cluster_claims_verify(as_json: bool, journal_path: str | None, workdir: str,
         raise SystemExit(1)
     if result.forks:
         raise SystemExit(2)
+
+
+def _read_workload_listing(path: Path) -> list[dict[str, Any]]:
+    """Read a workload listing, accepting a ``kubectl`` List or a bare array."""
+    doc: Any = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(doc, list):
+        return cast("list[dict[str, Any]]", doc)
+    if isinstance(doc, dict):
+        items: Any = cast("dict[str, Any]", doc).get("items")
+        if isinstance(items, list):
+            return cast("list[dict[str, Any]]", items)
+    raise click.ClickException(f"{path}: expected a workload list or a document with an 'items' array")
+
+
+def _render_workloads(workloads: tuple[Any, ...]) -> None:
+    from rich.table import Table
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Namespace")
+    table.add_column("Kind")
+    table.add_column("Name")
+    table.add_column("State")
+    table.add_column("Label")
+    for w in workloads:
+        table.add_row(w.namespace, w.kind, w.name, w.state.value, w.label_value or "-")
+    console.print(table)
+
+
+def _render_transitions(transitions: tuple[Any, ...]) -> None:
+    from rich.table import Table
+
+    if not transitions:
+        console.print("  no governance changes since the previous inventory")
+        return
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Change")
+    table.add_column("Workload")
+    table.add_column("From")
+    table.add_column("To")
+    for t in transitions:
+        table.add_row(
+            t.kind.value,
+            t.workload_ref,
+            t.previous_state.value if t.previous_state else "-",
+            t.current_state.value if t.current_state else "-",
+        )
+    console.print(table)
+
+
+@cluster_group.command("govern-inventory")
+@click.option(
+    "--manifests",
+    "manifests_file",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Workload listing, as 'kubectl get deploy,sts -A -o json' writes it.",
+)
+@click.option(
+    "--previous",
+    "previous_file",
+    type=click.Path(exists=True, dir_okay=False),
+    default=None,
+    help="An earlier inventory document, to report governance changes against.",
+)
+@click.option(
+    "--label-key",
+    default=None,
+    help="Label declaring the posture (default: bernstein.io/govern).",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit the inventory document instead of tables.")
+def cluster_govern_inventory(
+    manifests_file: str,
+    previous_file: str | None,
+    label_key: str | None,
+    as_json: bool,
+) -> None:
+    """Inventory cluster workloads by the governance label they declare.
+
+    Reads the listing and writes nothing back: a workload is enrolled by
+    carrying the label, not by having its manifest edited here. Unlabelled and
+    opted-out workloads stay in the inventory, and ``--previous`` reports a
+    workload that left governance as a change rather than as a missing row.
+    """
+    from bernstein.core.govern.cluster_inventory import (
+        GOVERN_LABEL,
+        ClusterGovernanceError,
+        ClusterWorkload,
+        build_inventory,
+        diff_workloads,
+        inventory_workloads,
+    )
+
+    key = label_key or GOVERN_LABEL
+    try:
+        workloads = inventory_workloads(_read_workload_listing(Path(manifests_file)), label_key=key)
+        previous: tuple[Any, ...] = ()
+        if previous_file is not None:
+            prior_doc = json.loads(Path(previous_file).read_text(encoding="utf-8"))
+            previous = tuple(ClusterWorkload.from_dict(row) for row in prior_doc.get("workloads", []))
+        transitions = diff_workloads(cast("Any", previous), workloads)
+    except ClusterGovernanceError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    document = {
+        "label_key": key,
+        "workloads": [w.to_dict() for w in workloads],
+        "inventory_hash": build_inventory(workloads).content_hash(),
+        "transitions": [t.to_dict() for t in transitions],
+    }
+
+    if as_json or is_json():
+        print_json(document)
+        return
+
+    console.print()
+    console.print(f"[bold]Cluster governance inventory[/bold] label={key}")
+    _render_workloads(workloads)
+    console.print(f"  inventory hash  {document['inventory_hash']}")
+    console.print()
+    console.print("[bold]Governance changes[/bold]")
+    _render_transitions(transitions)

--- a/src/bernstein/core/govern/cluster_inventory.py
+++ b/src/bernstein/core/govern/cluster_inventory.py
@@ -1,0 +1,448 @@
+"""Cluster-scoped governance by declaration (#4988).
+
+``bernstein cluster`` and ``deploy/helm/bernstein/`` govern the orchestrator's
+own workload. An operator whose agents run as ordinary workloads next to it had
+to wire the ingest boundary by hand, once per workload -- so governance covered
+the workloads someone remembered.
+
+This module makes the coverage declarative. It is a read-only projection from a
+listing of Kubernetes workload manifests (``kubectl get ... -o json``) onto:
+
+* a :class:`ClusterWorkload` record per workload, carrying its governance
+  state as declared by a label;
+* an :class:`~bernstein.core.govern.inventory_models.Inventory` in the shape
+  :func:`~bernstein.core.govern.compute_plan` already consumes, so the posture
+  check needs no second inventory format;
+* :class:`GovernanceTransition` records diffed between two snapshots, so
+  leaving governance is an event rather than a row that stops appearing.
+
+Three properties hold by construction:
+
+* **No manifest is written.** Enrolling a workload is labelling it; nothing in
+  this module edits, patches, or annotates the manifests it reads. A workload
+  is inventoried exactly as the cluster reports it.
+* **Nothing drops out silently.** An unlabelled workload is inventoried as
+  ``UNGOVERNED`` rather than skipped, an opted-out workload as ``OPTED_OUT``,
+  and a label value that cannot be read raises instead of resolving to a
+  posture nobody declared.
+* **The projection is deterministic.** Records sort by ``(namespace, kind,
+  name)`` and carry no wall-clock or environment state, so two operators
+  listing the same cluster derive byte-identical inventories and therefore the
+  same :meth:`Inventory.content_hash`.
+
+Telemetry routing stays out of the data path: :func:`route_workload_telemetry`
+hands a governed workload's OTLP spans to the existing ingest boundary under a
+source label derived from the workload's own identity, so the signed receipt
+names which workload the spans came from. An admission webhook -- a blocking
+path -- is deliberately not part of this surface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Final, cast
+
+from bernstein.core.govern.inventory_models import Inventory, Surface
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.observability.otlp_ingest_receipt import IngestReceipt
+
+__all__ = [
+    "GOVERN_LABEL",
+    "GOVERN_LABEL_DISABLED",
+    "GOVERN_LABEL_ENABLED",
+    "ClusterGovernanceError",
+    "ClusterWorkload",
+    "GovernanceState",
+    "GovernanceTransition",
+    "TransitionKind",
+    "build_inventory",
+    "diff_workloads",
+    "inventory_workloads",
+    "route_workload_telemetry",
+    "telemetry_source_label",
+]
+
+#: Label key a workload sets to declare its governance posture. The key sits in
+#: the same group as the CRDs in :mod:`bernstein.core.orchestration.operator`.
+GOVERN_LABEL: Final = "bernstein.io/govern"
+
+#: Label value enrolling a workload into governance.
+GOVERN_LABEL_ENABLED: Final = "enabled"
+
+#: Label value opting a workload out. The workload stays in the inventory.
+GOVERN_LABEL_DISABLED: Final = "disabled"
+
+#: Accepted spellings, normalised to lower case with surrounding space stripped.
+#: ``"true"``/``"false"`` are accepted because Kubernetes tooling renders
+#: boolean-looking values that way; anything else is a typo, not a posture.
+_ENABLED_VALUES: Final = frozenset({GOVERN_LABEL_ENABLED, "true"})
+_DISABLED_VALUES: Final = frozenset({GOVERN_LABEL_DISABLED, "false"})
+
+#: Namespace assumed when a manifest omits one, matching ``kubectl`` behaviour.
+_DEFAULT_NAMESPACE: Final = "default"
+
+
+class ClusterGovernanceError(ValueError):
+    """Raised when a workload listing cannot be projected onto a posture."""
+
+
+class GovernanceState(Enum):
+    """Governance posture a workload declares through its label.
+
+    - ``GOVERNED``: the label enrols the workload; its telemetry is routed to
+      the ingest boundary and its posture is diffed against the playbook.
+    - ``OPTED_OUT``: the label explicitly declines governance. The workload is
+      still inventoried, so opting out is visible rather than absent.
+    - ``UNGOVERNED``: no label. Reported, never omitted -- an unlabelled
+      workload is the case the inventory exists to surface.
+    """
+
+    GOVERNED = "governed"
+    OPTED_OUT = "opted_out"
+    UNGOVERNED = "ungoverned"
+
+
+class TransitionKind(Enum):
+    """How a workload's governance changed between two inventory snapshots.
+
+    - ``ENROLLED``: the workload became governed (labelled, or arrived
+      already labelled).
+    - ``OPTED_OUT``: the workload stopped being governed while still running.
+      Removing the label lands here, so it is an event and not a silent
+      disappearance from the inventory.
+    - ``APPEARED``: a new workload that is not governed.
+    - ``WITHDRAWN``: the workload is no longer in the listing at all. Distinct
+      from ``OPTED_OUT``: the workload is gone, not merely unenrolled.
+    """
+
+    ENROLLED = "enrolled"
+    OPTED_OUT = "opted_out"
+    APPEARED = "appeared"
+    WITHDRAWN = "withdrawn"
+
+
+def telemetry_source_label(namespace: str, kind: str, name: str) -> str:
+    """Return the ingest source label identifying one cluster workload.
+
+    The same string identifies the workload as an inventory surface, so a
+    signed ingest receipt and a govern-plan entry name the workload the same
+    way and can be joined without a lookup table.
+    """
+    return f"k8s:{namespace}/{kind}/{name}"
+
+
+@dataclass(frozen=True, slots=True)
+class ClusterWorkload:
+    """One workload as the cluster reports it, plus its declared posture.
+
+    Attributes:
+        uid: The workload's ``metadata.uid``, or its reference when the
+            listing came from files rather than the API and carries no uid.
+        namespace: The workload's namespace.
+        kind: The workload's kind (``Deployment``, ``StatefulSet``, ...).
+        name: The workload's name.
+        state: Posture declared by :data:`GOVERN_LABEL`.
+        label_value: The label value as written, or ``None`` when unlabelled.
+            Kept verbatim so the inventory reports what the cluster says.
+    """
+
+    uid: str
+    namespace: str
+    kind: str
+    name: str
+    state: GovernanceState
+    label_value: str | None
+
+    @property
+    def ref(self) -> str:
+        """Return ``namespace/kind/name``, the workload's stable identity."""
+        return f"{self.namespace}/{self.kind}/{self.name}"
+
+    @property
+    def telemetry_source_label(self) -> str:
+        """Return the ingest source label this workload's spans arrive under."""
+        return telemetry_source_label(self.namespace, self.kind, self.name)
+
+    def to_surface(self) -> Surface:
+        """Return this workload as a govern-plan inventory surface."""
+        return Surface(
+            surface=self.telemetry_source_label,
+            observed_value=self.state.value,
+            evidence_ref=f"uid:{self.uid}",
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical serialization."""
+        return {
+            "uid": self.uid,
+            "namespace": self.namespace,
+            "kind": self.kind,
+            "name": self.name,
+            "state": self.state.value,
+            "label_value": self.label_value,
+            "telemetry_source_label": self.telemetry_source_label,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> ClusterWorkload:
+        """Rebuild a workload record from its serialized form."""
+        try:
+            state = GovernanceState(str(raw["state"]))
+        except (KeyError, ValueError) as exc:
+            raise ClusterGovernanceError(f"malformed workload record: {exc}") from exc
+        label_value = raw.get("label_value")
+        return cls(
+            uid=str(raw["uid"]),
+            namespace=str(raw["namespace"]),
+            kind=str(raw["kind"]),
+            name=str(raw["name"]),
+            state=state,
+            label_value=None if label_value is None else str(label_value),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class GovernanceTransition:
+    """One governance change between two inventory snapshots.
+
+    Attributes:
+        kind: What changed.
+        workload_ref: ``namespace/kind/name`` of the workload that changed.
+        uid: The workload's uid from whichever snapshot still has it.
+        previous_state: Posture in the earlier snapshot, ``None`` when the
+            workload was not in it.
+        current_state: Posture in the later snapshot, ``None`` when the
+            workload is no longer in it.
+    """
+
+    kind: TransitionKind
+    workload_ref: str
+    uid: str
+    previous_state: GovernanceState | None
+    current_state: GovernanceState | None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical serialization."""
+        return {
+            "kind": self.kind.value,
+            "workload_ref": self.workload_ref,
+            "uid": self.uid,
+            "previous_state": None if self.previous_state is None else self.previous_state.value,
+            "current_state": None if self.current_state is None else self.current_state.value,
+        }
+
+
+def _declared_state(label_value: str | None, *, ref: str, label_key: str) -> GovernanceState:
+    """Resolve a label value onto a posture, refusing values nobody declared."""
+    if label_value is None:
+        return GovernanceState.UNGOVERNED
+    normalised = label_value.strip().lower()
+    if normalised in _ENABLED_VALUES:
+        return GovernanceState.GOVERNED
+    if normalised in _DISABLED_VALUES:
+        return GovernanceState.OPTED_OUT
+    raise ClusterGovernanceError(
+        f"{ref}: label {label_key}={label_value!r} is not a governance declaration; "
+        f"expected one of {sorted(_ENABLED_VALUES | _DISABLED_VALUES)}"
+    )
+
+
+def _read_workload(manifest: dict[str, Any], *, label_key: str) -> ClusterWorkload:
+    """Project one manifest onto a record. Reads only; never writes back."""
+    metadata_raw = manifest.get("metadata")
+    if not isinstance(metadata_raw, dict):
+        raise ClusterGovernanceError("workload manifest has no metadata object")
+    metadata = cast("dict[str, Any]", metadata_raw)
+
+    name = str(metadata.get("name") or "")
+    if not name:
+        raise ClusterGovernanceError("workload manifest has no metadata.name")
+    kind = str(manifest.get("kind") or "")
+    if not kind:
+        raise ClusterGovernanceError(f"{name}: workload manifest has no kind")
+    namespace = str(metadata.get("namespace") or _DEFAULT_NAMESPACE)
+    ref = f"{namespace}/{kind}/{name}"
+
+    labels_raw: Any = metadata.get("labels") or {}
+    if not isinstance(labels_raw, dict):
+        raise ClusterGovernanceError(f"{ref}: metadata.labels is not a mapping")
+    labels = cast("dict[str, Any]", labels_raw)
+    raw_label: Any = labels.get(label_key)
+    label_value = None if raw_label is None else str(raw_label)
+
+    # A manifest read from a file carries no uid. Falling back to the reference
+    # keeps such a listing usable while still giving every record an evidence
+    # anchor, rather than refusing the whole listing over a server-side field.
+    uid = str(metadata.get("uid") or ref)
+
+    return ClusterWorkload(
+        uid=uid,
+        namespace=namespace,
+        kind=kind,
+        name=name,
+        state=_declared_state(label_value, ref=ref, label_key=label_key),
+        label_value=label_value,
+    )
+
+
+def inventory_workloads(
+    manifests: list[dict[str, Any]],
+    *,
+    label_key: str = GOVERN_LABEL,
+) -> tuple[ClusterWorkload, ...]:
+    """Inventory *manifests* by their declared governance posture.
+
+    Every manifest produces a record: governed, opted out, or ungoverned. None
+    is skipped, and none is modified -- the manifests are read and the records
+    are new objects, so enrolling a workload never means editing it.
+
+    Records are sorted by ``(namespace, kind, name)`` so the projection is a
+    pure function of the listing's contents, not its order.
+
+    Args:
+        manifests: Workload manifests, as ``kubectl get ... -o json`` reports
+            them under ``items``.
+        label_key: Label declaring the posture. Overridable so an operator
+            running more than one governance domain can key on their own label.
+
+    Returns:
+        The workload records, sorted.
+
+    Raises:
+        ClusterGovernanceError: When a manifest is not a workload, when the
+            label carries a value that is not a governance declaration, or when
+            two manifests describe the same workload.
+    """
+    records = [_read_workload(m, label_key=label_key) for m in manifests]
+
+    seen: dict[str, ClusterWorkload] = {}
+    for record in records:
+        if record.ref in seen:
+            raise ClusterGovernanceError(f"{record.ref}: listed twice; a workload has one posture, not two")
+        seen[record.ref] = record
+
+    return tuple(sorted(records, key=lambda w: (w.namespace, w.kind, w.name)))
+
+
+def build_inventory(workloads: tuple[ClusterWorkload, ...]) -> Inventory:
+    """Return *workloads* as a govern-plan inventory.
+
+    The result feeds :func:`~bernstein.core.govern.compute_plan` directly: the
+    cluster inventory and the posture inventory are one artifact, so a playbook
+    clause names a workload by the same identifier its ingest receipts carry.
+    """
+    return Inventory(surfaces=tuple(w.to_surface() for w in workloads))
+
+
+def diff_workloads(
+    previous: tuple[ClusterWorkload, ...],
+    current: tuple[ClusterWorkload, ...],
+) -> tuple[GovernanceTransition, ...]:
+    """Return the governance transitions between two inventory snapshots.
+
+    Leaving governance always produces a record. A workload that removes the
+    label yields ``OPTED_OUT``; a workload that is gone from the listing yields
+    ``WITHDRAWN``. The two are distinct because "stopped being governed" and
+    "stopped existing" call for different operator responses.
+
+    Transitions are ordered by workload reference, so the same pair of
+    snapshots yields the same list on any host.
+    """
+    before = {w.ref: w for w in previous}
+    after = {w.ref: w for w in current}
+
+    transitions: list[GovernanceTransition] = []
+    for ref in sorted(before.keys() | after.keys()):
+        prior = before.get(ref)
+        now = after.get(ref)
+
+        if now is None:
+            gone = before[ref]
+            transitions.append(
+                GovernanceTransition(
+                    kind=TransitionKind.WITHDRAWN,
+                    workload_ref=ref,
+                    uid=gone.uid,
+                    previous_state=gone.state,
+                    current_state=None,
+                )
+            )
+            continue
+
+        if prior is None:
+            kind = TransitionKind.ENROLLED if now.state is GovernanceState.GOVERNED else TransitionKind.APPEARED
+            transitions.append(
+                GovernanceTransition(
+                    kind=kind,
+                    workload_ref=ref,
+                    uid=now.uid,
+                    previous_state=None,
+                    current_state=now.state,
+                )
+            )
+            continue
+
+        if prior.state is now.state:
+            continue
+        kind = TransitionKind.ENROLLED if now.state is GovernanceState.GOVERNED else TransitionKind.OPTED_OUT
+        transitions.append(
+            GovernanceTransition(
+                kind=kind,
+                workload_ref=ref,
+                uid=now.uid,
+                previous_state=prior.state,
+                current_state=now.state,
+            )
+        )
+
+    return tuple(transitions)
+
+
+def route_workload_telemetry(
+    workload: ClusterWorkload,
+    spans: list[dict[str, Any]],
+    *,
+    audit_dir: Path,
+    hmac_key: bytes,
+    profile_name: str = "generic",
+) -> IngestReceipt:
+    """Route one governed workload's OTLP spans to the ingest boundary.
+
+    The spans are handed to
+    :class:`~bernstein.core.observability.otlp_ingest_receipt.IngestOTLPReceipt`
+    under the workload's own source label, so the signed, chain-anchored
+    receipt names which workload the activity came from. Nothing here sits in
+    the workload's data path: the operator points a collector at Bernstein and
+    the route is chosen by the label the workload already carries.
+
+    Args:
+        workload: The workload the spans belong to.
+        spans: OTLP/JSON spans in the order the source submitted them.
+        audit_dir: Audit-chain directory the receipt anchors into.
+        hmac_key: The audit-chain HMAC key.
+        profile_name: Ingest profile driving attribute mapping.
+
+    Returns:
+        The signed :class:`IngestReceipt` for the batch.
+
+    Raises:
+        ClusterGovernanceError: When *workload* is not governed. Opting out
+            stops ingest; it does not quietly keep ingesting.
+    """
+    if workload.state is not GovernanceState.GOVERNED:
+        raise ClusterGovernanceError(f"{workload.ref}: telemetry not routed, workload state is {workload.state.value}")
+
+    from bernstein.core.observability.otlp_ingest_receipt import IngestOTLPReceipt
+
+    boundary = IngestOTLPReceipt(
+        source_label=workload.telemetry_source_label,
+        profile_name=profile_name,
+        audit_dir=audit_dir,
+        hmac_key=hmac_key,
+    )
+    receipt, _ = boundary.ingest_batch(spans)
+    return receipt

--- a/tests/fixtures/cluster/agent-workloads.json
+++ b/tests/fixtures/cluster/agent-workloads.json
@@ -1,0 +1,47 @@
+{
+  "apiVersion": "v1",
+  "kind": "List",
+  "items": [
+    {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "metadata": {
+        "name": "research-agent",
+        "namespace": "agents",
+        "uid": "3f2b1c40-0f3a-4a7e-9f2f-11d9c0a1b2c3",
+        "labels": {
+          "app.kubernetes.io/name": "research-agent",
+          "bernstein.io/govern": "enabled"
+        }
+      },
+      "spec": {"replicas": 2}
+    },
+    {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "metadata": {
+        "name": "scratch-agent",
+        "namespace": "agents",
+        "uid": "9a8b7c60-1d2e-4f30-8a1b-22e0d1f2a3b4",
+        "labels": {
+          "app.kubernetes.io/name": "scratch-agent"
+        }
+      },
+      "spec": {"replicas": 1}
+    },
+    {
+      "apiVersion": "apps/v1",
+      "kind": "StatefulSet",
+      "metadata": {
+        "name": "batch-agent",
+        "namespace": "agents",
+        "uid": "5c4d3e20-2a1b-4c5d-9e8f-33a1b2c3d4e5",
+        "labels": {
+          "app.kubernetes.io/name": "batch-agent",
+          "bernstein.io/govern": "disabled"
+        }
+      },
+      "spec": {"replicas": 1}
+    }
+  ]
+}

--- a/tests/unit/cli/test_cluster_govern_inventory_cmd.py
+++ b/tests/unit/cli/test_cluster_govern_inventory_cmd.py
@@ -1,0 +1,87 @@
+"""``bernstein cluster govern-inventory``: the operator surface for #4988.
+
+13. test_cli_lists_every_workload_and_leaves_the_listing_file_untouched
+14. test_cli_reports_leaving_governance_against_a_previous_inventory
+15. test_cli_rejects_a_label_value_that_is_not_a_declaration
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.cluster_cmd import cluster_group
+
+FIXTURE = Path(__file__).resolve().parents[3] / "tests" / "fixtures" / "cluster" / "agent-workloads.json"
+
+
+def _write_listing(tmp_path: Path, items: list[dict[str, Any]]) -> Path:
+    path = tmp_path / "workloads.json"
+    path.write_text(json.dumps({"kind": "List", "items": items}), encoding="utf-8")
+    return path
+
+
+def _fixture_items() -> list[dict[str, Any]]:
+    return list(json.loads(FIXTURE.read_text(encoding="utf-8"))["items"])
+
+
+def test_cli_lists_every_workload_and_leaves_the_listing_file_untouched(tmp_path: Path) -> None:
+    listing = _write_listing(tmp_path, _fixture_items())
+    before = listing.read_bytes()
+
+    result = CliRunner().invoke(cluster_group, ["govern-inventory", "--manifests", str(listing), "--json"])
+
+    assert result.exit_code == 0, result.output
+    document = json.loads(result.output)
+    states = {w["name"]: w["state"] for w in document["workloads"]}
+    assert states == {
+        "batch-agent": "opted_out",
+        "research-agent": "governed",
+        "scratch-agent": "ungoverned",
+    }
+    assert document["inventory_hash"].startswith("sha256:")
+    assert listing.read_bytes() == before
+
+
+def test_cli_reports_leaving_governance_against_a_previous_inventory(tmp_path: Path) -> None:
+    runner = CliRunner()
+    listing = _write_listing(tmp_path, _fixture_items())
+    first = runner.invoke(cluster_group, ["govern-inventory", "--manifests", str(listing), "--json"])
+    assert first.exit_code == 0, first.output
+    previous = tmp_path / "previous.json"
+    previous.write_text(first.output, encoding="utf-8")
+
+    unlabelled = _fixture_items()
+    del unlabelled[0]["metadata"]["labels"]["bernstein.io/govern"]
+    later = _write_listing(tmp_path, unlabelled)
+
+    result = runner.invoke(
+        cluster_group,
+        ["govern-inventory", "--manifests", str(later), "--previous", str(previous), "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    transitions = json.loads(result.output)["transitions"]
+    assert transitions == [
+        {
+            "kind": "opted_out",
+            "workload_ref": "agents/Deployment/research-agent",
+            "uid": "3f2b1c40-0f3a-4a7e-9f2f-11d9c0a1b2c3",
+            "previous_state": "governed",
+            "current_state": "ungoverned",
+        }
+    ]
+
+
+def test_cli_rejects_a_label_value_that_is_not_a_declaration(tmp_path: Path) -> None:
+    items = _fixture_items()
+    items[0]["metadata"]["labels"]["bernstein.io/govern"] = "enabledd"
+    listing = _write_listing(tmp_path, items)
+
+    result = CliRunner().invoke(cluster_group, ["govern-inventory", "--manifests", str(listing), "--json"])
+
+    assert result.exit_code != 0
+    assert "enabledd" in result.output

--- a/tests/unit/core/govern/test_cluster_inventory.py
+++ b/tests/unit/core/govern/test_cluster_inventory.py
@@ -26,7 +26,6 @@ from typing import Any
 import pytest
 
 from bernstein.core.govern import compute_plan
-from bernstein.core.govern.plan_models import PlanEntryKind
 from bernstein.core.govern.cluster_inventory import (
     GOVERN_LABEL,
     ClusterGovernanceError,
@@ -38,6 +37,7 @@ from bernstein.core.govern.cluster_inventory import (
     route_workload_telemetry,
     telemetry_source_label,
 )
+from bernstein.core.govern.plan_models import PlanEntryKind
 
 FIXTURE = Path(__file__).resolve().parents[4] / "tests" / "fixtures" / "cluster" / "agent-workloads.json"
 

--- a/tests/unit/core/govern/test_cluster_inventory.py
+++ b/tests/unit/core/govern/test_cluster_inventory.py
@@ -1,0 +1,302 @@
+"""Cluster-scoped governance by declaration (issue #4988).
+
+The properties under test, each named for what it protects:
+
+1. test_labelled_workload_is_inventoried_without_mutating_its_manifest
+2. test_unlabelled_workload_is_reported_ungoverned_not_omitted
+3. test_explicit_opt_out_label_is_recorded_not_dropped
+4. test_unrecognised_label_value_is_rejected_not_read_as_ungoverned
+5. test_inventory_is_identical_regardless_of_listing_order
+6. test_removing_the_label_emits_an_opt_out_transition
+7. test_deleted_workload_emits_withdrawn_not_opt_out
+8. test_new_labelled_workload_is_enrolled_without_a_manifest_edit
+9. test_unchanged_workload_emits_no_transition
+10. test_governed_workload_telemetry_is_anchored_under_its_own_source_label
+11. test_opted_out_workload_telemetry_is_refused_by_the_route
+12. test_inventory_feeds_the_playbook_diff_without_translation
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.govern import compute_plan
+from bernstein.core.govern.plan_models import PlanEntryKind
+from bernstein.core.govern.cluster_inventory import (
+    GOVERN_LABEL,
+    ClusterGovernanceError,
+    GovernanceState,
+    TransitionKind,
+    build_inventory,
+    diff_workloads,
+    inventory_workloads,
+    route_workload_telemetry,
+    telemetry_source_label,
+)
+
+FIXTURE = Path(__file__).resolve().parents[4] / "tests" / "fixtures" / "cluster" / "agent-workloads.json"
+
+
+def _fixture_items() -> list[dict[str, Any]]:
+    return list(json.loads(FIXTURE.read_text(encoding="utf-8"))["items"])
+
+
+def _workload(
+    name: str,
+    *,
+    namespace: str = "agents",
+    kind: str = "Deployment",
+    uid: str | None = None,
+    label: str | None = "enabled",
+) -> dict[str, Any]:
+    labels: dict[str, str] = {"app.kubernetes.io/name": name}
+    if label is not None:
+        labels[GOVERN_LABEL] = label
+    return {
+        "apiVersion": "apps/v1",
+        "kind": kind,
+        "metadata": {
+            "name": name,
+            "namespace": namespace,
+            "uid": uid or f"uid-{name}",
+            "labels": labels,
+        },
+    }
+
+
+def _by_name(workloads: Any, name: str) -> Any:
+    for w in workloads:
+        if w.name == name:
+            return w
+    raise AssertionError(f"{name} missing from inventory")
+
+
+@pytest.fixture
+def audit_chain(tmp_path: Path) -> tuple[Path, bytes]:
+    audit_dir = tmp_path / "audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    return audit_dir, b"k" * 32
+
+
+def _genai_span(span_id: str = "f1e2d3c4b5a69788") -> dict[str, Any]:
+    return {
+        "traceId": "abc123def456abc123def456abc123de",
+        "spanId": span_id,
+        "name": "gen_ai.chat",
+        "kind": "SPAN_KIND_CLIENT",
+        "attributes": [
+            {"key": "gen_ai.system", "value": {"stringValue": "anthropic"}},
+            {"key": "gen_ai.operation.name", "value": {"stringValue": "chat"}},
+        ],
+    }
+
+
+# 1 --------------------------------------------------------------------------
+
+
+def test_labelled_workload_is_inventoried_without_mutating_its_manifest() -> None:
+    """Governance by declaration reads manifests; it never writes them back."""
+    items = _fixture_items()
+    pristine = copy.deepcopy(items)
+
+    workloads = inventory_workloads(items)
+
+    governed = _by_name(workloads, "research-agent")
+    assert governed.state is GovernanceState.GOVERNED
+    assert governed.namespace == "agents"
+    assert governed.kind == "Deployment"
+    assert governed.telemetry_source_label == telemetry_source_label("agents", "Deployment", "research-agent")
+    assert items == pristine
+
+
+# 2 --------------------------------------------------------------------------
+
+
+def test_unlabelled_workload_is_reported_ungoverned_not_omitted() -> None:
+    """A workload nobody labelled stays visible, marked ungoverned."""
+    workloads = inventory_workloads(_fixture_items())
+
+    names = {w.name for w in workloads}
+    assert names == {"research-agent", "scratch-agent", "batch-agent"}
+
+    scratch = _by_name(workloads, "scratch-agent")
+    assert scratch.state is GovernanceState.UNGOVERNED
+    assert scratch.label_value is None
+
+
+# 3 --------------------------------------------------------------------------
+
+
+def test_explicit_opt_out_label_is_recorded_not_dropped() -> None:
+    """An opted-out workload is inventoried as opted out, not deleted."""
+    workloads = inventory_workloads(_fixture_items())
+
+    batch = _by_name(workloads, "batch-agent")
+    assert batch.state is GovernanceState.OPTED_OUT
+    assert batch.label_value == "disabled"
+
+
+# 4 --------------------------------------------------------------------------
+
+
+def test_unrecognised_label_value_is_rejected_not_read_as_ungoverned() -> None:
+    """A declaration that cannot be read must not resolve to a posture."""
+    with pytest.raises(ClusterGovernanceError) as exc:
+        inventory_workloads([_workload("typo-agent", label="enabledd")])
+
+    assert "typo-agent" in str(exc.value)
+    assert "enabledd" in str(exc.value)
+
+
+# 5 --------------------------------------------------------------------------
+
+
+def test_inventory_is_identical_regardless_of_listing_order() -> None:
+    """Two operators listing the same cluster get the same inventory hash."""
+    items = _fixture_items()
+    forward = build_inventory(inventory_workloads(items))
+    reversed_ = build_inventory(inventory_workloads(list(reversed(items))))
+
+    assert forward.content_hash() == reversed_.content_hash()
+
+
+# 6 --------------------------------------------------------------------------
+
+
+def test_removing_the_label_emits_an_opt_out_transition() -> None:
+    """Dropping the label is an event, not a silent disappearance."""
+    before = inventory_workloads([_workload("research-agent", label="enabled")])
+    after = inventory_workloads([_workload("research-agent", label=None)])
+
+    transitions = diff_workloads(before, after)
+
+    assert [t.kind for t in transitions] == [TransitionKind.OPTED_OUT]
+    only = transitions[0]
+    assert only.workload_ref == "agents/Deployment/research-agent"
+    assert only.previous_state is GovernanceState.GOVERNED
+    assert only.current_state is GovernanceState.UNGOVERNED
+
+
+# 7 --------------------------------------------------------------------------
+
+
+def test_deleted_workload_emits_withdrawn_not_opt_out() -> None:
+    """A workload that is gone is reported as gone, distinctly from opting out."""
+    before = inventory_workloads([_workload("research-agent"), _workload("batch-agent")])
+    after = inventory_workloads([_workload("research-agent")])
+
+    transitions = diff_workloads(before, after)
+
+    assert [t.kind for t in transitions] == [TransitionKind.WITHDRAWN]
+    assert transitions[0].workload_ref == "agents/Deployment/batch-agent"
+    assert transitions[0].current_state is None
+
+
+# 8 --------------------------------------------------------------------------
+
+
+def test_new_labelled_workload_is_enrolled_without_a_manifest_edit() -> None:
+    """A workload that arrives already labelled inherits the posture."""
+    before = inventory_workloads([_workload("research-agent")])
+    after_items = [_workload("research-agent"), _workload("new-agent", label="enabled")]
+    pristine = copy.deepcopy(after_items)
+    after = inventory_workloads(after_items)
+
+    transitions = diff_workloads(before, after)
+
+    assert [t.kind for t in transitions] == [TransitionKind.ENROLLED]
+    assert transitions[0].workload_ref == "agents/Deployment/new-agent"
+    assert transitions[0].previous_state is None
+    assert after_items == pristine
+
+
+# 9 --------------------------------------------------------------------------
+
+
+def test_unchanged_workload_emits_no_transition() -> None:
+    """A steady cluster produces an empty transition list."""
+    snapshot = inventory_workloads(_fixture_items())
+
+    assert diff_workloads(snapshot, snapshot) == ()
+
+
+# 10 -------------------------------------------------------------------------
+
+
+def test_governed_workload_telemetry_is_anchored_under_its_own_source_label(
+    audit_chain: tuple[Path, bytes],
+) -> None:
+    """The route carries workload identity into the signed ingest receipt."""
+    audit_dir, hmac_key = audit_chain
+    governed = _by_name(inventory_workloads(_fixture_items()), "research-agent")
+
+    receipt = route_workload_telemetry(
+        governed,
+        [_genai_span()],
+        audit_dir=audit_dir,
+        hmac_key=hmac_key,
+    )
+
+    assert receipt.source_label == "k8s:agents/Deployment/research-agent"
+    assert receipt.span_count == 1
+    assert receipt.signature
+    assert receipt.chain_entry_hash
+
+
+# 11 -------------------------------------------------------------------------
+
+
+def test_opted_out_workload_telemetry_is_refused_by_the_route(
+    audit_chain: tuple[Path, bytes],
+) -> None:
+    """Opting out stops ingest; it does not silently keep ingesting."""
+    audit_dir, hmac_key = audit_chain
+    opted_out = _by_name(inventory_workloads(_fixture_items()), "batch-agent")
+
+    with pytest.raises(ClusterGovernanceError) as exc:
+        route_workload_telemetry(
+            opted_out,
+            [_genai_span()],
+            audit_dir=audit_dir,
+            hmac_key=hmac_key,
+        )
+
+    assert "opted_out" in str(exc.value)
+
+
+# 12 -------------------------------------------------------------------------
+
+
+def test_inventory_feeds_the_playbook_diff_without_translation() -> None:
+    """The cluster inventory is the govern-plan inventory, not a parallel one."""
+    inventory = build_inventory(inventory_workloads(_fixture_items()))
+
+    plan = compute_plan(
+        playbook={
+            "forbidden": [
+                {
+                    "surface": "k8s:agents/Deployment/scratch-agent",
+                    "clause": "no ad-hoc agent workloads in the agents namespace",
+                }
+            ],
+            "required": [
+                {
+                    "surface": "k8s:agents/Deployment/audit-agent",
+                    "clause": "the audit agent runs in every cluster",
+                    "declared_value": "governed",
+                }
+            ],
+        },
+        inventory=inventory.to_dict(),
+        run_id="cluster-govern",
+        timestamp=1_788_000_000,
+    )
+
+    seen = {e.surface: (e.kind, e.observed_value) for e in plan.entries}
+    assert seen["k8s:agents/Deployment/scratch-agent"] == (PlanEntryKind.FORBIDDEN, "ungoverned")
+    assert seen["k8s:agents/Deployment/audit-agent"][0] is PlanEntryKind.ABSENT


### PR DESCRIPTION
## What

A cluster-scoped surface that governs agent workloads by declaration: `bernstein cluster govern-inventory` reads a Kubernetes workload listing and derives each workload's posture from the `bernstein.io/govern` label it already carries, without editing any manifest.

In scope:

- `src/bernstein/core/govern/cluster_inventory.py` — a read-only projection from a workload listing onto workload records, a govern-plan `Inventory`, and the governance transitions between two snapshots.
- `route_workload_telemetry()` — hands a governed workload's OTLP spans to the existing ingest boundary under a source label derived from the workload's own identity.
- `bernstein cluster govern-inventory` — the operator command over that projection.
- Operator documentation and a release-note fragment.

Explicitly **not** in scope, matching the issue:

- No admission webhook and no blocking path. Nothing added here can stop a workload from starting.
- No multi-cluster federation.
- No change to `deploy/helm/bernstein/`. The issue's "Where to start" says the chart is generated by `scripts/gen_distribution_manifests.py` and that a drift test covers it; neither is true at HEAD — that script writes `server.json`, `.plugin/plugin.json`, `plugin.json`, `mcp.json` and `CITATION.cff` (`scripts/gen_distribution_manifests.py:64-70`), and no test references `deploy/helm/bernstein/`. Shipping the chart change would have meant hand-editing a chart the issue says never to hand-edit, so that acceptance item is left for a follow-up that first decides how the chart is generated.

## Why

`bernstein cluster` and the Helm chart govern the orchestrator's own workload. An operator whose agents run as ordinary workloads next to it had to wire the ingest boundary by hand, once per workload — so the governed set was whatever someone remembered to wire. The inventory the posture check consumes (`src/bernstein/core/govern/__init__.py`) had no producer for cluster workloads at all, so `bernstein governance plan` could not be pointed at a cluster.

The failure mode worth designing against is not "a workload is missed" but "a workload stops being reported and nobody notices". An inventory that lists only governed workloads makes leaving governance look identical to never having been enrolled, and identical to the workload being deleted.

## How

The projection reads manifests and writes new records; nothing in the module edits, patches, or annotates what it read. Enrolling a workload is labelling it.

Every workload in the listing produces a record:

| Label | State |
| --- | --- |
| `bernstein.io/govern: enabled` | `governed` — telemetry routed to the ingest boundary |
| `bernstein.io/govern: disabled` | `opted_out` — declined, still listed |
| (absent) | `ungoverned` — listed, so it can be found |

`diff_workloads()` separates the two ways of leaving: a workload that drops the label is `opted_out`, a workload gone from the listing is `withdrawn`.

Records sort by `(namespace, kind, name)` and carry no wall-clock or environment state, so the inventory's `content_hash()` is a function of the listing's contents rather than its order — two operators against the same cluster derive the same hash.

`build_inventory()` returns the inventory in the shape `compute_plan()` already consumes, so the posture check needs no second format and a playbook clause names a workload by the same identifier its ingest receipts carry: `k8s:<namespace>/<kind>/<name>`.

`route_workload_telemetry()` constructs `IngestOTLPReceipt` with that identifier as `source_label`, so the signed, chain-anchored receipt names the workload the spans came from. It refuses a workload that is not governed, so opting out stops ingest rather than quietly continuing it.

**The open decision, and how it was resolved.** A label value that is neither spelling — `enabledd`, `yes`, `1` — could be read as "not governed" or refused. It is refused (`ClusterGovernanceError`, naming the workload and the value), because reading an unparseable declaration as "ungoverned" reproduces exactly the silent-disappearance failure this surface exists to prevent: a typo would drop a workload out of governance with no event. `true`/`false` are accepted alongside `enabled`/`disabled` because Kubernetes tooling renders boolean-looking values that way; everything else is a typo, not a posture.

## Tests

`tests/unit/core/govern/test_cluster_inventory.py`:

1. `test_labelled_workload_is_inventoried_without_mutating_its_manifest` — **load-bearing**: governance by declaration is only true if the projection never writes back. Asserts the input manifests are byte-identical after the call.
2. `test_unlabelled_workload_is_reported_ungoverned_not_omitted`
3. `test_explicit_opt_out_label_is_recorded_not_dropped`
4. `test_unrecognised_label_value_is_rejected_not_read_as_ungoverned`
5. `test_inventory_is_identical_regardless_of_listing_order`
6. `test_removing_the_label_emits_an_opt_out_transition`
7. `test_deleted_workload_emits_withdrawn_not_opt_out`
8. `test_new_labelled_workload_is_enrolled_without_a_manifest_edit`
9. `test_unchanged_workload_emits_no_transition`
10. `test_governed_workload_telemetry_is_anchored_under_its_own_source_label`
11. `test_opted_out_workload_telemetry_is_refused_by_the_route`
12. `test_inventory_feeds_the_playbook_diff_without_translation`

`tests/unit/cli/test_cluster_govern_inventory_cmd.py`:

13. `test_cli_lists_every_workload_and_leaves_the_listing_file_untouched`
14. `test_cli_reports_leaving_governance_against_a_previous_inventory`
15. `test_cli_rejects_a_label_value_that_is_not_a_declaration`

All fifteen failed on the unmodified tree: 1-12 with `ModuleNotFoundError: bernstein.core.govern.cluster_inventory` at collection, and 13-15 because `bernstein cluster` had no `govern-inventory` command, so every invocation returned Click's "No such command" instead of an inventory.

Each property was then confirmed to bite by breaking the implementation deliberately and checking that the right test — and only the right test — went red:

| Deliberate defect | Test that caught it |
| --- | --- |
| annotate the manifest while reading it | 1, 8 |
| skip unlabelled workloads | 2, 6, 12 |
| report a deleted workload as opted out | 7 |
| route telemetry regardless of posture | 11 |

Fixtures: `tests/fixtures/cluster/agent-workloads.json` — one labelled Deployment, one unlabelled Deployment in the same namespace, one explicitly opted-out StatefulSet.

## Checklist

- [x] `uv run ruff check src/` — clean.
- [x] `uv run ruff format --check` on the two changed source files — clean.
- [x] `uv run pyright src/` — `cluster_inventory.py` is clean under strict mode; `cluster_cmd.py` is unchanged at its 18 pre-existing errors (no new ones).
- [x] `uv run python scripts/run_tests.py --parallel 2 -x` on the new files: 15 passed.
- [x] `uv run python scripts/run_tests.py --parallel 2 --affected origin/main` — 195 files, 194 passed. The one failure, `tests/unit/cli/test_run_banner.py::test_bare_invocation_prints_banner_when_splash_disabled`, is not from this change: it fails identically on an unmodified `origin/main` checkout of the same tree. It times out waiting on the splash background future (`src/bernstein/cli/main.py:841`, `_splash_future.result(timeout=10)`), which is a load-sensitive wait, not a cluster-governance path.
- [x] `uv run lint-imports` — 3 contracts kept, 0 broken.
- [x] Type hints on every new public function, dataclass field and return.
- [x] Operator workflow: `docs/operations/cluster-mode.md` gains a "Governing workloads that are not ours" section and a code pointer.
- [x] Release-note fragment: `docs/release-notes/fragments/4988-cluster-govern-by-declaration.md`.
- [x] `uv run bernstein agents-md sync` — run; produced no changes.
- [ ] README section — N/A, no README-level behaviour change.
- [ ] `docs/api/` schemas — N/A, no HTTP surface added.
- [ ] `docs/contributing/testing.md` — N/A, no new test layer.

Part of #4988

## Remaining

- The chart acceptance item. `deploy/helm/bernstein/` has no generator and no drift test at HEAD, so wiring an OTLP route into the chart needs a prior decision about how the chart is produced. Nothing in this PR touches it.
- Reading the workload listing from the cluster API rather than from a file. The projection takes manifests, so `kubectl get ... -o json` is the current path; a live-API reader is additive and does not change these properties.
