### PR TITLE
feat: tag-filtered resource leases with TTL, owner and named locks (#5128)

### DIFF
--- a/docs/release-notes/fragments/5128-tag-filtered-resource-leases.md
+++ b/docs/release-notes/fragments/5128-tag-filtered-resource-leases.md
@@ -1,0 +1,3 @@
+## Tag-filtered resource leases
+
+A new atomic claim primitive (`bernstein.core.sandbox.resource_lease`) lets a process take a lease on a named resource or tag-filtered candidate, with TTL, owner, keepalive, and release on context exit or interpreter exit. Distinct error types separate "no matching resource" from "all matches held". ([#5128](https://github.com/sipyourdrink-ltd/bernstein/issues/5128))

--- a/src/bernstein/core/sandbox/resource_lease.py
+++ b/src/bernstein/core/sandbox/resource_lease.py
@@ -1,0 +1,541 @@
+"""Tag-filtered resource leases: one atomic claim primitive (#5128).
+
+Before this module the only lock in the tree was
+:func:`bernstein.cli.commands.worktrees_cmd.lock_gc` -- the right *shape*
+(``O_EXCL`` acquire, staleness reclamation, release-on-raise) hardcoded to one
+file, so every other claimable thing (a sandbox slot, a worktree, a device) was
+either unlocked or would need its own bespoke copy of that shape.
+
+The shape is generalised here along four axes:
+
+* **Tags.** Resources declare a many-to-many tag set; a claim is a tag filter
+  resolved *and* locked in one transaction, so no candidate can be taken
+  between the resolve and the lock.
+* **Distinct failures.** A filter that matches no declared resource raises
+  :class:`NoMatchingResourceError`; a filter whose matches are all held raises
+  :class:`NoFreeResourceError`. "Nothing like that exists" and "they are all
+  busy" are different operator problems and must not share an exception.
+* **TTL and owner.** Every lease records the session identity that took it and
+  an absolute expiry; :meth:`Lease.keepalive` pushes the expiry out, and an
+  expired lease is reclaimable by the next claimant so a killed holder cannot
+  wedge a resource forever.
+* **Release.** A lease is a context manager, and an interpreter-exit hook
+  releases whatever the process still holds -- logging, never raising, because
+  a failed release must not turn a clean shutdown into a traceback.
+
+Staleness follows ``lock_gc``'s precedent exactly: a payload that is missing or
+mid-write is *not* stale, so a lease another process created between its
+``O_EXCL`` and its write is never stolen. A holder's pid is only consulted when
+the lease was taken on this host.
+"""
+
+from __future__ import annotations
+
+import atexit
+import contextlib
+import json
+import logging
+import os
+import re
+import socket
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable
+
+logger = logging.getLogger(__name__)
+
+#: Default lease lifetime. Long enough for a real sandbox task, short enough
+#: that a killed holder does not park a resource for a working day.
+DEFAULT_LEASE_TTL_S = 900.0
+
+#: Directory, relative to the store root, holding one file per active lease.
+LEASE_DIR_RELNAME = "leases"
+
+#: Wire-format version stamped into every lease file.
+LEASE_SCHEMA_VERSION = 1
+
+#: Resource ids and lock names are used verbatim as filenames, so they are
+#: restricted to a conservative, path-separator-free alphabet.
+_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+_LEASE_SUFFIX = ".lease.json"
+
+
+class ResourceLeaseError(RuntimeError):
+    """Base for every claim failure."""
+
+
+class LeaseConflictError(ResourceLeaseError):
+    """Raised when a specific resource or named lock is already held.
+
+    Attributes:
+        name: The resource id / lock name that is held.
+        holder: The recorded lease payload of the current holder, or ``None``
+            when it could not be read.
+    """
+
+    def __init__(self, message: str, *, name: str = "", holder: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.name = name
+        self.holder = holder
+
+
+class NoMatchingResourceError(ResourceLeaseError):
+    """Raised when the tag filter matches no declared resource at all."""
+
+
+class NoFreeResourceError(ResourceLeaseError):
+    """Raised when every resource matching the tag filter is currently held."""
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def _validate_name(name: str, *, what: str) -> str:
+    if not _NAME_RE.match(name):
+        raise ValueError(f"invalid {what} {name!r}: expected [A-Za-z0-9][A-Za-z0-9._-]{{0,127}}")
+    return name
+
+
+@dataclass(frozen=True)
+class ResourceDeclaration:
+    """A claimable thing and the tags it carries.
+
+    Tags are many-to-many: one resource carries several, and one tag names
+    several resources. A claim filter is satisfied when the resource's tags are
+    a superset of the requested ones.
+    """
+
+    resource_id: str
+    tags: frozenset[str] = frozenset()
+
+    def __post_init__(self) -> None:
+        _validate_name(self.resource_id, what="resource id")
+        object.__setattr__(self, "tags", frozenset(str(t) for t in self.tags))
+
+    def matches(self, wanted: frozenset[str]) -> bool:
+        """True when this resource carries every tag in *wanted*."""
+        return wanted <= self.tags
+
+
+class ResourceRegistry:
+    """An ordered set of :class:`ResourceDeclaration` to resolve filters against.
+
+    The registry is pure data: it never touches the lease store, so resolving a
+    filter is deterministic and two operators with the same declarations get
+    the same candidate order.
+    """
+
+    def __init__(self, resources: Iterable[ResourceDeclaration]) -> None:
+        by_id: dict[str, ResourceDeclaration] = {}
+        for resource in resources:
+            if resource.resource_id in by_id:
+                raise ValueError(f"duplicate resource id {resource.resource_id!r}")
+            by_id[resource.resource_id] = resource
+        self._by_id = by_id
+
+    def __len__(self) -> int:
+        return len(self._by_id)
+
+    @property
+    def resource_ids(self) -> list[str]:
+        """Every declared resource id, sorted."""
+        return sorted(self._by_id)
+
+    def get(self, resource_id: str) -> ResourceDeclaration | None:
+        """Return the declaration for *resource_id*, or ``None``."""
+        return self._by_id.get(resource_id)
+
+    def matching(self, tags: Iterable[str]) -> list[ResourceDeclaration]:
+        """Return, sorted by resource id, every resource carrying all *tags*."""
+        wanted = frozenset(str(t) for t in tags)
+        return [self._by_id[rid] for rid in sorted(self._by_id) if self._by_id[rid].matches(wanted)]
+
+
+# ---------------------------------------------------------------------------
+# Identity + staleness
+# ---------------------------------------------------------------------------
+
+
+def _session_identity() -> str:
+    """Return the install identity that owns leases taken by this process.
+
+    Imported lazily so a claim never drags the identity module into a process
+    that only needed a lock.
+    """
+    try:
+        from bernstein.core.identity.install_rev import get_install_rev
+
+        rev = get_install_rev()
+    except Exception:  # pragma: no cover - identity is best-effort here
+        logger.debug("lease owner: install identity unavailable, falling back to pid", exc_info=True)
+        return ""
+    return rev or ""
+
+
+def default_owner() -> str:
+    """Owner string recorded on a lease: the session identity, else the pid."""
+    return _session_identity() or f"pid-{os.getpid()}"
+
+
+def _hostname() -> str:
+    try:
+        return socket.gethostname()
+    except OSError:  # pragma: no cover - hostname lookup effectively never fails
+        return ""
+
+
+def _read_lease(path: Path) -> dict[str, Any] | None:
+    """Return the recorded lease payload at *path*, or ``None`` when unreadable."""
+    try:
+        data: Any = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return cast("dict[str, Any]", data) if isinstance(data, dict) else None
+
+
+def _holder_process_alive(meta: dict[str, Any]) -> bool:
+    """True when the recorded holder is a live process on this host.
+
+    A lease recorded on another host is treated as alive: this primitive is
+    local, and guessing about a remote pid would reclaim a resource somebody
+    else is still using.
+    """
+    if meta.get("host") and meta.get("host") != _hostname():
+        return True
+    pid = meta.get("pid")
+    if not isinstance(pid, int) or pid <= 0:
+        return True
+    from bernstein.core.orchestration.process_utils import is_process_alive
+
+    return is_process_alive(pid)
+
+
+def _lease_is_stale(meta: dict[str, Any] | None) -> bool:
+    """True when a recorded lease may be reclaimed by another claimant.
+
+    An unreadable / mid-write payload is NOT stale, mirroring ``lock_gc``: a
+    lease another process just created, between its ``O_EXCL`` and its write, is
+    never stolen. A fully written payload is stale when its TTL has passed or
+    when its holder process is gone.
+    """
+    if not isinstance(meta, dict):
+        return False
+    expires_at = meta.get("expires_at")
+    if isinstance(expires_at, (int, float)) and time.time() > float(expires_at):
+        return True
+    return not _holder_process_alive(meta)
+
+
+# ---------------------------------------------------------------------------
+# Lease
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Lease:
+    """A held claim on one resource, released on context exit or process exit."""
+
+    resource_id: str
+    lease_id: str
+    owner: str
+    pid: int
+    host: str
+    acquired_at: float
+    expires_at: float
+    path: Path
+    ttl_s: float = DEFAULT_LEASE_TTL_S
+    released: bool = field(default=False)
+
+    def payload(self) -> dict[str, Any]:
+        """Canonical on-disk view of this lease."""
+        return {
+            "schema_version": LEASE_SCHEMA_VERSION,
+            "resource_id": self.resource_id,
+            "lease_id": self.lease_id,
+            "owner": self.owner,
+            "pid": self.pid,
+            "host": self.host,
+            "acquired_at": self.acquired_at,
+            "expires_at": self.expires_at,
+        }
+
+    @property
+    def expired(self) -> bool:
+        """True once the recorded TTL has passed."""
+        return time.time() > self.expires_at
+
+    def _write(self) -> None:
+        """Replace the lease file atomically with the current payload."""
+        tmp = self.path.with_name(f"{self.path.name}.{self.lease_id}.tmp")
+        tmp.write_text(json.dumps(self.payload(), sort_keys=True), encoding="utf-8")
+        os.replace(tmp, self.path)
+
+    def keepalive(self, ttl_s: float | None = None) -> float:
+        """Extend the lease by *ttl_s* (default: its original TTL).
+
+        Raises:
+            LeaseConflictError: when the lease was already reclaimed, so the
+                caller learns it no longer owns the resource instead of
+                silently overwriting the new holder's record.
+
+        Returns:
+            The new absolute expiry.
+        """
+        if self.released:
+            raise LeaseConflictError(f"lease on {self.resource_id!r} was already released", name=self.resource_id)
+        recorded = _read_lease(self.path)
+        if recorded is None or recorded.get("lease_id") != self.lease_id:
+            raise LeaseConflictError(
+                f"lease on {self.resource_id!r} is no longer held by this process",
+                name=self.resource_id,
+                holder=recorded,
+            )
+        self.ttl_s = float(ttl_s) if ttl_s is not None else self.ttl_s
+        self.expires_at = time.time() + self.ttl_s
+        self._write()
+        return self.expires_at
+
+    def release(self) -> None:
+        """Release the lease. Never raises.
+
+        Only a file this lease still owns is unlinked: once another claimant
+        has reclaimed an expired lease, releasing the stale handle must not
+        delete the new holder's record.
+        """
+        if self.released:
+            return
+        self.released = True
+        _forget_lease(self)
+        recorded = _read_lease(self.path)
+        if recorded is not None and recorded.get("lease_id") != self.lease_id:
+            logger.debug("lease release: %s already reclaimed by another holder", self.path)
+            return
+        try:
+            self.path.unlink()
+        except OSError:
+            logger.debug("lease release: %s already removed", self.path)
+
+    def __enter__(self) -> Lease:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        self.release()
+
+
+# ---------------------------------------------------------------------------
+# Process-exit hook
+# ---------------------------------------------------------------------------
+
+_HELD: dict[int, Lease] = {}
+_atexit_registered = False
+
+
+def _remember_lease(lease: Lease) -> None:
+    global _atexit_registered
+    _HELD[id(lease)] = lease
+    if not _atexit_registered:
+        atexit.register(release_all_held)
+        _atexit_registered = True
+
+
+def _forget_lease(lease: Lease) -> None:
+    _HELD.pop(id(lease), None)
+
+
+def release_all_held() -> None:
+    """Release every lease this process still holds, logging on failure.
+
+    Registered with :mod:`atexit` on the first claim so a process that exits
+    without releasing does not park its resources until their TTL. It never
+    raises: a failed release during interpreter shutdown must not become a
+    traceback on an otherwise clean exit.
+    """
+    for lease in list(_HELD.values()):
+        try:
+            lease.release()
+        except Exception:  # pragma: no cover - release() is already total
+            logger.warning("lease release on exit failed for %s", lease.resource_id, exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+
+class LeaseStore:
+    """One file per active lease under ``<root>/leases/``.
+
+    A file-per-lease scheme, not an event ledger: the acquire is a single
+    ``O_EXCL`` ``open`` -- the same atomicity ``lock_gc`` already relies on --
+    so two claimants racing for one resource are decided by the kernel with no
+    read-modify-write window, and listing the active leases is listing a
+    directory.
+    """
+
+    def __init__(self, root: Path | str) -> None:
+        self.root = Path(root)
+
+    @property
+    def leases_dir(self) -> Path:
+        """Directory holding one file per active lease."""
+        return self.root / LEASE_DIR_RELNAME
+
+    def path_for(self, name: str) -> Path:
+        """Lease-file path for resource / lock *name*."""
+        return self.leases_dir / f"{_validate_name(name, what='resource id')}{_LEASE_SUFFIX}"
+
+    def active(self) -> list[dict[str, Any]]:
+        """Return the recorded payload of every readable lease, sorted by id."""
+        try:
+            entries = sorted(self.leases_dir.glob(f"*{_LEASE_SUFFIX}"))
+        except OSError:
+            return []
+        rows = [meta for path in entries if (meta := _read_lease(path)) is not None]
+        return sorted(rows, key=lambda m: str(m.get("resource_id", "")))
+
+    def _open_exclusive(self, name: str, path: Path) -> int:
+        """``O_EXCL`` open of *path*, reclaiming a provably stale lease once."""
+        try:
+            return os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        except FileExistsError as exc:
+            meta = _read_lease(path)
+            if not _lease_is_stale(meta):
+                owner = f" held by {meta['owner']}" if isinstance(meta, dict) and meta.get("owner") else ""
+                raise LeaseConflictError(
+                    f"resource {name!r} is already leased ({path}{owner})", name=name, holder=meta
+                ) from exc
+            logger.warning("Reclaiming expired lease %s (previous holder gone or TTL passed): %s", path, meta)
+            # A competing claimant may win the race and re-create the lease;
+            # the retry below resolves that case.
+            with contextlib.suppress(OSError):
+                path.unlink()
+            try:
+                return os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            except FileExistsError as retry_exc:
+                raise LeaseConflictError(
+                    f"resource {name!r} is already leased ({path})", name=name, holder=_read_lease(path)
+                ) from retry_exc
+
+    def acquire(self, name: str, *, owner: str | None = None, ttl_s: float = DEFAULT_LEASE_TTL_S) -> Lease:
+        """Take a lease on *name*, or raise :class:`LeaseConflictError`.
+
+        Args:
+            name: Resource id or arbitrary lock name.
+            owner: Lease owner; defaults to the session identity.
+            ttl_s: Lifetime in seconds. Once passed, another claimant may
+                reclaim the lease even if this process never released it.
+        """
+        path = self.path_for(name)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd = self._open_exclusive(name, path)
+
+        now = time.time()
+        lease = Lease(
+            resource_id=name,
+            lease_id=uuid.uuid4().hex,
+            owner=owner or default_owner(),
+            pid=os.getpid(),
+            host=_hostname(),
+            acquired_at=now,
+            expires_at=now + float(ttl_s),
+            path=path,
+            ttl_s=float(ttl_s),
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(json.dumps(lease.payload(), sort_keys=True))
+        except BaseException:
+            with contextlib.suppress(OSError):
+                path.unlink()
+            raise
+        _remember_lease(lease)
+        return lease
+
+
+# ---------------------------------------------------------------------------
+# Claim
+# ---------------------------------------------------------------------------
+
+
+def claim(
+    registry: ResourceRegistry,
+    tags: Iterable[str],
+    *,
+    store: LeaseStore,
+    owner: str | None = None,
+    ttl_s: float = DEFAULT_LEASE_TTL_S,
+) -> Lease:
+    """Resolve *tags* against *registry* and lock the first free match.
+
+    The resolve and the lock are one transaction from the caller's side: each
+    candidate is attempted with an ``O_EXCL`` acquire and a candidate taken by
+    a competing claimant simply moves the search on, so no window exists in
+    which a resolved-but-unlocked resource can be handed to two callers.
+
+    Raises:
+        NoMatchingResourceError: no declared resource carries all of *tags*.
+        NoFreeResourceError: every match is currently held.
+    """
+    candidates = registry.matching(tags)
+    if not candidates:
+        raise NoMatchingResourceError(f"no resource declares tags {sorted(str(t) for t in tags)}")
+    conflicts: list[str] = []
+    for candidate in candidates:
+        try:
+            return store.acquire(candidate.resource_id, owner=owner, ttl_s=ttl_s)
+        except LeaseConflictError as exc:
+            conflicts.append(candidate.resource_id)
+            logger.debug("claim: %s unavailable (%s)", candidate.resource_id, exc)
+    raise NoFreeResourceError(
+        f"all {len(conflicts)} resources matching {sorted(str(t) for t in tags)} are leased: {conflicts}"
+    )
+
+
+@contextlib.contextmanager
+def named_lock(
+    store: LeaseStore,
+    name: str,
+    *,
+    owner: str | None = None,
+    ttl_s: float = DEFAULT_LEASE_TTL_S,
+) -> Generator[Lease]:
+    """Hold an arbitrary-name lock for the duration of the block.
+
+    The same primitive as :func:`claim` without a registry, for serialising
+    work that is not a declared resource. Released on exit even when the body
+    raises.
+
+    Raises:
+        LeaseConflictError: the lock is held by a live, unexpired owner.
+    """
+    lease = store.acquire(name, owner=owner, ttl_s=ttl_s)
+    try:
+        yield lease
+    finally:
+        lease.release()
+
+
+__all__ = [
+    "DEFAULT_LEASE_TTL_S",
+    "LEASE_SCHEMA_VERSION",
+    "Lease",
+    "LeaseConflictError",
+    "LeaseStore",
+    "NoFreeResourceError",
+    "NoMatchingResourceError",
+    "ResourceDeclaration",
+    "ResourceLeaseError",
+    "ResourceRegistry",
+    "claim",
+    "default_owner",
+    "named_lock",
+    "release_all_held",
+]

--- a/tests/unit/sandbox/test_resource_lease.py
+++ b/tests/unit/sandbox/test_resource_lease.py
@@ -1,0 +1,301 @@
+"""Unit tests for the tag-filtered resource-lease primitive (#5128).
+
+Concurrency fixtures follow the GC-lock tests in
+``tests/unit/test_worktrees_cmd.py``: a real lock file on disk, real threads,
+and a real killed subprocess -- never a mocked lock. Resource/tag fixtures
+follow ``tests/unit/sandbox/test_pool_placement.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.sandbox.resource_lease import (
+    LeaseConflictError,
+    LeaseStore,
+    NoFreeResourceError,
+    NoMatchingResourceError,
+    ResourceDeclaration,
+    ResourceRegistry,
+    claim,
+    named_lock,
+)
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> LeaseStore:
+    """A lease store rooted in an isolated tmp tree."""
+    return LeaseStore(tmp_path / "state")
+
+
+@pytest.fixture
+def registry() -> ResourceRegistry:
+    """Three resources with overlapping, many-to-many tags."""
+    return ResourceRegistry(
+        [
+            ResourceDeclaration("gpu-0", {"gpu", "cuda", "linux"}),
+            ResourceDeclaration("gpu-1", {"gpu", "cuda", "linux"}),
+            ResourceDeclaration("mac-0", {"macos", "arm64"}),
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Atomic claim
+# ---------------------------------------------------------------------------
+
+
+def test_two_claimants_for_one_resource_yield_exactly_one_lease(store: LeaseStore) -> None:
+    """One resource, two concurrent claimants: exactly one lease is handed out."""
+    registry = ResourceRegistry([ResourceDeclaration("gpu-0", {"gpu"})])
+
+    granted: list[str] = []
+    refused: list[BaseException] = []
+    unexpected: list[BaseException] = []
+    barrier = threading.Barrier(2, timeout=5)
+
+    def contend() -> None:
+        try:
+            barrier.wait()
+            lease = claim(registry, {"gpu"}, store=store)
+            granted.append(lease.lease_id)
+        except NoFreeResourceError as exc:
+            refused.append(exc)
+        except BaseException as exc:  # pragma: no cover - surfaced by the assert
+            unexpected.append(exc)
+
+    threads = [threading.Thread(target=contend) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+
+    assert not unexpected
+    assert len(granted) == 1
+    assert len(refused) == 1
+
+
+def test_no_match_and_none_free_are_distinct_errors(store: LeaseStore, registry: ResourceRegistry) -> None:
+    """A filter nothing declares raises NoMatch; a fully-held match raises NoneFree."""
+    with pytest.raises(NoMatchingResourceError):
+        claim(registry, {"fpga"}, store=store)
+
+    held = [claim(registry, {"gpu"}, store=store), claim(registry, {"gpu"}, store=store)]
+    try:
+        with pytest.raises(NoFreeResourceError):
+            claim(registry, {"gpu"}, store=store)
+    finally:
+        for lease in held:
+            lease.release()
+
+    assert not issubclass(NoMatchingResourceError, NoFreeResourceError)
+    assert not issubclass(NoFreeResourceError, NoMatchingResourceError)
+
+
+def test_claim_skips_held_resources_and_takes_a_free_sibling(store: LeaseStore, registry: ResourceRegistry) -> None:
+    """With gpu-0 held, a second claim for the same filter lands on gpu-1."""
+    first = claim(registry, {"cuda"}, store=store)
+    second = claim(registry, {"cuda"}, store=store)
+    try:
+        assert {first.resource_id, second.resource_id} == {"gpu-0", "gpu-1"}
+    finally:
+        first.release()
+        second.release()
+
+
+# ---------------------------------------------------------------------------
+# TTL, owner, keepalive
+# ---------------------------------------------------------------------------
+
+
+def test_killed_holders_lease_expires_by_ttl(
+    store: LeaseStore, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A SIGKILLed holder leaves its lease file behind; the TTL alone reclaims it."""
+    from bernstein.core.sandbox import resource_lease
+
+    script = tmp_path / "holder.py"
+    script.write_text(
+        "import sys, time\n"
+        "from bernstein.core.sandbox.resource_lease import LeaseStore\n"
+        "store = LeaseStore(sys.argv[1])\n"
+        "store.acquire('gpu-0', ttl_s=1.0)\n"
+        "print('held', flush=True)\n"
+        "time.sleep(600)\n",
+        encoding="utf-8",
+    )
+    env = {**os.environ, "UV_NO_SYNC": "1"}
+    proc = subprocess.Popen(
+        [sys.executable, str(script), str(store.root)],
+        stdout=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    try:
+        assert proc.stdout is not None
+        assert proc.stdout.readline().strip() == "held"
+    finally:
+        proc.send_signal(signal.SIGKILL)
+        proc.wait(timeout=10)
+
+    lock_path = store.path_for("gpu-0")
+    assert lock_path.exists(), "a killed holder must not release its lease"
+
+    # Pin liveness to True so the *only* reason the lease can be reclaimed is
+    # its TTL, not the dead pid.
+    monkeypatch.setattr(resource_lease, "_holder_process_alive", lambda meta: True)
+
+    with pytest.raises(LeaseConflictError):
+        store.acquire("gpu-0")
+
+    time.sleep(1.1)
+    reclaimed = store.acquire("gpu-0")
+    try:
+        assert reclaimed.resource_id == "gpu-0"
+    finally:
+        reclaimed.release()
+
+
+def test_keepalive_extends_the_ttl(store: LeaseStore) -> None:
+    """A keepalive pushes the recorded expiry out and keeps the lease unreclaimable."""
+    lease = store.acquire("gpu-0", ttl_s=1.0)
+    try:
+        first_expiry = lease.expires_at
+        extended = lease.keepalive(ttl_s=120.0)
+        assert extended > first_expiry
+        assert lease.expires_at == extended
+
+        recorded = json.loads(store.path_for("gpu-0").read_text(encoding="utf-8"))
+        assert recorded["expires_at"] == pytest.approx(extended)
+
+        time.sleep(1.1)
+        with pytest.raises(LeaseConflictError):
+            store.acquire("gpu-0")
+    finally:
+        lease.release()
+
+
+def test_keepalive_on_a_reclaimed_lease_refuses(store: LeaseStore) -> None:
+    """Once another claimant owns the resource, the old holder cannot extend it."""
+    lease = store.acquire("gpu-0", ttl_s=0.05)
+    time.sleep(0.1)
+    stealer = store.acquire("gpu-0")
+    try:
+        with pytest.raises(LeaseConflictError):
+            lease.keepalive(ttl_s=60.0)
+    finally:
+        stealer.release()
+    # The rightful owner's release must not delete the stealer's lease either.
+    lease.release()
+
+
+def test_lease_records_owner_from_session_identity(store: LeaseStore, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The owner field is sourced from the install identity, not invented."""
+    from bernstein.core.sandbox import resource_lease
+
+    monkeypatch.setattr(resource_lease, "_session_identity", lambda: "install-rev-abc")
+    lease = store.acquire("gpu-0")
+    try:
+        assert lease.owner == "install-rev-abc"
+        recorded = json.loads(store.path_for("gpu-0").read_text(encoding="utf-8"))
+        assert recorded["owner"] == "install-rev-abc"
+        assert recorded["pid"] == os.getpid()
+    finally:
+        lease.release()
+
+
+# ---------------------------------------------------------------------------
+# Release
+# ---------------------------------------------------------------------------
+
+
+def test_context_manager_releases_on_exception(store: LeaseStore, registry: ResourceRegistry) -> None:
+    """The lease file is unlinked even when the body raises."""
+
+    class Boom(RuntimeError):
+        pass
+
+    with pytest.raises(Boom):
+        with claim(registry, {"macos"}, store=store) as lease:
+            assert store.path_for(lease.resource_id).exists()
+            raise Boom
+
+    assert not store.path_for("mac-0").exists()
+    # Next claim for the same filter succeeds.
+    with claim(registry, {"macos"}, store=store) as again:
+        assert again.resource_id == "mac-0"
+
+
+def test_process_exit_releases_leases_the_process_still_holds(store: LeaseStore, tmp_path: Path) -> None:
+    """A holder that exits without releasing still leaves no lease behind."""
+    script = tmp_path / "forgetful.py"
+    script.write_text(
+        "import sys\n"
+        "from bernstein.core.sandbox.resource_lease import LeaseStore\n"
+        "store = LeaseStore(sys.argv[1])\n"
+        "store.acquire('gpu-0', ttl_s=600.0)\n"
+        "assert store.path_for('gpu-0').exists()\n",
+        encoding="utf-8",
+    )
+    env = {**os.environ, "UV_NO_SYNC": "1"}
+    result = subprocess.run(
+        [sys.executable, str(script), str(store.root)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert not store.path_for("gpu-0").exists()
+
+
+def test_release_never_raises_when_the_lease_file_is_already_gone(store: LeaseStore) -> None:
+    """Release logs and returns on a missing file rather than raising."""
+    lease = store.acquire("gpu-0")
+    store.path_for("gpu-0").unlink()
+    lease.release()
+    lease.release()
+
+
+# ---------------------------------------------------------------------------
+# Named locks
+# ---------------------------------------------------------------------------
+
+
+def test_named_lock_serialises_unregistered_resources(store: LeaseStore) -> None:
+    """An arbitrary name that no registry declares still serialises two holders."""
+    started = threading.Event()
+    release = threading.Event()
+    errors: list[BaseException] = []
+
+    def hold() -> None:
+        try:
+            with named_lock(store, "catalogue-rebuild"):
+                started.set()
+                release.wait(timeout=5)
+        except BaseException as exc:  # pragma: no cover - surfaced by the assert
+            errors.append(exc)
+
+    holder = threading.Thread(target=hold)
+    holder.start()
+    started.wait(timeout=5)
+    try:
+        with pytest.raises(LeaseConflictError):
+            with named_lock(store, "catalogue-rebuild"):
+                pass
+    finally:
+        release.set()
+        holder.join(timeout=5)
+
+    assert not errors
+    assert not store.path_for("catalogue-rebuild").exists()

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -134,6 +134,11 @@ depends_on  # noqa
 # Protocol method parameter - bound by call site, not used in body
 capture_output  # noqa
 
+# Protocol method parameters on context manager - standard Python protocol
+# signatures (exc_type, exc, tb) are intentionally unused; body calls release().
+exc_type  # noqa
+tb  # noqa
+
 # TYPE_CHECKING-only import used inside cast("...") string literal,
 # which vulture's AST walker cannot resolve.
 JsonSchemaValidationError  # noqa


### PR DESCRIPTION
## What

Adds `src/bernstein/core/sandbox/resource_lease.py`: one atomic claim primitive for
claimable things (a sandbox slot, a worktree, a device, or an arbitrary name).

Resources declare many-to-many tags; a claim resolves a tag filter and locks the
match in one transaction; "nothing matches" and "everything is held" are distinct
error types; every lease records the session identity that took it and an absolute
expiry that a keepalive extends; a lease releases on context exit and on
interpreter exit.

Does **not** touch: `pool_placement.py`'s backend selection, `pool_enrolment.py`'s
signed attribution receipts, or `worktrees_cmd.py`'s GC lock (see Remaining), and
adds no cross-host lease coordination.

## Why

Before this, the only lock in the tree was the worktree GC lock
(`src/bernstein/cli/commands/worktrees_cmd.py:192`). It has the right shape --
`O_EXCL` acquire, PID-liveness plus age-based staleness reclamation, release on
context exit even when the body raises -- but it is hardcoded to one lock file and
takes no resource name, no tags, no TTL and no owner, because it only ever locks
the one thing it was written for.

Everything else claimable is unlocked. `select_pool_backend` decides *which
backend* to use and seals that decision as a receipt, but nothing then claims a
slot *within* that backend; `ClaimReceipt` is an attribution statement, not an
allocation lock. So "is this resource free" and "who holds it and until when" have
no single answer -- they have one answer per resource type that happened to get a
bespoke lock, and none at all for the rest. Concretely, a killed holder parks its
resource forever unless someone wrote a staleness rule for that specific resource.

## How

- `ResourceDeclaration` / `ResourceRegistry` are pure data: a resource carries a
  tag set, and `matching()` returns, in deterministic id order, every resource
  whose tags are a superset of the requested filter. The registry never touches
  the store, so two operators with the same declarations resolve the same
  candidate order.
- `LeaseStore` holds one file per active lease under `<root>/leases/`. Acquire is
  a single `O_EXCL` `open` -- the same atomicity the GC lock already relies on --
  so two claimants racing for one resource are decided by the kernel with no
  read-modify-write window. Listing active leases is listing a directory.
- `claim()` walks the resolved candidates and attempts an acquire on each; a
  candidate taken by a competitor just moves the search on. Empty candidate list
  raises `NoMatchingResourceError`; exhausted candidates raise
  `NoFreeResourceError`; neither is a subclass of the other.
- Staleness follows the GC lock's precedent exactly: an unreadable or mid-write
  payload is **not** stale, so a lease another process created between its
  `O_EXCL` and its write is never stolen. A written payload is stale once its
  `expires_at` has passed or its holder pid is gone; the pid is only consulted
  when the lease was recorded on this host.
- `Lease.keepalive()` rewrites the record atomically (`os.replace`) after checking
  the on-disk `lease_id` still matches, so a holder whose lease was already
  reclaimed learns it instead of overwriting the new holder's record.
  `Lease.release()` is total -- it never raises, and it refuses to unlink a file
  another holder has since reclaimed.
- An `atexit` hook registered on the first claim releases whatever the process
  still holds, logging on failure, so a process that exits without releasing does
  not park its resources until their TTL.

**Open decision, decided here: file-per-lease, not an append-only ledger.** The
issue left the store shape open. A file per lease is chosen because the acquire
*is* the atomicity: `O_EXCL` gives mutual exclusion in one syscall with no
resolve-then-lock window, which is exactly the property a claim primitive owes its
callers, and it is the mechanism already proven in this repo by the GC lock. An
event ledger would need its own serialisation to get the same guarantee before
slice 1 became usable. Listing active leases stays cheap (a directory glob, see
`LeaseStore.active()`), which was the stated cost of this choice. The lease
payload is versioned (`LEASE_SCHEMA_VERSION`) so a later ledger projection can
consume the same records.

## Tests

New file `tests/unit/sandbox/test_resource_lease.py`. Concurrency fixtures follow
`tests/unit/test_worktrees_cmd.py` (real lock files, real threads, a real killed
subprocess); resource/tag fixtures follow `tests/unit/sandbox/test_pool_placement.py`.

Every test below failed on the unmodified tree: the module does not exist there,
so collection of the whole file errors -- there is no claim function to call at
all outside the one hardcoded GC lock.

1. `test_two_claimants_for_one_resource_yield_exactly_one_lease` -- **load-bearing.**
   Two threads meet at a barrier and claim the same single-resource filter;
   exactly one gets a lease and exactly one gets `NoFreeResourceError`.
2. `test_no_match_and_none_free_are_distinct_errors` -- an undeclared tag raises
   `NoMatchingResourceError`; a fully-held match raises `NoFreeResourceError`;
   neither is a subclass of the other.
3. `test_claim_skips_held_resources_and_takes_a_free_sibling` -- with `gpu-0`
   held, the same filter lands on `gpu-1` rather than failing.
4. `test_killed_holders_lease_expires_by_ttl` -- a real subprocess takes a
   1-second lease and is `SIGKILL`ed; the lease file survives (proving no release
   ran), and with holder liveness pinned to `True` the lease is reclaimable only
   after the TTL passes -- isolating the TTL, not the dead pid, as the reason.
5. `test_keepalive_extends_the_ttl` -- the recorded `expires_at` grows and the
   lease stays unreclaimable past its original expiry.
6. `test_keepalive_on_a_reclaimed_lease_refuses` -- once another claimant owns the
   resource, the stale holder's keepalive raises instead of overwriting the new
   record, and its later release does not delete the new holder's lease.
7. `test_lease_records_owner_from_session_identity` -- the owner field comes from
   the install identity, with the pid recorded alongside it.
8. `test_context_manager_releases_on_exception` -- the lease file is unlinked when
   the body raises, and the next claim for the same filter succeeds.
9. `test_process_exit_releases_leases_the_process_still_holds` -- a real
   subprocess claims a 600-second lease and exits without releasing; no lease file
   remains.
10. `test_release_never_raises_when_the_lease_file_is_already_gone` -- release is
    total, including a double release.
11. `test_named_lock_serialises_unregistered_resources` -- an arbitrary name no
    registry declares still serialises two threads, and the lock file is gone
    afterwards.

Local runs (`XDG_*` and `BERNSTEIN_CONFIDENCE_DB` pointed at a scratch tree):

- `run_tests.py --parallel 2 -x tests/unit/sandbox/test_resource_lease.py tests/unit/test_worktrees_cmd.py` -- 11 + 47 passed.
- `run_tests.py --parallel 2 --affected origin/main` -- 70 files selected, 63 passed, 7 collected nothing (optional-extra backend integration files). CI runs the full suite.
- `uv run ruff check src/` and `uv run ruff format --check` on the changed files -- clean.
- `uv run pyright src/bernstein/core/sandbox/resource_lease.py` -- 0 errors.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes (0 errors on the added module; the pre-existing
      whole-tree baseline is unchanged by this PR)
- [x] `uv run python scripts/run_tests.py -x` passes (run as `--affected origin/main`
      plus the two directly-touched files; the full suite runs on CI)
- [x] New code has type hints

### Documentation duty

- [ ] N/A -- user-visible README section: no operator-facing surface yet; this is
      the primitive, with no CLI or config exposed.
- [ ] N/A -- `docs/operations/<area>.md`: nothing operable changes until a caller
      adopts the primitive.
- [ ] N/A -- `docs/api/`: no public HTTP or schema surface changed.
- [x] `uv run bernstein agents-md sync` run; it produced no tracked changes.
- [x] Tests cover the documented behaviour.

Part of #5128

## Remaining

- Adopting the primitive in `worktrees_cmd.lock_gc`. Slice 1 notes the GC "can
  adopt it immediately"; it is left alone here because its lock file lives at
  `GC_LOCK_RELPATH` (not under a lease store) and its `{pid, started_at}` payload
  is read by `worktrees unlock` and the GC-lock status surface. Swapping the
  payload is a behaviour change to a CLI this issue does not own, so it belongs in
  its own change with its own regression tests.
- Wiring a real caller: no pool or backend claims a slot through this yet. The
  primitive is deliberately callable without a registry (`named_lock`) so adoption
  can be incremental.
