### PR TITLE
feat: one durable record per model call, joinable from the cost row (#5107)

### DIFF
--- a/src/bernstein/core/cost/model_call_ledger.py
+++ b/src/bernstein/core/cost/model_call_ledger.py
@@ -1,0 +1,662 @@
+"""One durable record per adapter invocation, joinable from the cost side.
+
+``bernstein.core.cost.model_prices`` prices a call's tokens and nothing
+else: :func:`~bernstein.core.cost.model_prices.price_model_usage` never
+sees the capability that made the call, the adapter it went to, the
+resolved parameters, or the payload that went in and came back. Task
+records and dead-letter entries each replay their own kind of row, and
+neither is a model call. So "we spent $40 yesterday" has never been
+answerable as "we spent $40 on these 30 calls, here is what each one sent
+and got back."
+
+This module holds the missing row. :class:`ModelCallRecord` carries the
+whole call - capability id, adapter id, model identifier with version,
+resolved parameters and the schema version they were validated against,
+input, output, status, the three instants, and the journal entry id that
+ties the call back to the work ledger. :class:`ModelCallLedger` appends
+those records to ``.sdd/runtime/model_calls.jsonl`` and owns the three
+operations over them: the guarded status graph, the opt-in short circuit
+for an identical call, and operator-invoked replay.
+
+Where the record lives. It is its own append-only JSONL store rather than
+a new entry kind on the hash-chained work ledger
+(``core/persistence/work_ledger.py``). The record already carries a
+``journal_entry_id`` field, so the join to the chain exists without
+putting a per-call, per-token-payload row into a per-task chain whose
+growth rate is orders of magnitude lower; and reuse lookup is a hash
+index over this file rather than a walk of the task-graph chain.
+
+Usage::
+
+    ledger = ModelCallLedger(sdd_dir=Path(".sdd"))
+    record = ledger.invoke(
+        capability_id="review.summarise",
+        adapter_id="claude",
+        model="claude-opus-4",
+        parameters={"temperature": 0.0},
+        input_text=prompt,
+        call=lambda: adapter.complete(prompt),
+    )
+    priced = price_model_usage(record.model, n_in, n_out, model_call_id=record.id)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field, replace
+from typing import TYPE_CHECKING, Any, Literal, cast, get_args
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+MODEL_CALL_SCHEMA_VERSION = 1
+"""Schema version stamped on every row this module writes."""
+
+ModelCallStatus = Literal["pending", "running", "succeeded", "failed"]
+
+_ALLOWED_TRANSITIONS: dict[ModelCallStatus, frozenset[ModelCallStatus]] = {
+    "pending": frozenset({"running"}),
+    "running": frozenset({"succeeded", "failed"}),
+    "succeeded": frozenset(),
+    "failed": frozenset(),
+}
+"""The whole status graph, in one place.
+
+``succeeded`` and ``failed`` have no outgoing edges: a finished call is a
+fact, not a snapshot a later message may overwrite. Every transition goes
+through :meth:`ModelCallLedger.transition`, which consults this mapping;
+nothing else is allowed to set a status.
+"""
+
+_ROW_KIND_RECORD = "model_call"
+_ROW_KIND_REFUSAL = "transition_refused"
+
+
+class InvalidStatusTransitionError(RuntimeError):
+    """A status transition outside :data:`_ALLOWED_TRANSITIONS` was attempted.
+
+    Attributes:
+        record_id: The record whose status the caller tried to change.
+        from_status: The status the record actually holds.
+        to_status: The status the caller asked for.
+    """
+
+    def __init__(
+        self,
+        record_id: str,
+        from_status: ModelCallStatus,
+        to_status: ModelCallStatus,
+    ) -> None:
+        super().__init__(f"model call {record_id}: refused transition {from_status} -> {to_status}")
+        self.record_id = record_id
+        self.from_status = from_status
+        self.to_status = to_status
+
+
+def _as_object(value: Any) -> dict[str, Any]:
+    """Return *value* as a str-keyed dict, or ``{}`` when it is not a mapping.
+
+    Rows reach the reader from a file other processes append to, so a row
+    that is not a JSON object is skipped rather than raising: one bad line
+    must not cost an operator the rest of the ledger.
+    """
+    if not isinstance(value, dict):
+        return {}
+    return {str(k): v for k, v in cast("dict[Any, Any]", value).items()}
+
+
+def _canonical(value: Any) -> Any:
+    """Return a JSON-encodable projection of *value*.
+
+    Parameters and payloads reach the record from adapter call sites, so
+    they may hold objects ``json`` cannot encode. Anything outside the
+    JSON scalar/container set is projected to its ``repr`` rather than
+    raising: a record that cannot be hashed is worse than one whose exotic
+    parameter is recorded as text.
+    """
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, dict):
+        return {str(k): _canonical(v) for k, v in cast("dict[Any, Any]", value).items()}
+    if isinstance(value, (list, tuple)):
+        return [_canonical(v) for v in cast("list[Any] | tuple[Any, ...]", value)]
+    return repr(value)
+
+
+@dataclass(frozen=True)
+class ModelCallRecord:
+    """One adapter invocation, in full.
+
+    Attributes:
+        id: Unique record id; the join key the cost row references.
+        capability_id: The capability that made the call.
+        adapter_id: The adapter the call went to.
+        model: Model identifier as the adapter names it.
+        model_version: Provider version string for ``model``, or ``""``.
+        parameters: Resolved parameters as sent to the adapter.
+        parameter_schema_version: Version of the adapter's declared
+            parameter schema the parameters were validated against.
+        input_text: What was sent.
+        output_text: What came back; ``""`` until the call finishes.
+        status: One of :data:`ModelCallStatus`; see
+            :data:`_ALLOWED_TRANSITIONS` for the legal graph.
+        error: Failure message when ``status`` is ``"failed"``.
+        created_at: Unix instant the record was created.
+        started_at: Unix instant of ``pending`` -> ``running``, or ``0.0``.
+        finished_at: Unix instant of the terminal transition, or ``0.0``.
+        journal_entry_id: Work-ledger entry this call belongs to, if any.
+        reused_from: Id of the record whose stored output served this call
+            under ``--reuse-identical``; ``""`` when the adapter ran.
+        replay_of: Id of the record this one replays; ``""`` otherwise.
+        schema_version: :data:`MODEL_CALL_SCHEMA_VERSION` at write time.
+    """
+
+    id: str
+    capability_id: str
+    adapter_id: str
+    model: str
+    model_version: str = ""
+    parameters: dict[str, Any] = field(default_factory=dict[str, Any])
+    parameter_schema_version: str = ""
+    input_text: str = ""
+    output_text: str = ""
+    status: ModelCallStatus = "pending"
+    error: str = ""
+    created_at: float = 0.0
+    started_at: float = 0.0
+    finished_at: float = 0.0
+    journal_entry_id: str = ""
+    reused_from: str = ""
+    replay_of: str = ""
+    schema_version: int = MODEL_CALL_SCHEMA_VERSION
+
+    @classmethod
+    def new(
+        cls,
+        *,
+        capability_id: str,
+        adapter_id: str,
+        model: str,
+        model_version: str = "",
+        parameters: Mapping[str, Any] | None = None,
+        parameter_schema_version: str = "",
+        input_text: str = "",
+        journal_entry_id: str = "",
+        replay_of: str = "",
+    ) -> ModelCallRecord:
+        """Build a ``pending`` record with a fresh id and ``created_at``.
+
+        Args:
+            capability_id: The capability making the call.
+            adapter_id: The adapter the call goes to.
+            model: Model identifier as the adapter names it.
+            model_version: Provider version string for ``model``.
+            parameters: Resolved parameters for the call.
+            parameter_schema_version: Version of the adapter's declared
+                parameter schema these parameters satisfy.
+            input_text: What is being sent.
+            journal_entry_id: Work-ledger entry this call belongs to.
+            replay_of: Id of the record this one replays.
+
+        Returns:
+            A new ``pending`` record.
+        """
+        return cls(
+            id=uuid.uuid4().hex[:16],
+            capability_id=capability_id,
+            adapter_id=adapter_id,
+            model=model,
+            model_version=model_version,
+            parameters=dict(_canonical(dict(parameters or {}))),
+            parameter_schema_version=parameter_schema_version,
+            input_text=input_text,
+            journal_entry_id=journal_entry_id,
+            replay_of=replay_of,
+            created_at=time.time(),
+        )
+
+    @property
+    def model_identifier(self) -> str:
+        """Model and version as one string, e.g. ``"claude-opus-4@20260501"``."""
+        return f"{self.model}@{self.model_version}" if self.model_version else self.model
+
+    @property
+    def reused(self) -> bool:
+        """Whether a stored record's output served this call."""
+        return bool(self.reused_from)
+
+    def content_hash(self) -> str:
+        """Return the SHA-256 digest over this call's identity.
+
+        The digest covers exactly the four fields that decide whether two
+        calls are the same call - capability id, model identifier,
+        resolved parameters, input - and nothing that varies between two
+        identical calls (id, instants, output, status). Keys are sorted at
+        every depth, so parameter dicts built in different insertion
+        orders hash the same.
+
+        Returns:
+            Hex digest usable as the ``--reuse-identical`` lookup key.
+        """
+        document = {
+            "capability_id": self.capability_id,
+            "input": self.input_text,
+            "model": self.model_identifier,
+            "parameters": _canonical(self.parameters),
+        }
+        encoded = json.dumps(document, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible representation of the record."""
+        return {
+            "id": self.id,
+            "capability_id": self.capability_id,
+            "adapter_id": self.adapter_id,
+            "model": self.model,
+            "model_version": self.model_version,
+            "parameters": self.parameters,
+            "parameter_schema_version": self.parameter_schema_version,
+            "input_text": self.input_text,
+            "output_text": self.output_text,
+            "status": self.status,
+            "error": self.error,
+            "created_at": self.created_at,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "journal_entry_id": self.journal_entry_id,
+            "reused_from": self.reused_from,
+            "replay_of": self.replay_of,
+            "schema_version": self.schema_version,
+            "content_hash": self.content_hash(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> ModelCallRecord:
+        """Rebuild a record from a deserialised row.
+
+        Args:
+            data: One decoded JSONL row.
+
+        Returns:
+            The record. An unrecognised ``status`` degrades to
+            ``"failed"`` rather than widening the status set.
+        """
+        status = str(data.get("status", "pending"))
+        if status not in get_args(ModelCallStatus):
+            logger.warning("model call ledger: unknown status %r; reading as failed", status)
+            status = "failed"
+        params: Any = data.get("parameters")
+        return cls(
+            id=str(data.get("id", "")),
+            capability_id=str(data.get("capability_id", "")),
+            adapter_id=str(data.get("adapter_id", "")),
+            model=str(data.get("model", "")),
+            model_version=str(data.get("model_version", "")),
+            parameters=_as_object(params),
+            parameter_schema_version=str(data.get("parameter_schema_version", "")),
+            input_text=str(data.get("input_text", "")),
+            output_text=str(data.get("output_text", "")),
+            status=status,  # type: ignore[arg-type]
+            error=str(data.get("error", "")),
+            created_at=float(data.get("created_at", 0.0)),
+            started_at=float(data.get("started_at", 0.0)),
+            finished_at=float(data.get("finished_at", 0.0)),
+            journal_entry_id=str(data.get("journal_entry_id", "")),
+            reused_from=str(data.get("reused_from", "")),
+            replay_of=str(data.get("replay_of", "")),
+            schema_version=int(data.get("schema_version", MODEL_CALL_SCHEMA_VERSION)),
+        )
+
+
+@dataclass(frozen=True)
+class TransitionRefusal:
+    """A refused status transition, journaled next to the records.
+
+    Attributes:
+        record_id: Record whose status the caller tried to change.
+        from_status: Status the record actually held.
+        to_status: Status the caller asked for.
+        at: Unix instant of the refusal.
+    """
+
+    record_id: str
+    from_status: str
+    to_status: str
+    at: float
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible representation of the refusal."""
+        return {
+            "record_id": self.record_id,
+            "from_status": self.from_status,
+            "to_status": self.to_status,
+            "at": self.at,
+        }
+
+
+class ModelCallLedger:
+    """Append-only store of :class:`ModelCallRecord` rows.
+
+    Backed by ``<sdd_dir>/runtime/model_calls.jsonl``. Rows are never
+    rewritten: a replay appends a new record pointing at the original with
+    ``replay_of`` instead of editing the original in place, so an operator
+    reading a record sees what that invocation actually sent and received,
+    forever.
+
+    Args:
+        sdd_dir: Path to the ``.sdd`` state directory.
+    """
+
+    def __init__(self, sdd_dir: Path) -> None:
+        self._sdd_dir = sdd_dir
+        self._path = sdd_dir / "runtime" / "model_calls.jsonl"
+        self._records: list[ModelCallRecord] = []
+        self._refusals: list[TransitionRefusal] = []
+        self._loaded = False
+
+    @property
+    def path(self) -> Path:
+        """Path of the JSONL file backing this ledger."""
+        return self._path
+
+    # -- reading ---------------------------------------------------------
+
+    def _ensure_loaded(self) -> None:
+        """Load rows from disk once."""
+        if self._loaded:
+            return
+        self._records = []
+        self._refusals = []
+        if self._path.exists():
+            try:
+                lines = self._path.read_text().splitlines()
+            except OSError as exc:
+                logger.warning("model call ledger: failed to read %s: %s", self._path, exc)
+                lines = []
+            for line in lines:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    parsed: Any = json.loads(stripped)
+                except json.JSONDecodeError as exc:
+                    logger.debug("model call ledger: skipping malformed row: %s", exc)
+                    continue
+                if not isinstance(parsed, dict):
+                    continue
+                row = _as_object(parsed)
+                kind = row.get("kind")
+                if kind == _ROW_KIND_RECORD:
+                    self._records.append(ModelCallRecord.from_dict(_as_object(row.get("record"))))
+                elif kind == _ROW_KIND_REFUSAL:
+                    self._refusals.append(
+                        TransitionRefusal(
+                            record_id=str(row.get("record_id", "")),
+                            from_status=str(row.get("from_status", "")),
+                            to_status=str(row.get("to_status", "")),
+                            at=float(row.get("at", 0.0)),
+                        )
+                    )
+        self._loaded = True
+
+    def list_records(self, *, limit: int = 100) -> list[ModelCallRecord]:
+        """Return records in write order, oldest first.
+
+        Args:
+            limit: Maximum records to return.
+
+        Returns:
+            Up to *limit* records.
+        """
+        self._ensure_loaded()
+        return self._records[:limit]
+
+    def get_record(self, record_id: str) -> ModelCallRecord | None:
+        """Return the record with *record_id*, or ``None``.
+
+        Args:
+            record_id: Record id, e.g. a cost row's ``model_call_id``.
+
+        Returns:
+            The matching record, or ``None`` when unknown.
+        """
+        self._ensure_loaded()
+        for record in self._records:
+            if record.id == record_id:
+                return record
+        return None
+
+    def refusals(self) -> list[TransitionRefusal]:
+        """Return every journaled transition refusal, oldest first."""
+        self._ensure_loaded()
+        return list(self._refusals)
+
+    def replays_of(self, record_id: str) -> list[str]:
+        """Return the ids of records that replay *record_id*.
+
+        Args:
+            record_id: The original record's id.
+
+        Returns:
+            Replay record ids in write order.
+        """
+        self._ensure_loaded()
+        return [r.id for r in self._records if r.replay_of == record_id]
+
+    def find_reusable(self, content_hash: str) -> ModelCallRecord | None:
+        """Return the newest succeeded record with *content_hash*.
+
+        Args:
+            content_hash: Digest from :meth:`ModelCallRecord.content_hash`.
+
+        Returns:
+            The record whose stored output may serve an identical call, or
+            ``None`` when no succeeded record matches.
+        """
+        self._ensure_loaded()
+        for record in reversed(self._records):
+            if record.status == "succeeded" and record.content_hash() == content_hash:
+                return record
+        return None
+
+    # -- transitions -----------------------------------------------------
+
+    def transition(self, record: ModelCallRecord, to_status: ModelCallStatus) -> ModelCallRecord:
+        """Return *record* moved to *to_status*, or refuse the move.
+
+        The only way a record's status changes. ``pending`` -> ``running``
+        stamps ``started_at``; ``running`` -> ``succeeded``/``failed``
+        stamps ``finished_at``. Any other pair - including any edge out of
+        a terminal status - is journaled to the ledger file and raised, so
+        a refusal survives the process that attempted it.
+
+        Args:
+            record: The record to move.
+            to_status: The status asked for.
+
+        Returns:
+            A new record at *to_status*; *record* itself is unchanged.
+
+        Raises:
+            InvalidStatusTransitionError: *to_status* is not reachable
+                from ``record.status``.
+        """
+        if to_status not in _ALLOWED_TRANSITIONS[record.status]:
+            refusal = TransitionRefusal(
+                record_id=record.id,
+                from_status=record.status,
+                to_status=to_status,
+                at=time.time(),
+            )
+            self._ensure_loaded()
+            self._refusals.append(refusal)
+            self._append_row({"kind": _ROW_KIND_REFUSAL, **refusal.to_dict()})
+            logger.warning(
+                "model call ledger: refused transition %s -> %s on record %s",
+                record.status,
+                to_status,
+                record.id,
+            )
+            raise InvalidStatusTransitionError(record.id, record.status, to_status)
+
+        now = time.time()
+        if to_status == "running":
+            return replace(record, status=to_status, started_at=now)
+        return replace(record, status=to_status, finished_at=now)
+
+    # -- writing ---------------------------------------------------------
+
+    def invoke(
+        self,
+        *,
+        capability_id: str,
+        adapter_id: str,
+        model: str,
+        call: Callable[[], str],
+        model_version: str = "",
+        parameters: Mapping[str, Any] | None = None,
+        parameter_schema_version: str = "",
+        input_text: str = "",
+        journal_entry_id: str = "",
+        reuse_identical: bool = False,
+    ) -> ModelCallRecord:
+        """Run one adapter invocation and write the record for it.
+
+        Args:
+            capability_id: The capability making the call.
+            adapter_id: The adapter the call goes to.
+            model: Model identifier as the adapter names it.
+            call: Zero-argument callable that performs the invocation and
+                returns the adapter's output.
+            model_version: Provider version string for ``model``.
+            parameters: Resolved parameters for the call.
+            parameter_schema_version: Version of the adapter's declared
+                parameter schema these parameters satisfy.
+            input_text: What is being sent.
+            journal_entry_id: Work-ledger entry this call belongs to.
+            reuse_identical: When ``True`` and a succeeded record with the
+                same content hash exists, serve that record's output
+                instead of calling the adapter. Off by default: reuse
+                changes what an invocation means, so it is opt-in.
+
+        Returns:
+            The written record. ``reused`` is ``True`` when the adapter
+            was not called.
+
+        Raises:
+            Exception: Whatever *call* raised, after the failed record has
+                been written.
+        """
+        record = ModelCallRecord.new(
+            capability_id=capability_id,
+            adapter_id=adapter_id,
+            model=model,
+            model_version=model_version,
+            parameters=parameters,
+            parameter_schema_version=parameter_schema_version,
+            input_text=input_text,
+            journal_entry_id=journal_entry_id,
+        )
+
+        if reuse_identical:
+            source = self.find_reusable(record.content_hash())
+            if source is not None:
+                now = time.time()
+                reused = replace(
+                    record,
+                    status="succeeded",
+                    output_text=source.output_text,
+                    reused_from=source.id,
+                    started_at=now,
+                    finished_at=now,
+                )
+                self._store(reused)
+                logger.info(
+                    "model call ledger: %s reused output of %s (%s)",
+                    reused.id,
+                    source.id,
+                    capability_id,
+                )
+                return reused
+
+        return self._run(record, call)
+
+    def replay(self, record_id: str, *, call: Callable[[], str]) -> ModelCallRecord | None:
+        """Re-execute a stored call and write a new record linked to it.
+
+        The original is not touched: the replay is a separate record whose
+        ``replay_of`` names the original, so both invocations keep the
+        payload they actually saw. Operator-invoked - this is not a retry
+        policy.
+
+        Args:
+            record_id: Id of the record to replay.
+            call: Zero-argument callable that performs the re-execution
+                with the original's stored parameters.
+
+        Returns:
+            The new record, or ``None`` when *record_id* is unknown.
+
+        Raises:
+            Exception: Whatever *call* raised, after the failed replay
+                record has been written.
+        """
+        original = self.get_record(record_id)
+        if original is None:
+            logger.warning("model call ledger: replay of unknown record %s", record_id)
+            return None
+
+        record = ModelCallRecord.new(
+            capability_id=original.capability_id,
+            adapter_id=original.adapter_id,
+            model=original.model,
+            model_version=original.model_version,
+            parameters=original.parameters,
+            parameter_schema_version=original.parameter_schema_version,
+            input_text=original.input_text,
+            journal_entry_id=original.journal_entry_id,
+            replay_of=original.id,
+        )
+        return self._run(record, call)
+
+    def _run(self, record: ModelCallRecord, call: Callable[[], str]) -> ModelCallRecord:
+        """Drive *record* through the status graph around *call*."""
+        running = self.transition(record, "running")
+        try:
+            output = call()
+        except Exception as exc:
+            failed = replace(
+                self.transition(running, "failed"),
+                error=f"{type(exc).__name__}: {exc}",
+            )
+            self._store(failed)
+            raise
+        succeeded = replace(
+            self.transition(running, "succeeded"),
+            output_text=output,
+        )
+        self._store(succeeded)
+        return succeeded
+
+    def _store(self, record: ModelCallRecord) -> None:
+        """Append *record* to memory and to the JSONL file."""
+        self._ensure_loaded()
+        self._records.append(record)
+        self._append_row({"kind": _ROW_KIND_RECORD, "record": record.to_dict()})
+
+    def _append_row(self, row: dict[str, Any]) -> None:
+        """Append one JSON row to the ledger file."""
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            with self._path.open("a") as handle:
+                handle.write(json.dumps(row, sort_keys=True, separators=(",", ":")) + "\n")
+        except OSError as exc:
+            logger.warning("model call ledger: failed to write %s: %s", self._path, exc)

--- a/src/bernstein/core/cost/model_prices.py
+++ b/src/bernstein/core/cost/model_prices.py
@@ -126,6 +126,13 @@ class UsagePriceResult:
             explicit ``$0`` rather than silently vanishing from totals or
             being estimated with a heuristic that would look precise but
             isn't.
+        model_call_id: Id of the
+            :class:`~bernstein.core.cost.model_call_ledger.ModelCallRecord`
+            this row prices, or ``""`` when the caller has no record. It is
+            the only join key between a dollar amount and the call that
+            produced it: with it, ``ModelCallLedger.get_record`` answers
+            what that spend actually sent and received, without a second
+            index.
     """
 
     model: str
@@ -133,9 +140,16 @@ class UsagePriceResult:
     output_tokens: int
     cost_usd: float
     priced: bool
+    model_call_id: str = ""
 
 
-def price_model_usage(model: str, input_tokens: int, output_tokens: int) -> UsagePriceResult:
+def price_model_usage(
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    *,
+    model_call_id: str = "",
+) -> UsagePriceResult:
     """Price one LLM call's token usage against :data:`MODEL_COSTS_PER_1M_TOKENS`.
 
     Bug 13 (2026-07-02): a 45-minute MiniMax-M3 run on the ``openai_agents``
@@ -156,6 +170,8 @@ def price_model_usage(model: str, input_tokens: int, output_tokens: int) -> Usag
             as a substring against :data:`MODEL_COSTS_PER_1M_TOKENS` keys.
         input_tokens: Prompt tokens consumed by this call.
         output_tokens: Completion tokens consumed by this call.
+        model_call_id: Id of the model-call record this usage belongs to,
+            carried onto the result so cost and call outcome join by id.
 
     Returns:
         A :class:`UsagePriceResult` with the computed cost and whether the
@@ -178,6 +194,7 @@ def price_model_usage(model: str, input_tokens: int, output_tokens: int) -> Usag
                 output_tokens=output_tokens,
                 cost_usd=cost,
                 priced=True,
+                model_call_id=model_call_id,
             )
     logger.warning(
         "price_model_usage: no pricing-table entry for model %r - metering at "
@@ -194,6 +211,7 @@ def price_model_usage(model: str, input_tokens: int, output_tokens: int) -> Usag
         output_tokens=output_tokens,
         cost_usd=0.0,
         priced=False,
+        model_call_id=model_call_id,
     )
 
 

--- a/tests/unit/cost/test_model_call_ledger.py
+++ b/tests/unit/cost/test_model_call_ledger.py
@@ -1,0 +1,296 @@
+"""Unit tests for the per-invocation model-call ledger.
+
+Cost accounting prices tokens (``bernstein.core.cost.model_prices``) but
+carries no call identity: which capability called which adapter, with what
+resolved parameters, what went in and what came back. These tests pin the
+record that holds all of it, its content hash, the guarded status graph,
+the opt-in identical-call short circuit, and the replay contract that
+leaves the original record untouched.
+
+Everything here runs against a real ``.sdd`` directory and a real JSONL
+file: the ledger's whole job is durability, so an in-memory double would
+prove nothing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.cost.model_call_ledger import (
+    InvalidStatusTransitionError,
+    ModelCallLedger,
+    ModelCallRecord,
+)
+from bernstein.core.cost.model_prices import price_model_usage
+
+
+def _ledger(tmp_path: Path) -> ModelCallLedger:
+    return ModelCallLedger(sdd_dir=tmp_path / ".sdd")
+
+
+class TestRecordIdentity:
+    def test_one_record_per_invocation_carries_full_call_identity(self, tmp_path: Path) -> None:
+        """Load-bearing: one record holds every field of a model call.
+
+        On the pre-change tree no type combines capability id, adapter id,
+        model identifier, resolved parameters, input and output, so an
+        operator reading the cost ledger cannot reconstruct what a call
+        actually sent or received.
+        """
+        ledger = _ledger(tmp_path)
+
+        record = ledger.invoke(
+            capability_id="review.summarise",
+            adapter_id="claude",
+            model="claude-opus-4",
+            model_version="20260501",
+            parameters={"temperature": 0.0, "max_tokens": 512},
+            parameter_schema_version="claude/2",
+            input_text="summarise this diff",
+            journal_entry_id="entry-7",
+            call=lambda: "the diff renames two helpers",
+        )
+
+        assert record.capability_id == "review.summarise"
+        assert record.adapter_id == "claude"
+        assert record.model == "claude-opus-4"
+        assert record.model_version == "20260501"
+        assert record.model_identifier == "claude-opus-4@20260501"
+        assert record.parameters == {"temperature": 0.0, "max_tokens": 512}
+        assert record.parameter_schema_version == "claude/2"
+        assert record.input_text == "summarise this diff"
+        assert record.output_text == "the diff renames two helpers"
+        assert record.status == "succeeded"
+        assert record.journal_entry_id == "entry-7"
+        assert record.created_at > 0.0
+        assert record.started_at >= record.created_at
+        assert record.finished_at >= record.started_at
+
+        # Exactly one record on disk, and it round-trips through JSONL.
+        stored = ledger.list_records()
+        assert len(stored) == 1
+        assert stored[0] == record
+
+        rows = [
+            json.loads(line)
+            for line in (tmp_path / ".sdd" / "runtime" / "model_calls.jsonl").read_text().splitlines()
+            if line.strip()
+        ]
+        assert len(rows) == 1
+        assert rows[0]["kind"] == "model_call"
+
+    def test_content_hash_is_stable_for_identical_inputs(self) -> None:
+        """The hash covers call identity only, independent of key order."""
+        first = ModelCallRecord.new(
+            capability_id="x",
+            adapter_id="claude",
+            model="claude-opus-4",
+            parameters={"temperature": 0.0, "top_p": 1.0},
+            input_text="hello",
+        )
+        second = ModelCallRecord.new(
+            capability_id="x",
+            adapter_id="claude",
+            model="claude-opus-4",
+            parameters={"top_p": 1.0, "temperature": 0.0},
+            input_text="hello",
+        )
+
+        assert first.id != second.id
+        assert first.content_hash() == second.content_hash()
+
+        # Any of the four identity fields changing changes the hash.
+        assert (
+            ModelCallRecord.new(
+                capability_id="y",
+                adapter_id="claude",
+                model="claude-opus-4",
+                parameters={"temperature": 0.0, "top_p": 1.0},
+                input_text="hello",
+            ).content_hash()
+            != first.content_hash()
+        )
+        assert (
+            ModelCallRecord.new(
+                capability_id="x",
+                adapter_id="claude",
+                model="claude-opus-4",
+                parameters={"temperature": 0.0, "top_p": 1.0},
+                input_text="goodbye",
+            ).content_hash()
+            != first.content_hash()
+        )
+
+
+class TestReuseIdentical:
+    def test_reuse_identical_short_circuits_and_marks_reused(self, tmp_path: Path) -> None:
+        ledger = _ledger(tmp_path)
+        calls: list[str] = []
+
+        def _call() -> str:
+            calls.append("called")
+            return "answer"
+
+        first = ledger.invoke(
+            capability_id="x",
+            adapter_id="claude",
+            model="claude-opus-4",
+            parameters={"temperature": 0.0},
+            input_text="question",
+            call=_call,
+            reuse_identical=True,
+        )
+        second = ledger.invoke(
+            capability_id="x",
+            adapter_id="claude",
+            model="claude-opus-4",
+            parameters={"temperature": 0.0},
+            input_text="question",
+            call=_call,
+            reuse_identical=True,
+        )
+
+        assert calls == ["called"]
+        assert first.reused is False
+        assert second.reused is True
+        assert second.reused_from == first.id
+        assert second.output_text == first.output_text
+        assert second.content_hash() == first.content_hash()
+        assert len(ledger.list_records()) == 2
+
+    def test_reuse_identical_default_off_always_calls_adapter(self, tmp_path: Path) -> None:
+        ledger = _ledger(tmp_path)
+        calls: list[str] = []
+
+        def _call() -> str:
+            calls.append("called")
+            return "answer"
+
+        for _ in range(2):
+            record = ledger.invoke(
+                capability_id="x",
+                adapter_id="claude",
+                model="claude-opus-4",
+                parameters={"temperature": 0.0},
+                input_text="question",
+                call=_call,
+            )
+            assert record.reused is False
+            assert record.reused_from == ""
+
+        assert calls == ["called", "called"]
+
+
+class TestStatusTransitions:
+    def test_invalid_status_transition_raises_and_is_journaled(self, tmp_path: Path) -> None:
+        ledger = _ledger(tmp_path)
+        record = ModelCallRecord.new(
+            capability_id="x",
+            adapter_id="claude",
+            model="claude-opus-4",
+            parameters={},
+            input_text="question",
+        )
+
+        # pending -> succeeded skips running and is refused.
+        with pytest.raises(InvalidStatusTransitionError):
+            ledger.transition(record, "succeeded")
+
+        running = ledger.transition(record, "running")
+        succeeded = ledger.transition(running, "succeeded")
+
+        # A terminal status has no outgoing edge.
+        with pytest.raises(InvalidStatusTransitionError):
+            ledger.transition(succeeded, "running")
+
+        refusals = ledger.refusals()
+        assert [(r.from_status, r.to_status) for r in refusals] == [
+            ("pending", "succeeded"),
+            ("succeeded", "running"),
+        ]
+        assert all(r.record_id == record.id for r in refusals)
+
+    def test_refusal_is_journaled_to_the_same_durable_file(self, tmp_path: Path) -> None:
+        ledger = _ledger(tmp_path)
+        record = ModelCallRecord.new(
+            capability_id="x",
+            adapter_id="claude",
+            model="claude-opus-4",
+            parameters={},
+            input_text="question",
+        )
+        with pytest.raises(InvalidStatusTransitionError):
+            ledger.transition(record, "failed")
+
+        reopened = _ledger(tmp_path)
+        assert len(reopened.refusals()) == 1
+        assert reopened.list_records() == []
+
+
+class TestReplay:
+    def test_replay_writes_new_record_linked_to_original_which_stays_immutable(self, tmp_path: Path) -> None:
+        ledger = _ledger(tmp_path)
+        outputs = iter(["first answer", "second answer"])
+
+        original = ledger.invoke(
+            capability_id="x",
+            adapter_id="claude",
+            model="claude-opus-4",
+            parameters={"temperature": 0.0},
+            input_text="question",
+            call=lambda: next(outputs),
+        )
+
+        replayed = ledger.replay(original.id, call=lambda: next(outputs))
+        assert replayed is not None
+        assert replayed.id != original.id
+        assert replayed.replay_of == original.id
+        # The stored parameters are re-executed verbatim.
+        assert replayed.capability_id == original.capability_id
+        assert replayed.parameters == original.parameters
+        assert replayed.input_text == original.input_text
+        assert replayed.content_hash() == original.content_hash()
+        assert replayed.output_text == "second answer"
+
+        # The original is untouched on disk, not rebuilt in place.
+        reopened = _ledger(tmp_path)
+        stored_original = reopened.get_record(original.id)
+        assert stored_original == original
+        assert stored_original is not None
+        assert stored_original.output_text == "first answer"
+        assert stored_original.replay_of == ""
+        assert len(reopened.list_records()) == 2
+        assert reopened.replays_of(original.id) == [replayed.id]
+
+    def test_replay_of_unknown_record_returns_none(self, tmp_path: Path) -> None:
+        ledger = _ledger(tmp_path)
+        assert ledger.replay("nope", call=lambda: "x") is None
+
+
+class TestCostJoin:
+    def test_cost_row_carries_model_call_id(self, tmp_path: Path) -> None:
+        ledger = _ledger(tmp_path)
+        record = ledger.invoke(
+            capability_id="x",
+            adapter_id="claude",
+            model="gpt-5-mini",
+            parameters={},
+            input_text="question",
+            call=lambda: "answer",
+        )
+
+        priced = price_model_usage(
+            "gpt-5-mini",
+            input_tokens=1_000,
+            output_tokens=100,
+            model_call_id=record.id,
+        )
+        assert priced.model_call_id == record.id
+        assert ledger.get_record(priced.model_call_id) == record
+
+    def test_cost_row_model_call_id_defaults_to_empty(self) -> None:
+        priced = price_model_usage("gpt-5-mini", input_tokens=1_000, output_tokens=100)
+        assert priced.model_call_id == ""


### PR DESCRIPTION
## What

Adds `src/bernstein/core/cost/model_call_ledger.py`: one durable record per adapter invocation, and the store that owns it.

- `ModelCallRecord` — capability id, adapter id, model identifier with version string, resolved parameters plus the parameter-schema version they were validated against, input, output, status, `created_at` / `started_at` / `finished_at`, journal entry id.
- `ModelCallRecord.content_hash()` — SHA-256 over exactly the four call-identity fields (capability id, model identifier, parameters, input), keys sorted at every depth.
- `ModelCallLedger` — append-only JSONL store at `.sdd/runtime/model_calls.jsonl` with the guarded status graph, the opt-in identical-call short circuit, and operator-invoked replay.
- `UsagePriceResult.model_call_id` (defaulted to `""`) and a `model_call_id` keyword on `price_model_usage`, so a priced row joins to its call record by id.

What it explicitly does not do:

- Does not wire any adapter call site to the ledger, and adds no CLI surface. `reuse_identical` is a keyword on `ModelCallLedger.invoke`; `replay` is a method taking a record id. The `--reuse-identical` flag and the `replay <record-id>` command are the next slice, once an invocation path writes records.
- No currency conversion or provider billing reconciliation.
- No principal/grant attribution on the record — this only adds the join key.
- No automatic retry: `replay` is operator-invoked.
- No parameter-schema registry on the adapter base. The record carries the schema version it was validated against; declaring schemas is a separate surface the issue does not scope.

## Why

The most expensive step in the system is the one an operator currently cannot reconstruct. `price_model_usage` (`src/bernstein/core/cost/model_prices.py:138`) prices tokens and nothing else: it never sees the capability that made the call, the adapter it went to, the resolved parameters, or the payload. `core/orchestration/activity.py` hashes activity payloads but is not keyed to a model call. `core/tasks/task_store_core.py:703` and `core/tasks/dead_letter_queue.py:269` each replay their own kind of row, neither of which is a model call. So "we spent $40 yesterday" has never been answerable as "we spent $40 on these 30 calls, here is what each one sent and got back."

## How

**Where the record is persisted** — the one open decision in the issue. It gets its own append-only JSONL store under `.sdd/runtime/`, not a new entry kind on the hash-chained work ledger (`core/persistence/work_ledger.py`). Two reasons: the record already carries a `journal_entry_id` field, so the join to the chain exists without putting a per-call, per-payload row into a per-task chain whose growth rate is orders of magnitude lower; and reuse lookup becomes a hash index over this one file rather than a walk of the task-graph chain. The field list in the issue already assumes this shape — a record that *is* a ledger entry would not carry a journal entry id.

**Status graph.** `_ALLOWED_TRANSITIONS` states the whole graph in one mapping: `pending → running → {succeeded, failed}`, with no outgoing edges from either terminal status. `ModelCallLedger.transition` is the only way a status changes; it consults the mapping, and on a refusal journals a `transition_refused` row to the same file (naming the record, the attempted `from → to`, and the instant) before raising `InvalidStatusTransitionError`. A refusal therefore survives the process that attempted it.

**Reuse.** `invoke(..., reuse_identical=True)` looks up the newest succeeded record with the same content hash and, on a hit, writes a record carrying that record's output with `reused_from` set instead of calling the adapter. A new record rather than the bare stored one: otherwise the ledger loses the fact that a second invocation happened at all, which is exactly the question the record exists to answer. Default off — reuse changes what an invocation means.

**Replay.** `replay(record_id, call=...)` re-executes the stored parameters and appends a new record whose `replay_of` names the original, in the shape of the DLQ's `replay` (new linked record) rather than task-store's `replay_jsonl` (rebuild-in-place). The file is never rewritten, so "the original stays immutable" holds literally: the replay link is the only state, read back via `replays_of(record_id)`.

**Cost join.** `UsagePriceResult` gains an optional `model_call_id`; `price_model_usage` carries it through both the priced and the unpriced return. Defaulted, so no existing caller changes.

## Tests

New file `tests/unit/cost/test_model_call_ledger.py`, against a real `.sdd` directory and a real JSONL file — the ledger's whole job is durability, so an in-memory double would prove nothing. All ten failed before the change: the module did not exist, so the file did not import. Tests 9 and 10 were additionally re-run against the unmodified `model_prices.py` and failed with `AttributeError` on `model_call_id`.

1. `test_one_record_per_invocation_carries_full_call_identity` — **load-bearing**. One record holds capability id, adapter id, model identifier with version, parameters, schema version, input, output, status, the three instants and the journal entry id; exactly one row lands on disk and round-trips.
2. `test_content_hash_is_stable_for_identical_inputs` — same four identity fields hash the same regardless of parameter-dict insertion order; changing any one of them changes the digest.
3. `test_reuse_identical_short_circuits_and_marks_reused` — matching hash, adapter called once, second record marked `reused_from` the first and carrying its output.
4. `test_reuse_identical_default_off_always_calls_adapter` — default behaviour unchanged: two identical calls, two adapter invocations, neither marked reused.
5. `test_invalid_status_transition_raises_and_is_journaled` — `pending → succeeded` and any edge out of a terminal status raise, and both refusals are journaled with the attempted pair.
6. `test_refusal_is_journaled_to_the_same_durable_file` — a refusal is readable by a freshly opened ledger, and does not create a record.
7. `test_replay_writes_new_record_linked_to_original_which_stays_immutable` — the replay names the original in `replay_of`, re-executes the stored parameters, and the original re-read from disk still holds its own output.
8. `test_replay_of_unknown_record_returns_none` — an unknown id refuses rather than inventing a record.
9. `test_cost_row_carries_model_call_id` — a priced row's `model_call_id` resolves back to the record through `get_record`.
10. `test_cost_row_model_call_id_defaults_to_empty` — existing callers keep the old result shape.

Locally green: `tests/unit/cost/test_model_call_ledger.py`, plus the tests of the touched modules and of every importer of `model_prices` — `tests/unit/test_cost_price_model_usage.py`, `tests/unit/test_cost_preflight_v2.py`, `tests/unit/test_preflight.py`, `tests/unit/test_run_preflight_model_resolution.py`, `tests/unit/test_agent_lifecycle.py`, `tests/unit/agents/test_agent_lifecycle_helpers.py`, `tests/unit/adapters/test_openai_agents.py`, `tests/unit/adapters/test_openai_agents_builtins.py`, `tests/unit/cost/test_cost_scheduling.py` (370 tests). `--affected origin/main` selects 1041 files here because `model_prices` is widely re-exported, so it was run as the importer set above instead; CI runs the full suite.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes (clean on both changed source files)
- [x] `uv run python scripts/run_tests.py -x` passes for the files listed above
- [x] New code has type hints

### Documentation duty

- [ ] User-visible README section updated — N/A, no user-visible surface yet (no CLI flag, no wired call site)
- [ ] `docs/operations/<area>.md` updated — N/A, nothing operable yet
- [ ] `docs/api/` schema regenerated — N/A, no public schema changed
- [x] `uv run bernstein agents-md sync` run — produced no tracked change
- [x] Tests cover the documented behaviour

## Remaining

- Wire the adapter invocation path to `ModelCallLedger.invoke` so records are written for real calls, and set `journal_entry_id` from the work-ledger entry in flight.
- Expose the operator surface: a `--reuse-identical` flag on the run path and a `replay <record-id>` command over `ModelCallLedger.replay`.
- Set `model_call_id` at the call sites that price usage (`core/agents/agent_lifecycle.py:1208`, `adapters/openai_agents_runner.py:1635`) once those sites hold a record id.

Part of #5107
