### PR TITLE
feat: govern audit watch cycle -- remediate once, re-verify, still fail the cycle (#5125)

### DIFF
--- a/src/bernstein/core/govern/audit_watch.py
+++ b/src/bernstein/core/govern/audit_watch.py
@@ -1,0 +1,392 @@
+"""The ``govern audit`` watch cycle: detect, remediate once, re-verify, still fail.
+
+Issue #5125. Detection without a bounded, logged response is a pager that never
+stops ringing. This module is the loop that turns a repeating failure into *one*
+attempted fix plus a visible record.
+
+One tick runs the whole check set. A check that fails produces a
+:class:`WatchFinding` carrying the health document read at detection time. If an
+:class:`ApprovedRemediation` is bound to that check id, the plan is executed
+exactly once and the check is re-run, so the finding also carries the health
+document read after the attempt. Both snapshots are content-addressed, so an
+operator reading the finding six weeks later can answer "what did it see before,
+and what did it see after?" without re-running anything.
+
+The property that is easy to get wrong: **a check remediated back to green still
+fails the cycle it failed in**. The intuitive loop re-verifies, sees green and
+exits 0 -- and an operator watching exit codes then never learns that anything
+needed fixing. Here the finding is minted at detection, so the exit code of a
+cycle is a fact about what failed, not about what is still failing at the end of
+it.
+
+This module owns the cycle only. It does not define what a check is beyond the
+structural :class:`Check` protocol (that contract is #5072's), and it does not
+author, approve or execute remediation plans -- an :class:`ApprovedRemediation`
+is consumed as already approved and executed through the
+:class:`RemediationRunner` seam that ``govern apply`` (#4982) satisfies.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Iterator
+
+    from bernstein.core.lineage.spine import LineageSpine
+
+#: Actor recorded on the lineage entry for a journaled remediation.
+_JOURNAL_ACTOR = "bernstein.govern.audit"
+
+
+def _canonical_bytes(payload: dict[str, Any]) -> bytes:
+    """Serialize *payload* to canonical JSON bytes (sorted keys, no padding)."""
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+@dataclass(frozen=True, slots=True)
+class HealthDocument:
+    """What one check read about one surface at one moment.
+
+    Attributes:
+        check_id: Stable id of the check that produced this document.
+        passed: Whether the check judged the surface healthy.
+        observed: Everything the check read, verbatim. Kept whole rather than
+            summarised: a finding that only carried "failed" would not tell a
+            later reader what changed between the before and after snapshots.
+        timestamp: Integer timestamp of the observation.
+    """
+
+    check_id: str
+    passed: bool
+    observed: dict[str, Any]
+    timestamp: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical serialization."""
+        return {
+            "check_id": self.check_id,
+            "passed": self.passed,
+            "observed": self.observed,
+            "timestamp": self.timestamp,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> HealthDocument:
+        """Rebuild a HealthDocument from a serialized dict."""
+        return cls(
+            check_id=str(raw["check_id"]),
+            passed=bool(raw["passed"]),
+            observed=dict(raw.get("observed", {})),
+            timestamp=int(raw["timestamp"]),
+        )
+
+    def content_hash(self) -> str:
+        """Return the ``sha256:``-prefixed content address of this document."""
+        return "sha256:" + hashlib.sha256(_canonical_bytes(self.to_dict())).hexdigest()
+
+
+class Check(Protocol):
+    """A check the watch cycle can run and re-run.
+
+    The full check contract -- areas, the three-state verdict, evidence pairs --
+    is #5072's. The cycle needs only an identity and something it can call
+    twice.
+    """
+
+    check_id: str
+
+    def run(self) -> HealthDocument:
+        """Read the surface and report its health."""
+        ...  # pragma: no cover - protocol
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovedRemediation:
+    """A remediation plan a human has already approved, bound to one check.
+
+    This module never mints one: approval happens in ``govern apply`` (#4982).
+    A plan reaching the cycle is, by construction, already reviewed.
+
+    Attributes:
+        check_id: The check this plan is bound to. A plan runs only for its
+            own check.
+        plan_id: Identity of the approved plan, recorded on the finding.
+        approved_by: Who approved it.
+        approved_at: Integer timestamp of the approval.
+    """
+
+    check_id: str
+    plan_id: str
+    approved_by: str
+    approved_at: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical serialization."""
+        return {
+            "check_id": self.check_id,
+            "plan_id": self.plan_id,
+            "approved_by": self.approved_by,
+            "approved_at": self.approved_at,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RemediationOutcome:
+    """What executing an approved plan reported.
+
+    ``ok`` is the executor's own verdict on the run; it is deliberately not the
+    same question as "is the check green now", which only the re-verification
+    answers.
+    """
+
+    plan_id: str
+    ok: bool
+    detail: str
+
+
+class RemediationRunner(Protocol):
+    """Executes an approved remediation plan.
+
+    ``govern apply`` (#4982) is the implementation; the cycle holds only this
+    seam so it can ship and be tested before that command exists.
+    """
+
+    def run(self, remediation: ApprovedRemediation) -> RemediationOutcome:
+        """Execute *remediation* and report what happened."""
+        ...  # pragma: no cover - protocol
+
+
+@dataclass(frozen=True, slots=True)
+class WatchFinding:
+    """One check that failed in one cycle, with what was done about it.
+
+    Attributes:
+        check_id: The check that failed.
+        health_before: The health document read at detection time.
+        health_after: The health document read after the remediation attempt,
+            or ``None`` when no plan was bound to the check and nothing was
+            attempted.
+        plan_id: The approved plan that was run, or ``None``.
+        remediation_attempted: Whether a plan was executed for this finding.
+        remediation_detail: The executor's own account of the attempt, or the
+            exception that ended it. Empty when nothing was attempted.
+        tick: The 1-based cycle this finding was minted in.
+    """
+
+    check_id: str
+    health_before: HealthDocument
+    health_after: HealthDocument | None
+    plan_id: str | None
+    remediation_attempted: bool
+    remediation_detail: str
+    tick: int
+
+    @property
+    def remediated_to_green(self) -> bool:
+        """Whether a remediation ran and the re-verification then passed."""
+        return self.remediation_attempted and self.health_after is not None and self.health_after.passed
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical serialization."""
+        return {
+            "check_id": self.check_id,
+            "health_before": self.health_before.to_dict(),
+            "health_after": self.health_after.to_dict() if self.health_after is not None else None,
+            "plan_id": self.plan_id,
+            "remediation_attempted": self.remediation_attempted,
+            "remediation_detail": self.remediation_detail,
+            "remediated_to_green": self.remediated_to_green,
+            "tick": self.tick,
+        }
+
+    def to_canonical_bytes(self) -> bytes:
+        """Serialize the finding to canonical JSON bytes.
+
+        This is the form hashed into the lineage spine, so two replays over the
+        same observations journal byte-identical entries.
+        """
+        return _canonical_bytes(self.to_dict())
+
+    def content_hash(self) -> str:
+        """Return the ``sha256:``-prefixed content address of this finding."""
+        return "sha256:" + hashlib.sha256(self.to_canonical_bytes()).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class CycleResult:
+    """The outcome of one tick.
+
+    Attributes:
+        tick: The 1-based cycle number.
+        checks_run: The check ids run this cycle, in order.
+        findings: One finding per check that failed at detection time.
+    """
+
+    tick: int
+    checks_run: tuple[str, ...]
+    findings: tuple[WatchFinding, ...]
+
+    @property
+    def exit_code(self) -> int:
+        """Non-zero when anything failed in this cycle, remediated or not.
+
+        A finding is minted at detection, so a check fixed inside the cycle
+        keeps its finding and the cycle keeps failing. An operator reading exit
+        codes alone sees that something needed fixing, not just that it is fine
+        now.
+        """
+        return 1 if self.findings else 0
+
+
+class AuditWatch:
+    """Runs a check set on a schedule and responds once to each failure.
+
+    Args:
+        checks: The checks to run each tick, in order.
+        remediations: Already-approved plans, at most one per check id. A check
+            with no plan is only ever reported.
+        runner: Executes approved plans. Required whenever *remediations* is
+            non-empty.
+        spine: Lineage spine to journal attempted remediations into. ``None``
+            disables journaling.
+        clock: Source of the cycle timestamp, injected so a replay journals the
+            same bytes.
+
+    Raises:
+        ValueError: When *remediations* is non-empty and no *runner* was given,
+            or when two plans claim the same check id.
+    """
+
+    def __init__(
+        self,
+        *,
+        checks: Iterable[Check],
+        remediations: Iterable[ApprovedRemediation] = (),
+        runner: RemediationRunner | None = None,
+        spine: LineageSpine | None = None,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._checks = tuple(checks)
+        plans: dict[str, ApprovedRemediation] = {}
+        for plan in remediations:
+            if plan.check_id in plans:
+                msg = f"two approved plans bound to check {plan.check_id!r}"
+                raise ValueError(msg)
+            plans[plan.check_id] = plan
+        if plans and runner is None:
+            msg = "approved remediations were given with no runner to execute them"
+            raise ValueError(msg)
+        self._plans = plans
+        self._runner = runner
+        self._spine = spine
+        self._clock = clock
+        self._tick = 0
+
+    def tick(self) -> CycleResult:
+        """Run every check once, respond to each failure, and report the cycle."""
+        self._tick += 1
+        findings: list[WatchFinding] = []
+        for check in self._checks:
+            health = check.run()
+            if health.passed:
+                continue
+            findings.append(self._respond(check, health))
+        return CycleResult(
+            tick=self._tick,
+            checks_run=tuple(check.check_id for check in self._checks),
+            findings=tuple(findings),
+        )
+
+    def watch(
+        self,
+        *,
+        interval: float,
+        once: bool = False,
+        sleeper: Callable[[float], None] = time.sleep,
+    ) -> Iterator[CycleResult]:
+        """Yield one :class:`CycleResult` per tick, sleeping *interval* between.
+
+        Args:
+            interval: Seconds to wait between ticks.
+            once: Run a single tick and stop, for a cron-driven harness.
+            sleeper: The wait between ticks, injected so the interval is
+                assertable without wall-clock timing.
+        """
+        while True:
+            yield self.tick()
+            if once:
+                return
+            sleeper(interval)
+
+    def _respond(self, check: Check, health_before: HealthDocument) -> WatchFinding:
+        """Attempt the approved plan for *check*, if any, and re-verify."""
+        plan = self._plans.get(check.check_id)
+        runner = self._runner
+        # ``runner is None`` cannot happen while a plan exists -- ``__init__``
+        # rejects that wiring -- but folding it in here keeps the "only report"
+        # path the single answer to "nothing can be attempted".
+        if plan is None or runner is None:
+            return WatchFinding(
+                check_id=check.check_id,
+                health_before=health_before,
+                health_after=None,
+                plan_id=None,
+                remediation_attempted=False,
+                remediation_detail="",
+                tick=self._tick,
+            )
+
+        try:
+            detail = runner.run(plan).detail
+        except Exception as exc:
+            # A plan that explodes ends the attempt, not the watch loop: the
+            # exception becomes the record instead of the last thing the
+            # operator sees.
+            detail = f"{type(exc).__name__}: {exc}"
+
+        finding = WatchFinding(
+            check_id=check.check_id,
+            health_before=health_before,
+            health_after=check.run(),
+            plan_id=plan.plan_id,
+            remediation_attempted=True,
+            remediation_detail=detail,
+            tick=self._tick,
+        )
+        self._journal(finding)
+        return finding
+
+    def _journal(self, finding: WatchFinding) -> None:
+        """Anchor an attempted remediation in the lineage spine."""
+        if self._spine is None:
+            return
+        self._spine.record(
+            artifact_path=f"governance-audit-remediation-{finding.check_id}.json",
+            content=finding.to_canonical_bytes(),
+            actor=_JOURNAL_ACTOR,
+            step_id=finding.plan_id or "",
+            model="none",
+            timestamp=int(self._clock()),
+        )
+
+
+__all__ = [
+    "ApprovedRemediation",
+    "AuditWatch",
+    "Check",
+    "CycleResult",
+    "HealthDocument",
+    "RemediationOutcome",
+    "RemediationRunner",
+    "WatchFinding",
+]

--- a/tests/unit/core/govern/test_audit_watch.py
+++ b/tests/unit/core/govern/test_audit_watch.py
@@ -1,0 +1,253 @@
+"""Tests for the govern audit watch cycle (issue #5125).
+
+The properties under test are the cycle's, not any individual check's: that a
+tick re-runs the whole check set, that a failed check with an approved
+remediation bound to it gets exactly one attempt plus a re-verification, that
+both health documents survive onto the finding, and -- the one that is easy to
+get wrong -- that a check which was remediated back to green still fails the
+cycle it failed in.
+"""
+
+from __future__ import annotations
+
+import itertools
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.govern.audit_watch import (
+    ApprovedRemediation,
+    AuditWatch,
+    HealthDocument,
+    RemediationOutcome,
+)
+from bernstein.core.lineage.spine import LineageSpine
+
+_KEY = b"0" * 32
+_NOW = 1_700_000_000
+
+
+class _Check:
+    """A check whose verdict is read from a list of scripted outcomes."""
+
+    def __init__(self, check_id: str, verdicts: list[bool]) -> None:
+        self.check_id = check_id
+        self._verdicts = verdicts
+        self.runs = 0
+
+    def run(self) -> HealthDocument:
+        passed = self._verdicts[min(self.runs, len(self._verdicts) - 1)]
+        self.runs += 1
+        return HealthDocument(
+            check_id=self.check_id,
+            passed=passed,
+            observed={"run": self.runs, "state": "green" if passed else "red"},
+            timestamp=_NOW + self.runs,
+        )
+
+
+class _Runner:
+    """A remediation runner that flips its bound check green when it succeeds."""
+
+    def __init__(self, *, ok: bool = True, flips: _Check | None = None) -> None:
+        self.calls: list[ApprovedRemediation] = []
+        self._ok = ok
+        self._flips = flips
+
+    def run(self, remediation: ApprovedRemediation) -> RemediationOutcome:
+        self.calls.append(remediation)
+        if self._ok and self._flips is not None:
+            self._flips._verdicts = [True]
+            self._flips.runs = 0
+        return RemediationOutcome(
+            plan_id=remediation.plan_id,
+            ok=self._ok,
+            detail="applied" if self._ok else "refused",
+        )
+
+
+class _RaisingRunner:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def run(self, remediation: ApprovedRemediation) -> RemediationOutcome:
+        self.calls += 1
+        raise RuntimeError("plan execution exploded")
+
+
+def _approved(check_id: str, plan_id: str = "plan-1") -> ApprovedRemediation:
+    return ApprovedRemediation(
+        check_id=check_id,
+        plan_id=plan_id,
+        approved_by="operator@example.com",
+        approved_at=_NOW,
+    )
+
+
+def test_watch_ticks_on_interval_and_reruns_check_set() -> None:
+    """Every tick re-runs every check, and the loop sleeps the given interval."""
+    slept: list[float] = []
+    first = _Check("MDL-001", [True])
+    second = _Check("OBS-004", [True])
+    watch = AuditWatch(checks=[first, second])
+
+    results = list(itertools.islice(watch.watch(interval=5.0, sleeper=slept.append), 3))
+
+    assert len(results) == 3
+    assert [r.tick for r in results] == [1, 2, 3]
+    assert first.runs == 3
+    assert second.runs == 3
+    assert all(r.checks_run == ("MDL-001", "OBS-004") for r in results)
+    # Three ticks, two gaps between them.
+    assert slept == [5.0, 5.0]
+
+
+def test_watch_once_runs_a_single_tick_and_never_sleeps() -> None:
+    """``once`` is the cron-driven escape: one tick, no interval wait."""
+    slept: list[float] = []
+    check = _Check("MDL-001", [True])
+    watch = AuditWatch(checks=[check])
+
+    results = list(watch.watch(interval=5.0, once=True, sleeper=slept.append))
+
+    assert len(results) == 1
+    assert check.runs == 1
+    assert slept == []
+
+
+def test_passing_check_set_exits_zero_and_records_no_finding() -> None:
+    """A cycle with nothing failing is the only cycle that exits zero."""
+    watch = AuditWatch(checks=[_Check("MDL-001", [True])])
+
+    result = watch.tick()
+
+    assert result.findings == ()
+    assert result.exit_code == 0
+
+
+def test_check_with_no_approved_plan_only_reports() -> None:
+    """No plan bound to the check means no remediation attempt, ever."""
+    check = _Check("OBS-004", [False])
+    runner = _Runner(flips=check)
+    watch = AuditWatch(checks=[check], remediations=[], runner=runner)
+
+    result = watch.tick()
+
+    assert runner.calls == []
+    assert check.runs == 1, "a check with no plan is never re-verified"
+    assert len(result.findings) == 1
+    finding = result.findings[0]
+    assert finding.remediation_attempted is False
+    assert finding.plan_id is None
+    assert finding.health_after is None
+    assert result.exit_code == 1
+
+
+def test_finding_carries_health_document_before_and_after() -> None:
+    """Both snapshots are present on a remediated finding, and distinguishable."""
+    check = _Check("OBS-004", [False])
+    runner = _Runner(flips=check)
+    watch = AuditWatch(checks=[check], remediations=[_approved("OBS-004")], runner=runner)
+
+    finding = watch.tick().findings[0]
+
+    assert finding.health_before.passed is False
+    assert finding.health_before.observed["state"] == "red"
+    assert finding.health_after is not None
+    assert finding.health_after.passed is True
+    assert finding.health_after.observed["state"] == "green"
+    assert finding.health_before.content_hash() != finding.health_after.content_hash()
+
+
+def test_remediated_then_green_check_still_fails_the_cycle() -> None:
+    """A check fixed inside the cycle still fails that cycle.
+
+    The intuitive-but-wrong loop re-verifies, sees green, and exits 0 -- which
+    hides from an operator reading exit codes that anything needed fixing.
+    """
+    check = _Check("OBS-004", [False])
+    runner = _Runner(flips=check)
+    watch = AuditWatch(checks=[check], remediations=[_approved("OBS-004")], runner=runner)
+
+    result = watch.tick()
+
+    assert len(runner.calls) == 1
+    finding = result.findings[0]
+    assert finding.remediated_to_green is True
+    assert result.exit_code == 1
+
+
+def test_failed_remediation_is_attempted_exactly_once_per_cycle() -> None:
+    """One bounded attempt per cycle, whether or not it worked."""
+    check = _Check("OBS-004", [False])
+    runner = _Runner(ok=False, flips=check)
+    watch = AuditWatch(checks=[check], remediations=[_approved("OBS-004")], runner=runner)
+
+    result = watch.tick()
+
+    assert len(runner.calls) == 1
+    finding = result.findings[0]
+    assert finding.remediation_attempted is True
+    assert finding.remediated_to_green is False
+    assert finding.health_after is not None
+    assert finding.health_after.passed is False
+    assert result.exit_code == 1
+
+
+def test_raising_remediation_runner_is_recorded_not_propagated() -> None:
+    """A plan that explodes ends the attempt, not the watch loop."""
+    check = _Check("OBS-004", [False])
+    runner = _RaisingRunner()
+    watch = AuditWatch(checks=[check], remediations=[_approved("OBS-004")], runner=runner)
+
+    result = watch.tick()
+
+    assert runner.calls == 1
+    finding = result.findings[0]
+    assert finding.remediation_attempted is True
+    assert "RuntimeError" in finding.remediation_detail
+    assert result.exit_code == 1
+
+
+def test_remediation_is_journaled_to_the_lineage_spine(tmp_path: Path) -> None:
+    """The remediated finding lands on the chain, verifiable offline."""
+    check = _Check("OBS-004", [False])
+    runner = _Runner(flips=check)
+    spine = LineageSpine(tmp_path / ".sdd" / "lineage", run_id="govern-audit", hmac_key=_KEY)
+    watch = AuditWatch(
+        checks=[check],
+        remediations=[_approved("OBS-004")],
+        runner=runner,
+        spine=spine,
+    )
+
+    finding = watch.tick().findings[0]
+
+    entries = list(spine.iter_entries())
+    assert len(entries) == 1
+    assert entries[0].artifact_path == "governance-audit-remediation-OBS-004.json"
+    assert entries[0].content_hash == finding.content_hash()
+    assert spine.verify().ok
+
+
+def test_unremediated_finding_is_not_journaled(tmp_path: Path) -> None:
+    """Only an attempted remediation produces a journal entry; a report does not."""
+    check = _Check("OBS-004", [False])
+    spine = LineageSpine(tmp_path / ".sdd" / "lineage", run_id="govern-audit", hmac_key=_KEY)
+    watch = AuditWatch(checks=[check], spine=spine)
+
+    watch.tick()
+
+    assert list(spine.iter_entries()) == []
+
+
+def test_remediations_without_a_runner_are_rejected() -> None:
+    """An approved plan with nothing able to execute it is a wiring error."""
+    with pytest.raises(ValueError, match="runner"):
+        AuditWatch(checks=[_Check("OBS-004", [False])], remediations=[_approved("OBS-004")])
+
+
+def test_health_document_serialization_round_trips() -> None:
+    doc = HealthDocument(check_id="MDL-001", passed=False, observed={"b": 1, "a": 2}, timestamp=_NOW)
+    assert HealthDocument.from_dict(doc.to_dict()) == doc
+    assert doc.content_hash().startswith("sha256:")


### PR DESCRIPTION
## What

Adds `bernstein.core.govern.audit_watch` — the watch cycle behind `govern audit --watch`: tick a check set on a schedule, respond once to each failed check, re-verify, and still fail the cycle.

One tick runs every check. A check that fails mints a `WatchFinding` carrying the `HealthDocument` read at detection time. When an `ApprovedRemediation` is bound to that check id, the plan is executed exactly once through a `RemediationRunner`, the check is re-run, and the second health document lands on the same finding. An attempted remediation is anchored in the lineage spine, content-addressed by the finding's canonical bytes.

**What this PR explicitly does not do:**

- It does not add a `govern audit` command or a `--watch` flag. `govern audit` does not exist on `main` and its check contract and registry are #5072's, which "blocks every other slice" of #5071. Defining a competing check contract here would collide with that slice head-on. The cycle therefore consumes checks through a minimal structural `Check` protocol (`check_id` plus `run() -> HealthDocument`) and nothing more.
- It does not author, approve, or execute remediation plans. `ApprovedRemediation` is consumed as already approved; execution goes through the `RemediationRunner` seam that `govern apply` (#4982) satisfies.
- It does not route the exit code anywhere. Alerting is out of scope per the issue.
- It does not re-export the new names from `bernstein/core/govern/__init__.py`, for the same collision reason: `Check` is a name #5072 will want.

## Why

Detection without a bounded, logged response is a pager that never stops ringing. A polling audit that only reports turns a repeating failure into an unbounded stream of identical alerts; one that remediates without a record turns it into silence. The cycle here does one attempted fix plus a visible record.

The load-bearing decision is the exit code. The intuitive loop remediates, re-verifies, sees green, and exits 0 — and an operator reading exit codes then never learns that anything needed fixing, only that it is fine now. Here the finding is minted at detection, so a cycle's exit code is a fact about what failed during it, not about what is still failing at the end of it.

The existing surface has no idiom for this. `bernstein schedule run` (`src/bernstein/cli/commands/schedule_cmd.py:393-406`) is the nearest scheduled-interval loop, but it drives trigger fires, not checks; `bernstein watch` (`watch_cmd.py:252-261`) is event-triggered, not scheduled. The tick shape here follows `schedule_run`'s `--interval`/`--once` pair; the journaling follows the `LineageSpine(...).record(...)` pattern already used by `governance_cmd.py:159-171`.

## How

`AuditWatch.tick()` runs every check in order and mints a finding per failure. `_respond` looks up the approved plan bound to the failing check id: no plan means report only, and the check is not re-run. With a plan, the runner is called exactly once — a runner that raises ends the attempt, not the loop, and the exception class becomes the record — then the check is re-run for `health_after` and the finding is journaled.

`CycleResult.exit_code` is `1` whenever the cycle holds any finding. Since findings are minted at detection and never retracted on a successful remediation, a remediated-then-green check keeps failing its cycle. `WatchFinding.remediated_to_green` is what distinguishes "was fixed" from "is still broken" for a reader, without touching the exit code.

`AuditWatch.watch()` is a generator that yields one `CycleResult` per tick and sleeps `interval` between them, with `once` as the cron-driven single-tick escape. `sleeper` and `clock` are injected so the interval is assertable and a replay journals identical bytes.

**Open decision, decided:** the issue asked whether slice 1 ships alone or waits for #4982. It ships now, and slice 2's cycle semantics ship with it — the "still fail the cycle", before/after health documents and journaling behaviours are all testable against the runner seam without #4982 existing, so holding them back would have bought nothing. What genuinely waits is the CLI wiring, which waits on #5072/#5071 rather than on #4982.

## Tests

`tests/unit/core/govern/test_audit_watch.py`. Every test failed before the change with `ModuleNotFoundError: No module named 'bernstein.core.govern.audit_watch'` — the import error the issue predicted. The issue's four named tests are kept verbatim; the file lives beside the other `core/govern` tests rather than under `tests/unit/cli/`, because this PR adds no CLI surface.

1. `test_remediated_then_green_check_still_fails_the_cycle` — **load-bearing.** Verified as a canary: replacing `exit_code` with the intuitive `1 if any(not f.remediated_to_green ...)` leaves the other eleven tests green and fails only this one.
2. `test_check_with_no_approved_plan_only_reports` — no plan bound means the runner is never called and the check is never re-run.
3. `test_finding_carries_health_document_before_and_after` — both snapshots present on a remediated finding, and distinguishable by content hash.
4. `test_watch_ticks_on_interval_and_reruns_check_set` — three ticks re-run the whole check set three times, with two interval waits between them.
5. `test_watch_once_runs_a_single_tick_and_never_sleeps` — the cron-driven escape.
6. `test_passing_check_set_exits_zero_and_records_no_finding` — the only cycle that exits zero.
7. `test_failed_remediation_is_attempted_exactly_once_per_cycle` — one bounded attempt whether or not it worked.
8. `test_raising_remediation_runner_is_recorded_not_propagated` — a plan that explodes ends the attempt, not the loop.
9. `test_remediation_is_journaled_to_the_lineage_spine` — real spine on disk, one entry, `content_hash` equals the finding's, `verify()` passes.
10. `test_unremediated_finding_is_not_journaled` — a report alone writes nothing to the chain.
11. `test_remediations_without_a_runner_are_rejected` — an approved plan with nothing able to execute it is a wiring error, not a silent no-op.
12. `test_health_document_serialization_round_trips`.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes (`src/bernstein/core/govern/audit_watch.py`: 0 errors)
- [x] `uv run python scripts/run_tests.py -x` passes — run as `--parallel 2` over `tests/unit/core/govern`, the `govern`/`governance` test files, and the repo-wide structure guards (`test_shipped_tree_imports_only_shipped_code`, `test_orchestration_reachability`, `test_pipeline_sweep`, `test_cast_alias_form`, `test_path_containment`): 11 files, 286 tests, all green. `--affected origin/main` timed out locally on this machine; CI runs the full suite.
- [x] New code has type hints

### Documentation duty

- [ ] User-visible README section updated — N/A, no user-visible surface yet (no CLI command lands here).
- [ ] `docs/operations/<area>.md` updated — N/A, nothing operable until the CLI wiring lands.
- [ ] `docs/api/` schema regenerated — N/A, no public HTTP or CLI surface changed.
- [x] `uv run bernstein agents-md sync` run — produced no changes to tracked files.
- [x] Tests cover the documented behaviour.

Part of #5125

## Remaining

- `govern audit --watch` CLI wiring: the flag, the interval/`--once` options, and reading the check set from the registry. Waits on #5072 (check contract and registry) and #5071 (the `govern audit` command itself).
- A concrete `RemediationRunner` bound to real approved plans, plus loading approved plans from the chain. Waits on #4982 (`govern apply`).
