### PR TITLE
feat: rotate target secrets with mint, store, apply and a dated receipt (#5119)

### DIFF
--- a/src/bernstein/core/security/secret_rotation.py
+++ b/src/bernstein/core/security/secret_rotation.py
@@ -1,0 +1,645 @@
+"""Rotate a secret that lives on an external target: mint, store, apply.
+
+Operator pain solved
+====================
+
+:mod:`bernstein.core.security.secrets_broker` mints and revokes short-lived
+tokens against a read-only backend, and
+:mod:`bernstein.core.security.key_rotation` rotates Bernstein's *own* outbound
+API keys. Neither writes a new credential onto an external target -- a deploy
+account, a CI runner, a partner API -- and neither keeps a bounded history of
+what the credential used to be. Rotating such a secret by hand is where
+operators lock themselves out: the new value reaches the target, the old one is
+gone, and nobody can produce either again.
+
+Order of operations
+===================
+
+``mint -> store -> apply`` is the only order that cannot strand an operator::
+
+    rotator = SecretRotator(broker=broker, store=store, journal=journal)
+    run = rotator.rotate(
+        target=target, principal="svc-deploy",
+        secret_name="DEPLOY_KEY", task_id="t-42",
+    )
+
+* **mint** asks the broker for new material.
+* **store** records it in a bounded per-``(target, principal)`` history *before*
+  anything on the target changes.
+* **apply** writes it to the target, then leaves a dated receipt there.
+
+A failure at apply raises :class:`RotationError` carrying the
+:class:`RotationRun` that says how far the run got. Because store already
+completed, both the previous version and the un-applied new one stay
+retrievable, and the target still holds the credential it had.
+
+``principal``
+=============
+
+``principal`` is the identity the credential authenticates *as on the target*
+-- a service account, a deploy user, an operator login the target itself
+recognises. It is deliberately not a Bernstein ``task_id``: a task id is
+per-run, so a ``(target, task_id)`` history would hold exactly one version and
+could never answer "what was this credential before". It is also not a
+Bernstein agent identity: one agent may rotate credentials for many principals
+on the same target.
+
+Receipts
+========
+
+Each successful rotation writes a :class:`RotationReceipt` on the target,
+carrying the version id, a fingerprint of the new material (never the material)
+and the rotation timestamp. :func:`audit_rotation_receipts` reads those
+receipts back and reports a single finding,
+``secret_rotation_receipt_not_current``, for a principal whose receipt is
+missing *or* older than the policy window -- from the operator's chair, "never
+rotated" and "stopped being rotated" are the same fact.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import secrets as _secrets
+import threading
+import time
+from abc import ABC, abstractmethod
+from collections import deque
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar, cast
+
+from bernstein.core.security.secrets_broker import (
+    SecretsBroker,
+    register_secret_for_redaction,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "RotationAuditFinding",
+    "RotationError",
+    "RotationJournal",
+    "RotationReceipt",
+    "RotationRun",
+    "RotationStep",
+    "RotationTarget",
+    "SecretRotator",
+    "SecretVersion",
+    "SecretVersionStore",
+    "audit_rotation_receipts",
+]
+
+_DEFAULT_MAX_VERSIONS = 3
+_MIN_MAX_VERSIONS = 2
+
+
+def _fingerprint(value: str) -> str:
+    """Return a short, non-reversible fingerprint of secret material."""
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]
+
+
+def _new_version_id(now: float) -> str:
+    """Return a sortable, collision-resistant version id."""
+    return f"v-{int(now)}-{_secrets.token_hex(4)}"
+
+
+class RotationError(Exception):
+    """Raised when a rotation run fails.
+
+    Attributes:
+        run: The :class:`RotationRun` describing how far the run got, or
+            ``None`` when the failure happened before a run could be shaped.
+    """
+
+    def __init__(self, message: str, *, run: RotationRun | None = None) -> None:
+        super().__init__(message)
+        self.run = run
+
+
+# ---------------------------------------------------------------------------
+# Version history (the "store" step)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SecretVersion:
+    """One stored version of a target secret.
+
+    ``value`` is excluded from ``repr`` so a stored version cannot leak the
+    credential into a traceback, a log line, or a test failure message.
+    """
+
+    target: str
+    principal: str
+    version_id: str
+    created_at: float
+    fingerprint: str
+    value: str = field(repr=False)
+
+
+class SecretVersionStore:
+    """Bounded, in-process version history keyed by ``(target, principal)``.
+
+    History is bounded so an incident never has to be reconstructed from an
+    unbounded pile of versions, and configurable because how many generations
+    an operator must be able to fall back to is a site policy. The bound is at
+    least two: rotation's whole safety property is that the previous version
+    stays retrievable while the new one is applied, and a bound of one would
+    evict it.
+
+    History lives in this process. Persisting versions to an external store is
+    the backend contract's job, not this module's.
+    """
+
+    def __init__(self, *, max_versions: int = _DEFAULT_MAX_VERSIONS) -> None:
+        if max_versions < _MIN_MAX_VERSIONS:
+            raise RotationError(
+                f"max_versions must be at least {_MIN_MAX_VERSIONS} so the previous version "
+                f"stays retrievable during a rotation; got {max_versions}"
+            )
+        self._max_versions = max_versions
+        self._lock = threading.Lock()
+        self._history: dict[tuple[str, str], deque[SecretVersion]] = {}
+
+    @property
+    def max_versions(self) -> int:
+        """Return the configured per-``(target, principal)`` history bound."""
+        return self._max_versions
+
+    def store(
+        self,
+        *,
+        target: str,
+        principal: str,
+        value: str,
+        version_id: str,
+        created_at: float,
+    ) -> SecretVersion:
+        """Record ``value`` as the newest version for ``(target, principal)``.
+
+        The oldest version is evicted once the history reaches the bound. The
+        value is registered with the redaction registry so it cannot survive
+        into a persisted transcript.
+        """
+        if not target:
+            raise RotationError("target must not be empty")
+        if not principal:
+            raise RotationError("principal must not be empty")
+        if not version_id:
+            raise RotationError("version_id must not be empty")
+
+        version = SecretVersion(
+            target=target,
+            principal=principal,
+            version_id=version_id,
+            created_at=created_at,
+            fingerprint=_fingerprint(value),
+            value=value,
+        )
+        with self._lock:
+            bucket = self._history.get((target, principal))
+            if bucket is None:
+                bucket = deque[SecretVersion](maxlen=self._max_versions)
+                self._history[(target, principal)] = bucket
+            bucket.append(version)
+        register_secret_for_redaction(value)
+        return version
+
+    def versions(self, *, target: str, principal: str) -> list[SecretVersion]:
+        """Return the retained versions for ``(target, principal)``, newest first."""
+        with self._lock:
+            bucket = self._history.get((target, principal))
+            return list(reversed(bucket)) if bucket else []
+
+    def latest(self, *, target: str, principal: str) -> SecretVersion | None:
+        """Return the newest retained version, or ``None`` when there is none."""
+        with self._lock:
+            bucket = self._history.get((target, principal))
+            return bucket[-1] if bucket else None
+
+    def get(self, *, target: str, principal: str, version_id: str) -> SecretVersion | None:
+        """Return a specific retained version, or ``None`` once it is evicted."""
+        with self._lock:
+            bucket = self._history.get((target, principal))
+            if not bucket:
+                return None
+            for version in bucket:
+                if version.version_id == version_id:
+                    return version
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Receipt
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RotationReceipt:
+    """The dated record a rotation leaves on the target it rotated.
+
+    Carries the fingerprint of the applied material, never the material, so a
+    receipt is safe to read back as a discoverable attribute of the target.
+    """
+
+    target: str
+    principal: str
+    version_id: str
+    fingerprint: str
+    rotated_at: int
+
+    def to_canonical_bytes(self) -> bytes:
+        """Serialise to canonical JSON bytes."""
+        return json.dumps(
+            {
+                "fingerprint": self.fingerprint,
+                "principal": self.principal,
+                "rotated_at": self.rotated_at,
+                "target": self.target,
+                "version_id": self.version_id,
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+
+    @classmethod
+    def from_bytes(cls, raw: bytes) -> RotationReceipt:
+        """Parse a receipt from its canonical JSON bytes."""
+        parsed: object = json.loads(raw)
+        if not isinstance(parsed, dict):
+            raise RotationError("rotation receipt payload is not an object")
+        row = cast("dict[str, Any]", parsed)
+        return cls(
+            target=str(row["target"]),
+            principal=str(row["principal"]),
+            version_id=str(row["version_id"]),
+            fingerprint=str(row["fingerprint"]),
+            rotated_at=int(row["rotated_at"]),
+        )
+
+    def age_seconds(self, *, now: float) -> float:
+        """Return how long ago this rotation happened, in seconds."""
+        return now - float(self.rotated_at)
+
+
+# ---------------------------------------------------------------------------
+# Target contract (the "apply" step)
+# ---------------------------------------------------------------------------
+
+
+class RotationTarget(ABC):
+    """A system that holds a secret Bernstein rotates on an operator's behalf.
+
+    Implementations are responsible for the two writes rotation performs on the
+    target: installing the new credential and recording the receipt that says
+    when it was installed.
+    """
+
+    name: str = ""
+
+    @abstractmethod
+    def apply(self, *, principal: str, value: str) -> None:
+        """Install ``value`` as ``principal``'s credential on this target.
+
+        Raises:
+            Exception: Any failure. The rotator turns it into a
+                :class:`RotationError` whose run stopped at
+                :attr:`RotationStep.STORE`.
+        """
+
+    @abstractmethod
+    def write_receipt(self, *, principal: str, receipt: RotationReceipt) -> None:
+        """Record ``receipt`` on the target as a readable attribute."""
+
+    @abstractmethod
+    def read_receipt(self, *, principal: str) -> RotationReceipt | None:
+        """Return the receipt this target holds for ``principal``, if any."""
+
+
+# ---------------------------------------------------------------------------
+# Run record + journal
+# ---------------------------------------------------------------------------
+
+
+class RotationStep(StrEnum):
+    """The steps a rotation run passes through, in order."""
+
+    MINT = "mint"
+    STORE = "store"
+    APPLY = "apply"
+    RECEIPT = "receipt"
+
+
+@dataclass(frozen=True)
+class RotationRun:
+    """What one rotation run did, and how far it got.
+
+    ``step_reached`` names the last step that *completed*: a run that minted
+    and stored but failed to apply reports :attr:`RotationStep.STORE`, which is
+    also the guarantee that both versions are still in the store.
+    """
+
+    target: str
+    principal: str
+    secret_name: str
+    task_id: str
+    version_id: str
+    token_id: str
+    fingerprint: str
+    step_reached: RotationStep | None
+    ok: bool
+    started_at: float
+    finished_at: float
+    previous_version_id: str = ""
+    error: str = ""
+
+    def to_row(self) -> dict[str, Any]:
+        """Return a JSON-safe journal row. Never carries secret material."""
+        return {
+            "error": self.error,
+            "finished_at": self.finished_at,
+            "fingerprint": self.fingerprint,
+            "ok": self.ok,
+            "previous_version_id": self.previous_version_id,
+            "principal": self.principal,
+            "secret_name": self.secret_name,
+            "started_at": self.started_at,
+            "step_reached": self.step_reached.value if self.step_reached is not None else "",
+            "target": self.target,
+            "task_id": self.task_id,
+            "token_id": self.token_id,
+            "version_id": self.version_id,
+        }
+
+
+class RotationJournal:
+    """Append-only JSONL journal of rotation runs."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = Path(path)
+        self._lock = threading.Lock()
+
+    @property
+    def path(self) -> Path:
+        """Return the journal file path."""
+        return self._path
+
+    def record(self, run: RotationRun) -> None:
+        """Append ``run`` to the journal."""
+        line = json.dumps(run.to_row(), ensure_ascii=False, separators=(",", ":"), sort_keys=True) + "\n"
+        with self._lock:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            with self._path.open("a", encoding="utf-8") as handle:
+                handle.write(line)
+
+    def rows(self) -> list[dict[str, Any]]:
+        """Return every journaled run, oldest first."""
+        if not self._path.is_file():
+            return []
+        rows: list[dict[str, Any]] = []
+        for line in self._path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            parsed: object = json.loads(line)
+            if isinstance(parsed, dict):
+                rows.append(cast("dict[str, Any]", parsed))
+        return rows
+
+
+# ---------------------------------------------------------------------------
+# The rotator
+# ---------------------------------------------------------------------------
+
+
+class SecretRotator:
+    """Run ``mint -> store -> apply`` against a :class:`RotationTarget`."""
+
+    def __init__(
+        self,
+        *,
+        broker: SecretsBroker,
+        store: SecretVersionStore,
+        journal: RotationJournal | None = None,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._broker = broker
+        self._store = store
+        self._journal = journal
+        self._clock = clock
+
+    def rotate(
+        self,
+        *,
+        target: RotationTarget,
+        principal: str,
+        secret_name: str,
+        task_id: str,
+        ttl_seconds: int | None = None,
+    ) -> RotationRun:
+        """Rotate ``principal``'s credential on ``target``.
+
+        Args:
+            target: The system holding the credential.
+            principal: The identity the credential authenticates as on the
+                target.
+            secret_name: Backing-store name the broker mints against.
+            task_id: Bernstein task id that owns the minted token.
+            ttl_seconds: Lifetime override for the minted token.
+
+        Returns:
+            The completed :class:`RotationRun`.
+
+        Raises:
+            RotationError: When any step fails. The exception's ``run``
+                attribute names the last completed step; the same run is
+                journaled before the error is raised.
+        """
+        if not principal:
+            raise RotationError("principal must not be empty")
+
+        started_at = self._clock()
+        version_id = _new_version_id(started_at)
+        target_name = target.name or type(target).__name__
+        previous = self._store.latest(target=target_name, principal=principal)
+        previous_version_id = previous.version_id if previous is not None else ""
+
+        def _fail(step: RotationStep | None, token_id: str, fingerprint: str, exc: BaseException) -> RotationError:
+            run = RotationRun(
+                target=target_name,
+                principal=principal,
+                secret_name=secret_name,
+                task_id=task_id,
+                version_id=version_id,
+                token_id=token_id,
+                fingerprint=fingerprint,
+                step_reached=step,
+                ok=False,
+                started_at=started_at,
+                finished_at=self._clock(),
+                previous_version_id=previous_version_id,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+            self._journal_run(run)
+            reached = step.value if step is not None else "nothing"
+            logger.error(
+                "secret rotation failed for %s/%s after %s: %s",
+                target_name,
+                principal,
+                reached,
+                run.error,
+            )
+            return RotationError(
+                f"rotation of {principal!r} on {target_name!r} failed after {reached}: {run.error}",
+                run=run,
+            )
+
+        # 1. mint -- new material, never derived from what the target holds.
+        try:
+            token = self._broker.mint(
+                secret_name=secret_name,
+                task_id=task_id,
+                ttl_seconds=ttl_seconds,
+                version_id=version_id,
+            )
+        except Exception as exc:
+            raise _fail(None, "", "", exc) from exc
+
+        fingerprint = _fingerprint(token.value)
+
+        # 2. store -- history is bounded, and the previous version survives.
+        try:
+            self._store.store(
+                target=target_name,
+                principal=principal,
+                value=token.value,
+                version_id=version_id,
+                created_at=started_at,
+            )
+        except Exception as exc:
+            raise _fail(RotationStep.MINT, token.token_id, fingerprint, exc) from exc
+
+        # 3. apply -- the only step that changes the target.
+        try:
+            target.apply(principal=principal, value=token.value)
+        except Exception as exc:
+            raise _fail(RotationStep.STORE, token.token_id, fingerprint, exc) from exc
+
+        # 4. receipt -- dated proof on the target that the apply happened.
+        receipt = RotationReceipt(
+            target=target_name,
+            principal=principal,
+            version_id=version_id,
+            fingerprint=fingerprint,
+            rotated_at=int(started_at),
+        )
+        try:
+            target.write_receipt(principal=principal, receipt=receipt)
+        except Exception as exc:
+            raise _fail(RotationStep.APPLY, token.token_id, fingerprint, exc) from exc
+
+        run = RotationRun(
+            target=target_name,
+            principal=principal,
+            secret_name=secret_name,
+            task_id=task_id,
+            version_id=version_id,
+            token_id=token.token_id,
+            fingerprint=fingerprint,
+            step_reached=RotationStep.RECEIPT,
+            ok=True,
+            started_at=started_at,
+            finished_at=self._clock(),
+            previous_version_id=previous_version_id,
+        )
+        self._journal_run(run)
+        return run
+
+    def _journal_run(self, run: RotationRun) -> None:
+        if self._journal is None:
+            return
+        try:
+            self._journal.record(run)
+        except OSError as exc:  # pragma: no cover - filesystem failure path
+            logger.error("secret rotation journal write failed: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Receipt audit
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RotationAuditFinding:
+    """A principal whose rotation receipt is not current.
+
+    Missing and stale are one finding on purpose: from the chair asking "who is
+    out of date", a target that was never rotated and one that stopped being
+    rotated are the same answer.
+    """
+
+    NAME: ClassVar[str] = "secret_rotation_receipt_not_current"
+
+    target: str
+    principal: str
+    receipt_present: bool
+    age_seconds: float | None
+    max_age_seconds: int
+    finding: str = NAME
+
+
+def audit_rotation_receipts(
+    *,
+    target: RotationTarget,
+    principals: Sequence[str],
+    max_age_seconds: int,
+    now: float | None = None,
+) -> list[RotationAuditFinding]:
+    """Report principals on ``target`` whose rotation receipt is not current.
+
+    Args:
+        target: The target to probe.
+        principals: The principals expected to be rotated on it.
+        max_age_seconds: Policy window; a receipt older than this is stale.
+        now: Wall-clock override for tests.
+
+    Returns:
+        One finding per principal whose receipt is missing or stale, in the
+        order ``principals`` was given.
+    """
+    if max_age_seconds <= 0:
+        raise RotationError("max_age_seconds must be positive")
+    current = now if now is not None else time.time()
+    target_name = target.name or type(target).__name__
+    findings: list[RotationAuditFinding] = []
+    for principal in principals:
+        receipt = target.read_receipt(principal=principal)
+        if receipt is None:
+            findings.append(
+                RotationAuditFinding(
+                    target=target_name,
+                    principal=principal,
+                    receipt_present=False,
+                    age_seconds=None,
+                    max_age_seconds=max_age_seconds,
+                )
+            )
+            continue
+        age = receipt.age_seconds(now=current)
+        if age > max_age_seconds:
+            findings.append(
+                RotationAuditFinding(
+                    target=target_name,
+                    principal=principal,
+                    receipt_present=True,
+                    age_seconds=age,
+                    max_age_seconds=max_age_seconds,
+                )
+            )
+    return findings

--- a/src/bernstein/core/security/secrets_broker.py
+++ b/src/bernstein/core/security/secrets_broker.py
@@ -181,7 +181,13 @@ AuditSink = Callable[[AuditEvent], None]
 
 @dataclass(frozen=True)
 class MintedToken:
-    """Result of a successful :meth:`SecretsBroker.mint` call."""
+    """Result of a successful :meth:`SecretsBroker.mint` call.
+
+    ``version_id`` is empty for an ordinary mint. A rotation run sets it so the
+    token, the stored secret version, and the receipt left on the target all
+    name the same version (see
+    :mod:`bernstein.core.security.secret_rotation`).
+    """
 
     token_id: str
     value: str
@@ -190,6 +196,7 @@ class MintedToken:
     expires_at: float
     ttl_seconds: int
     audience: str = ""
+    version_id: str = ""
 
     def is_expired(self, *, now: float | None = None) -> bool:
         """Return ``True`` when wall-clock time has passed ``expires_at``."""
@@ -629,6 +636,7 @@ class SecretsBroker:
         ttl_seconds: int | None = None,
         grant: Any = None,
         run_id: str | None = None,
+        version_id: str = "",
     ) -> MintedToken:
         """Mint a short-lived token for ``secret_name`` scoped to ``task_id``.
 
@@ -644,6 +652,8 @@ class SecretsBroker:
                 mode; the minted token inherits the grant's audience and expiry.
             run_id: Run scope for chain-anchored refusal records when no grant
                 is presented. Defaults to the grant's run id, else ``task_id``.
+            version_id: Secret-version identifier a rotation run assigns to the
+                material being minted. Empty for an ordinary mint.
 
         Returns:
             A :class:`MintedToken`. The ``value`` field is what the agent
@@ -692,6 +702,7 @@ class SecretsBroker:
             expires_at=expires_at,
             ttl_seconds=effective_ttl,
             audience=audience,
+            version_id=version_id,
         )
         registration = _Registration(
             token=token,
@@ -737,6 +748,7 @@ class SecretsBroker:
         ttl_seconds: int | None = None,
         grant: Any = None,
         run_id: str | None = None,
+        version_id: str = "",
     ) -> Generator[MintedToken, None, None]:
         """Mint a token; auto-revoke on context-manager exit."""
         token = self.mint(
@@ -745,6 +757,7 @@ class SecretsBroker:
             ttl_seconds=ttl_seconds,
             grant=grant,
             run_id=run_id,
+            version_id=version_id,
         )
         try:
             yield token

--- a/tests/unit/security/test_secret_rotation_pipeline.py
+++ b/tests/unit/security/test_secret_rotation_pipeline.py
@@ -1,0 +1,338 @@
+"""Unit tests for :mod:`bernstein.core.security.secret_rotation`.
+
+The pipeline under test rotates a secret that lives on an *external target*:
+mint the new material, store it with bounded per-``(target, principal)``
+history, then apply it to the target, in that order. Every test uses real
+objects -- a real broker over an in-memory backend, a real version store, a
+real on-disk journal -- so the ordering and the "previous version survives a
+failed apply" property are exercised where they actually hold.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.security.secret_rotation import (
+    RotationAuditFinding,
+    RotationError,
+    RotationJournal,
+    RotationReceipt,
+    RotationStep,
+    RotationTarget,
+    SecretRotator,
+    SecretVersionStore,
+    audit_rotation_receipts,
+)
+from bernstein.core.security.secrets_broker import (
+    BrokerConfig,
+    SecretsBackend,
+    SecretsBroker,
+    SecretsBrokerError,
+    clear_redaction_registry,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures: in-memory backend (same style as test_secrets_broker.py) and a
+# fake external target that records every apply.
+# ---------------------------------------------------------------------------
+
+
+class _MemoryBackend(SecretsBackend):
+    name = "memory"
+
+    def __init__(self, secrets: dict[str, str]) -> None:
+        self._secrets = secrets.copy()
+
+    def read(self, secret_name: str) -> str:
+        if secret_name not in self._secrets:
+            raise SecretsBrokerError(f"memory: no entry for {secret_name!r}")
+        return self._secrets[secret_name]
+
+
+class _FakeTarget(RotationTarget):
+    """A target that records applies and can be told to fail the apply step."""
+
+    name = "fake-target"
+
+    def __init__(self, *, fail_apply: bool = False) -> None:
+        self.fail_apply = fail_apply
+        self.applied: dict[str, str] = {}
+        self.apply_calls: list[str] = []
+        self.receipts: dict[str, RotationReceipt] = {}
+        self.calls: list[str] = []
+
+    def apply(self, *, principal: str, value: str) -> None:
+        self.calls.append("apply")
+        self.apply_calls.append(principal)
+        if self.fail_apply:
+            raise RuntimeError("target refused the new credential")
+        self.applied[principal] = value
+
+    def write_receipt(self, *, principal: str, receipt: RotationReceipt) -> None:
+        self.calls.append("write_receipt")
+        self.receipts[principal] = receipt
+
+    def read_receipt(self, *, principal: str) -> RotationReceipt | None:
+        return self.receipts.get(principal)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry() -> None:
+    clear_redaction_registry()
+    yield
+    clear_redaction_registry()
+
+
+@pytest.fixture
+def broker() -> SecretsBroker:
+    backend = _MemoryBackend({"DEPLOY_KEY": "backing-value-0123456789"})
+    return SecretsBroker(backend, config=BrokerConfig(backend="file_encrypted"))
+
+
+# ---------------------------------------------------------------------------
+# 1. Bounded, configurable version history (slice 1)
+# ---------------------------------------------------------------------------
+
+
+class TestVersionHistory:
+    def test_version_history_per_target_and_principal_is_bounded_and_configurable(self) -> None:
+        store = SecretVersionStore(max_versions=2)
+
+        for i in range(4):
+            store.store(
+                target="t1",
+                principal="svc-deploy",
+                value=f"value-{i}",
+                version_id=f"v{i}",
+                created_at=100.0 + i,
+            )
+        # A different principal on the same target keeps its own history.
+        store.store(target="t1", principal="svc-other", value="other", version_id="o0", created_at=100.0)
+        # ...and so does the same principal on a different target.
+        store.store(target="t2", principal="svc-deploy", value="elsewhere", version_id="e0", created_at=100.0)
+
+        kept = store.versions(target="t1", principal="svc-deploy")
+        assert [v.version_id for v in kept] == ["v3", "v2"], "newest first, oldest evicted at the bound"
+        assert store.get(target="t1", principal="svc-deploy", version_id="v1") is None
+
+        assert [v.version_id for v in store.versions(target="t1", principal="svc-other")] == ["o0"]
+        assert [v.version_id for v in store.versions(target="t2", principal="svc-deploy")] == ["e0"]
+
+        # The bound is configurable, not hard-coded.
+        wider = SecretVersionStore(max_versions=5)
+        for i in range(6):
+            wider.store(target="t1", principal="p", value=f"v{i}", version_id=f"v{i}", created_at=float(i))
+        assert len(wider.versions(target="t1", principal="p")) == 5
+
+    def test_history_bound_below_two_is_rejected(self) -> None:
+        with pytest.raises(RotationError, match="max_versions"):
+            SecretVersionStore(max_versions=1)
+
+    def test_stored_version_repr_does_not_leak_the_secret_value(self) -> None:
+        store = SecretVersionStore(max_versions=2)
+        version = store.store(
+            target="t1", principal="p", value="super-secret-material", version_id="v0", created_at=1.0
+        )
+        assert "super-secret-material" not in repr(version)
+        assert version.value == "super-secret-material"
+
+
+# ---------------------------------------------------------------------------
+# 2. Ordering (slice 2)
+# ---------------------------------------------------------------------------
+
+
+class TestRotationOrder:
+    def test_rotation_runs_mint_then_store_then_apply_in_order(self, broker: SecretsBroker, tmp_path: Path) -> None:
+        store = SecretVersionStore(max_versions=3)
+        journal = RotationJournal(tmp_path / "rotation.jsonl")
+        target = _FakeTarget()
+        rotator = SecretRotator(broker=broker, store=store, journal=journal)
+
+        observed: list[str] = []
+        original_store = store.store
+
+        def _tracking_store(**kwargs: object):  # type: ignore[no-untyped-def]
+            observed.append("store")
+            return original_store(**kwargs)  # type: ignore[arg-type]
+
+        store.store = _tracking_store  # type: ignore[method-assign]
+
+        original_apply = target.apply
+
+        def _tracking_apply(*, principal: str, value: str) -> None:
+            observed.append("apply")
+            original_apply(principal=principal, value=value)
+
+        target.apply = _tracking_apply  # type: ignore[method-assign]
+
+        run = rotator.rotate(
+            target=target,
+            principal="svc-deploy",
+            secret_name="DEPLOY_KEY",
+            task_id="t-42",
+        )
+
+        assert observed == ["store", "apply"], "store must complete before apply"
+        assert run.ok is True
+        assert run.step_reached is RotationStep.RECEIPT
+
+        # The applied value is the version the store recorded, not a re-mint.
+        stored = store.get(target=target.name, principal="svc-deploy", version_id=run.version_id)
+        assert stored is not None
+        assert target.applied["svc-deploy"] == stored.value
+
+        rows = journal.rows()
+        assert [row["step_reached"] for row in rows] == ["receipt"]
+        assert rows[0]["ok"] is True
+        assert stored.value not in json.dumps(rows), "the journal never carries secret material"
+
+    def test_minted_token_carries_the_version_id_the_store_recorded(
+        self, broker: SecretsBroker, tmp_path: Path
+    ) -> None:
+        store = SecretVersionStore(max_versions=3)
+        target = _FakeTarget()
+        rotator = SecretRotator(broker=broker, store=store, journal=RotationJournal(tmp_path / "j.jsonl"))
+
+        run = rotator.rotate(target=target, principal="svc-deploy", secret_name="DEPLOY_KEY", task_id="t-1")
+
+        live = {t.token_id: t for t in broker.list_live()}
+        token = live.get(run.token_id)
+        assert token is not None
+        assert token.version_id == run.version_id
+        assert store.get(target=target.name, principal="svc-deploy", version_id=token.version_id) is not None
+
+
+# ---------------------------------------------------------------------------
+# 3. Failure after store (load-bearing)
+# ---------------------------------------------------------------------------
+
+
+class TestFailureAfterStore:
+    def test_failure_after_store_leaves_previous_version_retrievable_and_target_unchanged(
+        self, broker: SecretsBroker, tmp_path: Path
+    ) -> None:
+        store = SecretVersionStore(max_versions=3)
+        journal = RotationJournal(tmp_path / "rotation.jsonl")
+        rotator = SecretRotator(broker=broker, store=store, journal=journal)
+
+        good = _FakeTarget()
+        first = rotator.rotate(target=good, principal="svc-deploy", secret_name="DEPLOY_KEY", task_id="t-1")
+        first_version = store.get(target=good.name, principal="svc-deploy", version_id=first.version_id)
+        assert first_version is not None
+        applied_before = dict(good.applied)
+        receipt_before = good.read_receipt(principal="svc-deploy")
+
+        good.fail_apply = True
+        with pytest.raises(RotationError) as excinfo:
+            rotator.rotate(target=good, principal="svc-deploy", secret_name="DEPLOY_KEY", task_id="t-2")
+
+        failed = excinfo.value.run
+        assert failed.step_reached is RotationStep.STORE, "the run got as far as store, no further"
+        assert failed.ok is False
+
+        # Both versions are retrievable: the one the target still holds and the
+        # one that was minted and stored but never applied.
+        versions = store.versions(target=good.name, principal="svc-deploy")
+        assert [v.version_id for v in versions] == [failed.version_id, first.version_id]
+        assert store.get(target=good.name, principal="svc-deploy", version_id=first.version_id) is not None
+        assert store.get(target=good.name, principal="svc-deploy", version_id=failed.version_id) is not None
+
+        # The target is unchanged: same credential, same receipt.
+        assert good.applied == applied_before
+        assert good.read_receipt(principal="svc-deploy") == receipt_before
+
+        # And the run is journaled with the step it reached.
+        rows = journal.rows()
+        assert [row["step_reached"] for row in rows] == ["receipt", "store"]
+        assert rows[1]["ok"] is False
+        assert "target refused the new credential" in rows[1]["error"]
+
+
+# ---------------------------------------------------------------------------
+# 4. Receipt staleness (slice 3)
+# ---------------------------------------------------------------------------
+
+
+class TestReceiptStaleness:
+    def test_rotation_receipt_older_than_policy_window_is_an_audit_finding(
+        self, broker: SecretsBroker, tmp_path: Path
+    ) -> None:
+        store = SecretVersionStore(max_versions=3)
+        target = _FakeTarget()
+        rotator = SecretRotator(
+            broker=broker,
+            store=store,
+            journal=RotationJournal(tmp_path / "j.jsonl"),
+            clock=lambda: 1_000_000.0,
+        )
+        rotator.rotate(target=target, principal="svc-deploy", secret_name="DEPLOY_KEY", task_id="t-1")
+
+        receipt = target.read_receipt(principal="svc-deploy")
+        assert receipt is not None
+        assert receipt.rotated_at == 1_000_000
+
+        fresh = audit_rotation_receipts(
+            target=target,
+            principals=["svc-deploy"],
+            max_age_seconds=86_400,
+            now=1_000_100.0,
+        )
+        assert fresh == []
+
+        stale = audit_rotation_receipts(
+            target=target,
+            principals=["svc-deploy"],
+            max_age_seconds=86_400,
+            now=1_000_000.0 + 86_401,
+        )
+        assert len(stale) == 1
+        assert stale[0].finding == RotationAuditFinding.NAME
+        assert stale[0].receipt_present is True
+        assert stale[0].age_seconds is not None and stale[0].age_seconds > 86_400
+
+    def test_missing_receipt_and_stale_receipt_share_one_finding_name(
+        self, broker: SecretsBroker, tmp_path: Path
+    ) -> None:
+        store = SecretVersionStore(max_versions=3)
+        target = _FakeTarget()
+        rotator = SecretRotator(
+            broker=broker,
+            store=store,
+            journal=RotationJournal(tmp_path / "j.jsonl"),
+            clock=lambda: 500.0,
+        )
+        rotator.rotate(target=target, principal="rotated", secret_name="DEPLOY_KEY", task_id="t-1")
+
+        findings = audit_rotation_receipts(
+            target=target,
+            principals=["rotated", "never-rotated"],
+            max_age_seconds=10,
+            now=1_000.0,
+        )
+        assert {f.principal for f in findings} == {"rotated", "never-rotated"}
+        assert {f.finding for f in findings} == {RotationAuditFinding.NAME}
+        by_principal = {f.principal: f for f in findings}
+        assert by_principal["never-rotated"].receipt_present is False
+        assert by_principal["never-rotated"].age_seconds is None
+        assert by_principal["rotated"].receipt_present is True
+
+
+# ---------------------------------------------------------------------------
+# Receipt round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestReceiptSerialisation:
+    def test_receipt_round_trips_through_canonical_bytes(self) -> None:
+        receipt = RotationReceipt(
+            target="t1",
+            principal="svc-deploy",
+            version_id="v-1",
+            fingerprint="abcd1234abcd1234",
+            rotated_at=1_000_000,
+        )
+        assert RotationReceipt.from_bytes(receipt.to_canonical_bytes()) == receipt

--- a/tests/unit/test_security_controls_are_wired.py
+++ b/tests/unit/test_security_controls_are_wired.py
@@ -76,7 +76,6 @@ KNOWN_UNCALLED: frozenset[str] = frozenset(
         "promptware_ingest.py:get_default_detector",
         "rbac.py:require_permission",
         "rbac.py:require_role",
-        "secrets_broker.py:register_secret_for_redaction",
         "secrets_broker.py:unregister_secret_for_redaction",
         "socket_guard.py:collect_unmonitored_destinations",
         "tenanting.py:build_tenant_registry",


### PR DESCRIPTION
## What

A rotation pipeline for a secret that lives on an **external target** — a deploy account, a CI runner, a partner API — in `src/bernstein/core/security/secret_rotation.py`:

- `SecretVersionStore` — bounded, configurable version history keyed by `(target, principal)`.
- `RotationTarget` — the two writes rotation performs on a target: install the credential, record the receipt.
- `SecretRotator.rotate` — runs mint → store → apply → receipt, journals every run, and raises `RotationError` carrying the run and the last step it completed.
- `RotationReceipt` / `audit_rotation_receipts` — a dated receipt on the target and a single finding, `secret_rotation_receipt_not_current`, for a principal whose receipt is missing or stale.
- `MintedToken` (and `SecretsBroker.mint` / `mint_scoped`) gain `version_id`, defaulting to `""`, so the token, the stored version and the receipt name the same version.

**What it explicitly does not do**

- It does not touch `key_rotation.py`. Rotating Bernstein's own outbound keys with leak detection stays where it is; this is about credentials on someone else's system.
- It does not implement a real target or a writable backend. The store/apply verbs are an ABC a fixture satisfies; the external-store contract is #4984 and the Vault backend is #5021.
- It does not persist version history outside the process. History is in-memory, guarded by a lock, the same lifetime as the broker's own token registry; durable storage belongs to the backend contract, not here.
- It does not bind proof-of-possession to the resulting tokens (#5030).
- No YAML config block: the history bound and the policy window are constructor / call arguments, because nothing in the repository reads a rotation config yet.

**Open decision, decided: what `principal` means.** `principal` is the identity the credential authenticates **as on the target** — a service account, a deploy user, a login the target itself recognises. Not a Bernstein `task_id`: a task id is per-run, so a `(target, task_id)` history would hold exactly one version and could never answer "what was this credential before", which is the whole point of the key. Not a Bernstein agent identity either: one agent rotates credentials for many principals on the same target. The decision is written into the module docstring so the next reader does not have to re-derive it.

## Why

`SecretsBroker` mints and revokes short-lived tokens against a backend whose only verb is `read` — there is no way to write a new version of a secret anywhere in it. `KeyRotationManager` rotates Bernstein's own outbound API keys and fetches replacements from a provider; it never writes to a target and never keeps a history.

So an operator rotating a credential that lives on an external system does it by hand, and the failure mode is a lock-out: the new value reaches the target, the old one is gone, and nothing can produce either again. Mint → store → apply is the only order that survives a partial failure. If apply fails after store, the previous version is still on the target and still retrievable, the new one is retrievable too, and the journal says exactly how far the run got. Applying before storing strands the operator on a secret nobody can reproduce; storing without a bound lets history grow until an incident forces someone to reconstruct the changes by hand.

## How

`SecretRotator.rotate` does four things in order and records which of them completed:

1. **mint** — `broker.mint(..., version_id=...)`. The version id is generated before the mint so the token carries it.
2. **store** — `SecretVersionStore.store` appends to a `deque(maxlen=max_versions)` per `(target, principal)`, evicting the oldest, and registers the value with the redaction registry. `max_versions` must be at least 2: a bound of one would evict the version whose survival is the safety property.
3. **apply** — `target.apply(...)`, the only step that changes the target.
4. **receipt** — `target.write_receipt(...)` with the version id, a SHA-256 fingerprint prefix of the material, and the rotation timestamp. Never the material itself.

Any step raising is turned into a `RotationError` whose `.run` names the last completed step; the same run is journaled first, so a failure is recorded even if the caller swallows the exception. `SecretVersion.value` is `field(repr=False)`, so a stored version cannot leak the credential into a traceback or a test failure message, and `RotationRun.to_row` carries fingerprints only.

`audit_rotation_receipts` reads receipts back off a target and returns one finding shape for both missing and stale. #5087 owns the general receipt-staleness shape for every entity kind; it is still open, so this is the secrets-specific instance and should be folded into that shape when it lands rather than duplicated further.

## Tests

`tests/unit/security/test_secret_rotation_pipeline.py`, 9 tests. Real broker over an in-memory backend, real version store, real on-disk journal.

1. `test_version_history_per_target_and_principal_is_bounded_and_configurable` — the bound evicts the oldest, the key really is `(target, principal)` (a second principal and a second target keep their own histories), and the bound is a parameter, not a constant.
2. `test_history_bound_below_two_is_rejected` — a bound of one is refused, with a reason.
3. `test_stored_version_repr_does_not_leak_the_secret_value` — `repr` of a stored version does not contain the credential.
4. `test_rotation_runs_mint_then_store_then_apply_in_order` — store completes before apply, the applied value is the version the store recorded, and the journal row carries no secret material.
5. `test_minted_token_carries_the_version_id_the_store_recorded` — the token, the run, and the store agree on one version id.
6. `test_failure_after_store_leaves_previous_version_retrievable_and_target_unchanged` — **load-bearing.** A rotation whose apply fails: both versions retrievable, target's credential and receipt untouched, run journaled with `step_reached == "store"`.
7. `test_rotation_receipt_older_than_policy_window_is_an_audit_finding` — inside the window, no finding; one second past it, one finding with the age.
8. `test_missing_receipt_and_stale_receipt_share_one_finding_name` — a never-rotated principal and a stale one produce the same finding name.
9. `test_receipt_round_trips_through_canonical_bytes` — receipt serialisation is lossless.

Each failed before the change: the module did not exist, so the file failed collection with `ModuleNotFoundError` on `bernstein.core.security.secret_rotation`. Beyond that, tests 4 and 6 were re-checked against a deliberately reordered implementation (apply before store) on the finished tree and both fail there — 6 with `['v-…ca84d997'] != ['v-…e81c25ec', 'v-…ca84d997']`, exactly the "previous version no longer retrievable" symptom — so the ordering assertions are load-bearing, not incidental.

`tests/unit/test_security_controls_are_wired.py` loses one line: `register_secret_for_redaction` now has a call site outside its own module, and that guard is shrink-only and fails on a stale exemption.

Also run green: `test_secrets_broker.py` (49), `test_secrets_broker_grants.py` (10), `test_broker_grant_config.py` (5), `test_key_rotation.py` (42), `test_security_controls_are_wired.py` (5), `tests/unit/fleet/test_fleet_connection.py`, `tests/unit/fleet/test_fleet_config_hardening.py`, `tests/unit/security/test_redactor_mask.py`. `run_tests.py --affected origin/main` selected nothing, so the importers of `secrets_broker` were enumerated by grep and run explicitly; CI runs the full suite.

## Checklist

- [x] `uv run ruff check src/` — clean; `ruff format --check` clean on the changed files.
- [x] `uv run pyright src/bernstein/core/security/secret_rotation.py` — 0 errors. `secrets_broker.py` reports 35, identical to `origin/main`.
- [x] `uv run python scripts/run_tests.py --parallel 2 -x <files>` — green (see above).
- [x] Type hints on every new function and method.
- [x] `uv run bernstein agents-md sync` — run, no files changed.
- [ ] README / translations — N/A, not touched.
- [ ] Release notes — N/A, no user-facing CLI or config surface changes.

Closes #5119
