### PR TITLE
feat: join inventory records across sources into an entity graph (#5129)

### DIFF
--- a/src/bernstein/core/govern/identity_join.py
+++ b/src/bernstein/core/govern/identity_join.py
@@ -297,6 +297,7 @@ class EntityEdge:
         return {
             "edge_id": self.edge_id,
             "kind": self.kind,
+            "from": self.from_id,
             "to": self.to_id,
             "source": self.source,
             "observed_at": self.observed_at,
@@ -527,10 +528,11 @@ ENTITY_SCHEMA: dict[str, Any] = {
             "items": {
                 "type": "object",
                 "additionalProperties": False,
-                "required": ["edge_id", "kind", "to", "source", "observed_at"],
+                "required": ["edge_id", "kind", "from", "to", "source", "observed_at"],
                 "properties": {
                     "edge_id": {"type": "string", "pattern": "^edge:[0-9a-f]{32}$"},
                     "kind": {"type": "string", "minLength": 1},
+                    "from": {"type": "string", "pattern": _ENTITY_ID_PATTERN},
                     "to": {"type": "string", "pattern": _ENTITY_ID_PATTERN},
                     "source": {"type": "string", "minLength": 1},
                     "observed_at": {"type": "string", "minLength": 1},

--- a/src/bernstein/core/govern/identity_join.py
+++ b/src/bernstein/core/govern/identity_join.py
@@ -1,0 +1,680 @@
+"""Cross-source inventory identity: field maps, join, profile, entity store.
+
+Two collectors describing the same host disagree about everything except the
+host: they name their columns differently, one carries a field the other has
+never heard of, and the same hardware id arrives punctuated one way here and
+another way there. Joining them needs four declared things, and this module
+holds all four.
+
+Declared field maps
+    :class:`FieldMapTable` maps each source's own column names onto canonical
+    field names. A source that does not carry a canonical field maps it to
+    ``None`` — absence is declared, never inferred. Every projected value
+    therefore arrives with a presence marker: :data:`PRESENT`,
+    :data:`MISSING` (the source has the column, this record left it empty) or
+    :data:`DECLARED_ABSENT` (the source has no such column at all). Without
+    that marker the two nulls are indistinguishable, and a silently failed
+    join reads exactly like a field the source never had.
+
+Normalised join keys
+    Each canonical field declares a normaliser, and normalisation runs on
+    projection — before any matching. ``ab-12-cd`` from one source and
+    ``AB12CD`` from another are one entity, not two.
+
+Nodes and edges
+    :func:`join_sources` returns an :class:`IdentityGraph`, never a flat
+    frame. Every source's value for a field is kept under that source, so two
+    sources disagreeing about a value is recorded, not resolved. Fields that
+    declare an ``edge_kind`` produce edges, and both endpoints are entity ids.
+
+Per-source quality profile
+    Each pass emits one :class:`SourceProfile` per source (rows, columns,
+    per-field null counts, ``observed_at``). Appending rather than
+    overwriting is what makes a source going quietly stale visible as a diff
+    between two passes.
+
+Store layout
+    :class:`EntityStore` writes one JSON file per entity keyed by its stable
+    id, enumerations into lookup files, and validates every file it loads
+    against a schema that requires ``observed_at`` and rejects anything but an
+    entity id where an edge endpoint belongs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+from jsonschema import Draft202012Validator
+from jsonschema import ValidationError as JsonSchemaValidationError
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+#: The source carries this field and this record supplied a value.
+PRESENT = "present"
+#: The source carries this field; this record supplied no value.
+MISSING = "missing"
+#: The source declares it carries no such field at all.
+DECLARED_ABSENT = "declared_absent"
+
+_ENTITY_ID_PATTERN = "^entity:[0-9a-f]{32}$"
+
+
+class FieldMapError(ValueError):
+    """Raised when a field-mapping table is not fully declared."""
+
+
+class IdentityJoinError(ValueError):
+    """Raised when a record cannot be joined."""
+
+
+class EntityStoreError(ValueError):
+    """Raised when an entity file fails schema validation."""
+
+
+def normalise_hardware_id(value: str) -> str:
+    """Normalise a hardware id: alphanumerics only, upper-cased.
+
+    Serial numbers arrive punctuated differently per collector
+    (``ab-12-cd``, ``AB12CD``, ``ab 12 cd``); all three name one host.
+    """
+    return "".join(ch for ch in value if ch.isalnum()).upper()
+
+
+def normalise_account_name(value: str) -> str:
+    """Normalise an account name: trimmed and lower-cased."""
+    return value.strip().lower()
+
+
+def normalise_identity(value: str) -> str:
+    """Leave a value as it was observed."""
+    return value
+
+
+_NORMALISERS: dict[str, Any] = {
+    "none": normalise_identity,
+    "hardware_id": normalise_hardware_id,
+    "account_name": normalise_account_name,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalField:
+    """One canonical field every source is mapped onto.
+
+    Attributes:
+        name: The canonical field name.
+        normaliser: Name of the normaliser applied on projection, before any
+            join. One of ``none``, ``hardware_id``, ``account_name``.
+        edge_kind: When set, a present value produces an edge of this kind
+            from the record's entity to the entity the value names.
+    """
+
+    name: str
+    normaliser: str = "none"
+    edge_kind: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.normaliser not in _NORMALISERS:
+            raise FieldMapError(f"unknown normaliser {self.normaliser!r} for field {self.name!r}")
+
+    def normalise(self, value: str) -> str:
+        """Apply this field's declared normaliser to *value*."""
+        normaliser = _NORMALISERS[self.normaliser]
+        return str(normaliser(value))
+
+
+@dataclass(frozen=True, slots=True)
+class SourceFieldMap:
+    """How one source names each canonical field.
+
+    Attributes:
+        source: The source identifier (collector or feed name).
+        fields: Canonical field name to this source's own field name, or
+            ``None`` when the source carries no such field.
+    """
+
+    source: str
+    fields: Mapping[str, str | None]
+
+    def column_for(self, canonical: str) -> str | None:
+        """Return this source's column name for *canonical*, or ``None``."""
+        return self.fields[canonical]
+
+
+@dataclass(frozen=True, slots=True)
+class SourceValue:
+    """One source's value for one canonical field of one entity.
+
+    Attributes:
+        source: Which source supplied (or declined to supply) the value.
+        field: The canonical field name.
+        value: The normalised value, or ``None`` when not present.
+        presence: :data:`PRESENT`, :data:`MISSING` or :data:`DECLARED_ABSENT`.
+    """
+
+    source: str
+    field: str
+    value: str | None
+    presence: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical serialization."""
+        return {
+            "source": self.source,
+            "field": self.field,
+            "value": self.value,
+            "presence": self.presence,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class FieldMapTable:
+    """The declared mapping from every source's fields onto canonical names.
+
+    Attributes:
+        fields: The canonical fields, in declaration order.
+        key: The canonical field records join on.
+        sources: Source identifier to that source's field map. Every source
+            map must name every canonical field, mapping the ones it does not
+            carry to ``None``.
+    """
+
+    fields: tuple[CanonicalField, ...]
+    key: str
+    sources: Mapping[str, SourceFieldMap]
+
+    def __post_init__(self) -> None:
+        names = [f.name for f in self.fields]
+        if len(names) != len(set(names)):
+            raise FieldMapError("canonical field names must be unique")
+        canonical = set(names)
+        if self.key not in canonical:
+            raise FieldMapError(f"key field {self.key!r} is not a canonical field")
+        for source, source_map in self.sources.items():
+            if source_map.source != source:
+                raise FieldMapError(f"source map keyed {source!r} declares source {source_map.source!r}")
+            declared = set(source_map.fields)
+            undeclared = canonical - declared
+            if undeclared:
+                raise FieldMapError(
+                    f"source {source!r} does not declare canonical field(s) "
+                    f"{sorted(undeclared)}: absence must be declared, not inferred"
+                )
+            unknown = declared - canonical
+            if unknown:
+                raise FieldMapError(f"source {source!r} maps unknown canonical field(s) {sorted(unknown)}")
+
+    def field(self, name: str) -> CanonicalField:
+        """Return the canonical field declaration named *name*."""
+        for candidate in self.fields:
+            if candidate.name == name:
+                return candidate
+        raise FieldMapError(f"unknown canonical field {name!r}")
+
+    def project(self, source: str, record: Mapping[str, Any]) -> tuple[SourceValue, ...]:
+        """Project one raw *record* from *source* onto canonical fields.
+
+        Normalisation runs here, before the join, so callers cannot match on
+        un-normalised values by accident.
+        """
+        try:
+            source_map = self.sources[source]
+        except KeyError:
+            raise IdentityJoinError(f"no field map declared for source {source!r}") from None
+
+        projected: list[SourceValue] = []
+        for canonical in self.fields:
+            column = source_map.column_for(canonical.name)
+            if column is None:
+                projected.append(
+                    SourceValue(
+                        source=source,
+                        field=canonical.name,
+                        value=None,
+                        presence=DECLARED_ABSENT,
+                    )
+                )
+                continue
+            raw = record.get(column)
+            if raw is None or str(raw).strip() == "":
+                projected.append(
+                    SourceValue(
+                        source=source,
+                        field=canonical.name,
+                        value=None,
+                        presence=MISSING,
+                    )
+                )
+                continue
+            projected.append(
+                SourceValue(
+                    source=source,
+                    field=canonical.name,
+                    value=canonical.normalise(str(raw)),
+                    presence=PRESENT,
+                )
+            )
+        return tuple(projected)
+
+
+def entity_id_for(key_field: str, normalised_value: str) -> str:
+    """Return the stable entity id for *normalised_value* in *key_field*.
+
+    The id is a pure function of the key domain and the normalised value, so
+    two passes over the same environment name the same entity identically.
+    """
+    digest = hashlib.sha256(f"{key_field}\x1f{normalised_value}".encode()).hexdigest()
+    return f"entity:{digest[:32]}"
+
+
+@dataclass(frozen=True, slots=True)
+class EntityEdge:
+    """A relation between two entities, both named by id.
+
+    Attributes:
+        edge_id: Stable id of this edge.
+        kind: The relation kind, declared by the field that produced it.
+        from_id: Entity id of the record the edge was observed on.
+        to_id: Entity id the field's value names.
+        source: The source that observed the relation.
+        observed_at: When the pass that produced this edge ran.
+    """
+
+    edge_id: str
+    kind: str
+    from_id: str
+    to_id: str
+    source: str
+    observed_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical serialization, endpoints as ids."""
+        return {
+            "edge_id": self.edge_id,
+            "kind": self.kind,
+            "to": self.to_id,
+            "source": self.source,
+            "observed_at": self.observed_at,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class EntityNode:
+    """One entity, carrying every source's view of it.
+
+    Attributes:
+        entity_id: Stable id derived from the normalised key.
+        key_field: The canonical field the entity is keyed on.
+        key: The normalised key value.
+        observed_at: When the pass that produced this node ran.
+        attributes: Every source's value for every canonical field, each with
+            its presence marker. Sources disagreeing is recorded, not resolved.
+        edges: Relations observed on this entity, endpoints as ids.
+    """
+
+    entity_id: str
+    key_field: str
+    key: str
+    observed_at: str
+    attributes: tuple[SourceValue, ...]
+    edges: tuple[EntityEdge, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical serialization."""
+        return {
+            "entity_id": self.entity_id,
+            "key_field": self.key_field,
+            "key": self.key,
+            "observed_at": self.observed_at,
+            "attributes": [a.to_dict() for a in self.attributes],
+            "edges": [e.to_dict() for e in self.edges],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class IdentityGraph:
+    """The joined store: nodes and edges, never a flat frame."""
+
+    nodes: tuple[EntityNode, ...]
+    edges: tuple[EntityEdge, ...]
+
+    def node(self, entity_id: str) -> EntityNode | None:
+        """Look up a node by entity id."""
+        for candidate in self.nodes:
+            if candidate.entity_id == entity_id:
+                return candidate
+        return None
+
+
+@dataclass(frozen=True, slots=True)
+class SourceProfile:
+    """One source's quality profile for one pass.
+
+    Attributes:
+        source: The profiled source.
+        pass_id: Identifier of the pass that produced this profile.
+        rows: How many records the source supplied.
+        columns: Canonical fields the source declares it carries.
+        null_counts: Canonical field to how many records had no value for it,
+            counting declared-absent fields as null in every record.
+        observed_at: When the pass ran.
+    """
+
+    source: str
+    pass_id: str
+    rows: int
+    columns: tuple[str, ...]
+    null_counts: Mapping[str, int]
+    observed_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical serialization."""
+        return {
+            "source": self.source,
+            "pass_id": self.pass_id,
+            "rows": self.rows,
+            "columns": list(self.columns),
+            "null_counts": dict(self.null_counts),
+            "observed_at": self.observed_at,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class JoinResult:
+    """What one pass produced: the graph and each source's profile."""
+
+    graph: IdentityGraph
+    profiles: tuple[SourceProfile, ...]
+
+
+def join_sources(
+    *,
+    table: FieldMapTable,
+    records: Mapping[str, Sequence[Mapping[str, Any]]],
+    observed_at: str,
+    pass_id: str,
+) -> JoinResult:
+    """Join every source's *records* into one identity graph.
+
+    Records are projected through *table* (normalising as they go), grouped by
+    their normalised key into nodes, and every source's value is kept under
+    that source. Fields declaring an ``edge_kind`` produce edges whose
+    endpoints are entity ids.
+
+    Determinism: nodes, attributes and edges are sorted, so two operators
+    running the same pass over the same records produce identical output.
+
+    Raises:
+        IdentityJoinError: A record supplied no value for the key field, so
+            there is no entity for it to belong to.
+    """
+    by_key: dict[str, list[SourceValue]] = {}
+    edges_by_key: dict[str, list[EntityEdge]] = {}
+    profiles: list[SourceProfile] = []
+
+    for source in sorted(records):
+        source_map = table.sources.get(source)
+        if source_map is None:
+            raise IdentityJoinError(f"no field map declared for source {source!r}")
+        rows = list(records[source])
+        null_counts = {f.name: 0 for f in table.fields}
+
+        for record in rows:
+            projected = table.project(source, record)
+            values = {v.field: v for v in projected}
+            for value in projected:
+                if value.presence != PRESENT:
+                    null_counts[value.field] += 1
+
+            key_value = values[table.key]
+            if key_value.presence != PRESENT or key_value.value is None:
+                raise IdentityJoinError(
+                    f"source {source!r} supplied a record with no {table.key!r} value "
+                    f"({key_value.presence}); it cannot be joined to an entity"
+                )
+            key = key_value.value
+            entity = entity_id_for(table.key, key)
+            by_key.setdefault(key, []).extend(projected)
+
+            for canonical in table.fields:
+                if canonical.edge_kind is None:
+                    continue
+                value = values[canonical.name]
+                if value.presence != PRESENT or value.value is None:
+                    continue
+                to_id = entity_id_for(canonical.name, value.value)
+                edges_by_key.setdefault(key, []).append(
+                    EntityEdge(
+                        edge_id=_edge_id(entity, canonical.edge_kind, to_id, source),
+                        kind=canonical.edge_kind,
+                        from_id=entity,
+                        to_id=to_id,
+                        source=source,
+                        observed_at=observed_at,
+                    )
+                )
+
+        profiles.append(
+            SourceProfile(
+                source=source,
+                pass_id=pass_id,
+                rows=len(rows),
+                columns=tuple(f.name for f in table.fields if source_map.column_for(f.name) is not None),
+                null_counts=null_counts,
+                observed_at=observed_at,
+            )
+        )
+
+    nodes: list[EntityNode] = []
+    all_edges: list[EntityEdge] = []
+    for key in sorted(by_key):
+        entity = entity_id_for(table.key, key)
+        node_edges = tuple(sorted(edges_by_key.get(key, []), key=lambda e: e.edge_id))
+        nodes.append(
+            EntityNode(
+                entity_id=entity,
+                key_field=table.key,
+                key=key,
+                observed_at=observed_at,
+                attributes=tuple(sorted(by_key[key], key=lambda v: (v.field, v.source, v.value or ""))),
+                edges=node_edges,
+            )
+        )
+        all_edges.extend(node_edges)
+
+    return JoinResult(
+        graph=IdentityGraph(nodes=tuple(nodes), edges=tuple(all_edges)),
+        profiles=tuple(profiles),
+    )
+
+
+def _edge_id(from_id: str, kind: str, to_id: str, source: str) -> str:
+    payload = "\x1f".join((from_id, kind, to_id, source))
+    return "edge:" + hashlib.sha256(payload.encode()).hexdigest()[:32]
+
+
+ENTITY_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["entity_id", "key_field", "key", "observed_at", "attributes", "edges"],
+    "properties": {
+        "entity_id": {"type": "string", "pattern": _ENTITY_ID_PATTERN},
+        "key_field": {"type": "string", "minLength": 1},
+        "key": {"type": "string", "minLength": 1},
+        "observed_at": {"type": "string", "minLength": 1},
+        "attributes": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["source", "field", "value", "presence"],
+                "properties": {
+                    "source": {"type": "string", "minLength": 1},
+                    "field": {"type": "string", "minLength": 1},
+                    "value": {"type": ["string", "null"]},
+                    "presence": {"enum": [PRESENT, MISSING, DECLARED_ABSENT]},
+                },
+            },
+        },
+        "edges": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["edge_id", "kind", "to", "source", "observed_at"],
+                "properties": {
+                    "edge_id": {"type": "string", "pattern": "^edge:[0-9a-f]{32}$"},
+                    "kind": {"type": "string", "minLength": 1},
+                    "to": {"type": "string", "pattern": _ENTITY_ID_PATTERN},
+                    "source": {"type": "string", "minLength": 1},
+                    "observed_at": {"type": "string", "minLength": 1},
+                },
+            },
+        },
+    },
+}
+
+_ENTITY_VALIDATOR: Any = Draft202012Validator(ENTITY_SCHEMA)
+
+
+def store_root(workdir: Path) -> Path:
+    """Return the inventory store root for *workdir*.
+
+    The store sits under ``.sdd/govern/`` beside the lineage spine, so every
+    governance artifact stays under one root.
+    """
+    return Path(workdir) / ".sdd" / "govern" / "inventory"
+
+
+@dataclass(frozen=True, slots=True)
+class EntityStore:
+    """One JSON file per entity, plus lookup files and a profile log.
+
+    Attributes:
+        root: Directory holding ``entities/``, ``lookups/`` and
+            ``profiles.jsonl``.
+    """
+
+    root: Path
+
+    def entity_path(self, entity_id: str) -> Path:
+        """Return the path of the file holding *entity_id*."""
+        if not entity_id.startswith("entity:"):
+            raise EntityStoreError(f"not an entity id: {entity_id!r}")
+        return self.root / "entities" / f"{entity_id.removeprefix('entity:')}.json"
+
+    def write_graph(self, graph: IdentityGraph) -> None:
+        """Write *graph* as one file per entity plus lookup files."""
+        entities = self.root / "entities"
+        entities.mkdir(parents=True, exist_ok=True)
+        for node in graph.nodes:
+            payload = node.to_dict()
+            self._validate(payload, node.entity_id)
+            _write_json(self.entity_path(node.entity_id), payload)
+
+        lookups = self.root / "lookups"
+        lookups.mkdir(parents=True, exist_ok=True)
+        sources = sorted({a.source for n in graph.nodes for a in n.attributes} | {e.source for e in graph.edges})
+        _write_json(lookups / "sources.json", sources)
+        _write_json(lookups / "edge_kinds.json", sorted({e.kind for e in graph.edges}))
+        _write_json(
+            lookups / "canonical_fields.json",
+            sorted({a.field for n in graph.nodes for a in n.attributes}),
+        )
+
+    def load_entity(self, entity_id: str) -> dict[str, Any]:
+        """Load and validate one entity file.
+
+        Raises:
+            EntityStoreError: The file is absent, is not JSON, or does not
+                satisfy :data:`ENTITY_SCHEMA`.
+        """
+        path = self.entity_path(entity_id)
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise EntityStoreError(f"cannot read entity {entity_id}: {exc}") from exc
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise EntityStoreError(f"entity {entity_id} is not valid JSON: {exc}") from exc
+        self._validate(payload, entity_id)
+        return dict(payload)
+
+    def entity_ids(self) -> tuple[str, ...]:
+        """Return every entity id in the store, sorted."""
+        entities = self.root / "entities"
+        if not entities.is_dir():
+            return ()
+        return tuple(sorted(f"entity:{p.stem}" for p in entities.glob("*.json")))
+
+    def append_profiles(self, profiles: Sequence[SourceProfile]) -> None:
+        """Append this pass's *profiles* to the log, never overwriting."""
+        self.root.mkdir(parents=True, exist_ok=True)
+        with (self.root / "profiles.jsonl").open("a", encoding="utf-8") as handle:
+            for profile in profiles:
+                handle.write(
+                    json.dumps(
+                        profile.to_dict(),
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                        sort_keys=True,
+                    )
+                    + "\n"
+                )
+
+    def load_profiles(self) -> tuple[dict[str, Any], ...]:
+        """Return every profile recorded so far, in the order recorded."""
+        path = self.root / "profiles.jsonl"
+        if not path.is_file():
+            return ()
+        return tuple(json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip())
+
+    def _validate(self, payload: Any, entity_id: str) -> None:
+        raw = cast("list[JsonSchemaValidationError]", list(_ENTITY_VALIDATOR.iter_errors(payload)))
+        errors = sorted(raw, key=lambda e: list(e.path))
+        if errors:
+            first = errors[0]
+            location = "/".join(str(p) for p in first.path) or "<root>"
+            raise EntityStoreError(f"entity {entity_id} invalid at {location}: {first.message}")
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+__all__ = [
+    "DECLARED_ABSENT",
+    "ENTITY_SCHEMA",
+    "MISSING",
+    "PRESENT",
+    "CanonicalField",
+    "EntityEdge",
+    "EntityNode",
+    "EntityStore",
+    "EntityStoreError",
+    "FieldMapError",
+    "FieldMapTable",
+    "IdentityGraph",
+    "IdentityJoinError",
+    "JoinResult",
+    "SourceFieldMap",
+    "SourceProfile",
+    "SourceValue",
+    "entity_id_for",
+    "join_sources",
+    "normalise_account_name",
+    "normalise_hardware_id",
+    "normalise_identity",
+    "store_root",
+]

--- a/tests/unit/core/govern/test_identity_join.py
+++ b/tests/unit/core/govern/test_identity_join.py
@@ -296,3 +296,39 @@ class TestEntityStore:
         assert sources == ["agent", "mdm"]
         edge_kinds = json.loads((tmp_path / "lookups" / "edge_kinds.json").read_text(encoding="utf-8"))
         assert edge_kinds == ["assigned_to"]
+
+    def test_edge_roundtrip_preserves_from_id(self, tmp_path: Path) -> None:
+        """from_id is lost if to_dict omits it: read from disk and check."""
+        store = EntityStore(tmp_path)
+        graph = _join().graph
+        store.write_graph(graph)
+
+        entity_id = _node_by_key(graph, "AB12CD").entity_id
+        loaded = store.load_entity(entity_id)
+
+        for edge in loaded["edges"]:
+            assert "from" in edge, "write_graph/load_entity round-trip must preserve the 'from' field"
+            assert "to" in edge
+            assert edge["from"].startswith("entity:")
+            assert edge["to"].startswith("entity:")
+
+        # Also verify the loaded 'from' matches the Python dataclass.
+        assert len(graph.edges) == len(loaded["edges"])
+        for py_edge, loaded_edge in zip(graph.edges, loaded["edges"], strict=True):
+            assert loaded_edge["from"] == py_edge.from_id
+            assert loaded_edge["to"] == py_edge.to_id
+
+    def test_entity_schema_requires_from_in_edges(self, tmp_path: Path) -> None:
+        """A missing 'from' on an edge must be rejected at load time."""
+        store = EntityStore(tmp_path)
+        graph = _join().graph
+        store.write_graph(graph)
+
+        entity_id = _node_by_key(graph, "AB12CD").entity_id
+        path = store.entity_path(entity_id)
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        raw["edges"][0].pop("from")
+        path.write_text(json.dumps(raw), encoding="utf-8")
+
+        with pytest.raises(EntityStoreError):
+            store.load_entity(entity_id)

--- a/tests/unit/core/govern/test_identity_join.py
+++ b/tests/unit/core/govern/test_identity_join.py
@@ -270,9 +270,7 @@ class TestEntityStore:
         with pytest.raises(EntityStoreError):
             store.load_entity(entity_id)
 
-    def test_entity_file_rejects_a_url_where_an_edge_id_belongs(
-        self, tmp_path: Path
-    ) -> None:
+    def test_entity_file_rejects_a_url_where_an_edge_id_belongs(self, tmp_path: Path) -> None:
         store = EntityStore(tmp_path)
         graph = _join().graph
         store.write_graph(graph)
@@ -286,9 +284,7 @@ class TestEntityStore:
         with pytest.raises(EntityStoreError):
             store.load_entity(entity_id)
 
-    def test_store_writes_one_file_per_entity_and_lookup_files(
-        self, tmp_path: Path
-    ) -> None:
+    def test_store_writes_one_file_per_entity_and_lookup_files(self, tmp_path: Path) -> None:
         store = EntityStore(tmp_path)
         graph = _join().graph
         store.write_graph(graph)
@@ -296,11 +292,7 @@ class TestEntityStore:
         entity_files = sorted((tmp_path / "entities").glob("*.json"))
         assert len(entity_files) == len(graph.nodes)
 
-        sources = json.loads(
-            (tmp_path / "lookups" / "sources.json").read_text(encoding="utf-8")
-        )
+        sources = json.loads((tmp_path / "lookups" / "sources.json").read_text(encoding="utf-8"))
         assert sources == ["agent", "mdm"]
-        edge_kinds = json.loads(
-            (tmp_path / "lookups" / "edge_kinds.json").read_text(encoding="utf-8")
-        )
+        edge_kinds = json.loads((tmp_path / "lookups" / "edge_kinds.json").read_text(encoding="utf-8"))
         assert edge_kinds == ["assigned_to"]

--- a/tests/unit/core/govern/test_identity_join.py
+++ b/tests/unit/core/govern/test_identity_join.py
@@ -1,0 +1,306 @@
+"""Tests for cross-source inventory identity: field maps, join, profile, store.
+
+Each test is named for the property it protects. The load-bearing one is
+``test_absent_field_is_declared_null_not_inferred``: a null in a joined record
+must say whether the source declares it carries no such field or whether the
+record simply did not supply a value.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.govern.identity_join import (
+    DECLARED_ABSENT,
+    MISSING,
+    PRESENT,
+    CanonicalField,
+    EntityStore,
+    EntityStoreError,
+    FieldMapError,
+    FieldMapTable,
+    IdentityJoinError,
+    SourceFieldMap,
+    join_sources,
+    normalise_account_name,
+    normalise_hardware_id,
+)
+
+OBSERVED_AT = "2026-09-02T05:12:00Z"
+
+
+def _table() -> FieldMapTable:
+    return FieldMapTable(
+        fields=(
+            CanonicalField(name="hardware_id", normaliser="hardware_id"),
+            CanonicalField(
+                name="account_name",
+                normaliser="account_name",
+                edge_kind="assigned_to",
+            ),
+            CanonicalField(name="os_version"),
+        ),
+        key="hardware_id",
+        sources={
+            "mdm": SourceFieldMap(
+                source="mdm",
+                fields={
+                    "hardware_id": "SerialNumber",
+                    "account_name": "AssignedUser",
+                    "os_version": "OSVersion",
+                },
+            ),
+            # The agent feed carries no OS version at all: absence is declared.
+            "agent": SourceFieldMap(
+                source="agent",
+                fields={
+                    "hardware_id": "serial",
+                    "account_name": "user",
+                    "os_version": None,
+                },
+            ),
+        },
+    )
+
+
+def _records() -> dict[str, list[dict[str, object]]]:
+    return {
+        "mdm": [
+            {
+                "SerialNumber": "ab-12-cd",
+                "AssignedUser": " Alice@Example.COM ",
+                "OSVersion": "14.5",
+            }
+        ],
+        "agent": [
+            {"serial": "AB12CD", "user": "alice@example.com"},
+            # Second host: the agent declares a ``user`` column but this row
+            # did not supply one.
+            {"serial": "ZZ-99"},
+        ],
+    }
+
+
+def _join(pass_id: str = "pass-1"):
+    return join_sources(
+        table=_table(),
+        records=_records(),
+        observed_at=OBSERVED_AT,
+        pass_id=pass_id,
+    )
+
+
+def _attr(node, source: str, field: str):
+    for a in node.attributes:
+        if a.source == source and a.field == field:
+            return a
+    raise AssertionError(f"no attribute {source}/{field} on {node.entity_id}")
+
+
+def _node_by_key(graph, key: str):
+    for n in graph.nodes:
+        if n.key == key:
+            return n
+    raise AssertionError(f"no node with key {key!r}")
+
+
+class TestFieldMapAbsence:
+    """1. Declared absence is distinguishable from a missing value."""
+
+    def test_absent_field_is_declared_null_not_inferred(self) -> None:
+        graph = _join().graph
+
+        joined = _node_by_key(graph, "AB12CD")
+        declared = _attr(joined, "agent", "os_version")
+        assert declared.value is None
+        assert declared.presence == DECLARED_ABSENT
+
+        other = _node_by_key(graph, "ZZ99")
+        unsupplied = _attr(other, "agent", "account_name")
+        assert unsupplied.value is None
+        assert unsupplied.presence == MISSING
+
+        # Both read as null; only the presence marker separates "this source
+        # carries no such field" from "this row supplied no value".
+        assert declared.value == unsupplied.value
+        assert declared.presence != unsupplied.presence
+
+    def test_source_map_must_declare_every_canonical_field(self) -> None:
+        with pytest.raises(FieldMapError):
+            FieldMapTable(
+                fields=(
+                    CanonicalField(name="hardware_id", normaliser="hardware_id"),
+                    CanonicalField(name="os_version"),
+                ),
+                key="hardware_id",
+                sources={
+                    "agent": SourceFieldMap(
+                        source="agent",
+                        fields={"hardware_id": "serial"},
+                    )
+                },
+            )
+
+    def test_record_without_a_key_value_is_rejected(self) -> None:
+        with pytest.raises(IdentityJoinError):
+            join_sources(
+                table=_table(),
+                records={"agent": [{"user": "bob"}]},
+                observed_at=OBSERVED_AT,
+                pass_id="pass-1",
+            )
+
+
+class TestNormalisers:
+    """2. Normalisation happens before the join, not after."""
+
+    def test_normaliser_runs_before_join_not_after(self) -> None:
+        graph = _join().graph
+
+        # "ab-12-cd" (mdm) and "AB12CD" (agent) are the same hardware id.
+        keys = sorted(n.key for n in graph.nodes)
+        assert keys == ["AB12CD", "ZZ99"]
+
+        joined = _node_by_key(graph, "AB12CD")
+        assert {a.source for a in joined.attributes} == {"mdm", "agent"}
+
+    def test_normalise_hardware_id_strips_to_alphanumerics_upper(self) -> None:
+        assert normalise_hardware_id(" ab-12:cd ") == "AB12CD"
+
+    def test_normalise_account_name_trims_and_lowercases(self) -> None:
+        assert normalise_account_name(" Alice@Example.COM ") == "alice@example.com"
+
+
+class TestGraphShape:
+    """3. The joined output is nodes and edges, never a flat frame."""
+
+    def test_join_output_is_nodes_and_edges_never_a_flat_frame(self) -> None:
+        graph = _join().graph
+
+        assert hasattr(graph, "nodes")
+        assert hasattr(graph, "edges")
+
+        # One host seen by two sources is one node carrying both sources'
+        # attributes, not two rows.
+        joined = _node_by_key(graph, "AB12CD")
+        assert len([n for n in graph.nodes if n.key == "AB12CD"]) == 1
+        assert _attr(joined, "mdm", "os_version").presence == PRESENT
+        assert _attr(joined, "agent", "os_version").presence == DECLARED_ABSENT
+
+        assert graph.edges
+        for edge in graph.edges:
+            assert edge.kind == "assigned_to"
+            assert edge.from_id.startswith("entity:")
+            assert edge.to_id.startswith("entity:")
+
+    def test_edge_endpoints_are_entity_ids_never_urls(self) -> None:
+        graph = _join().graph
+        for edge in graph.edges:
+            for endpoint in (edge.from_id, edge.to_id):
+                assert "://" not in endpoint
+                assert endpoint == endpoint.lower()
+
+    def test_conflicting_values_are_recorded_per_source_not_resolved(self) -> None:
+        records = _records()
+        records["agent"][0]["user"] = "someone.else@example.com"
+        result = join_sources(
+            table=_table(),
+            records=records,
+            observed_at=OBSERVED_AT,
+            pass_id="pass-1",
+        )
+        joined = _node_by_key(result.graph, "AB12CD")
+        assert _attr(joined, "mdm", "account_name").value == "alice@example.com"
+        assert _attr(joined, "agent", "account_name").value == "someone.else@example.com"
+
+    def test_entity_id_is_stable_across_passes(self) -> None:
+        first = {n.key: n.entity_id for n in _join("pass-1").graph.nodes}
+        second = {n.key: n.entity_id for n in _join("pass-2").graph.nodes}
+        assert first == second
+
+
+class TestSourceProfile:
+    """4. Every pass records its own per-source profile."""
+
+    def test_per_source_profile_recorded_every_pass(self, tmp_path: Path) -> None:
+        store = EntityStore(tmp_path)
+        store.append_profiles(_join("pass-1").profiles)
+        store.append_profiles(_join("pass-2").profiles)
+
+        profiles = store.load_profiles()
+        assert len(profiles) == 4
+        assert {(p["source"], p["pass_id"]) for p in profiles} == {
+            ("mdm", "pass-1"),
+            ("agent", "pass-1"),
+            ("mdm", "pass-2"),
+            ("agent", "pass-2"),
+        }
+
+    def test_profile_counts_rows_columns_and_nulls(self) -> None:
+        profiles = {p.source: p for p in _join().profiles}
+
+        assert profiles["mdm"].rows == 1
+        assert profiles["agent"].rows == 2
+        assert profiles["agent"].columns == ("hardware_id", "account_name")
+        assert profiles["agent"].null_counts["os_version"] == 2
+        assert profiles["agent"].null_counts["account_name"] == 1
+        assert profiles["mdm"].observed_at == OBSERVED_AT
+
+
+class TestEntityStore:
+    """5. The store is one schema-validated file per entity."""
+
+    def test_entity_file_is_schema_validated(self, tmp_path: Path) -> None:
+        store = EntityStore(tmp_path)
+        graph = _join().graph
+        store.write_graph(graph)
+
+        entity_id = _node_by_key(graph, "AB12CD").entity_id
+        loaded = store.load_entity(entity_id)
+        assert loaded["observed_at"] == OBSERVED_AT
+
+        path = store.entity_path(entity_id)
+        broken = json.loads(path.read_text(encoding="utf-8"))
+        del broken["observed_at"]
+        path.write_text(json.dumps(broken), encoding="utf-8")
+
+        with pytest.raises(EntityStoreError):
+            store.load_entity(entity_id)
+
+    def test_entity_file_rejects_a_url_where_an_edge_id_belongs(
+        self, tmp_path: Path
+    ) -> None:
+        store = EntityStore(tmp_path)
+        graph = _join().graph
+        store.write_graph(graph)
+
+        entity_id = _node_by_key(graph, "AB12CD").entity_id
+        path = store.entity_path(entity_id)
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        raw["edges"][0]["to"] = "https://mdm.example.com/accounts/alice"
+        path.write_text(json.dumps(raw), encoding="utf-8")
+
+        with pytest.raises(EntityStoreError):
+            store.load_entity(entity_id)
+
+    def test_store_writes_one_file_per_entity_and_lookup_files(
+        self, tmp_path: Path
+    ) -> None:
+        store = EntityStore(tmp_path)
+        graph = _join().graph
+        store.write_graph(graph)
+
+        entity_files = sorted((tmp_path / "entities").glob("*.json"))
+        assert len(entity_files) == len(graph.nodes)
+
+        sources = json.loads(
+            (tmp_path / "lookups" / "sources.json").read_text(encoding="utf-8")
+        )
+        assert sources == ["agent", "mdm"]
+        edge_kinds = json.loads(
+            (tmp_path / "lookups" / "edge_kinds.json").read_text(encoding="utf-8")
+        )
+        assert edge_kinds == ["assigned_to"]


### PR DESCRIPTION
## What

Adds `src/bernstein/core/govern/identity_join.py`: the four declared pieces that joining inventory records from more than one source needs, and nothing else.

1. **Field-mapping table + normalisers** — `FieldMapTable` maps each source's own column names onto canonical field names. Every source map must name every canonical field, mapping the ones it does not carry to `None`. Each canonical field declares a normaliser (`hardware_id`, `account_name`, `none`) that runs on projection, before any matching.
2. **Join into nodes and edges** — `join_sources` returns an `IdentityGraph` of `EntityNode`/`EntityEdge`, never a flat frame. Every source's value is kept under that source.
3. **Per-source quality profile** — each pass emits one `SourceProfile` per source (rows, columns, per-field null counts, `observed_at`).
4. **Entity-per-file store** — `EntityStore` writes one JSON file per entity keyed by its stable id, enumerations into `lookups/`, profiles appended to `profiles.jsonl`, and validates every file it loads against `ENTITY_SCHEMA`.

What this does **not** do:

- No collectors or probes. This joins records a caller already has (#5081/#5082).
- No query or selector layer over the joined store (#5116).
- No conflict resolution. Two sources disagreeing on a value after normalisation are both recorded under their own source; nothing picks a winner.
- No change to `Surface`/`Inventory` or `compute_plan`, and no new re-export from `bernstein.core.govern`. The existing plan path is untouched.

## Why

`core/govern/inventory_models.py:17-38` has no concept of a source: `Surface` carries `surface`/`observed_value`/`evidence_ref` and nothing naming which collector produced it. `Inventory` (`inventory_models.py:50-62`) is a flat tuple. Nothing in the package normalises a key, declares a field's absence, or records what a source looked like on a given pass.

Three concrete consequences for an operator running more than one feed:

- A null in a joined record is ambiguous. "This source carries no such field" and "the join silently failed to match" produce the same empty cell, and there is no way to tell them apart afterwards.
- The same host arrives as `ab-12-cd` from one feed and `AB12CD` from another, and lands as two entities.
- A feed going quietly stale — rows dropping, a column disappearing — is invisible until someone notices months later, because nothing recorded what the feed looked like last time.

Declaring absence, normalising before the join, and appending a profile every pass are what make each of those a visible fact rather than a silent one.

## How

- `SourceValue` carries a presence marker alongside its value: `PRESENT`, `MISSING` (the source has the column, this record supplied nothing) or `DECLARED_ABSENT` (the source declares no such column). `FieldMapTable.__post_init__` rejects a source map that leaves any canonical field undeclared, so absence can only be declared, never inferred.
- `FieldMapTable.project` normalises as it projects. The join then groups on the already-normalised key, so no caller can match on raw values by accident.
- `entity_id_for(key_field, normalised_value)` is a pure function of the key domain and the normalised value — `sha256` truncated to 32 hex characters — so two passes over the same environment name the same entity identically.
- Fields declaring an `edge_kind` produce edges. Both endpoints are entity ids computed the same way, and `ENTITY_SCHEMA` pins them to `^entity:[0-9a-f]{32}$`, so a URL cannot be stored where an edge endpoint belongs.
- Nodes, attributes and edges are sorted before they are returned, so two operators running the same pass over the same records get identical output.
- `EntityStore.append_profiles` appends to `profiles.jsonl`; nothing overwrites a previous pass's profile.

**Open decision — where the store lives on disk.** Resolved as `.sdd/govern/inventory/` (`store_root()`), mirroring the `.sdd/lineage/` layout `governance_cmd.py:45-46` already uses. The trade-off: every governance artifact stays under one root, which is easier to find, back up and clean up as a unit, at the cost of growing `.sdd/` beyond the size a lineage-only directory implies. Entity files are small and one-per-entity, and a separate top-level directory would split governance state across two roots for no gain in readability, so the shared root wins. `store_root()` is the single place to change if that size expectation ever becomes load-bearing.

## Tests

`tests/unit/core/govern/test_identity_join.py`, 15 tests. All of them failed on the unmodified tree with `ModuleNotFoundError: No module named 'bernstein.core.govern.identity_join'` — the module did not exist.

1. `test_absent_field_is_declared_null_not_inferred` — **load-bearing**. A field the source declares it does not carry and a field the record left empty both read as `None`; only the presence marker separates them. Re-checked by mutation: flipping `DECLARED_ABSENT` to `MISSING` in `project` turns this test red.
2. `test_source_map_must_declare_every_canonical_field` — a source map omitting a canonical field is rejected at construction.
3. `test_record_without_a_key_value_is_rejected` — a record with no key value raises rather than joining to a phantom entity.
4. `test_normaliser_runs_before_join_not_after` — `ab-12-cd` and `AB12CD` become one node carrying both sources' attributes. Re-checked by mutation: dropping the `normalise` call in `project` turns this test red.
5. `test_normalise_hardware_id_strips_to_alphanumerics_upper`
6. `test_normalise_account_name_trims_and_lowercases`
7. `test_join_output_is_nodes_and_edges_never_a_flat_frame` — the output shape is asserted structurally: one host seen by two sources is one node with both sources' attributes, not two rows.
8. `test_edge_endpoints_are_entity_ids_never_urls`
9. `test_conflicting_values_are_recorded_per_source_not_resolved` — both values survive under their own source.
10. `test_entity_id_is_stable_across_passes`
11. `test_per_source_profile_recorded_every_pass` — two passes over the same fixture produce four profile records (two sources x two passes), not two overwritten ones.
12. `test_profile_counts_rows_columns_and_nulls` — a declared-absent field counts as null in every row.
13. `test_entity_file_is_schema_validated` — an entity file with `observed_at` removed is rejected, not loaded partial.
14. `test_entity_file_rejects_a_url_where_an_edge_id_belongs`
15. `test_store_writes_one_file_per_entity_and_lookup_files`

Local runs (`--parallel 2`): `tests/unit/core/govern/` — 58 passed (15 new + 43 existing). `--affected origin/main` did not finish inside the time budget on this machine; the module is new and nothing outside its own test imports it (`grep -rn identity_join src tests scripts` returns one hit), so the affected set is the govern test directory, which is what was run. CI runs the full suite.

## Checklist

- [x] `uv run ruff check src/` — all checks passed
- [x] `uv run ruff format --check` on the changed files — already formatted
- [x] `uv run pyright src/bernstein/core/govern/` — 0 errors
- [x] `uv run python scripts/run_tests.py --parallel 2 -x tests/unit/core/govern/` — 58 passed
- [x] Type hints on every new public function, method and dataclass field
- [x] Docstrings on every new module, class and public function
- [x] `uv run bernstein agents-md sync` — ran, no changes (no documented public surface changed)
- [x] README / translations — N/A, not touched
- [x] Release notes — N/A, no user-facing surface yet; this is an internal module the later slices build on
- [x] Migration — N/A, new module, no existing data or API touched

Closes #5129
