### PR TITLE
feat(audit): witness co-signing of chain checkpoints (#3161)

### DIFF
--- a/docs/release-notes/fragments/3161-witness-cosign-audit-checkpoints.md
+++ b/docs/release-notes/fragments/3161-witness-cosign-audit-checkpoints.md
@@ -1,0 +1,20 @@
+## Witness co-signing of audit checkpoints
+
+Adds an optional second party that co-signs audit checkpoints, so a rewind of
+the chain segments and the checkpoints file together no longer verifies clean.
+A witness holds per-origin monotonic state and an Ed25519 key; it co-signs only
+when the submitted tree is a consistent extension of the last one it accepted,
+and refuses with a named cause (`size_regression`, `state_mismatch`,
+`inconsistent_extension`) otherwise. New CLI commands:
+
+- `bernstein audit witness export` – write the newest checkpoint payload for a witness to check
+- `bernstein audit witness cosign` – check a submitted checkpoint against witness state and co-sign it
+- `bernstein audit witness record` – store a co-signature, checked under the witness public key you pin
+
+`bernstein audit verify --witness-key <pub>` authenticates recorded
+co-signatures and exits non-zero when the local history contradicts one;
+`--witness-state <dir>` additionally reads the witness's own pins, which survive
+a rollback that deleted the local co-signature file. Co-signatures are Ed25519,
+so a third party can verify one offline with the public key alone.
+
+(#3161)

--- a/docs/security/audit-log.md
+++ b/docs/security/audit-log.md
@@ -476,10 +476,77 @@ nothing - which is why `bernstein doctor` reports the anchoring state
 (`never anchored` / `anchored at N entries, last at T`) rather than
 letting an unanchored install look as strong as an anchored one.
 
-still open, and deliberately not shipped here: a witness
-co-signature protocol between two installs, and operator-supplied
+still open, and deliberately not shipped here: operator-supplied
 external sinks (object lock, append-only bucket) for checkpoint
 retention.
+
+### Witness co-signatures: a second party that remembers
+
+an anchor says a history of a given size existed at a point in time.
+a **witness** says something the local host cannot say about itself:
+that it already accepted a tree this one has to extend. a witness is
+a minimal second party - another host, a separate unix user, or an
+operator laptop - holding per-origin monotonic state (the newest
+checkpoint it accepted for a chain origin) and an ed25519 key.
+
+the witness co-signs only when the submitted checkpoint is a
+consistent extension of its pin. it refuses otherwise, and the cause
+is named:
+
+| cause | what it means |
+| --- | --- |
+| `size_regression` | the submitted tree holds fewer records than the pinned one |
+| `state_mismatch` | a second tree at the size the witness already pinned, or a different origin |
+| `inconsistent_extension` | a pinned segment is gone, shrank, or changed under a length it was pinned at; or the submitted leaves do not rebuild the submitted root |
+
+three commands, one per host:
+
+```bash
+# on the log host: the checkpoint payload, no secrets in it
+bernstein audit witness export --out cp.json
+
+# on the witness: check against its own state, then co-sign
+bernstein audit witness cosign --checkpoint cp.json --key witness.key \
+    --state-dir ~/.bernstein-witness --out cosig.json
+
+# on the log host: store it, checked under the key you pin
+bernstein audit witness record --cosignature cosig.json --witness-key witness.pub
+```
+
+co-signatures live in `.sdd/audit/checkpoints/cosignatures.jsonl`,
+append-only and fsynced, beside `checkpoints.jsonl` and never inside
+it - same reason as anchors. witness state lives in the witness's own
+directory, one file per chain origin, written temp-file + rename +
+fsync so a crash leaves the old pin rather than a truncated one.
+
+`bernstein audit verify` then runs a **witness co-signatures** pillar:
+
+- pass `--witness-key <witness.pub>` to authenticate the recorded
+  co-signatures. without it they are reported as present but
+  unauthenticated and drive no verdict: a witness key taken from the
+  record itself is a witness vouching for itself.
+- pass `--witness-state <dir>` as well to read the witness's own pins
+  directly. that is the copy an actor who rewinds the local history
+  cannot delete.
+- a local history shorter than the newest witnessed record count, a
+  different chain origin, or a witnessed checkpoint that is no longer
+  on record are all **contradictions**, and each exits non-zero naming
+  the witnessed checkpoint.
+
+what the witness does *not* check: it never sees the audit key or the
+chain segments, so it cannot re-hash a segment prefix. a pinned
+segment that grew is accepted on the strength of the local gate, which
+does hold the bytes. what the witness adds is the memory.
+
+a witness holding no state for a chain co-signs and says so - a first
+acceptance, or one taken after the state was lost, proves nothing
+about history before it. that is the local-only guarantee again, and
+`witness cosign` prints it rather than passing silently. keep the
+state directory backed up for the same reason you keep
+`anchors.jsonl` off the writing machine.
+
+a witness contradiction is **not** clearable with `audit ack-tear`,
+for the same reason an anchor contradiction is not.
 
 ## Replaying a log
 

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -13,6 +13,7 @@ Commands:
   bernstein audit seal --anchor-git  Also create a git tag.
   bernstein audit ack-tear           Acknowledge recorded tear evidence.
   bernstein audit anchor             Anchor a checkpoint with an RFC 3161 token.
+  bernstein audit witness            Co-sign checkpoints from a second party.
   bernstein audit verify             Verify HMAC chain, Merkle tree, checkpoint.
   bernstein audit verify --hmac-only Verify HMAC chain only.
   bernstein audit verify --merkle-only  Verify Merkle tree only.
@@ -37,7 +38,7 @@ from __future__ import annotations
 
 import contextlib
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 import click
 from rich.panel import Panel
@@ -51,6 +52,8 @@ if TYPE_CHECKING:
     from cryptography.x509 import Certificate
 
     from bernstein.core.persistence.checkpoint_anchor import CheckpointAnchor
+    from bernstein.core.persistence.checkpoint_witness import WitnessClaim
+    from bernstein.core.persistence.lineage_signer import LineageVerifier
 
 AUDIT_DIR = Path(".sdd/audit")
 MERKLE_DIR = AUDIT_DIR / "merkle"
@@ -270,12 +273,36 @@ def seal_cmd(anchor_git: bool, allow_broken_chain: bool) -> None:
         "the issuing TSA is not authenticated."
     ),
 )
+@click.option(
+    "--witness-key",
+    "witness_key",
+    default=None,
+    type=click.Path(dir_okay=False, exists=True, resolve_path=True),
+    help=(
+        "Path to the witness's Ed25519 public key (PEM or raw 32 bytes). "
+        "Authenticates recorded checkpoint co-signatures. Without it a "
+        "co-signature is reported as present but unauthenticated and drives "
+        "no verdict."
+    ),
+)
+@click.option(
+    "--witness-state",
+    "witness_state",
+    default=None,
+    type=click.Path(file_okay=False, exists=True, resolve_path=True),
+    help=(
+        "Path to the witness's own state directory. Reading it directly "
+        "survives a rollback that deleted the local co-signature file."
+    ),
+)
 def verify_cmd(
     merkle_only: bool,
     hmac_only: bool,
     receipt_path: str | None,
     payload_path: str | None,
     rfc3161_trust_bundle: str | None,
+    witness_key: str | None,
+    witness_state: str | None,
 ) -> None:
     """Verify audit log integrity (HMAC chain per RFC 2104 + Merkle tree).
 
@@ -294,6 +321,9 @@ def verify_cmd(
                                           Also authenticate the TSA that
                                           signed each recorded checkpoint
                                           anchor
+      bernstein audit verify --witness-key w.pub
+                                          Also check the local history against
+                                          the checkpoints a witness co-signed
 
     Exits non-zero on any chain break, missing record, or HMAC mismatch.
     Run from cron and fail the run on non-zero exit (cite: docs/security/audit-log.md).
@@ -339,6 +369,15 @@ def verify_cmd(
     # for the same reason the checkpoint pillar does.
     if not _verify_anchors(rfc3161_trust_bundle):
         failed_pillars.append("External Anchors")
+
+    # Witness co-signatures are the other half of that pillar: an anchor says
+    # a history of a given size existed at a point in time, a witness says it
+    # already accepted a tree this one has to extend. With one honest witness,
+    # rewinding the chain and the checkpoints together no longer verifies
+    # clean. Runs regardless of --hmac-only / --merkle-only for the same
+    # reason the checkpoint and anchor pillars do.
+    if not _verify_witness(witness_key, witness_state):
+        failed_pillars.append("Witness Co-signatures")
 
     # Evidence bundles are a third integrity pillar: a tampered evidence file
     # must fail verify exactly like a tampered chain entry (#2362). This runs
@@ -1399,6 +1438,371 @@ def _decode_tsa_response(raw: bytes) -> bytes:
     except (UnicodeDecodeError, binascii.Error, ValueError) as exc:
         msg = f"token file is neither DER nor base64: {exc}"
         raise click.ClickException(msg) from None
+
+
+@audit_group.group("witness")
+def witness_group() -> None:
+    """Co-sign checkpoints from a second party that remembers (#3161).
+
+    A checkpoint proves the audit history did not shrink relative to material
+    on this disk, and an actor who can rewrite the chain can rewrite that
+    material too. A witness is the party that cannot be rewritten from here:
+    another host, a separate unix user, or an operator laptop holding
+    per-origin monotonic state and an Ed25519 key. It co-signs a checkpoint
+    only when the tree is a consistent extension of the last one it accepted.
+
+    \b
+      bernstein audit witness export --out cp.json
+                                          On the log host: write the newest
+                                          checkpoint payload for transport
+      bernstein audit witness cosign --checkpoint cp.json --key w.key \\
+          --state-dir ~/.bernstein-witness --out cosig.json
+                                          On the witness: check and co-sign
+      bernstein audit witness record --cosignature cosig.json \\
+          --witness-key w.pub
+                                          On the log host: store the signature
+      bernstein audit verify --witness-key w.pub
+                                          Fail when the local history
+                                          contradicts what the witness signed
+
+    See docs/security/audit-log.md.
+    """
+
+
+def _newest_checkpoint() -> dict[str, object]:
+    """Return the newest local checkpoint payload, or raise for the operator."""
+    from bernstein.core.persistence.chain_checkpoint import (
+        CheckpointFileError,
+        load_checkpoints,
+    )
+    from bernstein.core.security.audit import AuditKeyMissingError, load_audit_key
+
+    if not AUDIT_DIR.is_dir():
+        raise click.ClickException(f"audit directory not found: {AUDIT_DIR}")
+    try:
+        key = load_audit_key()
+    except AuditKeyMissingError as exc:
+        raise click.ClickException(f"{exc} (checkpoints are signed with the audit key)") from None
+    try:
+        checkpoint = load_checkpoints(AUDIT_DIR, key).last
+    except CheckpointFileError as exc:
+        raise click.ClickException(str(exc)) from None
+    if checkpoint is None:
+        raise click.ClickException("no checkpoint recorded yet; run 'bernstein audit seal' first")
+    return checkpoint
+
+
+@witness_group.command("export")
+@click.option(
+    "--out",
+    "out_path",
+    default=None,
+    type=click.Path(dir_okay=False, resolve_path=True),
+    help="Write the checkpoint payload here instead of printing it.",
+)
+def witness_export_cmd(out_path: str | None) -> None:
+    """Write the newest checkpoint payload for a witness to check.
+
+    The payload carries the chain origin, the record count, the Merkle root
+    and the per-segment lengths and hashes - everything a witness needs, and
+    nothing that would let it read the log. It carries no secret: the audit
+    HMAC key never leaves this host.
+    """
+    import json as _json
+
+    checkpoint = _newest_checkpoint()
+    body = _json.dumps(checkpoint, sort_keys=True, separators=(",", ":"))
+    if out_path is None:
+        console.print(body)
+        return
+    Path(out_path).write_text(body + "\n", encoding="utf-8")
+    console.print(f"[green]Wrote[/green] checkpoint payload to {out_path}")
+    console.print(f"[dim]Pinned entries:[/dim] {checkpoint.get('entry_count', '-')}")
+
+
+@witness_group.command("cosign")
+@click.option(
+    "--checkpoint",
+    "checkpoint_path",
+    required=True,
+    type=click.Path(dir_okay=False, exists=True, resolve_path=True),
+    help="Checkpoint payload from 'bernstein audit witness export'.",
+)
+@click.option(
+    "--key",
+    "key_path",
+    required=True,
+    type=click.Path(dir_okay=False, exists=True, resolve_path=True),
+    help="The witness's Ed25519 private key (PEM PKCS#8 or raw 32 bytes).",
+)
+@click.option(
+    "--state-dir",
+    "state_dir",
+    required=True,
+    type=click.Path(file_okay=False, resolve_path=True),
+    help="The witness's own state directory: one pin per chain origin.",
+)
+@click.option("--witness-id", "witness_id", default="", help="Label recorded with the signature.")
+@click.option(
+    "--out",
+    "out_path",
+    default=None,
+    type=click.Path(dir_okay=False, resolve_path=True),
+    help="Write the co-signature here instead of printing it.",
+)
+def witness_cosign_cmd(
+    checkpoint_path: str,
+    key_path: str,
+    state_dir: str,
+    witness_id: str,
+    out_path: str | None,
+) -> None:
+    """Check a submitted checkpoint against witness state and co-sign it.
+
+    Exits non-zero, naming the cause, when the submission is not a consistent
+    extension of what this witness last accepted: a smaller tree, a second
+    tree at the size it already pinned, or a pinned segment that shrank or
+    changed under a length it was pinned at.
+
+    A witness holding no state for this chain co-signs and says so: a first
+    acceptance proves nothing about history before it, and neither does one
+    taken after the state was lost.
+    """
+    import json as _json
+
+    from bernstein.core.persistence.checkpoint_witness import (
+        WitnessRefusal,
+        cosign_checkpoint,
+    )
+    from bernstein.core.persistence.lineage_signer import (
+        Ed25519FileKeySigner,
+        LineageSignerError,
+    )
+
+    try:
+        checkpoint = _json.loads(Path(checkpoint_path).read_bytes())
+    except (OSError, ValueError) as exc:
+        raise click.ClickException(f"cannot read checkpoint payload: {exc}") from None
+    if not isinstance(checkpoint, dict):
+        raise click.ClickException("checkpoint payload is not a JSON object")
+    checkpoint = cast("dict[str, Any]", checkpoint)
+
+    try:
+        signer = Ed25519FileKeySigner.from_path(Path(key_path))
+    except LineageSignerError as exc:
+        raise click.ClickException(str(exc)) from None
+
+    try:
+        result = cosign_checkpoint(Path(state_dir), checkpoint, signer, witness_id=witness_id)
+    except WitnessRefusal as exc:
+        console.print(Panel("[bold red]Witness refused to co-sign[/bold red]", border_style="red", expand=False))
+        console.print(f"  [red]![/red] cause: {exc.reason}")
+        console.print(f"  [red]![/red] {exc.detail}")
+        raise SystemExit(1) from None
+
+    if result.bootstrapped:
+        console.print(
+            "[yellow]This witness held no state for this chain[/yellow] "
+            "[dim](first acceptance, or the state was lost). The co-signature says what "
+            "the tree looks like from now on; it says nothing about history before it.[/dim]"
+        )
+    body = _json.dumps(result.cosignature.to_document(), sort_keys=True, separators=(",", ":"))
+    if out_path is None:
+        console.print(body)
+    else:
+        Path(out_path).write_text(body + "\n", encoding="utf-8")
+        console.print(f"[green]Co-signed[/green] {result.cosignature.describe()}")
+        console.print(f"[dim]Wrote {out_path}[/dim]")
+
+
+@witness_group.command("record")
+@click.option(
+    "--cosignature",
+    "cosignature_path",
+    required=True,
+    type=click.Path(dir_okay=False, exists=True, resolve_path=True),
+    help="Co-signature document from 'bernstein audit witness cosign'.",
+)
+@click.option(
+    "--witness-key",
+    "witness_key_path",
+    required=True,
+    type=click.Path(dir_okay=False, exists=True, resolve_path=True),
+    help="The witness's Ed25519 public key (PEM or raw 32 bytes), pinned by the operator.",
+)
+def witness_record_cmd(cosignature_path: str, witness_key_path: str) -> None:
+    """Store a witness co-signature beside the checkpoints.
+
+    The signature is checked under the public key you pin here before anything
+    is written: a record filed under a key you do not trust is a claim with no
+    witness behind it.
+    """
+    import json as _json
+
+    from bernstein.core.persistence.checkpoint_witness import (
+        cosignatures_path,
+        parse_cosignature,
+        record_cosignature,
+    )
+
+    if not AUDIT_DIR.is_dir():
+        raise click.ClickException(f"audit directory not found: {AUDIT_DIR}")
+    try:
+        doc = _json.loads(Path(cosignature_path).read_bytes())
+    except (OSError, ValueError) as exc:
+        raise click.ClickException(f"cannot read co-signature: {exc}") from None
+    if not isinstance(doc, dict):
+        raise click.ClickException("co-signature is not a JSON object")
+    try:
+        cosignature = parse_cosignature(cast("dict[str, Any]", doc))
+    except ValueError as exc:
+        raise click.ClickException(f"malformed co-signature: {exc}") from None
+
+    verifier = _load_witness_verifier(witness_key_path)
+    try:
+        record_cosignature(AUDIT_DIR, cosignature, verifier)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from None
+
+    console.print(f"[green]Recorded[/green] {cosignature.describe()}")
+    console.print(f"[dim]Stored in {cosignatures_path(AUDIT_DIR)}[/dim]")
+    console.print(
+        "[dim]Keep the witness state off this machine: a co-signature deleted with "
+        "the history it contradicts protects nothing, and the witness's own pin is "
+        "what 'bernstein audit verify --witness-state' reads.[/dim]"
+    )
+
+
+def _load_witness_verifier(witness_key_path: str) -> LineageVerifier:
+    """Load the operator-pinned witness public key, or fail with their message."""
+    from bernstein.core.persistence.lineage_signer import (
+        Ed25519PublicKeyVerifier,
+        LineageSignerError,
+    )
+
+    try:
+        return Ed25519PublicKeyVerifier.from_path(Path(witness_key_path))
+    except LineageSignerError as exc:
+        raise click.ClickException(f"witness public key: {exc}") from None
+
+
+def _witness_claims(witness_key: str | None, witness_state: str | None) -> tuple[list[WitnessClaim], list[str], bool]:
+    """Return ``(claims, errors, unauthenticated)`` for the witness pillar.
+
+    Co-signatures only become claims once they verify under the operator's
+    pinned witness key. Without that key they are reported as present but
+    unauthenticated and drive no verdict: a signature that vouches for itself
+    vouches for nothing. The witness's own state directory, when the operator
+    can read it, is folded in under the same origins.
+    """
+    from bernstein.core.persistence.checkpoint_witness import (
+        CosignatureFileError,
+        load_cosignatures,
+        verify_cosignature,
+        witness_claims_from_state,
+    )
+
+    try:
+        cosignatures = load_cosignatures(AUDIT_DIR)
+    except CosignatureFileError as exc:
+        return [], list(exc.errors), False
+    if witness_key is None:
+        return [], [], bool(cosignatures)
+
+    verifier = _load_witness_verifier(witness_key)
+    claims: list[WitnessClaim] = []
+    errors: list[str] = []
+    for cosignature in cosignatures:
+        problems = verify_cosignature(cosignature, verifier)
+        if problems:
+            errors.extend(f"{cosignature.describe()}: {problem}" for problem in problems)
+            continue
+        claims.append(cosignature.claim())
+    if errors:
+        return [], errors, False
+
+    if witness_state is not None:
+        from bernstein.core.persistence.chain_checkpoint import compute_origin
+
+        origins = {claim.origin for claim in claims}
+        local_origin = compute_origin(AUDIT_DIR)
+        if local_origin is not None:
+            origins.add(local_origin)
+        claims.extend(witness_claims_from_state(Path(witness_state), sorted(origins)))
+    return claims, [], False
+
+
+def _verify_witness(witness_key: str | None = None, witness_state: str | None = None) -> bool:
+    """Verify recorded witness co-signatures against the local audit history.
+
+    Three ways to fail, all loud: the co-signature file itself does not read,
+    a co-signature does not verify under the pinned witness key, or the local
+    history contradicts what a witness signed.
+
+    An install with no witness passes and says so. Witnessing is optional, and
+    a single-host install must be able to run without one; what it must not do
+    is stay quiet about being unwitnessed.
+    """
+    from bernstein.core.persistence.checkpoint_witness import check_witness_contradictions
+
+    console.print()
+    claims, errors, unauthenticated = _witness_claims(witness_key, witness_state)
+    if errors:
+        console.print(Panel("[bold red]Witness Verification FAILED[/bold red]", border_style="red", expand=False))
+        for err in errors:
+            console.print(f"  [red]![/red] {err}")
+        return False
+
+    if unauthenticated:
+        console.print(
+            "[yellow]Witness co-signatures are on record but not authenticated[/yellow] "
+            "[dim](pass --witness-key <the witness public key> to check them; an "
+            "unpinned key is a witness vouching for itself).[/dim]"
+        )
+        return True
+
+    if not claims:
+        console.print(
+            "[yellow]Audit history is not witness co-signed[/yellow] "
+            "[dim](no co-signature recorded; a rollback of the chain and the "
+            "checkpoints together would leave nothing to contradict it).[/dim]"
+        )
+        console.print("[dim]To witness: bernstein audit witness export --out cp.json[/dim]")
+        return True
+
+    conflicts = check_witness_contradictions(
+        AUDIT_DIR,
+        claims,
+        checkpoint_roots=_known_checkpoint_roots(),
+    )
+    if conflicts:
+        console.print(Panel("[bold red]Witness Contradiction[/bold red]", border_style="red", expand=False))
+        for claim in claims:
+            console.print(f"  [red]![/red] {claim.describe()}")
+        for conflict in conflicts:
+            console.print(f"  [red]![/red] {conflict.detail}")
+        console.print(
+            "  [dim]The local audit history contradicts a checkpoint a witness signed.\n"
+            "  This is not clearable with 'bernstein audit ack-tear': an acknowledgement\n"
+            "  records that an operator looked at local damage, and it cannot withdraw a\n"
+            "  second party's signature. Restore the missing history, or treat the\n"
+            "  witnessed range as unaccounted for.[/dim]"
+        )
+        return False
+
+    strongest = max(claims, key=lambda claim: claim.entry_count)
+    console.print(Panel("[bold green]Witness Verification Passed[/bold green]", border_style="green", expand=False))
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("Key", style="dim", no_wrap=True, min_width=16)
+    table.add_column("Value")
+    table.add_row("Witness claims", str(len(claims)))
+    table.add_row("Witnessed entries", str(strongest.entry_count))
+    table.add_row("Witnessed root", strongest.checkpoint_root)
+    table.add_row("Source", strongest.source)
+    if witness_state is None:
+        table.add_row("Note", "witness state not consulted (pass --witness-state)")
+    console.print(table)
+    return True
 
 
 def _verify_merkle_tree() -> bool:

--- a/src/bernstein/core/persistence/chain_checkpoint.py
+++ b/src/bernstein/core/persistence/chain_checkpoint.py
@@ -50,8 +50,10 @@ consistent earlier state. Detecting that requires retention outside the
 local filesystem, which lives in
 :mod:`bernstein.core.persistence.checkpoint_anchor`: an optional RFC 3161
 token over a checkpoint's canonical bytes, so a history shorter than the
-newest anchored entry count contradicts a signature made off this machine.
-A witness co-signature between two installs is still a follow-up.
+newest anchored entry count contradicts a signature made off this machine,
+and :mod:`bernstein.core.persistence.checkpoint_witness`: an optional second
+party holding per-origin monotonic state, which co-signs a checkpoint only
+when the tree extends the last one it accepted.
 """
 
 from __future__ import annotations
@@ -179,8 +181,9 @@ def _sign(payload: dict[str, Any], key: bytes) -> str:
     authenticate the chain can authenticate its checkpoints with the same
     secret, and an attacker with write access to the audit directory (but not
     the key, which lives outside it) cannot forge one. Ed25519 co-signing of
-    checkpoints is a planned follow-up for keyless third-party verification;
-    it layers on top of this record rather than replacing it.
+    checkpoints, for keyless third-party verification, lives in
+    :mod:`bernstein.core.persistence.checkpoint_witness`; it layers on top of
+    this record rather than replacing it.
     """
     return _hmac.new(key, _canonical(payload), hashlib.sha256).hexdigest()
 

--- a/src/bernstein/core/persistence/checkpoint_anchor.py
+++ b/src/bernstein/core/persistence/checkpoint_anchor.py
@@ -51,8 +51,9 @@ as they already do for ``bernstein audit export --rfc3161-token``. An
 air-gapped install runs with no anchors at all - and ``bernstein doctor`` says
 so, rather than implying the seal is stronger than it is.
 
-Not covered here: witness co-signature between two installs, and operator-
-supplied external sinks for checkpoint retention. Both are follow-ups.
+Not covered here: witness co-signature between two installs, which lives in
+:mod:`bernstein.core.persistence.checkpoint_witness`, and operator-supplied
+external sinks for checkpoint retention.
 """
 
 from __future__ import annotations

--- a/src/bernstein/core/persistence/checkpoint_witness.py
+++ b/src/bernstein/core/persistence/checkpoint_witness.py
@@ -1,0 +1,923 @@
+"""Witness co-signing of audit checkpoints: a second party that remembers.
+
+:mod:`bernstein.core.persistence.chain_checkpoint` makes an audit-history
+shrink sticky, but only against material the log host holds itself. Its own
+module docstring names the residual: an actor with write access to both the
+chain segments and the checkpoints file can truncate both to a mutually
+consistent earlier state, and every local verification still passes, because
+from inside nothing remembers that a longer history existed.
+:mod:`bernstein.core.persistence.checkpoint_anchor` closes that with an RFC
+3161 token - a statement a TSA signed about *when* a history of a given size
+existed. This module closes it with the other half: a statement a witness
+signed about *what it already accepted*.
+
+A witness is a minimal second party - another host, a separate unix user, or
+an operator laptop - holding per-origin monotonic state: the newest checkpoint
+it accepted for a given chain origin. On each submission it checks, from the
+two payloads alone:
+
+* the submitted tree is not smaller than the one it pinned
+  (:data:`REFUSAL_SIZE_REGRESSION`),
+* the submission agrees with the state it holds - a checkpoint at the pinned
+  size must be the pinned checkpoint (:data:`REFUSAL_STATE_MISMATCH`),
+* the submitted tree extends the pinned one: every pinned leaf is still
+  present, no pinned segment shrank, a segment pinned at its current length
+  still hashes the same, and the submitted leaves rebuild the submitted root
+  (:data:`REFUSAL_INCONSISTENT_EXTENSION`).
+
+Only then does it Ed25519-sign the claim and advance its pin. This is the
+per-origin monotonicity rule of the C2SP tlog-witness model, in the shape of
+the per-day-segment tree bernstein already seals: with one honest witness,
+rewinding the chain and the checkpoints file together no longer verifies
+clean anywhere the witness state is consulted.
+
+What the witness can and cannot check
+-------------------------------------
+The witness never sees the audit key (the log's HMAC secret) and never sees
+the chain segments. It therefore cannot re-derive a checkpoint's HMAC or
+re-hash a segment prefix, and a pinned segment that *grew* is accepted on the
+strength of the log host's own byte-level gate in ``chain_checkpoint``. What
+the witness adds is the property the log host cannot give itself: a memory of
+the tree size and root it already saw, kept where a host-level compromise or
+a full-disk restore from an old backup cannot rewrite it.
+
+Storage discipline
+------------------
+Witness state lives in the witness's own directory, one JSON file per chain
+origin, named by ``sha256(origin)`` so a hostile checkpoint file cannot steer
+the path. Each write is a temp file plus ``os.replace`` plus an fsync of the
+file and its directory, so a crash leaves either the old pin or the new one -
+never a truncated one. A pin only ever advances.
+
+Co-signatures live on the log host in
+``<audit_dir>/checkpoints/cosignatures.jsonl``, beside ``checkpoints.jsonl``
+and ``anchors.jsonl`` and outside ``merkle/``. Append-only, one JSON object
+per line, fsynced; a crash-torn trailing fragment is skipped exactly as in
+the other two files. Nothing here writes to ``checkpoints.jsonl``: checkpoint
+payloads stay byte-deterministic, so two byte-identical audit directories
+sealed with the same key still produce byte-identical checkpoint files.
+
+Co-signature records are not HMAC-signed. The audit key is a local secret and
+an actor who can rewrite the chain has it; the Ed25519 signature is the
+protection, and its key belongs to the witness. That is also what makes
+verification keyless for a third party: an auditor holding only the witness
+public key can check a co-signature offline, which the HMAC-only checkpoint
+signature can never offer.
+
+Not covered here: an HTTP witness endpoint (the C2SP 400/409/422 wire
+protocol), witness quorums, and operator-supplied external sinks for
+co-signature retention.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+from bernstein.core.persistence.chain_checkpoint import (
+    CHECKPOINTS_SUBDIR,
+    CheckpointConflict,
+    chain_snapshot,
+    compute_origin,
+    count_entries,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+    from bernstein.core.persistence.lineage_signer import (
+        LineageSigner,
+        LineageVerifier,
+    )
+
+#: Schema version for co-signature records and witness state files.
+COSIGNATURE_VERSION = 1
+
+#: File name of the append-only co-signature log, beside ``checkpoints.jsonl``.
+COSIGNATURES_FILE = "cosignatures.jsonl"
+
+#: The only co-signature kind this module writes today.
+COSIGNATURE_KIND_ED25519 = "ed25519"
+
+#: Domain separator for the signing input. A witness co-signature must never
+#: be replayable as some other Ed25519 signature made by the same key.
+SIGNING_DOMAIN = b"bernstein/audit-checkpoint-witness/v1\n"
+
+#: The submitted tree is smaller than the one the witness pinned.
+REFUSAL_SIZE_REGRESSION = "size_regression"
+
+#: The submission disagrees with the state the witness holds for this origin.
+REFUSAL_STATE_MISMATCH = "state_mismatch"
+
+#: The submitted tree is not a consistent extension of the pinned one.
+REFUSAL_INCONSISTENT_EXTENSION = "inconsistent_extension"
+
+#: Conflict kinds raised by :func:`check_witness_contradictions`. None of them
+#: appear in :attr:`CheckpointConflict.ACKABLE_KINDS`: a co-signature is a
+#: statement by a second party, and a local acknowledgement cannot un-sign it.
+WITNESS_CONFLICT_KINDS = (
+    "witness_entry_count",
+    "witness_origin",
+    "witness_checkpoint_missing",
+)
+
+
+class WitnessRefusal(RuntimeError):
+    """Raised when a witness declines to co-sign a submitted checkpoint.
+
+    Attributes:
+        reason: One of :data:`REFUSAL_SIZE_REGRESSION`,
+            :data:`REFUSAL_STATE_MISMATCH`,
+            :data:`REFUSAL_INCONSISTENT_EXTENSION`. Distinct per cause so an
+            operator can tell "you are behind" from "you forked" from "your
+            history was rewritten".
+        detail: Human-readable explanation naming the pinned state.
+    """
+
+    def __init__(self, reason: str, detail: str) -> None:
+        self.reason = reason
+        self.detail = detail
+        super().__init__(f"witness refused to co-sign ({reason}): {detail}")
+
+
+class CosignatureFileError(RuntimeError):
+    """Raised when the co-signature file itself fails validation.
+
+    A committed line that does not parse or lacks the fields a co-signature is
+    made of means the append-only discipline was violated. A co-signature that
+    cannot be read is not the same as one that was never taken, so the
+    verifier must not silently treat the install as unwitnessed.
+    """
+
+    def __init__(self, errors: list[str]) -> None:
+        self.errors = errors
+        head = "; ".join(errors[:3])
+        super().__init__(f"Audit co-signature file failed validation: {head}")
+
+
+@dataclass(frozen=True)
+class WitnessClaim:
+    """One statement about the size of a history that a witness stands behind.
+
+    Both a recorded co-signature and the witness's own retained state project
+    into this shape, so the contradiction check reads the same whether the
+    operator has the co-signature file, the witness's state directory, or
+    both.
+
+    Attributes:
+        origin: Chain origin the witnessed checkpoint pinned.
+        entry_count: Number of canonical records that checkpoint pinned.
+        checkpoint_root: ``root_hash`` of the witnessed checkpoint.
+        source: Where the claim came from, for operator output.
+    """
+
+    origin: str
+    entry_count: int
+    checkpoint_root: str
+    source: str
+
+    def describe(self) -> str:
+        """Return a one-line identification of the claim for operator output."""
+        return (
+            f"{self.source}: checkpoint root {self.checkpoint_root[:16]}… over {self.entry_count} entries "
+            f"(origin {self.origin[:16]}…)"
+        )
+
+
+@dataclass(frozen=True)
+class WitnessPin:
+    """What one witness remembers about one chain origin.
+
+    Attributes:
+        origin: Chain origin this pin is for.
+        entry_count: Records pinned by the newest accepted checkpoint.
+        checkpoint_root: ``root_hash`` of that checkpoint.
+        payload_sha256: Hex SHA-256 of that checkpoint's canonical payload.
+        leaves: ``(file, byte_len, hash)`` per pinned segment.
+    """
+
+    origin: str
+    entry_count: int
+    checkpoint_root: str
+    payload_sha256: str
+    leaves: tuple[tuple[str, int, str], ...]
+
+    def claim(self, source: str = "witness state") -> WitnessClaim:
+        """Return this pin as a :class:`WitnessClaim`."""
+        return WitnessClaim(
+            origin=self.origin,
+            entry_count=self.entry_count,
+            checkpoint_root=self.checkpoint_root,
+            source=source,
+        )
+
+
+@dataclass(frozen=True)
+class WitnessCosignature:
+    """One witness's Ed25519 signature over a checkpoint claim.
+
+    Attributes:
+        origin: Chain origin the co-signed checkpoint pinned.
+        entry_count: Records that checkpoint pinned.
+        checkpoint_root: ``root_hash`` of that checkpoint.
+        payload_sha256: Hex SHA-256 of that checkpoint's canonical payload.
+        signature_b64: Base64 raw 64-byte Ed25519 signature over
+            :func:`cosignature_signing_input`.
+        witness_id: Informational label for the witness (may be empty).
+        line_no: 1-based line in the co-signature file, for error messages.
+    """
+
+    origin: str
+    entry_count: int
+    checkpoint_root: str
+    payload_sha256: str
+    signature_b64: str
+    witness_id: str = ""
+    line_no: int = 0
+
+    def signature_bytes(self) -> bytes:
+        """Return the decoded raw signature.
+
+        Raises:
+            ValueError: When ``signature_b64`` is not valid base64.
+        """
+        try:
+            return base64.b64decode(self.signature_b64, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            msg = f"co-signature is not valid base64: {exc}"
+            raise ValueError(msg) from exc
+
+    def claim(self) -> WitnessClaim:
+        """Return this co-signature as a :class:`WitnessClaim`."""
+        who = f"witness {self.witness_id}" if self.witness_id else "witness co-signature"
+        return WitnessClaim(
+            origin=self.origin,
+            entry_count=self.entry_count,
+            checkpoint_root=self.checkpoint_root,
+            source=who,
+        )
+
+    def describe(self) -> str:
+        """Return a one-line identification of the co-signature."""
+        return self.claim().describe()
+
+    def to_document(self) -> dict[str, Any]:
+        """Return the JSON document form written to disk and to transport."""
+        return {
+            "version": COSIGNATURE_VERSION,
+            "kind": COSIGNATURE_KIND_ED25519,
+            "origin": self.origin,
+            "entry_count": self.entry_count,
+            "checkpoint_root": self.checkpoint_root,
+            "payload_sha256": self.payload_sha256,
+            "signature_b64": self.signature_b64,
+            "witness_id": self.witness_id,
+        }
+
+
+@dataclass(frozen=True)
+class CosignResult:
+    """Outcome of an accepted submission.
+
+    Attributes:
+        cosignature: The signature the witness produced.
+        bootstrapped: ``True`` when the witness held no prior state for this
+            origin. A bootstrap proves nothing about history *before* it, so
+            every operator surface must say so rather than imply the
+            submission was checked against a pin.
+    """
+
+    cosignature: WitnessCosignature
+    bootstrapped: bool
+
+
+# ---------------------------------------------------------------------------
+# Paths + canonical form
+# ---------------------------------------------------------------------------
+
+
+def cosignatures_path(audit_dir: Path) -> Path:
+    """Return the append-only co-signature file path for *audit_dir*."""
+    return audit_dir / CHECKPOINTS_SUBDIR / COSIGNATURES_FILE
+
+
+def witness_state_path(state_dir: Path, origin: str) -> Path:
+    """Return the witness's state file for chain *origin*.
+
+    The file is named by ``sha256(origin)``: a witness reads checkpoints from
+    a host it does not trust, and an origin string taken from that payload
+    must never reach the filesystem as a path component.
+    """
+    return state_dir / f"{hashlib.sha256(origin.encode()).hexdigest()}.json"
+
+
+def _canonical(payload: dict[str, Any]) -> bytes:
+    """Serialise *payload* exactly as ``chain_checkpoint`` signs it."""
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+
+
+def checkpoint_payload_sha256(checkpoint: dict[str, Any]) -> str:
+    """Return the hex SHA-256 of a checkpoint payload's canonical bytes.
+
+    The same digest :func:`bernstein.core.persistence.checkpoint_anchor.checkpoint_digest`
+    hands a TSA, so a witness co-signature and an RFC 3161 anchor name the
+    same statement and an operator can line them up.
+    """
+    return hashlib.sha256(_canonical(checkpoint)).hexdigest()
+
+
+def cosignature_signing_input(
+    origin: str,
+    entry_count: int,
+    checkpoint_root: str,
+    payload_sha256: str,
+) -> bytes:
+    """Return the bytes a witness signs.
+
+    Everything a verifier acts on is inside the signature: the origin the
+    claim is about, the size of the history, the root, and the digest binding
+    the claim to one exact checkpoint payload. A verifier therefore needs the
+    co-signature record and the witness public key, and nothing else - not the
+    checkpoint, not the chain, not the audit key.
+    """
+    claim = {
+        "origin": origin,
+        "entry_count": int(entry_count),
+        "checkpoint_root": checkpoint_root,
+        "payload_sha256": payload_sha256,
+    }
+    return SIGNING_DOMAIN + _canonical(claim)
+
+
+# ---------------------------------------------------------------------------
+# Witness state
+# ---------------------------------------------------------------------------
+
+
+def load_witness_pin(state_dir: Path, origin: str) -> WitnessPin | None:
+    """Return the witness's pin for *origin*, or ``None`` when it holds none.
+
+    ``None`` is the honest answer for both "never witnessed this chain" and
+    "state was lost": the witness cannot tell them apart, and callers must
+    treat either as a bootstrap rather than as an endorsement.
+
+    Args:
+        state_dir: The witness's state directory.
+        origin: Chain origin to look up.
+
+    Returns:
+        The pin, or ``None``.
+    """
+    path = witness_state_path(state_dir, origin)
+    try:
+        raw = path.read_bytes()
+    except (FileNotFoundError, NotADirectoryError):
+        return None
+    except OSError:
+        return None
+    try:
+        doc = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(doc, dict):
+        return None
+    doc = cast("dict[str, Any]", doc)
+    if doc.get("version") != COSIGNATURE_VERSION:
+        return None
+    if str(doc.get("origin", "")) != origin:
+        return None
+    leaves = doc.get("leaves")
+    if not isinstance(leaves, list):
+        return None
+    return WitnessPin(
+        origin=origin,
+        entry_count=int(doc.get("entry_count", 0) or 0),
+        checkpoint_root=str(doc.get("checkpoint_root", "")),
+        payload_sha256=str(doc.get("payload_sha256", "")),
+        leaves=tuple(
+            (str(leaf.get("file", "")), int(leaf.get("byte_len", 0) or 0), str(leaf.get("hash", "")))
+            for leaf in cast("list[dict[str, Any]]", leaves)
+        ),
+    )
+
+
+def _save_witness_pin(state_dir: Path, pin: WitnessPin) -> None:
+    """Write *pin* durably, replacing whatever was there.
+
+    Temp file, fsync, ``os.replace``, then fsync the directory: a crash mid
+    write leaves the previous pin intact rather than a truncated one, which
+    would read as "no state" and silently degrade the witness to a bootstrap.
+    """
+    doc = {
+        "version": COSIGNATURE_VERSION,
+        "origin": pin.origin,
+        "entry_count": pin.entry_count,
+        "checkpoint_root": pin.checkpoint_root,
+        "payload_sha256": pin.payload_sha256,
+        "leaves": [{"file": name, "byte_len": byte_len, "hash": digest} for name, byte_len, digest in pin.leaves],
+    }
+    path = witness_state_path(state_dir, pin.origin)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, _canonical(doc) + b"\n")
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    os.replace(tmp, path)
+    dir_fd = os.open(str(path.parent), os.O_RDONLY)
+    try:
+        os.fsync(dir_fd)
+    finally:
+        os.close(dir_fd)
+
+
+def _pin_from_checkpoint(checkpoint: dict[str, Any]) -> WitnessPin:
+    leaves = cast("list[dict[str, Any]]", checkpoint.get("leaves", []))
+    return WitnessPin(
+        origin=str(checkpoint.get("origin", "")),
+        entry_count=int(checkpoint.get("entry_count", 0) or 0),
+        checkpoint_root=str(checkpoint.get("root_hash", "")),
+        payload_sha256=checkpoint_payload_sha256(checkpoint),
+        leaves=tuple(
+            (str(leaf.get("file", "")), int(leaf.get("byte_len", 0) or 0), str(leaf.get("hash", ""))) for leaf in leaves
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# The monotonicity check
+# ---------------------------------------------------------------------------
+
+
+def check_witness_extension(pin: WitnessPin | None, checkpoint: dict[str, Any]) -> None:
+    """Raise unless *checkpoint* is a consistent extension of *pin*.
+
+    Pure: the two payloads are the only inputs, so a witness can run this with
+    no access to the chain, the audit key, or the network.
+
+    Args:
+        pin: The witness's current state for this origin, or ``None`` when it
+            holds none (a bootstrap, which accepts anything).
+        checkpoint: The submitted checkpoint payload.
+
+    Raises:
+        WitnessRefusal: With :attr:`WitnessRefusal.reason` naming which of the
+            three rules the submission broke.
+    """
+    _check_self_consistent(checkpoint)
+    if pin is None:
+        return
+
+    origin = str(checkpoint.get("origin", ""))
+    if origin != pin.origin:
+        msg = f"submission is for origin {origin[:16]}…; this state is for {pin.origin[:16]}…"
+        raise WitnessRefusal(REFUSAL_STATE_MISMATCH, msg)
+
+    entry_count = int(checkpoint.get("entry_count", 0) or 0)
+    if entry_count < pin.entry_count:
+        msg = f"submitted tree holds {entry_count} records; the witness accepted {pin.entry_count}"
+        raise WitnessRefusal(REFUSAL_SIZE_REGRESSION, msg)
+
+    root = str(checkpoint.get("root_hash", ""))
+    if entry_count == pin.entry_count and root != pin.checkpoint_root:
+        msg = (
+            f"a second tree of {entry_count} records: root {root[:16]}… where the "
+            f"witness accepted {pin.checkpoint_root[:16]}…"
+        )
+        raise WitnessRefusal(REFUSAL_STATE_MISMATCH, msg)
+
+    _check_leaves_extend(pin, checkpoint)
+
+
+def _check_self_consistent(checkpoint: dict[str, Any]) -> None:
+    """Refuse a payload whose own leaves do not rebuild its own root."""
+    leaves = cast("list[dict[str, Any]]", checkpoint.get("leaves", []))
+    if not leaves:
+        return
+    from bernstein.core.persistence.merkle import build_merkle_tree
+
+    tree = build_merkle_tree(
+        [(str(leaf.get("file", "")), str(leaf.get("hash", ""))) for leaf in leaves],
+        scheme=int(checkpoint.get("scheme", 2) or 2),
+    )
+    if tree.root.hash != checkpoint.get("root_hash"):
+        msg = "submitted leaves do not rebuild the submitted root"
+        raise WitnessRefusal(REFUSAL_INCONSISTENT_EXTENSION, msg)
+
+
+def _check_leaves_extend(pin: WitnessPin, checkpoint: dict[str, Any]) -> None:
+    """Refuse unless every pinned segment is still there and did not regress.
+
+    A segment that grew is accepted: the witness holds no bytes, so it cannot
+    re-hash a longer prefix. That check belongs to the log host's own gate in
+    ``chain_checkpoint``, which does hold the bytes. What the witness adds is
+    that a segment can never get *shorter*, disappear, or change under a
+    length it was already pinned at.
+    """
+    submitted = {
+        str(leaf.get("file", "")): (int(leaf.get("byte_len", 0) or 0), str(leaf.get("hash", "")))
+        for leaf in cast("list[dict[str, Any]]", checkpoint.get("leaves", []))
+    }
+    for name, byte_len, digest in pin.leaves:
+        found = submitted.get(name)
+        if found is None:
+            msg = f"segment {name} was pinned by the witness and is absent from the submission"
+            raise WitnessRefusal(REFUSAL_INCONSISTENT_EXTENSION, msg)
+        new_len, new_hash = found
+        if new_len < byte_len:
+            msg = f"segment {name} is pinned at {byte_len} bytes; the submission claims {new_len}"
+            raise WitnessRefusal(REFUSAL_INCONSISTENT_EXTENSION, msg)
+        if new_len == byte_len and new_hash != digest:
+            msg = f"segment {name} kept its pinned length of {byte_len} bytes but changed content"
+            raise WitnessRefusal(REFUSAL_INCONSISTENT_EXTENSION, msg)
+
+
+# ---------------------------------------------------------------------------
+# Co-signing (witness side)
+# ---------------------------------------------------------------------------
+
+
+def cosign_checkpoint(
+    state_dir: Path,
+    checkpoint: dict[str, Any],
+    signer: LineageSigner,
+    *,
+    witness_id: str = "",
+) -> CosignResult:
+    """Co-sign *checkpoint* and advance the witness pin, or refuse.
+
+    The pin advances only after the signature exists, and a refusal never
+    touches it: a witness that forgot what it accepted is worse than one that
+    accepted nothing.
+
+    Args:
+        state_dir: The witness's state directory.
+        checkpoint: The submitted checkpoint payload.
+        signer: Ed25519 signer holding the witness key (any
+            :class:`~bernstein.core.persistence.lineage_signer.LineageSigner`,
+            so an operator's existing key custody applies unchanged).
+        witness_id: Informational label recorded with the signature.
+
+    Returns:
+        The :class:`CosignResult`, whose ``bootstrapped`` flag says whether
+        anything was actually compared.
+
+    Raises:
+        WitnessRefusal: When the submission is not a consistent extension.
+        OSError: When the state file cannot be written.
+    """
+    origin = str(checkpoint.get("origin", ""))
+    pin = load_witness_pin(state_dir, origin)
+    check_witness_extension(pin, checkpoint)
+
+    payload_sha256 = checkpoint_payload_sha256(checkpoint)
+    entry_count = int(checkpoint.get("entry_count", 0) or 0)
+    root = str(checkpoint.get("root_hash", ""))
+    signature = signer.sign(cosignature_signing_input(origin, entry_count, root, payload_sha256))
+
+    _save_witness_pin(state_dir, _pin_from_checkpoint(checkpoint))
+    return CosignResult(
+        cosignature=WitnessCosignature(
+            origin=origin,
+            entry_count=entry_count,
+            checkpoint_root=root,
+            payload_sha256=payload_sha256,
+            signature_b64=base64.b64encode(signature).decode("ascii"),
+            witness_id=witness_id,
+        ),
+        bootstrapped=pin is None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Verification (anyone, offline)
+# ---------------------------------------------------------------------------
+
+
+def verify_cosignature(cosignature: WitnessCosignature, verifier: LineageVerifier) -> list[str]:
+    """Return the problems with *cosignature*; empty when it holds up.
+
+    Needs only the record and the witness public key: no chain, no audit key,
+    no network. The public key must come from the operator, never from the
+    record - a witness that vouches for itself vouches for nothing.
+
+    Args:
+        cosignature: The co-signature to check.
+        verifier: Verifier built from the operator's pinned witness key.
+
+    Returns:
+        Human-readable error strings.
+    """
+    try:
+        signature = cosignature.signature_bytes()
+    except ValueError as exc:
+        return [str(exc)]
+    try:
+        bytes.fromhex(cosignature.payload_sha256)
+    except ValueError as exc:
+        return [f"co-signature payload_sha256 is not valid hex: {exc}"]
+    signing_input = cosignature_signing_input(
+        cosignature.origin,
+        cosignature.entry_count,
+        cosignature.checkpoint_root,
+        cosignature.payload_sha256,
+    )
+    if not verifier.verify(signing_input, signature):
+        return ["co-signature does not verify under the pinned witness public key"]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Co-signature file (log side)
+# ---------------------------------------------------------------------------
+
+
+def parse_cosignature(doc: dict[str, Any], line_no: int = 0) -> WitnessCosignature:
+    """Build a co-signature from one parsed document.
+
+    Args:
+        doc: The parsed JSON object.
+        line_no: 1-based line number, for error messages.
+
+    Returns:
+        The co-signature.
+
+    Raises:
+        ValueError: When a required field is missing or ill-typed.
+    """
+    if doc.get("version") != COSIGNATURE_VERSION:
+        msg = f"unsupported co-signature version {doc.get('version')!r}"
+        raise ValueError(msg)
+    kind = str(doc.get("kind", ""))
+    if kind != COSIGNATURE_KIND_ED25519:
+        msg = f"unsupported co-signature kind {kind!r}"
+        raise ValueError(msg)
+    for field in ("origin", "checkpoint_root", "payload_sha256", "signature_b64"):
+        value = doc.get(field)
+        if not isinstance(value, str) or not value:
+            msg = f"missing or empty {field}"
+            raise ValueError(msg)
+    entry_count = doc.get("entry_count")
+    if not isinstance(entry_count, int) or isinstance(entry_count, bool) or entry_count < 0:
+        msg = f"entry_count must be a non-negative integer, got {entry_count!r}"
+        raise ValueError(msg)
+    return WitnessCosignature(
+        origin=str(doc["origin"]),
+        entry_count=entry_count,
+        checkpoint_root=str(doc["checkpoint_root"]),
+        payload_sha256=str(doc["payload_sha256"]),
+        signature_b64=str(doc["signature_b64"]),
+        witness_id=str(doc.get("witness_id", "")),
+        line_no=line_no,
+    )
+
+
+def load_cosignatures(audit_dir: Path) -> list[WitnessCosignature]:
+    """Read and validate the co-signature file.
+
+    A torn trailing fragment (a crash-interrupted append) is skipped. Every
+    committed line must parse into a well-formed record; anything else raises,
+    because a co-signature that cannot be read is not the same as one that was
+    never taken.
+
+    Args:
+        audit_dir: The audit directory.
+
+    Returns:
+        Co-signatures in file order (empty when nothing is witnessed).
+
+    Raises:
+        CosignatureFileError: On any committed-line validation failure.
+    """
+    path = cosignatures_path(audit_dir)
+    try:
+        raw = path.read_bytes()
+    except FileNotFoundError:
+        return []
+    except OSError as exc:
+        raise CosignatureFileError([f"unreadable co-signature file: {exc}"]) from exc
+    if not raw:
+        return []
+
+    lines = raw.split(b"\n")
+    if lines and lines[-1] == b"":
+        lines.pop()
+
+    cosignatures: list[WitnessCosignature] = []
+    errors: list[str] = []
+    last_index = len(lines) - 1
+    for line_no, line in enumerate(lines):
+        try:
+            doc = json.loads(line)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            if line_no == last_index and not raw.endswith(b"\n"):
+                # Crash-interrupted append: ignore the fragment.
+                break
+            errors.append(f"{COSIGNATURES_FILE}:{line_no + 1}: unparsable committed line")
+            break
+        if not isinstance(doc, dict):
+            errors.append(f"{COSIGNATURES_FILE}:{line_no + 1}: not a JSON object")
+            break
+        try:
+            cosignatures.append(parse_cosignature(cast("dict[str, Any]", doc), line_no + 1))
+        except ValueError as exc:
+            errors.append(f"{COSIGNATURES_FILE}:{line_no + 1}: {exc}")
+            break
+
+    if errors:
+        raise CosignatureFileError(errors)
+    return cosignatures
+
+
+def newest_cosignature(cosignatures: Sequence[WitnessCosignature]) -> WitnessCosignature | None:
+    """Return the co-signature claiming the largest history, or ``None``.
+
+    File order is append order, but the strongest statement is the one over
+    the most entries: that is the count a rollback has to contradict.
+    """
+    if not cosignatures:
+        return None
+    return max(cosignatures, key=lambda cosig: cosig.entry_count)
+
+
+def record_cosignature(
+    audit_dir: Path,
+    cosignature: WitnessCosignature,
+    verifier: LineageVerifier,
+) -> WitnessCosignature:
+    """Append *cosignature* after checking it under the pinned witness key.
+
+    The log host stores nothing it could not verify: a record filed under a
+    key the operator does not trust would be a claim with no witness behind
+    it, and would go on to fail every later verification for the wrong reason.
+
+    Args:
+        audit_dir: The audit directory.
+        cosignature: The co-signature the witness produced.
+        verifier: Verifier built from the operator's pinned witness key.
+
+    Returns:
+        The recorded co-signature.
+
+    Raises:
+        ValueError: When the signature does not verify.
+        OSError: When the co-signature file cannot be written.
+    """
+    errors = verify_cosignature(cosignature, verifier)
+    if errors:
+        msg = f"refusing to record an unverified witness signature: {errors[0]}"
+        raise ValueError(msg)
+
+    path = cosignatures_path(audit_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = _canonical(cosignature.to_document()) + b"\n"
+    # Append + fsync: a co-signature still in the page cache when the next
+    # crash arrives cannot contradict anything afterwards.
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    try:
+        os.write(fd, line)
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    return cosignature
+
+
+# ---------------------------------------------------------------------------
+# Contradiction
+# ---------------------------------------------------------------------------
+
+
+def witness_claims_from_state(state_dir: Path, origins: Sequence[str]) -> list[WitnessClaim]:
+    """Return the witness's own pins for *origins* as claims.
+
+    The co-signature file lives on the log host, so an actor who rewinds the
+    history can delete it with everything else. The witness's state directory
+    is the copy that survives that, and an operator who can read it (a mounted
+    export, a second unix user, a laptop) can check against it directly.
+    """
+    claims: list[WitnessClaim] = []
+    for origin in origins:
+        pin = load_witness_pin(state_dir, origin)
+        if pin is not None:
+            claims.append(pin.claim())
+    return claims
+
+
+def check_witness_contradictions(
+    audit_dir: Path,
+    claims: Sequence[WitnessClaim],
+    *,
+    segments: list[tuple[str, bytes]] | None = None,
+    checkpoint_roots: set[str] | None = None,
+) -> list[CheckpointConflict]:
+    """Return the ways the local history contradicts *claims*.
+
+    Reported as :class:`CheckpointConflict` values so a witness contradiction
+    renders in the same shape as a checkpoint divergence or an anchor
+    contradiction. Their kinds are deliberately outside
+    :attr:`CheckpointConflict.ACKABLE_KINDS`: ``bernstein audit ack-tear``
+    records that an operator looked at local damage, and a local record cannot
+    withdraw a second party's signature.
+
+    Args:
+        audit_dir: The audit directory.
+        claims: Witness claims, from co-signatures and/or witness state.
+        segments: An existing :func:`chain_snapshot` to reuse.
+        checkpoint_roots: Roots of the checkpoints currently on record. When
+            supplied, a witnessed checkpoint that is no longer there is itself
+            a contradiction - that is exactly the "truncate the chain and the
+            checkpoints together" case. Omit when the audit key is
+            unavailable, since checkpoints cannot be read without it.
+
+    Returns:
+        Conflicts, empty when the local history is consistent with every
+        claim.
+    """
+    if not claims:
+        return []
+
+    snapshot = segments if segments is not None else chain_snapshot(audit_dir)
+    conflicts: list[CheckpointConflict] = []
+
+    strongest = max(claims, key=lambda claim: claim.entry_count)
+    current_count = count_entries(audit_dir, segments=snapshot)
+    if current_count < strongest.entry_count:
+        conflicts.append(
+            CheckpointConflict(
+                kind="witness_entry_count",
+                segment="",
+                offset=0,
+                detail=(
+                    f"chain holds {current_count} records; {strongest.source} co-signed "
+                    f"checkpoint root {strongest.checkpoint_root[:16]}… over {strongest.entry_count}"
+                ),
+            ),
+        )
+
+    origin = compute_origin(audit_dir, segments=snapshot)
+    if origin is not None and strongest.origin and origin != strongest.origin:
+        conflicts.append(
+            CheckpointConflict(
+                kind="witness_origin",
+                segment="",
+                offset=0,
+                detail=(f"chain origin {origin[:16]}… does not match the witnessed origin {strongest.origin[:16]}…"),
+            ),
+        )
+
+    if checkpoint_roots is not None:
+        for claim in claims:
+            if claim.checkpoint_root in checkpoint_roots:
+                continue
+            conflicts.append(
+                CheckpointConflict(
+                    kind="witness_checkpoint_missing",
+                    segment="",
+                    offset=0,
+                    detail=(
+                        f"witnessed checkpoint root {claim.checkpoint_root[:16]}… is no longer "
+                        "on record (the checkpoints file was truncated or replaced)"
+                    ),
+                ),
+            )
+    return conflicts
+
+
+__all__ = [
+    "COSIGNATURES_FILE",
+    "COSIGNATURE_KIND_ED25519",
+    "COSIGNATURE_VERSION",
+    "REFUSAL_INCONSISTENT_EXTENSION",
+    "REFUSAL_SIZE_REGRESSION",
+    "REFUSAL_STATE_MISMATCH",
+    "SIGNING_DOMAIN",
+    "WITNESS_CONFLICT_KINDS",
+    "CosignResult",
+    "CosignatureFileError",
+    "WitnessClaim",
+    "WitnessCosignature",
+    "WitnessPin",
+    "WitnessRefusal",
+    "check_witness_contradictions",
+    "check_witness_extension",
+    "checkpoint_payload_sha256",
+    "cosign_checkpoint",
+    "cosignature_signing_input",
+    "cosignatures_path",
+    "load_cosignatures",
+    "load_witness_pin",
+    "newest_cosignature",
+    "parse_cosignature",
+    "record_cosignature",
+    "verify_cosignature",
+    "witness_claims_from_state",
+    "witness_state_path",
+]

--- a/tests/unit/test_checkpoint_witness.py
+++ b/tests/unit/test_checkpoint_witness.py
@@ -442,3 +442,89 @@ def test_verify_says_so_when_no_witness_cosignature_is_on_record(cli_workspace: 
     result = CliRunner().invoke(audit_group, ["verify"])
     assert result.exit_code == 0, result.output
     assert "not witness" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# 5. The operator surface
+# ---------------------------------------------------------------------------
+
+
+def test_the_three_witness_commands_round_trip(cli_workspace: Path) -> None:
+    """export on the log host, cosign on the witness, record back on the log host."""
+    audit_dir = cli_workspace / ".sdd" / "audit"
+    signer = _witness_key(cli_workspace / "witness.key")
+    public_key = _public_key_file(signer, cli_workspace / "witness.pub")
+    state_dir = cli_workspace / "witness-state"
+    runner = CliRunner()
+    _cli_seal()
+
+    exported = cli_workspace / "cp.json"
+    assert runner.invoke(audit_group, ["witness", "export", "--out", str(exported)]).exit_code == 0
+
+    cosig = cli_workspace / "cosig.json"
+    result = runner.invoke(
+        audit_group,
+        [
+            "witness",
+            "cosign",
+            "--checkpoint",
+            str(exported),
+            "--key",
+            str(cli_workspace / "witness.key"),
+            "--state-dir",
+            str(state_dir),
+            "--out",
+            str(cosig),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    # A bootstrap must not read as an endorsement of history before it.
+    assert "no state for this chain" in result.output
+
+    recorded = runner.invoke(
+        audit_group,
+        ["witness", "record", "--cosignature", str(cosig), "--witness-key", str(public_key)],
+    )
+    assert recorded.exit_code == 0, recorded.output
+    assert load_cosignatures(audit_dir)
+
+    verified = runner.invoke(audit_group, ["verify", "--witness-key", str(public_key)])
+    assert verified.exit_code == 0, verified.output
+    assert "Witness Verification Passed" in verified.output
+
+
+def test_the_cosign_command_exits_non_zero_naming_the_refusal_cause(cli_workspace: Path) -> None:
+    """A refusal is a failed command, not a warning buried in output."""
+    audit_dir = cli_workspace / ".sdd" / "audit"
+    signer = _witness_key(cli_workspace / "witness.key")
+    state_dir = cli_workspace / "witness-state"
+    runner = CliRunner()
+    _cli_seal()
+
+    from bernstein.core.persistence.chain_checkpoint import load_checkpoints
+
+    checkpoint = load_checkpoints(audit_dir, _KEY).last
+    assert checkpoint is not None
+    cosign_checkpoint(state_dir, checkpoint, signer)
+
+    _truncate_history(audit_dir, keep=2)
+    checkpoints_path(audit_dir).unlink()
+    _cli_seal()
+    rewound = cli_workspace / "rewound.json"
+    assert runner.invoke(audit_group, ["witness", "export", "--out", str(rewound)]).exit_code == 0
+
+    result = runner.invoke(
+        audit_group,
+        [
+            "witness",
+            "cosign",
+            "--checkpoint",
+            str(rewound),
+            "--key",
+            str(cli_workspace / "witness.key"),
+            "--state-dir",
+            str(state_dir),
+        ],
+    )
+    assert result.exit_code == 1, result.output
+    assert REFUSAL_SIZE_REGRESSION in result.output

--- a/tests/unit/test_checkpoint_witness.py
+++ b/tests/unit/test_checkpoint_witness.py
@@ -1,0 +1,444 @@
+"""Witness co-signing of audit checkpoints (#3161).
+
+``chain_checkpoint`` makes an audit-history shrink sticky only against
+material the log host holds itself: an actor with write access to both the
+chain segments and the checkpoints file can truncate both to a mutually
+consistent earlier state and every local verification still passes. These
+tests pin the behaviour of the witness that closes that residual - a second
+party holding per-origin monotonic state, which co-signs a checkpoint only
+when the tree is a consistent extension of what it last accepted.
+
+Everything here is offline: real Ed25519 keys, real files, no network and no
+witness server. The witness "host" is a state directory plus a private key.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from click.testing import CliRunner
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from bernstein.cli.commands.audit_cmd import audit_group
+from bernstein.core.persistence.chain_checkpoint import (
+    checkpoints_path,
+    record_checkpoint,
+)
+from bernstein.core.persistence.checkpoint_witness import (
+    REFUSAL_INCONSISTENT_EXTENSION,
+    REFUSAL_SIZE_REGRESSION,
+    REFUSAL_STATE_MISMATCH,
+    CosignatureFileError,
+    WitnessRefusal,
+    check_witness_contradictions,
+    checkpoint_payload_sha256,
+    cosign_checkpoint,
+    cosignatures_path,
+    load_cosignatures,
+    load_witness_pin,
+    record_cosignature,
+    verify_cosignature,
+    witness_state_path,
+)
+from bernstein.core.persistence.lineage_signer import (
+    Ed25519FileKeySigner,
+    Ed25519PublicKeyVerifier,
+)
+from bernstein.core.persistence.merkle import build_merkle_tree, compute_seal
+from bernstein.core.security.audit import AuditLog
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_KEY = b"witness-substrate-test-key-012345"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed(tmp_path: Path, count: int = 6) -> Path:
+    audit_dir = tmp_path / ".sdd" / "audit"
+    log = AuditLog(audit_dir, key=_KEY)
+    for i in range(count):
+        log.log("test.event", "tester", "task", f"t-{i}", {"i": i})
+    return audit_dir
+
+
+def _seal_and_pin(audit_dir: Path) -> dict[str, Any]:
+    _tree, seal = compute_seal(audit_dir, key=_KEY)
+    return record_checkpoint(audit_dir, seal, key=_KEY)
+
+
+def _truncate_history(audit_dir: Path, keep: int) -> None:
+    """Drop all but the first *keep* records from the live segment.
+
+    The chain stays HMAC-intact (a prefix of a chain is a valid chain), so
+    only a pin held outside the truncated material can notice.
+    """
+    segment = next(iter(sorted(audit_dir.glob("*.jsonl"))))
+    body = [line for line in segment.read_bytes().split(b"\n") if line.strip()]
+    segment.write_bytes(b"".join(line + b"\n" for line in body[:keep]))
+
+
+def _rebuild_root(checkpoint: dict[str, Any]) -> None:
+    """Recompute ``root_hash`` in place so a hand-edited payload is self-consistent."""
+    leaves = [(str(leaf["file"]), str(leaf["hash"])) for leaf in checkpoint["leaves"]]
+    checkpoint["root_hash"] = build_merkle_tree(leaves, scheme=int(checkpoint.get("scheme", 2))).root.hash
+
+
+def _witness_key(path: Path) -> Ed25519FileKeySigner:
+    private = ed25519.Ed25519PrivateKey.generate()
+    path.write_bytes(
+        private.private_bytes_raw(),
+    )
+    path.chmod(0o600)
+    return Ed25519FileKeySigner.from_path(path)
+
+
+def _public_key_file(signer: Ed25519FileKeySigner, path: Path) -> Path:
+    path.write_bytes(signer.public_key_bytes())
+    return path
+
+
+@pytest.fixture()
+def witness(tmp_path: Path) -> tuple[Ed25519FileKeySigner, Path]:
+    """A witness: an Ed25519 signer plus its own durable state directory."""
+    return _witness_key(tmp_path / "witness.key"), tmp_path / "witness-state"
+
+
+@pytest.fixture()
+def cli_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A project root with a seeded audit chain and the audit key on disk."""
+    key_file = tmp_path / "audit.key"
+    key_file.write_bytes(_KEY)
+    key_file.chmod(0o600)
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(key_file))
+    monkeypatch.setenv("COLUMNS", "200")
+    _seed(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def _cli_seal() -> None:
+    result = CliRunner().invoke(audit_group, ["seal"])
+    assert result.exit_code == 0, result.output
+
+
+# ---------------------------------------------------------------------------
+# 1. Co-signing and per-origin state
+# ---------------------------------------------------------------------------
+
+
+def test_witness_cosigns_a_checkpoint_and_pins_its_state(
+    tmp_path: Path,
+    witness: tuple[Ed25519FileKeySigner, Path],
+) -> None:
+    """A first acceptance co-signs the checkpoint and records the pin."""
+    signer, state_dir = witness
+    audit_dir = _seed(tmp_path)
+    checkpoint = _seal_and_pin(audit_dir)
+
+    result = cosign_checkpoint(state_dir, checkpoint, signer, witness_id="witness-a")
+
+    assert result.bootstrapped is True
+    assert result.cosignature.entry_count == checkpoint["entry_count"]
+    assert result.cosignature.checkpoint_root == checkpoint["root_hash"]
+    assert result.cosignature.payload_sha256 == checkpoint_payload_sha256(checkpoint)
+    assert witness_state_path(state_dir, str(checkpoint["origin"])).exists()
+
+
+def test_witness_state_survives_a_witness_restart(
+    tmp_path: Path,
+    witness: tuple[Ed25519FileKeySigner, Path],
+) -> None:
+    """The pin is durable: a fresh read sees what the previous run accepted."""
+    signer, state_dir = witness
+    audit_dir = _seed(tmp_path)
+    checkpoint = _seal_and_pin(audit_dir)
+    cosign_checkpoint(state_dir, checkpoint, signer)
+
+    # A restart is a fresh read of the state directory - nothing in memory.
+    pin = load_witness_pin(state_dir, str(checkpoint["origin"]))
+    assert pin is not None
+    assert pin.entry_count == checkpoint["entry_count"]
+    assert pin.checkpoint_root == checkpoint["root_hash"]
+
+    # And the second acceptance is no longer a bootstrap.
+    AuditLog(audit_dir, key=_KEY).log("test.event", "tester", "task", "extra", {})
+    later = cosign_checkpoint(state_dir, _seal_and_pin(audit_dir), signer)
+    assert later.bootstrapped is False
+
+
+def test_witness_without_prior_state_reports_that_it_is_bootstrapping(
+    tmp_path: Path,
+    witness: tuple[Ed25519FileKeySigner, Path],
+) -> None:
+    """Losing witness state degrades to the local-only guarantee, loudly.
+
+    A witness whose state was deleted cannot refuse a rewound history - it has
+    nothing to compare against. It must say so rather than co-sign in silence.
+    """
+    signer, state_dir = witness
+    audit_dir = _seed(tmp_path)
+    checkpoint = _seal_and_pin(audit_dir)
+    cosign_checkpoint(state_dir, checkpoint, signer)
+
+    witness_state_path(state_dir, str(checkpoint["origin"])).unlink()
+    _truncate_history(audit_dir, keep=2)
+    checkpoints_path(audit_dir).unlink()
+    rewound = _seal_and_pin(audit_dir)
+
+    result = cosign_checkpoint(state_dir, rewound, signer)
+    assert result.bootstrapped is True
+    assert result.cosignature.entry_count == rewound["entry_count"]
+
+
+# ---------------------------------------------------------------------------
+# 2. Refusals, distinct per cause
+# ---------------------------------------------------------------------------
+
+
+def test_witness_refuses_a_checkpoint_that_shrinks_the_history(
+    tmp_path: Path,
+    witness: tuple[Ed25519FileKeySigner, Path],
+) -> None:
+    """A smaller tree is a size regression, named as such."""
+    signer, state_dir = witness
+    audit_dir = _seed(tmp_path)
+    cosign_checkpoint(state_dir, _seal_and_pin(audit_dir), signer)
+
+    _truncate_history(audit_dir, keep=2)
+    checkpoints_path(audit_dir).unlink()
+    rewound = _seal_and_pin(audit_dir)
+
+    with pytest.raises(WitnessRefusal) as excinfo:
+        cosign_checkpoint(state_dir, rewound, signer)
+    assert excinfo.value.reason == REFUSAL_SIZE_REGRESSION
+
+
+def test_witness_refuses_a_fork_at_the_size_it_already_accepted(
+    tmp_path: Path,
+    witness: tuple[Ed25519FileKeySigner, Path],
+) -> None:
+    """Same size, different root: the submission does not match witness state."""
+    signer, state_dir = witness
+    audit_dir = _seed(tmp_path)
+    checkpoint = _seal_and_pin(audit_dir)
+    cosign_checkpoint(state_dir, checkpoint, signer)
+
+    fork = json.loads(json.dumps(checkpoint))
+    fork["leaves"][0]["hash"] = hashlib.sha256(b"forked").hexdigest()
+    _rebuild_root(fork)
+
+    with pytest.raises(WitnessRefusal) as excinfo:
+        cosign_checkpoint(state_dir, fork, signer)
+    assert excinfo.value.reason == REFUSAL_STATE_MISMATCH
+
+
+def test_witness_refuses_a_larger_tree_whose_pinned_leaves_regressed(
+    tmp_path: Path,
+    witness: tuple[Ed25519FileKeySigner, Path],
+) -> None:
+    """Growth is not extension: a rewritten pinned segment fails consistency."""
+    signer, state_dir = witness
+    audit_dir = _seed(tmp_path)
+    checkpoint = _seal_and_pin(audit_dir)
+    cosign_checkpoint(state_dir, checkpoint, signer)
+
+    forged = json.loads(json.dumps(checkpoint))
+    forged["entry_count"] = int(checkpoint["entry_count"]) + 3
+    forged["leaves"][0]["byte_len"] = int(forged["leaves"][0]["byte_len"]) - 1
+    forged["leaves"][0]["hash"] = hashlib.sha256(b"rewritten").hexdigest()
+    _rebuild_root(forged)
+
+    with pytest.raises(WitnessRefusal) as excinfo:
+        cosign_checkpoint(state_dir, forged, signer)
+    assert excinfo.value.reason == REFUSAL_INCONSISTENT_EXTENSION
+
+
+def test_witness_refuses_a_checkpoint_whose_leaves_do_not_rebuild_its_root(
+    tmp_path: Path,
+    witness: tuple[Ed25519FileKeySigner, Path],
+) -> None:
+    """A payload that is internally inconsistent never gets a co-signature."""
+    signer, state_dir = witness
+    audit_dir = _seed(tmp_path)
+    checkpoint = _seal_and_pin(audit_dir)
+    cosign_checkpoint(state_dir, checkpoint, signer)
+
+    AuditLog(audit_dir, key=_KEY).log("test.event", "tester", "task", "extra", {})
+    grown = json.loads(json.dumps(_seal_and_pin(audit_dir)))
+    grown["root_hash"] = hashlib.sha256(b"claimed").hexdigest()
+
+    with pytest.raises(WitnessRefusal) as excinfo:
+        cosign_checkpoint(state_dir, grown, signer)
+    assert excinfo.value.reason == REFUSAL_INCONSISTENT_EXTENSION
+
+
+def test_a_refused_checkpoint_does_not_advance_witness_state(
+    tmp_path: Path,
+    witness: tuple[Ed25519FileKeySigner, Path],
+) -> None:
+    """A refusal leaves the pin exactly where it was."""
+    signer, state_dir = witness
+    audit_dir = _seed(tmp_path)
+    checkpoint = _seal_and_pin(audit_dir)
+    cosign_checkpoint(state_dir, checkpoint, signer)
+    before = witness_state_path(state_dir, str(checkpoint["origin"])).read_bytes()
+
+    _truncate_history(audit_dir, keep=2)
+    checkpoints_path(audit_dir).unlink()
+    with pytest.raises(WitnessRefusal):
+        cosign_checkpoint(state_dir, _seal_and_pin(audit_dir), signer)
+
+    assert witness_state_path(state_dir, str(checkpoint["origin"])).read_bytes() == before
+
+
+# ---------------------------------------------------------------------------
+# 3. Offline verification of the co-signature
+# ---------------------------------------------------------------------------
+
+
+def test_cosignature_verifies_offline_with_only_the_witness_public_key(
+    tmp_path: Path,
+    witness: tuple[Ed25519FileKeySigner, Path],
+) -> None:
+    """Keyless third-party verification: public key in, verdict out."""
+    signer, state_dir = witness
+    audit_dir = _seed(tmp_path)
+    checkpoint = _seal_and_pin(audit_dir)
+    cosig = cosign_checkpoint(state_dir, checkpoint, signer).cosignature
+
+    verifier = Ed25519PublicKeyVerifier.from_path(_public_key_file(signer, tmp_path / "witness.pub"))
+    assert verify_cosignature(cosig, verifier) == []
+
+
+def test_a_cosignature_from_another_key_does_not_verify(
+    tmp_path: Path,
+    witness: tuple[Ed25519FileKeySigner, Path],
+) -> None:
+    """A self-asserted witness key cannot pass as the operator's witness."""
+    signer, state_dir = witness
+    audit_dir = _seed(tmp_path)
+    checkpoint = _seal_and_pin(audit_dir)
+    cosig = cosign_checkpoint(state_dir, checkpoint, signer).cosignature
+
+    impostor = _witness_key(tmp_path / "impostor.key")
+    verifier = Ed25519PublicKeyVerifier.from_path(_public_key_file(impostor, tmp_path / "impostor.pub"))
+    assert verify_cosignature(cosig, verifier) != []
+
+
+def test_recording_refuses_a_cosignature_the_witness_key_does_not_verify(
+    tmp_path: Path,
+    witness: tuple[Ed25519FileKeySigner, Path],
+) -> None:
+    """The log host stores nothing it could not check against the pinned key."""
+    signer, state_dir = witness
+    audit_dir = _seed(tmp_path)
+    checkpoint = _seal_and_pin(audit_dir)
+    cosig = cosign_checkpoint(state_dir, checkpoint, signer).cosignature
+
+    impostor = _witness_key(tmp_path / "impostor.key")
+    verifier = Ed25519PublicKeyVerifier.from_path(_public_key_file(impostor, tmp_path / "impostor.pub"))
+    with pytest.raises(ValueError, match="signature"):
+        record_cosignature(audit_dir, cosig, verifier)
+    assert not cosignatures_path(audit_dir).exists()
+
+
+def test_a_tampered_cosignature_line_fails_to_load(
+    tmp_path: Path,
+    witness: tuple[Ed25519FileKeySigner, Path],
+) -> None:
+    """A damaged co-signature file is not the same as an unwitnessed install."""
+    signer, state_dir = witness
+    audit_dir = _seed(tmp_path)
+    checkpoint = _seal_and_pin(audit_dir)
+    cosig = cosign_checkpoint(state_dir, checkpoint, signer).cosignature
+    verifier = Ed25519PublicKeyVerifier.from_path(_public_key_file(signer, tmp_path / "witness.pub"))
+    record_cosignature(audit_dir, cosig, verifier)
+
+    cosignatures_path(audit_dir).write_bytes(b'{"version": 1, "kind": "nonsense"}\n')
+    with pytest.raises(CosignatureFileError):
+        load_cosignatures(audit_dir)
+
+
+# ---------------------------------------------------------------------------
+# 4. The load-bearing property: a mutually consistent rewind
+# ---------------------------------------------------------------------------
+
+
+def test_mutually_consistent_rewind_passes_locally_but_contradicts_the_witness(
+    cli_workspace: Path,
+    tmp_path: Path,
+) -> None:
+    """The whole point, with the contrast in one test.
+
+    Rewinding the chain segments and the checkpoints file together leaves the
+    local state self-consistent: ``bernstein audit verify`` passes. The same
+    rewind checked against witness state is a hard verdict naming the
+    witnessed checkpoint.
+    """
+    audit_dir = cli_workspace / ".sdd" / "audit"
+    signer = _witness_key(cli_workspace / "witness.key")
+    state_dir = cli_workspace / "witness-state"
+    public_key = _public_key_file(signer, cli_workspace / "witness.pub")
+    verifier = Ed25519PublicKeyVerifier.from_path(public_key)
+
+    _cli_seal()
+    from bernstein.core.persistence.chain_checkpoint import load_checkpoints
+
+    checkpoint = load_checkpoints(audit_dir, _KEY).last
+    assert checkpoint is not None
+    cosig = cosign_checkpoint(state_dir, checkpoint, signer).cosignature
+    record_cosignature(audit_dir, cosig, verifier)
+
+    runner = CliRunner()
+    assert runner.invoke(audit_group, ["verify", "--witness-key", str(public_key)]).exit_code == 0
+
+    # The full local rollback: history shrinks, every local pin that would
+    # have noticed is deleted with it, and the attacker re-seals so the
+    # remaining local state is mutually consistent.
+    _truncate_history(audit_dir, keep=2)
+    checkpoints_path(audit_dir).unlink()
+    cosignatures_path(audit_dir).unlink()
+    _cli_seal()
+
+    # Without a witness the rewind is clean - nothing local remembers.
+    assert runner.invoke(audit_group, ["verify"]).exit_code == 0
+
+    # Against the witness's own retained state it is a hard verdict that names
+    # the checkpoint the witness accepted.
+    result = runner.invoke(
+        audit_group,
+        ["verify", "--witness-key", str(public_key), "--witness-state", str(state_dir)],
+    )
+    assert result.exit_code == 1, result.output
+    assert "Witness Contradiction" in result.output
+    assert str(checkpoint["root_hash"])[:16] in result.output
+
+
+def test_a_cosignature_whose_checkpoint_is_gone_is_a_contradiction(
+    tmp_path: Path,
+    witness: tuple[Ed25519FileKeySigner, Path],
+) -> None:
+    """Deleting the checkpoints file does not delete what the witness signed."""
+    signer, state_dir = witness
+    audit_dir = _seed(tmp_path)
+    checkpoint = _seal_and_pin(audit_dir)
+    cosig = cosign_checkpoint(state_dir, checkpoint, signer).cosignature
+
+    conflicts = check_witness_contradictions(audit_dir, [cosig.claim()], checkpoint_roots=set())
+    assert [c.kind for c in conflicts] == ["witness_checkpoint_missing"]
+
+
+def test_verify_says_so_when_no_witness_cosignature_is_on_record(cli_workspace: Path) -> None:
+    """An unwitnessed install passes and is told it is unwitnessed."""
+    _cli_seal()
+    result = CliRunner().invoke(audit_group, ["verify"])
+    assert result.exit_code == 0, result.output
+    assert "not witness" in result.output.lower()


### PR DESCRIPTION
## What

Adds witness co-signing of audit checkpoints: a second party that holds
per-origin monotonic state and co-signs a checkpoint only when the submitted
tree is a consistent extension of the last one it accepted.

New module `src/bernstein/core/persistence/checkpoint_witness.py`, a sibling of
`checkpoint_anchor.py` and written to the same shape (append-only file beside
`checkpoints.jsonl`, torn-tail tolerance, conflicts reported as
`CheckpointConflict` values outside `ACKABLE_KINDS`).

New operator surface:

- `bernstein audit witness export` — on the log host, write the newest
  checkpoint payload for transport.
- `bernstein audit witness cosign` — on the witness, check the submission
  against its own state and co-sign, or exit non-zero naming the cause.
- `bernstein audit witness record` — on the log host, store a co-signature
  after checking it under the witness public key the operator pins.
- `bernstein audit verify --witness-key <pub> [--witness-state <dir>]` — a new
  "Witness Co-signatures" pillar.

**Not in this PR**, and deliberately: no HTTP witness endpoint (the C2SP
tlog-witness 400/409/422 wire protocol), no witness quorum, no witness
configuration in `bernstein.yaml`, no `bernstein doctor` row, and no change to
the checkpoint payload format or to `record_checkpoint`. Checkpoint payloads
stay byte-deterministic; nothing here writes to `checkpoints.jsonl`.

**The open decision, and how it was settled.** A recorded co-signature could be
trusted on the strength of a key carried inside the record itself. It is not:
without `--witness-key` the pillar reports co-signatures as present but
unauthenticated and produces no verdict, because a witness key taken from the
record is a witness vouching for itself. This mirrors
`--rfc3161-trusted-tsa-bundle`, which likewise refuses to identify a signer the
operator has not pinned. `record` applies the same rule at write time: the log
host stores nothing it could not check.

## Why

`docs/security/audit-log.md` states the residual of the signed-checkpoint gate
in its own words: an actor with write access to both the chain segments and the
checkpoints file can rewind both to a mutually consistent earlier state, and
every local check still passes. `checkpoint_anchor.py` closed half of that with
an RFC 3161 token — a statement about *when* a history of a given size existed.
The other half is a party that remembers *what it already accepted*, which the
log host cannot be for itself. Operators running compliance-sensitive workflows
need evidence that the pinned history existed where a host-level compromise or a
full-disk restore from an old backup cannot rewrite it.

Both sibling modules named this as an unshipped follow-up in their docstrings;
those notes are updated here.

## How

A checkpoint payload already pins `origin`, `entry_count`, `root_hash` and the
per-segment `leaves` (name, `byte_len`, hash). That is everything a witness
needs and nothing that would let it read the log — the audit HMAC key never
leaves the log host. From the two payloads alone the witness checks, in order:

1. the submitted leaves rebuild the submitted root;
2. the submission is for the origin this state is about;
3. `entry_count` did not decrease;
4. a submission at the pinned `entry_count` is the pinned checkpoint, not a
   second tree of the same size;
5. every pinned segment is still present, none shrank, and one still at its
   pinned length still hashes the same.

Only then does it Ed25519-sign the claim (`origin`, `entry_count`,
`root_hash`, `sha256(canonical checkpoint payload)`, under a domain separator)
and advance its pin. Signing the claim rather than the digest alone means
everything a verifier acts on is inside the signature, so verification needs the
record and the public key and nothing else.

Refusal causes are distinct constants — `size_regression`, `state_mismatch`,
`inconsistent_extension` — and reach the operator as an exit code plus a named
cause.

Witness state lives in the witness's own directory, one file per chain origin,
named by `sha256(origin)` so a checkpoint file from a host the witness does not
trust cannot steer a path. Writes are temp file + fsync + `os.replace` + a
directory fsync, so a crash leaves the old pin rather than a truncated one that
would read as "no state" and silently degrade the witness to a bootstrap. A
witness that holds no pin co-signs and reports that it bootstrapped, on both the
library result and the CLI.

Signing reuses the existing Ed25519 substrate
(`Ed25519FileKeySigner` / `Ed25519PublicKeyVerifier`, the same key custody every
other signing surface goes through) rather than minting a new key scheme.

What the witness deliberately does not check: it never sees the chain segments,
so a pinned segment that *grew* is accepted on the strength of the log host's
own byte-level prefix gate in `chain_checkpoint`, which does hold the bytes.
This is stated in the module docstring and in the operator guide rather than
implied away.

Size note: the module is 923 lines of which 411 are code — the rest is
docstrings and comments, at the density of `checkpoint_anchor.py` next to it.
The `audit_cmd.py` diff is mostly command help text and the pillar's operator
output.

## Tests

`tests/unit/test_checkpoint_witness.py`, 17 tests. Every one failed before the
change: the module did not exist, so the file did not collect
(`ModuleNotFoundError: No module named
'bernstein.core.persistence.checkpoint_witness'`).

1. `test_witness_cosigns_a_checkpoint_and_pins_its_state`
2. `test_witness_state_survives_a_witness_restart`
3. `test_witness_without_prior_state_reports_that_it_is_bootstrapping`
4. `test_witness_refuses_a_checkpoint_that_shrinks_the_history` — `size_regression`
5. `test_witness_refuses_a_fork_at_the_size_it_already_accepted` — `state_mismatch`
6. `test_witness_refuses_a_larger_tree_whose_pinned_leaves_regressed` — `inconsistent_extension`
7. `test_witness_refuses_a_checkpoint_whose_leaves_do_not_rebuild_its_root`
8. `test_a_refused_checkpoint_does_not_advance_witness_state`
9. `test_cosignature_verifies_offline_with_only_the_witness_public_key`
10. `test_a_cosignature_from_another_key_does_not_verify`
11. `test_recording_refuses_a_cosignature_the_witness_key_does_not_verify`
12. `test_a_tampered_cosignature_line_fails_to_load`
13. `test_mutually_consistent_rewind_passes_locally_but_contradicts_the_witness`
14. `test_a_cosignature_whose_checkpoint_is_gone_is_a_contradiction`
15. `test_verify_says_so_when_no_witness_cosignature_is_on_record`
16. `test_the_three_witness_commands_round_trip`
17. `test_the_cosign_command_exits_non_zero_naming_the_refusal_cause`

**Load-bearing: 13.** It performs the whole local rollback — truncate the chain
segment, delete `checkpoints.jsonl`, delete `cosignatures.jsonl`, re-seal so the
remaining local state is mutually consistent — and asserts both halves of the
contrast the issue asked for: `bernstein audit verify` still exits 0, and the
same tree checked against the witness's retained state exits 1 with a "Witness
Contradiction" naming the witnessed checkpoint root. Tests 4–7 give each refusal
cause its own case; 9–11 pin that a self-asserted key cannot stand in for the
operator's pinned one.

Locally green (this machine is shared, so a targeted selection rather than the
whole suite; CI runs the full suite):

- `run_tests.py --parallel 2 -x tests/unit/test_checkpoint_witness.py` — 17 passed.
- The 37 test files under `tests/` that import `audit_cmd`, `chain_checkpoint`
  or `checkpoint_anchor` — 37 files passed. `--affected origin/main` selected a
  set too large to finish in the local time budget, so the importer set was run
  instead.

## Checklist

- [x] `uv run ruff check src/` — clean.
- [x] `uv run ruff format --check` on the changed files — clean.
- [x] `uv run pyright src/bernstein/core/persistence/checkpoint_witness.py` — 0 errors;
      `audit_cmd.py` stays at its pre-existing 114.
- [x] `uv run python scripts/run_tests.py --parallel 2 -x <files>` — green.
- [x] Type hints on every new function and dataclass field.
- [x] Documentation duty: `docs/security/audit-log.md` gains a "Witness
      co-signatures" section under external anchors, and the stale "still open"
      note there and in both sibling module docstrings is corrected.
- [x] Release note: `docs/release-notes/fragments/3161-witness-cosign-audit-checkpoints.md`.
- [x] `uv run bernstein agents-md sync` — no tracked file changed.
- [ ] Schema / data migration — N/A, no stored format changed.
- [ ] Public API break — N/A, additive only.

Closes #3161
