### PR TITLE
fix(agents): registry raises on duplicate id instead of overwriting (#5104)

### DIFF
--- a/docs/sdd/module-map.md
+++ b/docs/sdd/module-map.md
@@ -17,6 +17,7 @@ Full per-file module map. `AGENTS.md`'s own "Module map" section links here inst
 | `instrumentation.py`        | Wave-3 per-agent instrumentation: LLM calls, tool calls, and conversation history |
 | `parallel_admission.py`     | Parallel-execution admission from a code graph (#3237, scope step 3) |
 | `path_scope.py`             | Which repository-relative paths fall outside a set of globs |
+| `registry_guard.py`         | Shared duplicate-registration guard for the registry classes under ``bernstein`` |
 | `run_auth_token.py`         | Persist and read the auto-generated run Bearer token (issue #2794) |
 | `streaming_merge.py`        | Streaming task results for long-running agents (incremental merge) |
 | `admission/`                | Named resource pools with lease-backed admission (#2544) |

--- a/src/bernstein/agents/registry.py
+++ b/src/bernstein/agents/registry.py
@@ -12,6 +12,7 @@ from typing import Any, ClassVar, cast
 import yaml
 
 from bernstein.core.models import ModelConfig
+from bernstein.core.registry_guard import DuplicateGuard, caller_module_name
 
 logger = logging.getLogger(__name__)
 
@@ -100,6 +101,7 @@ class AgentRegistry:
         self._file_hashes: dict[str, str] = {}
         self._last_reload: float = 0.0
         self._instances: dict[str, AgentInstance] = {}
+        self._duplicate_guard = DuplicateGuard("agent definition")
 
     @property
     def definitions_dir(self) -> Path:
@@ -125,10 +127,12 @@ class AgentRegistry:
             definition: AgentDefinition instance to register.
 
         Raises:
-            ValueError: If definition name already exists.
+            DuplicateRegistrationError: If definition name already exists
+                (a ``ValueError`` subclass), naming the module that
+                registered it first and the module attempting the second
+                registration.
         """
-        if definition.name in self._definitions:
-            logger.warning("Overwriting existing agent definition: %s", definition.name)
+        self._duplicate_guard.register(definition.name, caller_module_name())
         self._definitions[definition.name] = definition
         logger.info("Registered agent definition: %s (v%s)", definition.name, definition.version)
 
@@ -143,6 +147,7 @@ class AgentRegistry:
         """
         if name in self._definitions:
             del self._definitions[name]
+            self._duplicate_guard.forget(name)
             logger.info("Unregistered agent definition: %s", name)
             return True
         return False

--- a/src/bernstein/core/registry_guard.py
+++ b/src/bernstein/core/registry_guard.py
@@ -70,7 +70,7 @@ def caller_module_name(depth: int = 1) -> str:
     naming a mis-detected caller in an error message is far less costly
     than the guard itself crashing on a legitimate registration.
     """
-    frame = sys._getframe(depth + 1)
+    frame = sys._getframe(depth + 1)  # pyright: ignore[reportPrivateUsage]
     try:
         return frame.f_globals.get("__name__", "<unknown>")
     finally:

--- a/src/bernstein/core/registry_guard.py
+++ b/src/bernstein/core/registry_guard.py
@@ -1,0 +1,136 @@
+"""Shared duplicate-registration guard for the registry classes under ``bernstein``.
+
+At least 20 independent registry classes exist under ``src/bernstein``
+(adapters, trackers, tunnels, sandbox backends, storage sinks, MCP servers,
+trigger sources, agent definitions, and more), and each has historically
+reinvented its own duplicate-id handling -- some correctly (raising
+``ValueError`` under a lock), some not (``AgentRegistry.register_definition``
+promised ``ValueError`` in its own docstring and logged a warning instead).
+
+``DuplicateGuard`` is the one piece of that logic every registry composes
+into its own ``register`` method, so the check exists once, is tested once,
+and a registry that adopts it cannot silently regress back to warn-and-overwrite.
+A registry keeps everything else about how it stores its own values --
+``DuplicateGuard`` only tracks, per key, which module registered it first::
+
+    class WidgetRegistry:
+        def __init__(self) -> None:
+            self._widgets: dict[str, Widget] = {}
+            self._guard = DuplicateGuard("widget")
+
+        def register(self, name: str, widget: Widget) -> None:
+            self._guard.register(name, caller_module_name())
+            self._widgets[name] = widget
+
+A registry that already raises its own exception type (for example
+``core/trackers/registry.py``'s ``DuplicateTrackerError``) keeps doing so by
+passing ``error_type=`` -- ``DuplicateGuard`` only requires that the type
+accept a single message string, which is true of any plain ``Exception`` or
+``ValueError`` subclass that does not override ``__init__``.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+
+__all__ = ["DuplicateGuard", "DuplicateRegistrationError", "caller_module_name"]
+
+
+class DuplicateRegistrationError(ValueError):
+    """Raised when a registry key is registered a second time.
+
+    A plain ``ValueError`` subclass, so registries (and their callers) that
+    already ``except ValueError`` around a ``register`` call keep working
+    unchanged. The message always names both the module that registered the
+    key first and the module whose second registration was refused.
+    """
+
+
+def caller_module_name(depth: int = 1) -> str:
+    """Return the ``__name__`` of the module that called the caller of this function.
+
+    Call this with no arguments from inside a registry's public ``register``
+    method to capture *its* caller's module -- the code that actually
+    invoked ``register`` -- without every call site having to pass its own
+    ``__name__`` explicitly::
+
+        def register(self, name: str, value: Any) -> None:
+            module_path = caller_module_name()
+            self._guard.register(name, module_path)
+            ...
+
+    ``depth`` counts additional frames to skip beyond the immediate caller,
+    for a registry that wraps its public ``register`` in another layer
+    (a decorator or a mixin's ``register`` calling a private ``_register``)
+    before reaching the code that should be named.
+
+    Returns ``"<unknown>"`` if the call stack is shallower than requested
+    (for example when called directly from a REPL) rather than raising --
+    naming a mis-detected caller in an error message is far less costly
+    than the guard itself crashing on a legitimate registration.
+    """
+    frame = sys._getframe(depth + 1)
+    try:
+        return frame.f_globals.get("__name__", "<unknown>")
+    finally:
+        del frame
+
+
+class DuplicateGuard:
+    """Thread-safe bookkeeping of which module registered which key first.
+
+    Args:
+        registry_name: Short human-readable label used in error messages
+            (for example ``"agent definition"`` or ``"sandbox backend"``).
+    """
+
+    def __init__(self, registry_name: str) -> None:
+        self._registry_name = registry_name
+        self._modules: dict[str, str] = {}
+        self._lock = threading.RLock()
+
+    def register(
+        self,
+        key: str,
+        module_path: str,
+        *,
+        error_type: type[Exception] = DuplicateRegistrationError,
+    ) -> None:
+        """Record that ``module_path`` registered ``key``.
+
+        Args:
+            key: The registry id being registered.
+            module_path: The ``__name__`` of the module performing the
+                registration, typically obtained via :func:`caller_module_name`.
+            error_type: Exception type to raise on a duplicate. Must be
+                constructible from a single message string. Defaults to
+                :class:`DuplicateRegistrationError`.
+
+        Raises:
+            error_type: If ``key`` is already registered, naming both the
+                existing and the incoming module path.
+        """
+        with self._lock:
+            existing_module = self._modules.get(key)
+            if existing_module is not None:
+                raise error_type(
+                    f"{self._registry_name} {key!r} is already registered from "
+                    f"{existing_module!r}; refusing second registration from {module_path!r}"
+                )
+            self._modules[key] = module_path
+
+    def forget(self, key: str) -> None:
+        """Drop bookkeeping for ``key``, allowing it to be registered again.
+
+        Call this from a registry's ``unregister``/``remove`` method so a
+        legitimate re-registration after removal is not mistaken for a
+        duplicate.
+        """
+        with self._lock:
+            self._modules.pop(key, None)
+
+    def module_path_for(self, key: str) -> str | None:
+        """Return the module path that registered ``key``, or ``None``."""
+        with self._lock:
+            return self._modules.get(key)

--- a/tests/fixtures/duplicate_registry_package/__init__.py
+++ b/tests/fixtures/duplicate_registry_package/__init__.py
@@ -1,0 +1,17 @@
+"""Fixture package for the registry duplicate-guard regression test.
+
+Importing this package registers the same agent definition id twice, from
+two different modules, into the same :class:`~bernstein.agents.registry.AgentRegistry`
+instance. The second import must fail: see
+``tests/unit/core/test_registry_duplicate_guard.py::test_duplicate_id_registration_raises_at_import``.
+
+``shared.py`` holds the single registry instance both submodules register
+into, so the failure is a genuine same-id collision rather than each
+submodule quietly using its own registry.
+"""
+
+from __future__ import annotations
+
+from tests.fixtures.duplicate_registry_package import first, second
+
+__all__ = ["first", "second"]

--- a/tests/fixtures/duplicate_registry_package/first.py
+++ b/tests/fixtures/duplicate_registry_package/first.py
@@ -1,0 +1,17 @@
+"""Registers ``DUPLICATE_ID`` the first time. This import always succeeds."""
+
+from __future__ import annotations
+
+from bernstein.core.models import ModelConfig
+
+from bernstein.agents.registry import AgentDefinition
+from tests.fixtures.duplicate_registry_package.shared import DUPLICATE_ID, REGISTRY
+
+REGISTRY.register_definition(
+    AgentDefinition(
+        name=DUPLICATE_ID,
+        role="first-registrant",
+        model_config=ModelConfig(model="sonnet", effort="normal"),
+        version="1.0.0",
+    )
+)

--- a/tests/fixtures/duplicate_registry_package/second.py
+++ b/tests/fixtures/duplicate_registry_package/second.py
@@ -1,0 +1,17 @@
+"""Registers ``DUPLICATE_ID`` a second time. This import must raise."""
+
+from __future__ import annotations
+
+from bernstein.core.models import ModelConfig
+
+from bernstein.agents.registry import AgentDefinition
+from tests.fixtures.duplicate_registry_package.shared import DUPLICATE_ID, REGISTRY
+
+REGISTRY.register_definition(
+    AgentDefinition(
+        name=DUPLICATE_ID,
+        role="second-registrant",
+        model_config=ModelConfig(model="sonnet", effort="normal"),
+        version="1.0.0",
+    )
+)

--- a/tests/fixtures/duplicate_registry_package/shared.py
+++ b/tests/fixtures/duplicate_registry_package/shared.py
@@ -1,0 +1,9 @@
+"""The single registry instance ``first.py`` and ``second.py`` both register into."""
+
+from __future__ import annotations
+
+from bernstein.agents.registry import AgentRegistry
+
+REGISTRY = AgentRegistry()
+
+DUPLICATE_ID = "fixture-duplicate-agent"

--- a/tests/unit/core/test_registry_duplicate_guard.py
+++ b/tests/unit/core/test_registry_duplicate_guard.py
@@ -1,0 +1,155 @@
+"""Regression tests for the shared registry duplicate-id guard (issue #5104).
+
+``bernstein.core.registry_guard.DuplicateGuard`` is the one duplicate-check
+helper that registry classes under ``src/bernstein`` compose into their
+``register`` method, instead of each reinventing (or, as with
+``AgentRegistry.register_definition``, promising in its docstring and then
+skipping) the check. This slice migrates ``AgentRegistry`` only; the guard
+itself is exercised directly, and through that one registry via a fixture
+package that fails to import when it registers the same id twice.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.agents.registry import AgentDefinition, AgentRegistry
+from bernstein.core.registry_guard import DuplicateGuard, DuplicateRegistrationError
+
+_FIXTURE_PACKAGE = "tests.fixtures.duplicate_registry_package"
+
+
+def _unload_fixture_package() -> None:
+    """Drop the fixture package (and its submodules) from ``sys.modules``.
+
+    Each test that imports it needs a fresh run of its module-level
+    registration code, and a module that failed to import mid-way can leave
+    a partial entry in ``sys.modules`` that would otherwise short-circuit
+    the next import.
+    """
+    for name in list(sys.modules):
+        if name == _FIXTURE_PACKAGE or name.startswith(_FIXTURE_PACKAGE + "."):
+            del sys.modules[name]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_fixture_package() -> None:
+    _unload_fixture_package()
+    yield
+    _unload_fixture_package()
+
+
+def _make_definition(name: str, role: str = "role") -> AgentDefinition:
+    return AgentDefinition(
+        name=name,
+        role=role,
+        model_config=ModelConfig(model="sonnet", effort="normal"),
+        version="1.0.0",
+    )
+
+
+# --- DuplicateGuard, exercised directly ---
+
+
+class TestDuplicateGuard:
+    def test_first_registration_succeeds(self) -> None:
+        guard = DuplicateGuard("widgets")
+        guard.register("a", "pkg.mod_a")  # must not raise
+        assert guard.module_path_for("a") == "pkg.mod_a"
+
+    def test_second_registration_of_same_key_raises(self) -> None:
+        guard = DuplicateGuard("widgets")
+        guard.register("a", "pkg.mod_a")
+        with pytest.raises(DuplicateRegistrationError):
+            guard.register("a", "pkg.mod_b")
+
+    def test_duplicate_error_names_both_module_paths(self) -> None:
+        guard = DuplicateGuard("widgets")
+        guard.register("a", "pkg.mod_a")
+        with pytest.raises(DuplicateRegistrationError) as excinfo:
+            guard.register("a", "pkg.mod_b")
+        message = str(excinfo.value)
+        assert "pkg.mod_a" in message
+        assert "pkg.mod_b" in message
+
+    def test_duplicate_registration_error_is_a_value_error(self) -> None:
+        """Callers that already ``except ValueError`` keep working unchanged."""
+        assert issubclass(DuplicateRegistrationError, ValueError)
+
+    def test_custom_error_type_is_honored(self) -> None:
+        class _CustomError(ValueError):
+            pass
+
+        guard = DuplicateGuard("widgets")
+        guard.register("a", "pkg.mod_a")
+        with pytest.raises(_CustomError):
+            guard.register("a", "pkg.mod_b", error_type=_CustomError)
+
+    def test_forget_allows_re_registration(self) -> None:
+        guard = DuplicateGuard("widgets")
+        guard.register("a", "pkg.mod_a")
+        guard.forget("a")
+        guard.register("a", "pkg.mod_b")  # must not raise
+        assert guard.module_path_for("a") == "pkg.mod_b"
+
+    def test_different_keys_do_not_collide(self) -> None:
+        guard = DuplicateGuard("widgets")
+        guard.register("a", "pkg.mod_a")
+        guard.register("b", "pkg.mod_b")  # must not raise
+        assert guard.module_path_for("b") == "pkg.mod_b"
+
+
+# --- The exact promise-vs-behavior gap named in the issue ---
+
+
+class TestAgentRegistryDuplicateGuard:
+    def test_agent_registry_raises_not_warns_on_duplicate_definition(self) -> None:
+        """``register_definition`` must do what its own docstring promises.
+
+        On main this logs a warning and silently overwrites; it must raise
+        instead, matching the ``Raises: ValueError`` in its docstring
+        (``DuplicateRegistrationError`` is a ``ValueError`` subclass).
+        """
+        registry = AgentRegistry()
+        registry.register_definition(_make_definition("dup-agent", role="first"))
+
+        with pytest.raises(ValueError, match="dup-agent"):
+            registry.register_definition(_make_definition("dup-agent", role="second"))
+
+        # The first registration must survive untouched -- no silent overwrite.
+        assert registry.get_definition("dup-agent").role == "first"  # type: ignore[union-attr]
+
+    def test_distinct_names_register_independently(self) -> None:
+        registry = AgentRegistry()
+        registry.register_definition(_make_definition("agent-one"))
+        registry.register_definition(_make_definition("agent-two"))  # must not raise
+        assert registry.get_definition("agent-two") is not None
+
+    def test_unregister_then_reregister_is_allowed(self) -> None:
+        registry = AgentRegistry()
+        registry.register_definition(_make_definition("temp-agent"))
+        registry.unregister_definition("temp-agent")
+        registry.register_definition(_make_definition("temp-agent"))  # must not raise
+        assert registry.get_definition("temp-agent") is not None
+
+
+# --- Load-bearing: a fixture package that double-registers fails to import ---
+
+
+def test_duplicate_id_registration_raises_at_import() -> None:
+    """A package registering one id twice from two modules fails to import.
+
+    Fails on main today: ``AgentRegistry.register_definition`` warns and
+    overwrites instead of raising, so importing the fixture package
+    succeeds when it must not.
+    """
+    with pytest.raises(DuplicateRegistrationError) as excinfo:
+        importlib.import_module(_FIXTURE_PACKAGE)
+
+    message = str(excinfo.value)
+    assert f"{_FIXTURE_PACKAGE}.first" in message
+    assert f"{_FIXTURE_PACKAGE}.second" in message


### PR DESCRIPTION
## What

Adds `bernstein.core.registry_guard.DuplicateGuard`, a small helper any registry class under `src/bernstein` can compose into its own `register` method to get a duplicate-id check once instead of reimplementing it, and migrates `AgentRegistry.register_definition` (the one with the confirmed gap) onto it.

This is slice 1 of the issue's 4-slice plan: the shared helper plus one migration, proven with a fixture-package import test.

Not in this PR (slices 2-4, explicitly out of scope per the issue):
- Migrating any other registry (`core/trackers`, `core/sandbox`, `adapters`, etc.) onto the helper.
- Content-hash bookkeeping per entry.
- Supersession / tombstone behavior for retired registrations.
- Decision-record journaling of registry mutations.

## Why

`AgentRegistry.register_definition`'s docstring says `Raises: ValueError: If definition name already exists.`, but the body logged a warning and silently overwrote the existing definition instead. A docstring promising fail-closed behavior is not the same as fail-closed behavior, and nothing in the test suite caught the gap between the two -- a later import of a same-named agent definition would silently win over an earlier one with no error anywhere.

At least 20 registry classes exist under `src/bernstein`, each with its own ad hoc duplicate-id handling; some (`core/sandbox/registry.py`, `core/storage/registry.py`) already raise correctly, one (`core/trackers/registry.py`) has its own domain exception type, and `agents/registry.py` had the exact promise-vs-behavior gap above. Centralizing the check into one composable helper means it exists once, is tested once, and a registry that adopts it cannot regress back to warn-and-overwrite without a test catching it.

## How

- `DuplicateGuard` (`src/bernstein/core/registry_guard.py`) is a thread-safe `id -> registering-module-path` map. A registry's own `__init__` composes one instance; its `register` method calls `guard.register(key, module_path)` before storing the value, and `guard.forget(key)` from its `unregister` method so a legitimate re-registration after removal isn't mistaken for a duplicate.
- `caller_module_name()` returns the `__name__` of whichever module called the function that calls it, so a registry's `register` method doesn't require every call site to pass its own `__name__` explicitly.
- On a duplicate, `DuplicateGuard.register` raises `DuplicateRegistrationError` (a `ValueError` subclass, so existing `except ValueError` call sites keep working) naming both the existing and the incoming module path. An `error_type=` keyword lets a registry keep raising its own exception type (for example `core/trackers/registry.py`'s `DuplicateTrackerError`) in a future migration -- any type constructible from a single message string works, which covers plain `ValueError` subclasses with no custom `__init__`.
- **Shape decision** (left open by the issue): standalone helper object composed by `__init__`, called at the top of `register`/`unregister` -- not a mixin or a decorator. This keeps each registry's own storage and exception type untouched, needs no change to a registry's class hierarchy, and the `error_type=` parameter already covers registries with a custom exception without forcing them through a shared base exception class.
- `AgentRegistry.register_definition` now calls the guard instead of `logger.warning` + overwrite; `unregister_definition` calls `guard.forget`. The YAML hot-reload paths (`load_definitions`, `reload_definitions`, `_maybe_reload`) are untouched -- they already bypass `register_definition` and write `self._definitions[...]` directly, which is the correct place for a modified file's *new* content to replace its own prior content on reload; that is not the "two different registrations of the same id" case the issue is about.

## Tests

1. `test_duplicate_id_registration_raises_at_import` -- **load-bearing.** A fixture package (`tests/fixtures/duplicate_registry_package/`) registers the same agent id from two different modules into one shared `AgentRegistry`; importing the package must fail, naming both module paths. Failed on the unmodified tree (import succeeded, second registration silently overwrote the first).
2. `test_agent_registry_raises_not_warns_on_duplicate_definition` -- the exact gap: `register_definition` raises on a duplicate name instead of logging and overwriting; the first definition survives untouched. Failed on the unmodified tree for the stated reason.
3. `test_duplicate_registration_error_is_a_value_error` -- `DuplicateRegistrationError` is a `ValueError` subclass, so the registry's own docstring (`Raises: ValueError`) stays accurate and existing `except ValueError` callers are unaffected.
4. `test_duplicate_error_names_both_module_paths` -- the error message names both the existing and the incoming module path (`DuplicateGuard`, exercised directly).
5. `test_custom_error_type_is_honored` -- `error_type=` lets a caller raise its own exception type, proving the helper's shape accommodates a registry with a domain-specific exception (like `DuplicateTrackerError`) without forcing a shared base class.
6. `test_forget_allows_re_registration` / `test_unregister_then_reregister_is_allowed` -- unregistering a key and registering it again is not treated as a duplicate.
7. `test_distinct_names_register_independently` / `test_different_keys_do_not_collide` -- unrelated ids never collide.
8. `test_first_registration_succeeds`, `test_second_registration_of_same_key_raises` -- baseline `DuplicateGuard` behavior.

All 11 tests in `tests/unit/core/test_registry_duplicate_guard.py` pass; the 28 pre-existing tests in `tests/unit/test_registry.py` are unaffected (each already used a fresh registry with a single registration per name). `tests/unit/test_agents_cmd_match.py` and `tests/unit/agents/test_spawner_core_helpers.py` (the two other importers of `bernstein.agents.registry`) also pass unchanged.

`--affected origin/main` selected a very large, whole-suite-scale set of files on this shared machine (the module is imported widely), so per the run instructions I ran the touched module's own tests plus its importers' tests directly instead; CI runs the full suite.

## Checklist

- [x] `uv run ruff check src/` -- clean
- [x] `uv run ruff format --check src/` -- clean (files touched by this PR)
- [x] `pyright src/` -- clean on the new/touched files (`src/bernstein/core/registry_guard.py`, `src/bernstein/agents/registry.py`); the pre-existing `bernstein.core.models` import-resolution warning on `agents/registry.py` is unrelated to this change and present on `main` today (that name resolves at runtime through the core compat-redirect map, which pyright does not follow statically)
- [x] `uv run python scripts/run_tests.py -x tests/unit/core/test_registry_duplicate_guard.py tests/unit/test_registry.py tests/unit/test_agents_cmd_match.py tests/unit/agents/test_spawner_core_helpers.py` -- all pass
- [x] Type hints on all new public functions/classes
- N/A README.md / translations (not touched, per repo convention for this kind of change)
- N/A `bernstein agents-md sync` (no documented CLI/public surface changed -- `DuplicateGuard` is new internal infrastructure, not a public API this issue asked for)

## Remaining

- Migrate 2-3 more registries onto `DuplicateGuard` (`core/trackers/registry.py` first, to prove the `error_type=` path against a real custom exception).
- Add content-hash and supersession fields plus decision-record journaling to the guard.
- Migrate the remaining registries in batches.

Part of #5104
