### PR TITLE
fix: check the concrete nmap scan target against the network policy (#5150)

### DIFF
--- a/src/bernstein/adapters/nmap.py
+++ b/src/bernstein/adapters/nmap.py
@@ -110,8 +110,11 @@ class NmapAdapter(ScannerAdapter):
 
     def scan(self, target: Path, scope: ScanScope, workdir: Path) -> ScanResult:
         """Run an Nmap scan and normalize its volatile XML into a transcript."""
-        self.enforce_network_policy()
         target_name, ports = _validate_scope(target, scope)
+        # Checked with port=None (host-level): Nmap dials a caller-chosen port
+        # range, not one fixed port, so the policy is consulted against the
+        # concrete target host it is actually about to scan.
+        self.enforce_network_policy((target_name, None))
         binary = shutil.which(self._binary)
         if binary is None:
             raise NmapNotInstalledError(

--- a/src/bernstein/adapters/scanner.py
+++ b/src/bernstein/adapters/scanner.py
@@ -182,18 +182,25 @@ class ScannerAdapter(ABC):
 
     # --- inherited network + rate-limit infra ------------------------------
 
-    def enforce_network_policy(self) -> None:
-        """Refuse to scan when a declared endpoint is denied by the policy.
+    def enforce_network_policy(self, *extra_endpoints: tuple[str, int | None]) -> None:
+        """Refuse to scan when a declared or per-call endpoint is denied by the policy.
 
-        No-op when :attr:`external_endpoints` is empty (pure local scanner) or
+        Checks the class-level :attr:`external_endpoints` declaration (fixed
+        destinations known at import time, e.g. a cloud API) plus any
+        ``extra_endpoints`` the caller passes in - the concrete destination a
+        per-call scan is actually about to dial, for adapters like Nmap whose
+        target is a caller-supplied argument rather than a class attribute.
+
+        No-op when neither yields anything to check (pure local scanner) or
         when the policy is unrestricted.
         """
-        if not self.external_endpoints:
+        endpoints: tuple[tuple[str, int | None], ...] = tuple(self.external_endpoints) + extra_endpoints
+        if not endpoints:
             return
         from bernstein.core.security.network_policy import policy_from_env
 
         policy = policy_from_env()
-        for host, port in self.external_endpoints:
+        for host, port in endpoints:
             policy.check(host, port, source=f"scanner:{self.name()}")
 
     @property

--- a/tests/unit/adapters/test_nmap_scanner.py
+++ b/tests/unit/adapters/test_nmap_scanner.py
@@ -21,6 +21,7 @@ from bernstein.adapters.nmap import (
 from bernstein.adapters.scanner import DeterminismTier, OutputFormat, ScannerCategory, ScanScope
 from bernstein.adapters.scanner_conformance import ScannerConformanceHarness, load_scanner_golden_transcripts
 from bernstein.adapters.scanner_registry import get_scanner
+from bernstein.core.security.network_policy import NetworkPolicyDenied
 
 _FIXTURE_DIR = Path("tests/fixtures/scanners/nmap")
 _FIXTURE_A = _FIXTURE_DIR / "nmap-localhost-a.xml"
@@ -207,6 +208,57 @@ def test_invalid_port_scopes_fail_before_nmap_lookup(tmp_path: Path, ports: str)
     ):
         NmapAdapter().scan(Path("127.0.0.1"), ScanScope(config={"ports": ports}), tmp_path / "work")
     which.assert_not_called()
+
+
+def test_enforce_network_policy_checks_the_concrete_scan_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The hook must accept a per-call destination, not just the class-level declaration.
+
+    Fails today because ``enforce_network_policy()`` takes no arguments: there is
+    nothing to assert a target against, since ``NmapAdapter`` never sets
+    ``external_endpoints`` (its destination is per-scan, not fixed at import time).
+    """
+    monkeypatch.setenv("BERNSTEIN_NETWORK_POLICY", "10.0.0.0/8")
+    adapter = NmapAdapter()
+
+    with pytest.raises(NetworkPolicyDenied) as exc_info:
+        adapter.enforce_network_policy(("192.0.2.5", None))
+    assert exc_info.value.destination == "192.0.2.5"
+
+    # A target inside the granted range passes through without raising.
+    adapter.enforce_network_policy(("10.1.2.3", None))
+
+
+def test_nmap_scan_refused_when_target_outside_allow_network_scope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("BERNSTEIN_NETWORK_POLICY", "10.0.0.0/8")
+    adapter = NmapAdapter()
+
+    with (
+        patch("bernstein.adapters.nmap.shutil.which", return_value="/usr/local/bin/nmap") as which,
+        patch("bernstein.adapters.nmap.subprocess.run") as run,
+        pytest.raises(NetworkPolicyDenied, match="192.0.2.5"),
+    ):
+        adapter.scan(Path("192.0.2.5"), _scope(), tmp_path / "work")
+
+    which.assert_not_called()
+    run.assert_not_called()
+
+
+def test_nmap_scan_allowed_when_target_inside_allow_network_scope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("BERNSTEIN_NETWORK_POLICY", "10.0.0.0/8")
+    adapter = NmapAdapter()
+
+    with (
+        patch("bernstein.adapters.nmap.shutil.which", return_value="/usr/local/bin/nmap"),
+        patch("bernstein.adapters.nmap.subprocess.run", side_effect=_fake_nmap_run()) as run,
+    ):
+        result = adapter.scan(Path("10.1.2.3"), _scope(), tmp_path / "work")
+
+    assert result.transcript == _TRANSCRIPT
+    run.assert_called()
 
 
 def test_conformance_replays_both_recordings_and_checks_the_transcript(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

`ScannerAdapter.enforce_network_policy()` now also accepts the concrete
per-call destination a scan is about to dial, in addition to the class-level
`external_endpoints` declaration it already checked. `NmapAdapter.scan()`
resolves its target first, then calls the hook with that target, so an
out-of-scope host is refused with `NetworkPolicyDenied` before nmap ever runs.

## Why

`enforce_network_policy()` no-ops whenever `external_endpoints` is empty.
That fits adapters with a fixed destination declared at import time, but
`NmapAdapter` has no fixed destination — the host is a caller-supplied
argument on every call — so it never sets `external_endpoints` and the check
always took the early return. Under `--profile airgap` / `--allow-network`,
nmap scans reached the network with no enforcement at all, while every other
adapter with a declared endpoint was correctly gated.

## How

- `ScannerAdapter.enforce_network_policy()` (`src/bernstein/adapters/scanner.py`)
  takes an optional `*extra_endpoints` in addition to `external_endpoints`,
  checking the union of both against the active policy. Called with no
  arguments it behaves exactly as before (still a no-op for adapters that
  declare nothing), so `TrivyAdapter` and `GitleaksAdapter`, which call it
  unchanged, are unaffected.
- `NmapAdapter.scan()` (`src/bernstein/adapters/nmap.py`) resolves the target
  via `_validate_scope()` first, then calls `enforce_network_policy((target,
  None))` with the concrete host. Checked with `port=None` (host-level)
  because nmap scans a caller-chosen port range rather than one fixed port.

**Open decision (from the issue):** whether to widen the shared hook or give
nmap its own scan-time check. I widened `ScannerAdapter.enforce_network_policy()`
rather than adding a parallel nmap-only check, so the mechanism nmap uses is
the same one every other scanner adapter already relies on and any future
per-call-target scanner adapter gets it for free. I left the identical
`CLIAdapter.enforce_network_policy()` in `base.py` untouched — none of its
~15 subclasses have a per-call target, and widening it would add surface no
current caller needs.

Slice 2 from the issue (recording the checked destination on `ScanResult`)
is not part of this PR — Slice 1 is explicitly callable standalone, and the
denied case already carries the destination on `NetworkPolicyDenied`.

## Tests

1. `test_enforce_network_policy_checks_the_concrete_scan_target` —
   **load-bearing.** `enforce_network_policy()` took no arguments before this
   change, so there was nothing to assert a target against; this fails with
   `TypeError` on the unmodified tree.
2. `test_nmap_scan_refused_when_target_outside_allow_network_scope` — a
   target outside the granted `--allow-network` rule raises
   `NetworkPolicyDenied` and nmap never runs (`shutil.which` / `subprocess.run`
   are never called). Failed before this change because the scan proceeded
   straight to nmap.
3. `test_nmap_scan_allowed_when_target_inside_allow_network_scope` — a
   permitted target passes through unchanged (guards against over-blocking).
   This one already passed before the change (no enforcement existed to block
   it); it is included to prove the fix doesn't regress the allowed path.

```
uv run python scripts/run_tests.py --parallel 2 -x tests/unit/adapters/test_scanner.py tests/unit/adapters/test_nmap_scanner.py
```

`--affected origin/main` selects 39 files. This machine runs several other
agents' test suites concurrently, so instead of the full 39-file sweep I ran
the touched modules plus every test file that imports `scanner.py` or
`nmap.py` (`grep -rl` over `src/` and `tests/`): `test_scanner.py`,
`test_nmap_scanner.py`, `test_gitleaks_scanner.py`, `test_trivy_scanner.py`,
`test_scanner_conformance_harness.py`, `test_scanner_registry.py`,
`test_third_party_name_hygiene.py` — 7 files, 91 tests, all green. CI runs
the full suite.

## Checklist

- [x] `uv run ruff check src/`
- [x] `uv run ruff format --check src/` (files touched)
- [ ] `uv run pyright src/` — 2 pre-existing `reportUnknownVariableType` errors
      in `scanner.py` (unrelated lines, present on `origin/main` before this
      change; verified by diffing pyright output against the unmodified tree)
- [x] `uv run python scripts/run_tests.py -x <touched files>` — green
- [x] Type hints on all new/changed signatures
- [x] No behavior change for adapters that call `enforce_network_policy()`
      with no arguments (trivy, gitleaks, and every `CLIAdapter` subclass)
- N/A No public API / CLI surface added
- N/A No documentation changes needed (`docs/installation/air-gap.md`
      documents the unrelated `CLIAdapter` mirror, which this PR does not
      touch); `uv run bernstein agents-md sync` produced no diff

## Remaining

- Slice 2: record the checked destination (or refusal) on `ScanResult` so the
  decision is visible on the result object itself, not only via the raised
  exception.

Part of #5150
