### PR TITLE
feat: run journal fields, write-time enum validation, and a non-terminal-runs query (#5127)

### DIFF
--- a/docs/release-notes/fragments/5127-run-journal-fields.md
+++ b/docs/release-notes/fragments/5127-run-journal-fields.md
@@ -1,0 +1,1 @@
+`bernstein runs report` rows carry the run journal's triage facts — lifecycle state, attempt count, end instant, elapsed, executing host, parent run id and per-step timings — the work ledger validates `state`/`error_kind` against closed enumerations at append, and `list_non_terminal_runs` separates a run still in flight from one that died without a wrap-up (#5127).

--- a/src/bernstein/cli/commands/ledger_cmd.py
+++ b/src/bernstein/cli/commands/ledger_cmd.py
@@ -41,6 +41,7 @@ from bernstein.core.persistence.work_ledger import (
     LedgerError,
     LedgerReader,
     LedgerState,
+    RunJournalState,
     WorkLedger,
     replay_state,
     run_ledger_dir,
@@ -379,7 +380,11 @@ def ledger_resume_cmd(run_id: str, workdir: Path | None, output_json: bool, dry_
         ledger = WorkLedger.open(ledger_dir)
         ledger.append(
             kind=KIND_RUN_RESUMED,
-            payload={"from_head": state.head_hash, "resume_nonce": uuid.uuid4().hex},
+            payload={
+                "from_head": state.head_hash,
+                "resume_nonce": uuid.uuid4().hex,
+                "state": RunJournalState.RESUMED.value,
+            },
         )
     except LedgerError as exc:
         console.print(f"[red]Failed to record the resume entry:[/red] {exc}")

--- a/src/bernstein/core/persistence/runs_report.py
+++ b/src/bernstein/core/persistence/runs_report.py
@@ -30,9 +30,11 @@ Outcome classes (stable values -- the ``--json`` contract)
 
 Scope note: this module reports what a run's ledger holds; it does not poll
 process liveness. It is meant to run after a batch, so a run still actually
-in flight when invoked simply shows whatever its ledger holds so far -- the
-same "no run.closed entry yet" shape as a kill, which is the honest answer
-absent a heartbeat check.
+in flight when invoked shows the same "no run.closed entry yet" shape as a
+kill and classifies as ``infra-error``. That ambiguity is answered by
+:func:`list_non_terminal_runs`, which returns exactly the runs with no
+closing entry together with their age: a fresh entry on an aged run is a
+run still working, and no entry at all is one that died quietly.
 
 Failure-pattern analysis
 -------------------------
@@ -44,15 +46,19 @@ and contributing run IDs for downstream triage or automated remediation.
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.persistence.work_ledger import (
     KIND_RUN_CLOSED,
+    RUN_KINDS,
     LedgerError,
     LedgerReader,
     LedgerState,
+    RunErrorKind,
+    RunJournalState,
     default_ledger_root,
     replay_state,
     run_ledger_dir,
@@ -65,8 +71,10 @@ if TYPE_CHECKING:
     from bernstein.core.persistence.work_ledger import LedgerEntry
 
 #: Error-kind values on a wrap-up that indicate an infrastructure death
-#: rather than a task or gate outcome.
-_INFRA_ERROR_KINDS = frozenset({"adapter", "transport"})
+#: rather than a task or gate outcome. Same closed set the ledger enforces
+#: at append (:class:`~bernstein.core.persistence.work_ledger.RunErrorKind`),
+#: so the classifier and the writer cannot drift apart.
+_INFRA_ERROR_KINDS = frozenset(member.value for member in RunErrorKind)
 
 _NO_WRAPUP_EVIDENCE = "no wrap-up recorded before the run ended (likely killed mid-flight)"
 
@@ -151,12 +159,62 @@ class RunWrapUp:
 
 
 @dataclass(frozen=True)
+class RunStepTiming:
+    """Timing facts for one step (task) of a run, projected from its entries.
+
+    Attributes:
+        task_id: The step's task id.
+        started_at: Unix instant of the step's first ledger entry.
+        ended_at: Unix instant of the step's last ledger entry.
+        elapsed_seconds: ``ended_at - started_at``.
+        entries: How many ledger entries the step recorded -- the item count
+            behind the timings, so a step that churned is visible as such
+            next to one that ran once.
+    """
+
+    task_id: str
+    started_at: float
+    ended_at: float
+    elapsed_seconds: float
+    entries: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON shape carried inside a row's ``steps`` list."""
+        return {
+            "task_id": self.task_id,
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+            "elapsed_seconds": self.elapsed_seconds,
+            "entries": self.entries,
+        }
+
+
+@dataclass(frozen=True)
 class FinishedRun:
     """One row of ``bernstein runs report``: a classified finished run.
 
     Field names are the stable ``--json`` contract; a scheduler reacting to
     these rows programmatically should key off them, not off ``evidence``
     text.
+
+    The journal fields after ``started_at`` all default, so the five-field
+    positional construction older call sites use keeps working; they are
+    populated by :func:`classify_ledger_dir` from the run's own entries.
+
+    Attributes:
+        state: Recorded run-lifecycle state (see
+            :class:`~bernstein.core.persistence.work_ledger.RunJournalState`).
+        attempt_count: How many times a step of this run was started --
+            the sum of ``task.started`` transitions in the run's ledger. It
+            counts *replays inside this run*, which is the retry mechanism
+            the ledger actually has; a whole run resubmitted as a second
+            ledger is a separate record, not another attempt on this one.
+        ended_at: Unix instant of the run's closing entry (its last entry
+            when it never closed).
+        elapsed_seconds: ``ended_at - started_at``.
+        host: Host that executed the run, as recorded on its entries.
+        parent_run_id: Run that spawned this one, when it recorded one.
+        steps: Per-step timings, ordered by start instant.
     """
 
     run_id: str
@@ -164,15 +222,29 @@ class FinishedRun:
     outcome: RunOutcome
     evidence: str
     started_at: float
+    state: RunJournalState = RunJournalState.CLOSED
+    attempt_count: int = 0
+    ended_at: float = 0.0
+    elapsed_seconds: float = 0.0
+    host: str = ""
+    parent_run_id: str = ""
+    steps: tuple[RunStepTiming, ...] = ()
 
     def to_dict(self) -> dict[str, Any]:
-        """Return the stable JSON row shape (``outcome`` as its string value)."""
+        """Return the stable JSON row shape (enums as their string values)."""
         return {
             "run_id": self.run_id,
             "branch": self.branch,
             "outcome": self.outcome.value,
             "evidence": self.evidence,
             "started_at": self.started_at,
+            "state": self.state.value,
+            "attempt_count": self.attempt_count,
+            "ended_at": self.ended_at,
+            "elapsed_seconds": self.elapsed_seconds,
+            "host": self.host,
+            "parent_run_id": self.parent_run_id,
+            "steps": [step.to_dict() for step in self.steps],
         }
 
 
@@ -228,6 +300,71 @@ def _last_wrapup(entries: list[LedgerEntry]) -> RunWrapUp | None:
     return None
 
 
+def _step_timings(entries: list[LedgerEntry]) -> tuple[RunStepTiming, ...]:
+    """Project per-step timings from the task entries of one run.
+
+    A step is one task id: its window runs from its first ledger entry to
+    its last, whatever the transitions in between were, so a step replayed
+    twice reports the whole span rather than only its final attempt.
+    """
+    spans: dict[str, list[float]] = {}
+    counts: dict[str, int] = {}
+    for entry in entries:
+        if not entry.task_id or entry.kind in RUN_KINDS:
+            continue
+        window = spans.get(entry.task_id)
+        if window is None:
+            spans[entry.task_id] = [entry.ts, entry.ts]
+        else:
+            window[1] = entry.ts
+        counts[entry.task_id] = counts.get(entry.task_id, 0) + 1
+    steps = [
+        RunStepTiming(
+            task_id=task_id,
+            started_at=window[0],
+            ended_at=window[1],
+            elapsed_seconds=window[1] - window[0],
+            entries=counts[task_id],
+        )
+        for task_id, window in spans.items()
+    ]
+    steps.sort(key=lambda step: (step.started_at, step.task_id))
+    return tuple(steps)
+
+
+def _recorded_state(entries: list[LedgerEntry], *, run_closed: bool, resumes: int) -> RunJournalState:
+    """Return the run's lifecycle state, preferring what the writer recorded.
+
+    The last ``run.*`` entry that carries a valid ``state`` wins -- the
+    ledger validates that value at append. A ledger written before the
+    field existed falls back to the shape of its entries.
+    """
+    for entry in reversed(entries):
+        if entry.kind not in RUN_KINDS:
+            continue
+        raw = entry.payload.get("state")
+        if isinstance(raw, str):
+            try:
+                return RunJournalState(raw)
+            except ValueError:  # pragma: no cover - append rejects these
+                break
+        break
+    if run_closed:
+        return RunJournalState.CLOSED
+    return RunJournalState.RESUMED if resumes else RunJournalState.OPEN
+
+
+def _run_field(entries: list[LedgerEntry], name: str) -> str:
+    """Return the last string *name* recorded on any ``run.*`` entry."""
+    for entry in reversed(entries):
+        if entry.kind not in RUN_KINDS:
+            continue
+        raw = entry.payload.get(name)
+        if isinstance(raw, str) and raw:
+            return raw
+    return ""
+
+
 def classify_ledger_dir(ledger_dir: Path, *, run_id: str) -> FinishedRun | None:
     """Classify one on-disk ledger directory.
 
@@ -244,12 +381,21 @@ def classify_ledger_dir(ledger_dir: Path, *, run_id: str) -> FinishedRun | None:
     state = replay_state(entries, run_id=run_id)
     wrapup = _last_wrapup(entries)
     outcome, evidence = classify_run(state, wrapup)
+    started_at = entries[0].ts
+    ended_at = entries[-1].ts
     return FinishedRun(
         run_id=state.run_id or run_id,
         branch=wrapup.branch if wrapup is not None else "",
         outcome=outcome,
         evidence=evidence,
-        started_at=entries[0].ts,
+        started_at=started_at,
+        state=_recorded_state(entries, run_closed=state.run_closed, resumes=state.resumes),
+        attempt_count=sum(task.attempts for task in state.tasks.values()),
+        ended_at=ended_at,
+        elapsed_seconds=ended_at - started_at,
+        host=_run_field(entries, "host"),
+        parent_run_id=_run_field(entries, "parent_run_id"),
+        steps=_step_timings(entries),
     )
 
 
@@ -285,6 +431,86 @@ def list_finished_runs(sdd_dir: Path, *, since: float | None = None) -> list[Fin
         runs.append(run)
     runs.sort(key=lambda run: (-run.started_at, run.run_id))
     return runs
+
+
+@dataclass(frozen=True)
+class NonTerminalRun:
+    """One run that has ledger entries and no closing entry yet.
+
+    :func:`list_finished_runs` classifies *every* run directory it finds,
+    so a run still executing and a run killed before it could write a
+    wrap-up both surface there as ``infra-error``. This record answers the
+    other question -- which runs are still open, and for how long -- so an
+    operator can tell "still working" from "died silently" without reading
+    raw ledger entries.
+
+    Attributes:
+        run_id: The run's id.
+        started_at: Unix instant of its first ledger entry.
+        last_entry_at: Unix instant of its most recent ledger entry.
+        age_seconds: How long the run has been open at the evaluated instant.
+    """
+
+    run_id: str
+    started_at: float
+    last_entry_at: float
+    age_seconds: float
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON row shape for this record."""
+        return {
+            "run_id": self.run_id,
+            "started_at": self.started_at,
+            "last_entry_at": self.last_entry_at,
+            "age_seconds": self.age_seconds,
+        }
+
+
+def list_non_terminal_runs(sdd_dir: Path, *, now: float | None = None) -> list[NonTerminalRun]:
+    """Return every run whose ledger holds entries but no closing entry.
+
+    Args:
+        sdd_dir: The install's ``.sdd`` directory.
+        now: Unix instant to age the runs against; defaults to the wall
+            clock. Passing it keeps a caller's ages consistent across a
+            batch (and makes the ageing testable).
+
+    Returns:
+        One :class:`NonTerminalRun` per still-open run, oldest first -- the
+        order an operator triages in. A run directory that fails to read is
+        skipped rather than raised, the same contract
+        :func:`list_finished_runs` gives.
+    """
+    instant = time.time() if now is None else now
+    root = default_ledger_root(sdd_dir)
+    open_runs: list[NonTerminalRun] = []
+    try:
+        children = sorted(root.iterdir())
+    except OSError:
+        return []
+    for child in children:
+        if not child.is_dir():
+            continue
+        try:
+            reader = LedgerReader(run_ledger_dir(sdd_dir, child.name))
+            if not reader.exists():
+                continue
+            entries = list(reader.entries())
+        except (LedgerError, PathContainmentError, OSError):
+            continue
+        if not entries or any(entry.kind == KIND_RUN_CLOSED for entry in entries):
+            continue
+        started_at = entries[0].ts
+        open_runs.append(
+            NonTerminalRun(
+                run_id=child.name,
+                started_at=started_at,
+                last_entry_at=entries[-1].ts,
+                age_seconds=instant - started_at,
+            )
+        )
+    open_runs.sort(key=lambda run: (run.started_at, run.run_id))
+    return open_runs
 
 
 @dataclass(frozen=True)
@@ -385,10 +611,14 @@ def detect_failure_patterns(runs: list[FinishedRun]) -> list[FailurePatternDraft
 __all__ = [
     "FailurePatternDraft",
     "FinishedRun",
+    "NonTerminalRun",
+    "RunJournalState",
     "RunOutcome",
+    "RunStepTiming",
     "RunWrapUp",
     "classify_ledger_dir",
     "classify_run",
     "detect_failure_patterns",
     "list_finished_runs",
+    "list_non_terminal_runs",
 ]

--- a/src/bernstein/core/persistence/work_ledger.py
+++ b/src/bernstein/core/persistence/work_ledger.py
@@ -73,6 +73,7 @@ import re
 import threading
 import time
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.persistence.journal import GENESIS_HASH
@@ -135,6 +136,64 @@ _KIND_RE = re.compile(r"^[a-z][a-z0-9_.-]{0,63}$")
 #: Task ids share the git-ref-safe alphabet used across the persistence
 #: layer (worktree ids, snapshot ids).
 _TASK_ID_RE = re.compile(r"^[A-Za-z0-9_.-]{0,64}$")
+
+#: The ``run.`` and ``task.`` kind families are reserved: they are the durable
+#: run journal ``bernstein runs report`` classifies, so :meth:`WorkLedger.append`
+#: admits only the members declared above. Every other family (``admission.``,
+#: ``mission.``, anything a newer writer invents) keeps the open regex contract
+#: -- those ledgers own their own vocabularies.
+RUN_KINDS = frozenset({KIND_RUN_OPEN, KIND_RUN_RESUMED, KIND_RUN_CLOSED})
+TASK_KINDS = frozenset(
+    {
+        KIND_TASK_SCHEDULED,
+        KIND_TASK_STARTED,
+        KIND_TASK_COMPLETED,
+        KIND_TASK_FAILED,
+        KIND_TASK_ABANDONED,
+        KIND_TASK_SUSPENDED,
+        KIND_TASK_RESUMED,
+    }
+)
+_RESERVED_KIND_PREFIXES = ("run.", "task.")
+_RESERVED_KINDS = RUN_KINDS | TASK_KINDS
+
+
+class RunJournalState(StrEnum):
+    """Lifecycle state a ``run.*`` entry records for the run as a whole.
+
+    Written on the entry that causes the transition and read back by
+    :func:`bernstein.core.persistence.runs_report.classify_ledger_dir`, so
+    the state is a recorded fact rather than something a reader re-derives
+    from which kinds happen to be present.
+    """
+
+    OPEN = "open"
+    RESUMED = "resumed"
+    CLOSED = "closed"
+
+
+class RunErrorKind(StrEnum):
+    """Infrastructure deaths a run wrap-up may attribute its ending to.
+
+    The finished-run classifier maps exactly these values to
+    ``infra-error``. Keeping the set closed *at append* is the point: a
+    typo (``"adaptor"``) used to persist happily and then read back as an
+    ordinary wrap-up, silently reclassifying an adapter death as
+    ``no-changes``.
+    """
+
+    ADAPTER = "adapter"
+    TRANSPORT = "transport"
+
+
+#: Enumerated payload fields on a run-journal entry, and the closed set each
+#: one must draw from. ``error_kind`` also admits ``""`` -- the recorded
+#: absence of an infrastructure death.
+_RUN_JOURNAL_ENUMS: dict[str, type[StrEnum]] = {
+    "state": RunJournalState,
+    "error_kind": RunErrorKind,
+}
+_RUN_JOURNAL_OPTIONAL: frozenset[str] = frozenset({"error_kind"})
 
 
 # ---------------------------------------------------------------------------
@@ -493,6 +552,25 @@ def verify_entry_rows(rows: Iterable[dict[str, Any]]) -> LedgerVerification:
     return LedgerVerification(ok=not errors, head_hash=prev_hash, entries=entries, errors=errors)
 
 
+def _validate_run_journal_payload(kind: str, payload: dict[str, Any]) -> None:
+    """Reject an out-of-vocabulary enumerated field on a run-journal entry.
+
+    Raises:
+        LedgerError: When ``state`` or ``error_kind`` carries a value outside
+            its closed enumeration.
+    """
+    for name, enum_cls in _RUN_JOURNAL_ENUMS.items():
+        if name not in payload:
+            continue
+        raw = payload[name]
+        if raw == "" and name in _RUN_JOURNAL_OPTIONAL:
+            continue
+        allowed = sorted(member.value for member in enum_cls)
+        if not isinstance(raw, str) or raw not in allowed:
+            msg = f"invalid {name} {raw!r} on a {kind} entry: must be one of {allowed}"
+            raise LedgerError(msg)
+
+
 # ---------------------------------------------------------------------------
 # WorkLedger (writer)
 # ---------------------------------------------------------------------------
@@ -574,9 +652,15 @@ class WorkLedger:
         entry hash is computed, so the persisted chain verifies everywhere
         without ever carrying a secret.
 
+        Kinds in the reserved ``run.``/``task.`` families must be declared
+        members, and a run-journal entry's ``state``/``error_kind`` payload
+        fields must draw from :class:`RunJournalState` /
+        :class:`RunErrorKind`: the durable run record's enumerations are
+        enforced here, at the write, not left for a reader to interpret.
+
         Raises:
-            LedgerError: On a malformed kind/task id, a closed ledger, or a
-                failed file write.
+            LedgerError: On a malformed kind/task id, an out-of-vocabulary
+                run-journal field, a closed ledger, or a failed file write.
         """
         if self._closed:
             msg = f"ledger at {self._dir} is closed"
@@ -584,11 +668,17 @@ class WorkLedger:
         if not _KIND_RE.match(kind):
             msg = f"invalid ledger kind {kind!r}: must match {_KIND_RE.pattern}"
             raise LedgerError(msg)
+        if kind.startswith(_RESERVED_KIND_PREFIXES) and kind not in _RESERVED_KINDS:
+            msg = f"invalid ledger kind {kind!r}: the reserved run journal admits only {sorted(_RESERVED_KINDS)}"
+            raise LedgerError(msg)
         if not _TASK_ID_RE.match(task_id):
             msg = f"invalid task_id {task_id!r}: must match {_TASK_ID_RE.pattern}"
             raise LedgerError(msg)
 
-        clean_payload, redactions = _redact_payload(dict(payload or {}))
+        raw_payload = dict(payload or {})
+        if kind in RUN_KINDS:
+            _validate_run_journal_payload(kind, raw_payload)
+        clean_payload, redactions = _redact_payload(raw_payload)
 
         with self._lock:
             prev_hash = self._tip_hash
@@ -1026,12 +1116,16 @@ __all__ = [
     "KIND_TASK_STARTED",
     "KIND_TASK_SUSPENDED",
     "LEDGER_SCHEMA_VERSION",
+    "RUN_KINDS",
+    "TASK_KINDS",
     "ChainRelation",
     "LedgerEntry",
     "LedgerError",
     "LedgerReader",
     "LedgerState",
     "LedgerVerification",
+    "RunErrorKind",
+    "RunJournalState",
     "TaskState",
     "WorkLedger",
     "canonical_entry_payload",

--- a/src/bernstein/core/run_service/service.py
+++ b/src/bernstein/core/run_service/service.py
@@ -14,6 +14,7 @@ replaying the same ledger arrive at byte-identical projections.
 
 from __future__ import annotations
 
+import socket
 import time
 import uuid
 from dataclasses import dataclass
@@ -27,6 +28,7 @@ from bernstein.core.persistence.work_ledger import (
     KIND_TASK_SCHEDULED,
     LedgerReader,
     LedgerState,
+    RunJournalState,
     WorkLedger,
     replay_state,
     run_ledger_dir,
@@ -113,14 +115,30 @@ class RunService:
 
     # -- lifecycle ----------------------------------------------------------
 
-    def submit(self, goal: str, task_ids: Sequence[str], *, run_id: str | None = None) -> RunHandle:
+    def submit(
+        self,
+        goal: str,
+        task_ids: Sequence[str],
+        *,
+        run_id: str | None = None,
+        parent_run_id: str = "",
+    ) -> RunHandle:
         """Open a run: seed the ledger, persist the descriptor, sign a receipt.
 
         The goal is decomposed into *task_ids* by the caller (the planner); the
         ledger records ``run.open`` plus one ``task.scheduled`` per task. The
         goal text itself never enters the portable ledger -- only its digest.
+
+        Args:
+            goal: The run's goal text; only its digest reaches the ledger.
+            task_ids: The task ids the goal decomposed into.
+            run_id: Explicit run id; generated when omitted.
+            parent_run_id: The run that spawned this one, when there is one.
+                Recorded on ``run.open`` so ``bernstein runs report`` can
+                attribute a child run to its parent without a side table.
         """
         run_id = validate_run_id(run_id or f"run-{uuid.uuid4().hex[:12]}")
+        parent_run_id = validate_run_id(parent_run_id) if parent_run_id else ""
         descriptor = RunDescriptor(
             run_id=run_id,
             goal=goal,
@@ -131,14 +149,16 @@ class RunService:
         run_dir(self._sdd, run_id).mkdir(parents=True, exist_ok=True)
         ledger = WorkLedger.open(self._ledger_dir(run_id))
         try:
-            ledger.append(
-                kind=KIND_RUN_OPEN,
-                payload={
-                    "run_id": run_id,
-                    "goal_sha256": descriptor.goal_sha256,
-                    "task_count": len(descriptor.task_ids),
-                },
-            )
+            open_payload: dict[str, object] = {
+                "run_id": run_id,
+                "goal_sha256": descriptor.goal_sha256,
+                "task_count": len(descriptor.task_ids),
+                "state": RunJournalState.OPEN.value,
+                "host": socket.gethostname(),
+            }
+            if parent_run_id:
+                open_payload["parent_run_id"] = parent_run_id
+            ledger.append(kind=KIND_RUN_OPEN, payload=open_payload)
             for task_id in descriptor.task_ids:
                 ledger.append(kind=KIND_TASK_SCHEDULED, task_id=task_id)
             head = ledger.head_hash
@@ -238,7 +258,10 @@ class RunService:
         if not state.run_closed:
             ledger = WorkLedger.open(self._ledger_dir(run_id))
             try:
-                ledger.append(kind=KIND_RUN_CLOSED, payload={"run_id": run_id})
+                ledger.append(
+                    kind=KIND_RUN_CLOSED,
+                    payload={"run_id": run_id, "state": RunJournalState.CLOSED.value},
+                )
             finally:
                 ledger.close()
         head, count = self._head_and_count(run_id)
@@ -285,7 +308,11 @@ class RunService:
             try:
                 ledger.append(
                     kind=KIND_RUN_CLOSED,
-                    payload={"run_id": run_id, "outcome": resolved.value},
+                    payload={
+                        "run_id": run_id,
+                        "outcome": resolved.value,
+                        "state": RunJournalState.CLOSED.value,
+                    },
                 )
             finally:
                 ledger.close()

--- a/tests/unit/test_runs_cmd.py
+++ b/tests/unit/test_runs_cmd.py
@@ -63,7 +63,22 @@ class TestRunsReportJson:
         payload = json.loads(result.output)
         assert list(payload.keys()) == ["runs"]
         row = payload["runs"][0]
-        assert set(row.keys()) == {"run_id", "branch", "outcome", "evidence", "started_at"}
+        # The original five names are the stable contract and must stay; the
+        # run-journal fields (#5127) extend the row without renaming any of them.
+        assert set(row.keys()) == {
+            "run_id",
+            "branch",
+            "outcome",
+            "evidence",
+            "started_at",
+            "state",
+            "attempt_count",
+            "ended_at",
+            "elapsed_seconds",
+            "host",
+            "parent_run_id",
+            "steps",
+        }
         assert row["run_id"] == "run-pr"
         assert row["branch"] == "fix/thing"
         assert row["outcome"] == "pr-opened"

--- a/tests/unit/test_runs_report_journal_fields.py
+++ b/tests/unit/test_runs_report_journal_fields.py
@@ -177,7 +177,7 @@ class TestWriteTimeValidation:
     def test_typo_of_a_reserved_kind_is_rejected_at_write(self, tmp_path: Path) -> None:
         ledger = WorkLedger.open(run_ledger_dir(tmp_path / ".sdd", "run-typo"))
         with pytest.raises(LedgerError, match="reserved"):
-            ledger.append(kind="task.compelted", task_id="t1")
+            ledger.append(kind="task.competed", task_id="t1")
         ledger.close()
 
     def test_other_kind_families_keep_the_regex_contract(self, tmp_path: Path) -> None:

--- a/tests/unit/test_runs_report_journal_fields.py
+++ b/tests/unit/test_runs_report_journal_fields.py
@@ -1,0 +1,218 @@
+"""Run-journal fields on the durable run record (#5127).
+
+``bernstein runs report`` reads the work ledger, so the work ledger is the
+durable run journal. These tests pin the three properties the journal was
+missing:
+
+* the classified record carries what an operator needs to triage a run --
+  attempt count, end instant, elapsed, executing host, parent run id and
+  per-step timings -- not just ``(run_id, branch, outcome, evidence,
+  started_at)``;
+* the enumerated journal fields (``state``, ``error_kind``) and the
+  reserved ``run.``/``task.`` kind families are validated where they are
+  *written*, so a typo cannot silently reclassify a run at read time;
+* an in-progress run is answerable as such, instead of being reported as
+  an infrastructure death because it has no wrap-up yet.
+
+Fixtures build real :class:`WorkLedger` directories on disk, the idiom of
+``tests/unit/test_runs_report.py``'s ``TestListFinishedRuns``.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.persistence.runs_report import (
+    RunOutcome,
+    RunWrapUp,
+    list_finished_runs,
+    list_non_terminal_runs,
+)
+from bernstein.core.persistence.work_ledger import (
+    KIND_RUN_CLOSED,
+    KIND_RUN_OPEN,
+    KIND_TASK_COMPLETED,
+    KIND_TASK_FAILED,
+    KIND_TASK_SCHEDULED,
+    KIND_TASK_STARTED,
+    LedgerError,
+    RunErrorKind,
+    RunJournalState,
+    WorkLedger,
+    run_ledger_dir,
+)
+
+
+def _seed_retried_run(root: Path, run_id: str = "run-retried") -> None:
+    """Two failed attempts then a success for one task -- three attempts."""
+    ledger = WorkLedger.open(run_ledger_dir(root / ".sdd", run_id))
+    ledger.append(
+        kind=KIND_RUN_OPEN,
+        payload={
+            "run_id": run_id,
+            "state": RunJournalState.OPEN.value,
+            "host": "builder-7",
+            "parent_run_id": "run-parent",
+        },
+    )
+    ledger.append(kind=KIND_TASK_SCHEDULED, task_id="t1")
+    for _ in range(2):
+        ledger.append(kind=KIND_TASK_STARTED, task_id="t1")
+        ledger.append(kind=KIND_TASK_FAILED, task_id="t1")
+    ledger.append(kind=KIND_TASK_STARTED, task_id="t1")
+    ledger.append(kind=KIND_TASK_COMPLETED, task_id="t1")
+    ledger.append(
+        kind=KIND_RUN_CLOSED,
+        payload={
+            "run_id": run_id,
+            "state": RunJournalState.CLOSED.value,
+            **RunWrapUp(branch="fix/thing", pr_number=7).to_payload(),
+        },
+    )
+    ledger.close()
+
+
+def _seed_in_progress_run(root: Path, run_id: str = "run-live") -> None:
+    """A run with entries and no ``run.closed`` -- still executing."""
+    ledger = WorkLedger.open(run_ledger_dir(root / ".sdd", run_id))
+    ledger.append(kind=KIND_RUN_OPEN, payload={"run_id": run_id, "state": RunJournalState.OPEN.value})
+    ledger.append(kind=KIND_TASK_SCHEDULED, task_id="t1")
+    ledger.append(kind=KIND_TASK_STARTED, task_id="t1")
+    ledger.close()
+
+
+class TestJournalFields:
+    """Slice 1: the durable record carries the triage facts."""
+
+    def test_finished_run_carries_attempt_count_and_per_step_timings(self, tmp_path: Path) -> None:
+        _seed_retried_run(tmp_path)
+        runs = list_finished_runs(tmp_path / ".sdd")
+        assert len(runs) == 1
+        run = runs[0]
+
+        assert run.outcome is RunOutcome.PR_OPENED
+        # Three ``task.started`` transitions for t1: two failed replays plus
+        # the successful one.
+        assert run.attempt_count == 3
+
+        assert [step.task_id for step in run.steps] == ["t1"]
+        step = run.steps[0]
+        assert step.started_at > 0.0
+        assert step.ended_at >= step.started_at
+        assert step.elapsed_seconds == pytest.approx(step.ended_at - step.started_at)
+        # scheduled + 3 started + 2 failed + 1 completed
+        assert step.entries == 7
+
+    def test_finished_run_carries_end_instant_elapsed_host_and_parent_run_id(self, tmp_path: Path) -> None:
+        _seed_retried_run(tmp_path)
+        run = list_finished_runs(tmp_path / ".sdd")[0]
+
+        assert run.state is RunJournalState.CLOSED
+        assert run.ended_at >= run.started_at
+        assert run.elapsed_seconds == pytest.approx(run.ended_at - run.started_at)
+        assert run.host == "builder-7"
+        assert run.parent_run_id == "run-parent"
+
+    def test_json_row_keeps_the_existing_names_and_adds_the_journal_fields(self, tmp_path: Path) -> None:
+        _seed_retried_run(tmp_path)
+        row = list_finished_runs(tmp_path / ".sdd")[0].to_dict()
+        assert set(row) == {
+            "run_id",
+            "branch",
+            "outcome",
+            "evidence",
+            "started_at",
+            "state",
+            "attempt_count",
+            "ended_at",
+            "elapsed_seconds",
+            "host",
+            "parent_run_id",
+            "steps",
+        }
+        assert row["state"] == "closed"
+        assert row["steps"][0]["task_id"] == "t1"
+
+
+class TestWriteTimeValidation:
+    """Slice 2: the enumerated fields are closed at the write boundary."""
+
+    def test_malformed_state_value_is_rejected_at_write_not_read(self, tmp_path: Path) -> None:
+        ledger = WorkLedger.open(run_ledger_dir(tmp_path / ".sdd", "run-bad-state"))
+        with pytest.raises(LedgerError, match="state"):
+            ledger.append(kind=KIND_RUN_OPEN, payload={"run_id": "run-bad-state", "state": "opened"})
+        # Nothing was persisted: the chain is still empty.
+        assert ledger.next_seq == 0
+        ledger.close()
+
+    def test_malformed_error_kind_cannot_silently_reclassify_the_run(self, tmp_path: Path) -> None:
+        ledger = WorkLedger.open(run_ledger_dir(tmp_path / ".sdd", "run-bad-error"))
+        ledger.append(kind=KIND_RUN_OPEN, payload={"run_id": "run-bad-error"})
+        with pytest.raises(LedgerError, match="error_kind"):
+            # "adaptor" reads as a plain wrap-up to the classifier, which
+            # would report the run as no-changes instead of infra-error.
+            ledger.append(
+                kind=KIND_RUN_CLOSED,
+                payload={"run_id": "run-bad-error", "error_kind": "adaptor", "error_message": "oom"},
+            )
+        ledger.close()
+
+    def test_known_enum_values_still_append(self, tmp_path: Path) -> None:
+        ledger = WorkLedger.open(run_ledger_dir(tmp_path / ".sdd", "run-ok"))
+        ledger.append(kind=KIND_RUN_OPEN, payload={"run_id": "run-ok", "state": RunJournalState.OPEN.value})
+        ledger.append(
+            kind=KIND_RUN_CLOSED,
+            payload={
+                "run_id": "run-ok",
+                "state": RunJournalState.CLOSED.value,
+                "error_kind": RunErrorKind.TRANSPORT.value,
+            },
+        )
+        ledger.close()
+        assert list_finished_runs(tmp_path / ".sdd")[0].outcome is RunOutcome.INFRA_ERROR
+
+    def test_typo_of_a_reserved_kind_is_rejected_at_write(self, tmp_path: Path) -> None:
+        ledger = WorkLedger.open(run_ledger_dir(tmp_path / ".sdd", "run-typo"))
+        with pytest.raises(LedgerError, match="reserved"):
+            ledger.append(kind="task.compelted", task_id="t1")
+        ledger.close()
+
+    def test_other_kind_families_keep_the_regex_contract(self, tmp_path: Path) -> None:
+        """Admission and mission ledgers own their own vocabularies."""
+        ledger = WorkLedger.open(run_ledger_dir(tmp_path / ".sdd", "run-other"))
+        entry = ledger.append(kind="admission.grant", task_id="t1", payload={"state": "whatever"})
+        ledger.close()
+        assert entry.kind == "admission.grant"
+
+
+class TestNonTerminalRuns:
+    """Slice 4 (query half): in-progress is answerable as in-progress."""
+
+    def test_non_terminal_run_query_excludes_finished_runs(self, tmp_path: Path) -> None:
+        _seed_retried_run(tmp_path, "run-done")
+        _seed_in_progress_run(tmp_path, "run-live")
+
+        # The finished-run report still classifies both (its scope is
+        # unchanged); the new query answers only the second.
+        assert {run.run_id for run in list_finished_runs(tmp_path / ".sdd")} == {"run-done", "run-live"}
+        assert [run.run_id for run in list_non_terminal_runs(tmp_path / ".sdd")] == ["run-live"]
+
+    def test_non_terminal_run_carries_its_age(self, tmp_path: Path) -> None:
+        _seed_in_progress_run(tmp_path, "run-live")
+        now = time.time() + 600.0
+        run = list_non_terminal_runs(tmp_path / ".sdd", now=now)[0]
+        assert run.age_seconds == pytest.approx(now - run.started_at)
+        assert run.age_seconds >= 600.0
+        assert run.last_entry_at >= run.started_at
+
+    def test_oldest_non_terminal_run_sorts_first(self, tmp_path: Path) -> None:
+        _seed_in_progress_run(tmp_path, "run-old")
+        time.sleep(0.01)
+        _seed_in_progress_run(tmp_path, "run-new")
+        assert [run.run_id for run in list_non_terminal_runs(tmp_path / ".sdd")] == ["run-old", "run-new"]
+
+    def test_empty_ledger_root_has_no_non_terminal_runs(self, tmp_path: Path) -> None:
+        assert list_non_terminal_runs(tmp_path / ".sdd") == []


### PR DESCRIPTION
## What

Extends the durable run journal — the work ledger and the `FinishedRun`
record `bernstein runs report` projects from it — with the facts an
operator needs to triage a run, closes the journal's two enumerated
payload fields at the write boundary, and adds the query that separates a
run still in flight from one that died without a wrap-up.

Slices 1, 2 and the query half of slice 4 of #5127. What it deliberately
does **not** do:

- no change to `RunState` / `run_actor.py` — that record is in-memory by
  design and this PR extends the one that is already durable;
- no natural key and no submit dedup (slice 3);
- no SLA tie-in for an aged non-terminal run (the second half of slice 4);
- no new CLI subcommand: `list_non_terminal_runs` is a module query, which
  is what the acceptance item asks for.

## Why

`bernstein runs report` is the answer to "what happened to that batch",
and its row carried five fields: `run_id`, `branch`, `outcome`,
`evidence`, `started_at`. An operator chasing a slow or repeatedly-retried
run had to open raw ledger entries to learn when it ended, how long it
took, which host ran it, which step burned the time, or how many times a
step was replayed.

Two sharper problems sat underneath that:

1. **The classifier's vocabulary was enforced nowhere.** `error_kind` is a
   free-form string on the wrap-up payload; the reader maps exactly
   `"adapter"` and `"transport"` to `infra-error`. A writer that recorded
   `"adaptor"` persisted happily, and the run then read back as an
   ordinary wrap-up — an adapter death reported as `no-changes`. The same
   held for the kind itself: `task.compelted` matched the kind regex and
   became an unknown kind the projection silently ignored.
2. **In progress and died silently look identical.** `list_finished_runs`
   classifies every ledger directory it finds. A run with no `run.closed`
   entry *yet* and a run killed before it could write one both come back
   as `infra-error`, and there was no query for "what is still open, and
   for how long".

## How

**Record (`runs_report.py`).** `FinishedRun` gains `state`,
`attempt_count`, `ended_at`, `elapsed_seconds`, `host`, `parent_run_id`
and `steps` (a tuple of the new `RunStepTiming`: task id, start, end,
elapsed, entry count). Every new field defaults, so the existing
five-argument positional construction still works and no existing key in
the `--json` row is renamed or removed — the row is a superset.
`classify_ledger_dir` populates them by projecting the entries it already
reads; only `host` and `parent_run_id` needed new payload fields, written
on `run.open` by `RunService.submit`.

**Write boundary (`work_ledger.py`).** `WorkLedger.append` now closes the
reserved `run.` / `task.` kind families to their declared members, and
validates a run-journal entry's `state` against the new `RunJournalState`
and `error_kind` against the new `RunErrorKind`. Every other family
(`admission.`, `mission.`, anything a newer writer invents) keeps the open
regex contract — those ledgers own their own vocabularies, and closing the
whole set would break them. `runs_report._INFRA_ERROR_KINDS` is now
derived from `RunErrorKind`, so the classifier and the writer cannot drift
apart.

The pre-existing `outcome` key on `run.closed` is left alone: it carries
`RunClosureOutcome` (`completed` / `failed` / `cancelled` / `abandoned`),
which `RunService.close` already validates through the enum constructor,
and repointing that key at the report's `RunOutcome` would invalidate
every `run.closed` payload already on disk.

**Query (`runs_report.py`).** `list_non_terminal_runs(sdd_dir, now=...)`
returns one `NonTerminalRun` per run whose ledger has entries but no
closing entry, oldest first, each with `started_at`, `last_entry_at` and
`age_seconds`. `list_finished_runs` keeps its current scope unchanged, so
nothing that reads it today shifts.

**Open decision, resolved.** The issue leaves open whether "attempt count"
counts task replays inside one run's ledger or separate run directories
sharing a natural key. It counts the first: the sum of `task.started`
transitions in the run's own ledger. That is the retry mechanism the
ledger actually has today — the cross-run linkage does not exist until the
natural key lands in slice 3 — and counting it now keeps the field
meaningful rather than always zero. The docstring says so explicitly, so
slice 3 can add a separate cross-run field without redefining this one.

## Tests

New file `tests/unit/test_runs_report_journal_fields.py`, building real
`WorkLedger` directories on disk (the idiom of
`test_runs_report.py::TestListFinishedRuns`). Every one of these failed on
the unmodified tree — the first three by `ImportError`/`AttributeError`
for names that did not exist, the validation ones because the malformed
value appended without complaint.

1. `test_finished_run_carries_attempt_count_and_per_step_timings` —
   **load-bearing.** Two `task.started`/`task.failed` cycles then a
   `task.completed` for one task id; asserts `attempt_count == 3` and one
   step whose elapsed matches its window and whose entry count is 7.
2. `test_finished_run_carries_end_instant_elapsed_host_and_parent_run_id`
   — the remaining slice-1 fields, including the recorded lifecycle state.
3. `test_json_row_keeps_the_existing_names_and_adds_the_journal_fields` —
   the `--json` row is a superset: no existing key renamed or dropped.
4. `test_malformed_state_value_is_rejected_at_write_not_read` — `"opened"`
   raises `LedgerError` and nothing is persisted (`next_seq` stays 0).
5. `test_malformed_error_kind_cannot_silently_reclassify_the_run` —
   `"adaptor"` is refused at append instead of reading back as an ordinary
   wrap-up.
6. `test_known_enum_values_still_append` — a valid `transport` wrap-up
   still classifies as `infra-error`.
7. `test_typo_of_a_reserved_kind_is_rejected_at_write` —
   `task.compelted` is refused.
8. `test_other_kind_families_keep_the_regex_contract` —
   `admission.grant` with a free-form `state` payload still appends; the
   closure is scoped to the run journal.
9. `test_non_terminal_run_query_excludes_finished_runs` — the new query
   returns only the open run while `list_finished_runs` still returns both.
10. `test_non_terminal_run_carries_its_age` — age is measured against the
    supplied instant.
11. `test_oldest_non_terminal_run_sorts_first` — triage order.
12. `test_empty_ledger_root_has_no_non_terminal_runs` — empty root.

`tests/unit/test_runs_cmd.py::test_json_rows_carry_the_stable_field_names`
is updated to the extended key set; it still asserts the original five
names are present.

Green locally: the new file plus `test_runs_report.py`,
`test_runs_cmd.py`, `test_work_ledger.py`, `test_work_ledger_chaos.py`,
`test_ledger_cmd.py`, `test_ledger_git.py`, `test_insights.py`,
`test_admission.py`, `test_path_containment.py`, `test_task_suspension.py`,
the mission suites, the `run_service` unit and integration suites, the SLA
suites and `test_unreleased_notes_rotation.py`.
`--affected origin/main` selected far more than ~300 files, so I ran the
tests of the modules I touched plus the tests of every importer of
`work_ledger`, `runs_report` and `run_service.service` instead; CI runs the
full suite.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes — pyright on the changed files reports
      only the nine `reportUnknown*` findings `work_ledger.py` already has
      on `main` (verified against the base version of the file); the other
      three changed files are clean.
- [x] `uv run python scripts/run_tests.py -x` passes (scoped as described
      above)
- [x] New code has type hints

### Documentation duty

- [ ] User-visible README section updated — N/A (no README-level surface)
- [ ] `docs/operations/<area>.md` updated — N/A
- [ ] `docs/api/` schema regenerated — N/A (no HTTP schema change)
- [x] `uv run bernstein agents-md sync` run — no tracked file changed
- [x] Tests cover the documented behaviour
- [x] Release-note fragment added:
      `docs/release-notes/fragments/5127-run-journal-fields.md`

Part of #5127

## Remaining

- **Slice 3 — natural key + submit dedup.** Define
  `(task_definition_id, target, logical_run_instant)` and make submission
  an upsert against it so a duplicate submit returns the existing entry.
  Not started here: it needs a decision about where the key is stored
  (`RunService.submit` has no task-definition concept today), and it is the
  slice that would give `attempt_count` a second, cross-run meaning.
- **Slice 4, second half — SLA tie-in.** A non-terminal run past its
  declared SLA should open a decision record by extending
  `SLAMonitor._evaluate_one`. That needs a new SLA axis in `sla_eval` /
  `sla_store` and its evidence provider, which is a larger change than the
  query itself; `list_non_terminal_runs` is the evidence source it will
  read.
