### PR TITLE
feat: verify a dropped run receipt over the dashboard API (#5067)

### DIFF
--- a/docs/operations/governance.md
+++ b/docs/operations/governance.md
@@ -88,6 +88,38 @@ returns the canonical document. The route returns exactly the bytes
 `governance_coverage_json` produces, so a number pinned from the dashboard
 recomputes offline from `.sdd` alone.
 
+## Verifying a dropped receipt
+
+```
+POST /governance/verify-receipt
+```
+
+The request body is a run receipt, verbatim. The response is the canonical
+verdict document `src/bernstein/core/security/governance_receipt_verdict.py`
+produces from
+[`verify_run_receipt`](../reference/receipt.md) — the same verifier
+`bernstein verify receipt` runs. Nothing under `.sdd` and no key material is
+read, so the endpoint answers about the uploaded file and not about the
+installation serving it.
+
+| Field | Meaning |
+|---|---|
+| `status` | `ok`, `tampered` (a recompute or the signature diverged), or `malformed` (not a receipt at all, an empty upload included). |
+| `tier` | `integrity-only` on a pass; `null` when the receipt did not verify. |
+| `caveat` | Set exactly when `tier` is set. Names the key source, so the pass cannot be rendered as a bare tick. |
+| `divergent_step` | The first divergent journal step, when journal tamper was located. |
+
+The tier is always `integrity-only` because the signature is checked against
+the key embedded in the receipt: that proves the file is internally consistent
+and that no byte changed after signing, not who produced it. Provenance
+requires the operator's key out of band —
+`bernstein verify receipt <file> --public-key <pem>` — and no key can be pinned
+through the endpoint, because a key arriving in the same request as the receipt
+is the same channel rather than an independent anchor.
+
+A receipt that does not verify is answered with `200` and a failing verdict.
+The result is a statement about the evidence, not a failed request.
+
 ## Guarantees
 
 - **Verifiability** - `bernstein governance verify <run>` re-resolves and

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -7871,6 +7871,26 @@
         }
       }
     },
+    "/governance/verify-receipt": {
+      "post": {
+        "tags": [
+          "governance"
+        ],
+        "summary": "Verify Receipt",
+        "description": "Verify the posted receipt file and return the verdict document.\n\nThe request body is the receipt verbatim -- whatever the operator dropped,\nof whatever content type. Nothing under ``.sdd`` and no key material is\nread: the verifier works from the file's own bytes, so this endpoint\nanswers about the upload and not about the installation serving it.\n\nThe status is always 200 for a request that carried a body. A tampered\nreceipt, a file that is not a receipt, and an empty drop are all verdicts\nabout the evidence rather than failed requests, and each is the answer an\noperator dropped the file to get.\n\nNo key can be pinned through this endpoint, so the pass it reports is\nalways the integrity-only tier and always carries the caveat saying so.\nA key arriving in the same request as the receipt is not an out-of-band\nanchor -- it is the same channel, and treating it as one would report\nprovenance on the strength of the upload rather than of any evidence.",
+        "operationId": "verify_receipt_governance_verify_receipt_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
     "/handoff/{token}": {
       "get": {
         "summary": "Claim Handoff Token",
@@ -16638,6 +16658,26 @@
         "summary": "Governance Coverage",
         "description": "Return the canonical coverage document for ``?run_id=``.",
         "operationId": "governance_coverage_api_v1_governance_coverage_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/governance/verify-receipt": {
+      "post": {
+        "tags": [
+          "governance"
+        ],
+        "summary": "Verify Receipt",
+        "description": "Verify the posted receipt file and return the verdict document.\n\nThe request body is the receipt verbatim -- whatever the operator dropped,\nof whatever content type. Nothing under ``.sdd`` and no key material is\nread: the verifier works from the file's own bytes, so this endpoint\nanswers about the upload and not about the installation serving it.\n\nThe status is always 200 for a request that carried a body. A tampered\nreceipt, a file that is not a receipt, and an empty drop are all verdicts\nabout the evidence rather than failed requests, and each is the answer an\noperator dropped the file to get.\n\nNo key can be pinned through this endpoint, so the pass it reports is\nalways the integrity-only tier and always carries the caveat saying so.\nA key arriving in the same request as the receipt is not an out-of-band\nanchor -- it is the same channel, and treating it as one would report\nprovenance on the strength of the upload rather than of any evidence.",
+        "operationId": "verify_receipt_api_v1_governance_verify_receipt_post",
         "responses": {
           "200": {
             "description": "Successful Response",

--- a/docs/release-notes/fragments/5067-receipt-drop-verify.md
+++ b/docs/release-notes/fragments/5067-receipt-drop-verify.md
@@ -1,0 +1,19 @@
+## A verified receipt now says what the verification proved
+
+`POST /governance/verify-receipt` takes a run receipt as its request body and
+returns the offline verifier's verdict. Nothing under `.sdd` and no key
+material is read: the check works from the file's own bytes, so the endpoint
+answers about the upload rather than about the installation serving it.
+
+The verdict carries the tier the pass reached. A receipt whose only trust
+anchor is itself reaches `integrity-only`, and the document says so in a
+`caveat` field beside the result: the signature was checked against the key
+embedded in the receipt, which proves the file is internally consistent and not
+who produced it. Provenance still requires pinning the operator's key out of
+band with `bernstein verify receipt <file> --public-key <pem>`; no key can be
+pinned through the endpoint, because a key arriving in the same request as the
+receipt is the same channel and not an independent anchor.
+
+A tampered receipt, a file that is not a receipt, and an empty upload each come
+back as a verdict with `200` rather than an HTTP error — "this file attests
+nothing" is the answer the file was dropped to get.

--- a/src/bernstein/core/routes/governance.py
+++ b/src/bernstein/core/routes/governance.py
@@ -4,6 +4,9 @@
 can account for: the fraction of its actions tied to a principal, and the
 fraction covered by a recorded ``allow`` verdict.
 
+``POST /governance/verify-receipt`` -- what one dropped receipt proves, with
+the tier the pass reached attached to it.
+
 The route owns no arithmetic. It parses the query string, hands the values to
 :func:`bernstein.core.security.governance_coverage.governance_coverage_json`,
 and returns those bytes verbatim -- the same rule ``/artifacts/health``
@@ -28,6 +31,7 @@ from fastapi.responses import Response
 
 from bernstein.core.lineage.spine import SpineRunIdError
 from bernstein.core.security.governance_coverage import governance_coverage_json
+from bernstein.core.security.governance_receipt_verdict import receipt_verdict_json
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -61,4 +65,28 @@ def governance_coverage(request: Request) -> Response:
         payload = governance_coverage_json(_workdir(request), run_id, hmac_key=_hmac_key())
     except SpineRunIdError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from None
+    return Response(content=payload, media_type=_JSON_MEDIA_TYPE)
+
+
+@router.post("/governance/verify-receipt")
+async def verify_receipt(request: Request) -> Response:
+    """Verify the posted receipt file and return the verdict document.
+
+    The request body is the receipt verbatim -- whatever the operator dropped,
+    of whatever content type. Nothing under ``.sdd`` and no key material is
+    read: the verifier works from the file's own bytes, so this endpoint
+    answers about the upload and not about the installation serving it.
+
+    The status is always 200 for a request that carried a body. A tampered
+    receipt, a file that is not a receipt, and an empty drop are all verdicts
+    about the evidence rather than failed requests, and each is the answer an
+    operator dropped the file to get.
+
+    No key can be pinned through this endpoint, so the pass it reports is
+    always the integrity-only tier and always carries the caveat saying so.
+    A key arriving in the same request as the receipt is not an out-of-band
+    anchor -- it is the same channel, and treating it as one would report
+    provenance on the strength of the upload rather than of any evidence.
+    """
+    payload = receipt_verdict_json(await request.body())
     return Response(content=payload, media_type=_JSON_MEDIA_TYPE)

--- a/src/bernstein/core/security/governance_receipt_verdict.py
+++ b/src/bernstein/core/security/governance_receipt_verdict.py
@@ -1,0 +1,137 @@
+"""What a dropped receipt actually proves, said in the verdict itself (#5067).
+
+:func:`~bernstein.core.replay.run_receipt.verify_run_receipt` already draws the
+distinction that matters here: a pass against the key *embedded in the receipt*
+is trust-on-first-use and proves the file is internally consistent, while a
+pass against a key the operator pinned out of band additionally proves who
+produced it. The CLI says which tier it reached; nothing projected that
+distinction into a document, so any second surface wrapping the verifier would
+have had a boolean to render and would have rendered a tick.
+
+This module is that projection. It answers one question about one uploaded
+file, and it answers it with the tier attached:
+
+``tier``
+    ``"integrity-only"`` on a pass, ``None`` when the receipt did not verify at
+    all. There is no third value: this projection is for a receipt whose only
+    trust anchor is itself, so the provenance tier is not reachable through it
+    and is not offered as a field a caller could see set.
+
+``caveat``
+    Present exactly when ``tier`` is set, naming the key source in prose the
+    screen renders beside the tick. A failure claims nothing, so it qualifies
+    nothing and carries no caveat.
+
+Everything else is the verifier's own result carried through unchanged --
+``status``, the walked ranges, the first divergent journal step, the errors --
+so a verdict read off a screen and one recomputed offline with
+``bernstein verify receipt <file> --json`` are statements about the same bytes.
+
+Determinism: the document is canonical JSON (sorted keys, minimal separators)
+and a pure function of the receipt bytes. Nothing under ``.sdd`` is read and no
+key material is needed, which is the same guarantee the offline verifier makes.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from bernstein.core.replay.run_receipt import verify_run_receipt
+
+#: Version stamped into the verdict document. Bump only on a shape change.
+VERDICT_DOCUMENT_VERSION = 1
+
+#: The only tier a self-anchored receipt can reach. Matches the label
+#: ``bernstein verify receipt --json`` reports for the same file.
+TIER_INTEGRITY_ONLY = "integrity-only"
+
+#: Why the tick is not a provenance claim. Rendered beside the result, not
+#: behind a disclosure: a console that shows "verified" while meaning
+#: "self-consistent" is the thing this screen exists not to be.
+INTEGRITY_ONLY_CAVEAT = (
+    "The signature was checked against the key embedded in the receipt "
+    "(trust-on-first-use). That proves the file is internally consistent and "
+    "that no byte changed after signing; it does not prove who produced it, "
+    "because a forger holding the whole file could re-sign it with their own "
+    "key. For provenance, pin the operator's key out of band: "
+    "bernstein verify receipt <file> --public-key <pem>."
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ReceiptVerdict:
+    """The verifier's outcome for one uploaded receipt, with its tier."""
+
+    ok: bool
+    status: str
+    tier: str | None
+    caveat: str | None
+    run_id: str
+    journal_events: int
+    spine_entries: int
+    divergent_step: int | None
+    errors: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "v": VERDICT_DOCUMENT_VERSION,
+            "ok": self.ok,
+            "status": self.status,
+            "tier": self.tier,
+            "caveat": self.caveat,
+            "run_id": self.run_id,
+            "journal_events": self.journal_events,
+            "spine_entries": self.spine_entries,
+            "divergent_step": self.divergent_step,
+            "errors": list(self.errors),
+        }
+
+
+def collect_receipt_verdict(receipt_bytes: bytes) -> ReceiptVerdict:
+    """Verify *receipt_bytes* offline and label what the pass proves.
+
+    Args:
+        receipt_bytes: The uploaded file, verbatim. Anything that is not a
+            well-formed receipt -- an empty upload included -- is a
+            ``"malformed"`` verdict about that file rather than an error:
+            "this file attests nothing" is an answer the operator came for.
+
+    Returns:
+        The :class:`ReceiptVerdict`. ``tier`` and ``caveat`` are set together
+        and only on a pass.
+    """
+    result = verify_run_receipt(receipt_bytes)
+    tier = TIER_INTEGRITY_ONLY if result.ok else None
+    return ReceiptVerdict(
+        ok=result.ok,
+        status=result.status,
+        tier=tier,
+        caveat=INTEGRITY_ONLY_CAVEAT if tier is not None else None,
+        run_id=result.run_id,
+        journal_events=result.journal_events,
+        spine_entries=result.spine_entries,
+        divergent_step=result.divergent_step,
+        errors=list(result.errors),
+    )
+
+
+def receipt_verdict_json(receipt_bytes: bytes) -> str:
+    """Return the canonical verdict document for *receipt_bytes*.
+
+    **The** entry point: the drop-verify route returns exactly these bytes, so
+    the screen and an offline re-verification cannot differ about one file.
+    """
+    payload = collect_receipt_verdict(receipt_bytes).to_dict()
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+__all__ = [
+    "INTEGRITY_ONLY_CAVEAT",
+    "TIER_INTEGRITY_ONLY",
+    "VERDICT_DOCUMENT_VERSION",
+    "ReceiptVerdict",
+    "collect_receipt_verdict",
+    "receipt_verdict_json",
+]

--- a/tests/unit/security/test_governance_receipt_verdict.py
+++ b/tests/unit/security/test_governance_receipt_verdict.py
@@ -1,0 +1,92 @@
+"""A drop-verify verdict must never read as more than it proves (#5067).
+
+The receipt verifier already distinguishes an integrity-only pass from a
+provenance pass; nothing projected that distinction into a document a screen
+could render, so a console wrapping it would print a bare tick. These tests
+pin the projection: a pass carries the tier it reached and the caveat that
+explains it, and a failure carries neither.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from bernstein.core.security.governance_receipt_verdict import (
+    TIER_INTEGRITY_ONLY,
+    collect_receipt_verdict,
+    receipt_verdict_json,
+)
+
+_VECTORS = Path(__file__).resolve().parents[3] / "tests" / "fixtures" / "receipt-vectors"
+_VALID = _VECTORS / "valid-run-receipt.json"
+_TAMPERED = _VECTORS / "tampered-run-receipt.json"
+
+
+def test_verified_receipt_is_labelled_integrity_only_not_verified() -> None:
+    """A pass over a self-signed receipt reports the tier it actually reached."""
+    verdict = collect_receipt_verdict(_VALID.read_bytes())
+
+    assert verdict.ok is True
+    assert verdict.status == "ok"
+    assert verdict.tier == TIER_INTEGRITY_ONLY
+
+
+def test_integrity_only_pass_carries_the_embedded_key_caveat() -> None:
+    """The caveat names where the key came from, so the tick cannot stand alone."""
+    verdict = collect_receipt_verdict(_VALID.read_bytes())
+
+    assert verdict.caveat is not None
+    assert "embedded" in verdict.caveat
+
+
+def test_verified_receipt_reports_the_range_it_attests() -> None:
+    """The counts the verifier walked travel with the verdict."""
+    verdict = collect_receipt_verdict(_VALID.read_bytes())
+
+    assert verdict.run_id
+    assert verdict.journal_events > 0
+    assert verdict.spine_entries > 0
+
+
+def test_tampered_receipt_reports_no_tier_and_no_caveat() -> None:
+    """A receipt that did not verify claims nothing, so it qualifies nothing."""
+    verdict = collect_receipt_verdict(_TAMPERED.read_bytes())
+
+    assert verdict.ok is False
+    assert verdict.status == "tampered"
+    assert verdict.tier is None
+    assert verdict.caveat is None
+
+
+def test_tampered_receipt_carries_the_verifier_errors() -> None:
+    """The screen shows why, not just that it failed."""
+    verdict = collect_receipt_verdict(_TAMPERED.read_bytes())
+
+    assert verdict.errors
+
+
+def test_input_that_is_not_a_receipt_is_malformed_rather_than_tampered() -> None:
+    """ "Not a receipt" and "a tampered receipt" are different answers."""
+    verdict = collect_receipt_verdict(b'{"this": "is not a run receipt"}')
+
+    assert verdict.status == "malformed"
+    assert verdict.ok is False
+    assert verdict.tier is None
+
+
+def test_empty_input_is_reported_rather_than_raising() -> None:
+    """An empty drop is a verdict about the file, not a server error."""
+    verdict = collect_receipt_verdict(b"")
+
+    assert verdict.status == "malformed"
+    assert verdict.tier is None
+
+
+def test_document_is_canonical_and_stable() -> None:
+    """Two serialisations of the same bytes are byte-identical and sorted."""
+    first = receipt_verdict_json(_VALID.read_bytes())
+    second = receipt_verdict_json(_VALID.read_bytes())
+
+    assert first == second
+    assert first == json.dumps(json.loads(first), ensure_ascii=False, separators=(",", ":"), sort_keys=True)

--- a/tests/unit/test_governance_verify_receipt_route.py
+++ b/tests/unit/test_governance_verify_receipt_route.py
@@ -1,0 +1,80 @@
+"""``POST /governance/verify-receipt`` answers about the file, not about itself (#5067).
+
+The route owns no verification: it hands the uploaded bytes to
+:func:`bernstein.core.security.governance_receipt_verdict.receipt_verdict_json`
+and returns those bytes verbatim, so what an operator reads on the screen is
+what ``bernstein verify receipt --json`` reads from the same file offline.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from bernstein.cli.commands.verify_cmd import verify_cmd
+from bernstein.core.routes.governance import router as governance_router
+from bernstein.core.security.governance_receipt_verdict import receipt_verdict_json
+
+_VECTORS = Path(__file__).resolve().parents[1] / "fixtures" / "receipt-vectors"
+_VALID = _VECTORS / "valid-run-receipt.json"
+_TAMPERED = _VECTORS / "tampered-run-receipt.json"
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(governance_router)
+    return TestClient(app)
+
+
+def test_route_returns_the_verdict_bytes_verbatim(client: TestClient) -> None:
+    """One serialiser: the response body is the projection's own bytes."""
+    payload = _VALID.read_bytes()
+
+    response = client.post("/governance/verify-receipt", content=payload)
+
+    assert response.status_code == 200
+    assert response.text == receipt_verdict_json(payload)
+
+
+def test_route_verdict_matches_the_offline_cli_for_the_same_file() -> None:
+    """The screen and the offline verifier cannot disagree about one file."""
+    cli = CliRunner().invoke(verify_cmd, ["receipt", str(_VALID), "--json"])
+    assert cli.exit_code == 0, cli.output
+    offline = json.loads(cli.output)
+
+    served = json.loads(receipt_verdict_json(_VALID.read_bytes()))
+
+    assert served["ok"] == offline["ok"]
+    assert served["status"] == offline["status"]
+    assert served["tier"] == offline["tier"]
+    assert served["run_id"] == offline["run_id"]
+    assert served["journal_events"] == offline["journal_events"]
+    assert served["spine_entries"] == offline["spine_entries"]
+    assert served["errors"] == offline["errors"]
+
+
+def test_route_reports_a_tampered_receipt_with_200_and_a_failed_verdict(
+    client: TestClient,
+) -> None:
+    """A receipt that does not verify is an answer about the evidence, not an HTTP error."""
+    response = client.post("/governance/verify-receipt", content=_TAMPERED.read_bytes())
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is False
+    assert body["status"] == "tampered"
+    assert body["tier"] is None
+
+
+def test_route_reports_an_empty_drop_as_malformed(client: TestClient) -> None:
+    """An empty upload gets a verdict, not a traceback."""
+    response = client.post("/governance/verify-receipt", content=b"")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "malformed"


### PR DESCRIPTION
## What

Slice 4 of #5067, server side: the receipt drop-verify endpoint and the verdict it returns.

- `src/bernstein/core/security/governance_receipt_verdict.py` projects `verify_run_receipt`'s outcome into a canonical document carrying the tier the pass reached and the caveat that explains it.
- `POST /governance/verify-receipt` takes a receipt as its request body and returns those bytes.
- `docs/operations/governance.md` gains a "Verifying a dropped receipt" section; `docs/reference/openapi.json` is regenerated for the new path.

What this PR explicitly does **not** do:

- No `web/` change, so no drop zone, no rendered result, and no re-captured browser renders. That is the client half of slice 4 and it is not started here.
- No `/governance` route or coverage panel (slice 1), no "not covered" list (slice 3), no decision detail view (slice 5).
- No change to `verify_run_receipt`, to `bernstein verify receipt`, or to the receipt format. The verifier is wrapped, not touched.
- No key upload, no key storage, no new trust anchor.

## Why

The offline verifier already draws the distinction that matters about a receipt: a pass against the key **embedded in the receipt** is trust-on-first-use and proves the file is internally consistent, while a pass against a key the operator pinned out of band additionally proves who produced it. `bernstein verify receipt` prints which tier it reached and says in prose why the weaker one is weaker.

That distinction lived only in the CLI's rendering. `RunReceiptVerifyResult` exposes `ok`, `status`, counts and errors — no tier — so any second surface wrapping the verifier had a boolean to render, and a boolean renders as a tick. A console that shows "verified" when it means "self-consistent" is exactly the failure this screen exists not to repeat.

## How

One projection, one serialiser, the same rule `/governance/coverage` follows: the route parses nothing and computes nothing, it hands the request body to `receipt_verdict_json` and returns those bytes. What the screen shows and what `bernstein verify receipt --json` reads from the same file are then statements about the same bytes rather than two implementations that happen to agree today.

The document carries the verifier's own result unchanged — `status`, `run_id`, the walked journal and spine counts, `divergent_step`, `errors` — plus two fields it did not have:

| Field | Rule |
|---|---|
| `tier` | `"integrity-only"` on a pass, `null` otherwise. |
| `caveat` | Set exactly when `tier` is set; names the key source in prose the screen renders beside the result. |

`tier` and `caveat` are set together and only on a pass. A receipt that did not verify claims nothing, so it qualifies nothing — a caveat on a failure would read as a partial pass.

Failure is a verdict, not an HTTP error. A tampered receipt, a file that is not a receipt, and an empty upload each come back `200` with a failing verdict, because "this file attests nothing" is the answer the file was dropped to get; a `400` would render as a broken console instead of an answer. Malformed and tampered stay separate values so "not a receipt" cannot be read as "a receipt someone edited". Request size is already bounded by the app's body-limit middleware, so the route adds no second cap.

**The decision the issue left open**: whether the endpoint should accept a pinned public key and so be able to report the provenance tier. It does not. Pinning is only meaningful when the key reaches the verifier by a different route than the receipt; a key posted in the same request is the same channel, and a forger who produced the receipt would supply the matching key with it. Reporting `provenance` on that basis would be reporting a control as active because the request said so, which the issue rules out. The endpoint therefore reaches one tier, always says which, and points at the CLI flag that reaches the other.

## Tests

All twelve failed on the unmodified tree — the module did not exist, so both files failed collection. Each was then checked against the rule it pins by reverting that rule and confirming the assertion goes red.

`tests/unit/security/test_governance_receipt_verdict.py`

1. `test_verified_receipt_is_labelled_integrity_only_not_verified` — a pass over the committed valid vector reports the tier, not a bare `ok`.
2. `test_integrity_only_pass_carries_the_embedded_key_caveat` — the caveat is present and names where the key came from.
3. `test_verified_receipt_reports_the_range_it_attests` — the walked journal and spine counts travel with the verdict.
4. `test_tampered_receipt_reports_no_tier_and_no_caveat` — a failure qualifies nothing.
5. `test_tampered_receipt_carries_the_verifier_errors` — the screen can show why, not only that.
6. `test_input_that_is_not_a_receipt_is_malformed_rather_than_tampered` — the two failure kinds stay distinguishable.
7. `test_empty_input_is_reported_rather_than_raising` — an empty drop is a verdict.
8. `test_document_is_canonical_and_stable` — sorted keys, minimal separators, byte-identical across calls.

`tests/unit/test_governance_verify_receipt_route.py`

9. `test_route_returns_the_verdict_bytes_verbatim` — the response body equals `receipt_verdict_json` for the same upload.
10. `test_route_verdict_matches_the_offline_cli_for_the_same_file` — **load-bearing.** Runs `bernstein verify receipt --json` over the committed vector and asserts the served verdict agrees field for field, tier included. This is the property the endpoint exists for: an operator can pin what the screen said and recompute it offline. Renaming the tier label in the projection turns this test red while every other test stays green, which is the drift it is there to catch.
11. `test_route_reports_a_tampered_receipt_with_200_and_a_failed_verdict` — an unverifiable receipt is an answer about the evidence.
12. `test_route_reports_an_empty_drop_as_malformed` — an empty upload gets a verdict, not a traceback.

Local runs (`--parallel 2`, isolated `XDG_*` and confidence DB):

- the two new files, plus `test_governance_coverage_route.py`, `test_governance_coverage.py`, `test_run_receipt.py`, `test_run_receipt_format_vectors.py`, `test_verify_run_receipt_cmd.py`, `test_openapi_snapshot_drift.py`, `test_route_table.py`, `test_artifact_cli_route_parity.py`, `test_sdk_generator.py`, `test_receipt_reference_docs_drift.py`, `test_release_notes.py`, `test_docs_url_hygiene.py`, `test_docs_capability_reachability.py`, `test_docs_prose_cli_drift.py` — 16 files, all green.
- `--affected origin/main` selects 452 files, because the route module is reached from `server_app.py`, which nearly everything imports. Per the contributing guidance for a selection that large, the targeted set above was run instead: the tests of the touched modules plus the tests of their importers and of the regenerated snapshots. CI runs the full suite.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run ruff format --check src/` passes for the changed files
- [x] `uv run pyright src/` passes on the changed modules (`0 errors`)
- [x] `uv run python scripts/run_tests.py -x` passes for the files listed above
- [x] New code has type hints

### Documentation duty

- [ ] User-visible README section updated — N/A, no README-level surface changed
- [x] `docs/operations/governance.md` gains a "Verifying a dropped receipt" section
- [x] `docs/reference/openapi.json` regenerated for the new path
- [x] `uv run bernstein agents-md sync` run — no changes produced
- [x] Tests cover the documented behaviour

A release-notes fragment is added at `docs/release-notes/fragments/5067-receipt-drop-verify.md`.

Part of #5067

## Remaining

- Slice 1 — the `/governance` route and coverage panel in `web/`, with the SPA bundle rebuilt and the browser renders re-captured and rebound.
- Slice 3 — the "not covered" list, each row naming the gap and linking the issue that closes it.
- Slice 4, client half — the drop zone and the rendered result, including the caveat line this endpoint returns.
- Slice 5 — the decision detail view over `read_decisions`.
