### PR TITLE
fix: stage the SOC 2 evidence pack and promote it atomically (#5123)

### DIFF
--- a/src/bernstein/core/persistence/atomic_write.py
+++ b/src/bernstein/core/persistence/atomic_write.py
@@ -133,6 +133,35 @@ def write_atomic_text(path: Path, data: str, *, encoding: str = "utf-8") -> None
     write_atomic_bytes(path, data.encode(encoding))
 
 
+def promote_atomic(staged_path: Path, path: Path) -> None:
+    """Atomically move an already-written staged file onto *path*.
+
+    Companion to :func:`write_atomic_bytes` for producers that emit a
+    *set* of files which must become visible together: write every file
+    of the set into a scratch directory on the same filesystem with
+    :func:`write_atomic_text` / :func:`write_atomic_bytes`, and only once
+    the whole set is durable call this for each file. A failure at any
+    point before the first promote leaves the published location exactly
+    as it was, so a consumer reading it sees the previous complete set.
+
+    ``os.replace`` swaps the directory entry, so a reader holding *path*
+    sees either the previous file or the new one - never a truncated or
+    half-written mix.
+
+    Args:
+        staged_path: Fully written source file. Must live on the same
+            filesystem as *path*, otherwise ``os.replace`` raises.
+        path: Final destination. Parent directory is created if missing.
+
+    Raises:
+        OSError: Propagated from ``os.replace`` (e.g. a cross-device
+            staging path, or a destination that is a directory).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    os.replace(str(staged_path), str(path))
+    _fsync_dir(path.parent)
+
+
 def write_atomic_json(
     path: Path,
     payload: Any,
@@ -156,6 +185,7 @@ def write_atomic_json(
 
 
 __all__ = [
+    "promote_atomic",
     "write_atomic_bytes",
     "write_atomic_json",
     "write_atomic_text",

--- a/src/bernstein/core/security/audit_pack.py
+++ b/src/bernstein/core/security/audit_pack.py
@@ -77,6 +77,12 @@ STATUS_STALE: EvidenceStatus = "STALE"
 #: whether the run succeeded or failed.
 STAGING_PREFIX: str = ".staging-"
 
+#: Mode the published pack files carry. ``write_atomic_text`` stages at
+#: owner-only 0o600, which is right for runtime state but would silently
+#: narrow who can read an evidence pack that used to be created with the
+#: ordinary default; the staged files are chmod-ed back before promotion.
+_PUBLISHED_FILE_MODE: int = 0o644
+
 #: Default freshness window in days. Anything older flips a source to
 #: ``STALE``. Operators tune via :func:`generate_audit_pack(stale_after_days=N)`.
 DEFAULT_STALE_AFTER_DAYS: int = 30
@@ -606,6 +612,10 @@ def _publish_pack(
     stage - evidence resolution, rendering, manifest serialisation, either
     staged write - leaves the published path byte-for-byte as it was.
 
+    Staging writes owner-only, so both files are chmod-ed to
+    ``_PUBLISHED_FILE_MODE`` before promotion: staging must not change who
+    can read the published pack.
+
     Args:
         target_dir: Published evidence directory (already created).
         markdown: Rendered checklist body.
@@ -626,6 +636,8 @@ def _publish_pack(
     try:
         write_atomic_text(staged_md, markdown)
         write_atomic_text(staged_manifest, manifest_text)
+        staged_md.chmod(_PUBLISHED_FILE_MODE)
+        staged_manifest.chmod(_PUBLISHED_FILE_MODE)
         promote_atomic(staged_md, md_path)
         promote_atomic(staged_manifest, manifest_path)
     finally:

--- a/src/bernstein/core/security/audit_pack.py
+++ b/src/bernstein/core/security/audit_pack.py
@@ -16,7 +16,10 @@ This module provides that checklist:
   each source into a path or sha256 reference, and records freshness so
   the markdown can flag stale evidence (last-modified > N days).
 * :func:`generate_audit_pack` - renders the checklist as Markdown,
-  one row per (control, source).
+  one row per (control, source), plus a JSON manifest. The pair is
+  assembled in a scratch directory and promoted onto the published
+  path only once both files are durable, so a run that dies partway
+  through never leaves a consumer reading a half-built pack.
 
 The markdown is self-contained so it can be uploaded as a CI artifact
 or pasted into an external GRC tool without further processing.
@@ -30,10 +33,14 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
+import shutil
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
+
+from bernstein.core.persistence.atomic_write import promote_atomic, write_atomic_text
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -63,6 +70,12 @@ EvidenceStatus = Literal["OK", "PENDING", "STALE"]
 STATUS_OK: EvidenceStatus = "OK"
 STATUS_PENDING: EvidenceStatus = "PENDING"
 STATUS_STALE: EvidenceStatus = "STALE"
+
+#: Name prefix of the scratch directory where a pack is assembled before
+#: promotion. The directory lives inside the published output directory so
+#: promotion is a same-filesystem rename; it is removed once the run ends,
+#: whether the run succeeded or failed.
+STAGING_PREFIX: str = ".staging-"
 
 #: Default freshness window in days. Anything older flips a source to
 #: ``STALE``. Operators tune via :func:`generate_audit_pack(stale_after_days=N)`.
@@ -570,6 +583,55 @@ def _build_manifest(
     }
 
 
+def _publish_pack(
+    *,
+    target_dir: Path,
+    markdown: str,
+    md_path: Path,
+    manifest: dict[str, Any],
+    manifest_path: Path,
+) -> None:
+    """Stage the whole pack, then promote both files onto the published path.
+
+    The pack is two files that only make sense together: the markdown
+    checklist and the manifest that indexes it. Writing them straight to
+    ``target_dir`` gives a consumer two ways to read a half-built pack -
+    a torn file while a single ``write`` is in flight, and a new markdown
+    beside a stale manifest if the run dies between the two.
+
+    So both files are written under a content-addressed scratch directory
+    inside ``target_dir`` first (same filesystem, so promotion is a plain
+    rename), each one durable via :func:`write_atomic_text`. Only once the
+    complete pack is on disk is anything promoted. A failure at any earlier
+    stage - evidence resolution, rendering, manifest serialisation, either
+    staged write - leaves the published path byte-for-byte as it was.
+
+    Args:
+        target_dir: Published evidence directory (already created).
+        markdown: Rendered checklist body.
+        md_path: Published path for the markdown.
+        manifest: Manifest payload.
+        manifest_path: Published path for the manifest.
+
+    Raises:
+        OSError: Propagated from the staged writes or the promotion.
+    """
+    manifest_text = json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+    digest = hashlib.sha256(markdown.encode("utf-8") + manifest_text.encode("utf-8")).hexdigest()
+    # Content digest names the pack; pid + randomness keep two concurrent
+    # writers of different generations from sharing a scratch directory.
+    staging_dir = target_dir / f"{STAGING_PREFIX}{digest[:16]}.{os.getpid()}.{os.urandom(4).hex()}"
+    staged_md = staging_dir / md_path.name
+    staged_manifest = staging_dir / manifest_path.name
+    try:
+        write_atomic_text(staged_md, markdown)
+        write_atomic_text(staged_manifest, manifest_text)
+        promote_atomic(staged_md, md_path)
+        promote_atomic(staged_manifest, manifest_path)
+    finally:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+
+
 def generate_audit_pack(
     *,
     workdir: Path | None = None,
@@ -593,6 +655,8 @@ def generate_audit_pack(
         stale_after_days: Threshold for the ``STALE`` flag.
         now: Override clock for tests.
         write: When False, return rendered content without touching disk.
+            When True, the pack is staged in full and then promoted onto
+            ``output_dir`` so a failed run never publishes a partial pack.
 
     Returns:
         :class:`AuditPackResult`.
@@ -616,10 +680,12 @@ def generate_audit_pack(
         target_dir.mkdir(parents=True, exist_ok=True)
         md_path = target_dir / f"soc2-evidence-{period_label}.md"
         manifest_path = target_dir / f"soc2-evidence-{period_label}.json"
-        md_path.write_text(markdown, encoding="utf-8")
-        manifest_path.write_text(
-            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
+        _publish_pack(
+            target_dir=target_dir,
+            markdown=markdown,
+            md_path=md_path,
+            manifest=manifest,
+            manifest_path=manifest_path,
         )
         logger.info("SOC 2 evidence pack written: %s", md_path)
 
@@ -636,6 +702,7 @@ __all__ = [
     "DEFAULT_EVIDENCE_SOURCES",
     "DEFAULT_STALE_AFTER_DAYS",
     "PENDING_EVIDENCE",
+    "STAGING_PREFIX",
     "STATUS_OK",
     "STATUS_PENDING",
     "STATUS_STALE",

--- a/tests/unit/security/test_audit_pack_staged_write.py
+++ b/tests/unit/security/test_audit_pack_staged_write.py
@@ -1,0 +1,202 @@
+"""Staged-write / atomic-promote guarantees for the SOC 2 evidence pack.
+
+``generate_audit_pack`` is a multi-stage producer: it resolves several
+independent evidence sources, renders a markdown checklist, builds a JSON
+manifest, and then publishes *two* files under the evidence directory.
+Consumers of that directory (auditors, CI artefact collectors, GRC sync
+jobs) must never observe a generation caught mid-write: what they read is
+either a complete pack or the previous complete pack.
+
+These tests pin that guarantee at the filesystem layer - real files, real
+directories, a real fault injected between the stages of one run.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from bernstein.core.security import audit_pack
+from bernstein.core.security.audit_pack import generate_audit_pack
+
+_FIXED_NOW = datetime(2026, 3, 1, 12, 0, 0, tzinfo=UTC)
+_PERIOD = "2026-Q1"
+
+
+@pytest.fixture()
+def workdir(tmp_path: Path) -> Path:
+    """A project root carrying one real evidence artefact.
+
+    The pack resolves every declared source against this root; sources
+    without an artefact resolve to ``PENDING``, which is a valid pack.
+    One real file is enough to exercise a non-trivial rendering.
+    """
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / "CODE_OF_CONDUCT.md").write_text("# code of conduct\n", encoding="utf-8")
+    return root
+
+
+def _mutate_evidence(workdir: Path, body: str) -> None:
+    """Change a resolved evidence artefact so a completed pack would differ."""
+    (workdir / "CODE_OF_CONDUCT.md").write_text(body, encoding="utf-8")
+
+
+@pytest.fixture()
+def published(tmp_path: Path) -> Path:
+    """The published output directory consumers read from."""
+    out = tmp_path / "published"
+    out.mkdir()
+    return out
+
+
+def _md_path(published: Path) -> Path:
+    return published / f"soc2-evidence-{_PERIOD}.md"
+
+
+def _manifest_path(published: Path) -> Path:
+    return published / f"soc2-evidence-{_PERIOD}.json"
+
+
+def _run(workdir: Path, published: Path) -> None:
+    generate_audit_pack(
+        workdir=workdir,
+        output_dir=published,
+        period_label=_PERIOD,
+        now=_FIXED_NOW,
+        write=True,
+    )
+
+
+def _break_manifest_serialisation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fail the run at the manifest-serialisation stage.
+
+    The markdown body is fully rendered (and, on an unfixed tree, already
+    written to the published path) before the manifest is serialised, so
+    this is a fault *between* the two output stages of a single run.
+    """
+
+    def exploding_dumps(obj: Any, **kwargs: Any) -> str:
+        if isinstance(obj, dict) and obj.get("report_type") == "soc2_evidence_pack":
+            msg = "injected failure while serialising the evidence manifest"
+            raise RuntimeError(msg)
+        return json.dumps(obj, **kwargs)
+
+    shim = SimpleNamespace(
+        dumps=exploding_dumps,
+        loads=json.loads,
+        JSONDecodeError=json.JSONDecodeError,
+    )
+    monkeypatch.setattr(audit_pack, "json", shim)
+
+
+def test_killed_run_between_stages_leaves_published_path_unchanged(
+    workdir: Path,
+    published: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A run that dies between stages must publish nothing at all."""
+    _break_manifest_serialisation(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="injected failure"):
+        _run(workdir, published)
+
+    assert not _md_path(published).exists(), "the markdown was published even though the run never completed"
+    assert not _manifest_path(published).exists()
+    assert list(published.iterdir()) == [], f"published directory not clean: {list(published.iterdir())}"
+
+
+def test_failed_run_is_a_clean_noop_for_consumers(
+    workdir: Path,
+    published: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed re-generation leaves the previous complete pack intact."""
+    _run(workdir, published)
+    before_md = _md_path(published).read_bytes()
+    before_manifest = _manifest_path(published).read_bytes()
+
+    # Change the evidence so a completed second run would differ.
+    _mutate_evidence(workdir, "# code of conduct v2\n")
+    _break_manifest_serialisation(monkeypatch)
+    with pytest.raises(RuntimeError, match="injected failure"):
+        _run(workdir, published)
+
+    assert _md_path(published).read_bytes() == before_md
+    assert _manifest_path(published).read_bytes() == before_manifest
+
+
+def test_resumed_run_produces_byte_identical_artefact_to_uninterrupted_run(
+    workdir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Re-running after an interruption reproduces the uninterrupted pack."""
+    clean_dir = tmp_path / "clean"
+    clean_dir.mkdir()
+    _run(workdir, clean_dir)
+    expected_md = _md_path(clean_dir).read_bytes()
+    expected_manifest = _manifest_path(clean_dir).read_bytes()
+
+    resumed_dir = tmp_path / "resumed"
+    resumed_dir.mkdir()
+    with monkeypatch.context() as interrupted:
+        _break_manifest_serialisation(interrupted)
+        with pytest.raises(RuntimeError, match="injected failure"):
+            _run(workdir, resumed_dir)
+
+    _run(workdir, resumed_dir)
+
+    assert _md_path(resumed_dir).read_bytes() == expected_md
+    assert _manifest_path(resumed_dir).read_bytes() == expected_manifest
+
+
+@pytest.mark.skipif(os.name == "nt", reason="st_ino is not a stable identity on Windows")
+def test_publish_replaces_the_file_by_rename_so_readers_never_see_truncation(
+    workdir: Path,
+    published: Path,
+) -> None:
+    """Publishing swaps a directory entry instead of truncating in place."""
+    _run(workdir, published)
+    first_md_ino = _md_path(published).stat().st_ino
+    first_manifest_ino = _manifest_path(published).stat().st_ino
+
+    _mutate_evidence(workdir, "# code of conduct v2\n")
+    _run(workdir, published)
+
+    assert _md_path(published).stat().st_ino != first_md_ino, (
+        "markdown was rewritten in place - a reader can observe a truncated file"
+    )
+    assert _manifest_path(published).stat().st_ino != first_manifest_ino
+
+
+def test_successful_run_leaves_no_staging_residue_in_published_directory(
+    workdir: Path,
+    published: Path,
+) -> None:
+    """Staging is an implementation detail: consumers see only the pack."""
+    _run(workdir, published)
+
+    assert sorted(p.name for p in published.iterdir()) == [
+        f"soc2-evidence-{_PERIOD}.json",
+        f"soc2-evidence-{_PERIOD}.md",
+    ]
+    manifest = json.loads(_manifest_path(published).read_text(encoding="utf-8"))
+    assert manifest["report_type"] == "soc2_evidence_pack"
+    # The published markdown is the exact rendered body, not a partial flush.
+    rendered = generate_audit_pack(
+        workdir=workdir,
+        period_label=_PERIOD,
+        now=_FIXED_NOW,
+        write=False,
+    ).markdown
+    assert hashlib.sha256(_md_path(published).read_bytes()).hexdigest() == (
+        hashlib.sha256(rendered.encode("utf-8")).hexdigest()
+    )

--- a/tests/unit/security/test_audit_pack_staged_write.py
+++ b/tests/unit/security/test_audit_pack_staged_write.py
@@ -200,3 +200,15 @@ def test_successful_run_leaves_no_staging_residue_in_published_directory(
     assert hashlib.sha256(_md_path(published).read_bytes()).hexdigest() == (
         hashlib.sha256(rendered.encode("utf-8")).hexdigest()
     )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes are not meaningful on Windows")
+def test_published_pack_is_readable_the_way_a_direct_write_left_it(
+    workdir: Path,
+    published: Path,
+) -> None:
+    """Staging must not change who can read the published evidence pack."""
+    _run(workdir, published)
+
+    assert _md_path(published).stat().st_mode & 0o777 == 0o644
+    assert _manifest_path(published).stat().st_mode & 0o777 == 0o644

--- a/tests/unit/test_atomic_write.py
+++ b/tests/unit/test_atomic_write.py
@@ -334,3 +334,23 @@ def test_runtime_write_file_locks_atomic(tmp_path: Path) -> None:
     data = json.loads(lock_path.read_text(encoding="utf-8"))
     assert any(entry["file_path"] == "src/foo.py" for entry in data)
     assert [p.name for p in lock_path.parent.iterdir() if ".tmp." in p.name] == []
+
+
+def test_promote_atomic_swaps_the_directory_entry_and_consumes_the_staged_file(
+    tmp_path: Path,
+) -> None:
+    """promote_atomic replaces the destination by rename, not by truncation."""
+    from bernstein.core.persistence.atomic_write import promote_atomic, write_atomic_text
+
+    published = tmp_path / "published" / "pack.md"
+    write_atomic_text(published, "old\n")
+    old_ino = published.stat().st_ino
+
+    staged = tmp_path / "published" / ".staging" / "pack.md"
+    write_atomic_text(staged, "new\n")
+
+    promote_atomic(staged, published)
+
+    assert published.read_text(encoding="utf-8") == "new\n"
+    assert published.stat().st_ino != old_ino
+    assert not staged.exists()


### PR DESCRIPTION
## What

`generate_audit_pack` (the SOC 2 evidence pack) no longer writes to the published
evidence directory directly. Both output files — the markdown checklist and the
JSON manifest — are assembled in a scratch directory inside the output directory
and promoted with `os.replace` only after the complete pack is durable on disk.

`promote_atomic` joins `write_atomic_bytes` / `write_atomic_text` /
`write_atomic_json` in `core/persistence/atomic_write.py` as the promote half of
that staged-write pattern.

This is slices 1 and 2 of #5123. It does **not** add `--from-stage` /
`--reuse-artifacts` (slice 3) and does not touch `core/compliance/pack.py`
(slice 4) — see **Remaining**. It also does not change evidence-source
resolution or any pack content: byte-for-byte the same markdown and manifest
are produced, only the way they reach disk changed.

## Why

`generate_audit_pack` is a multi-stage producer — it reads the HMAC audit chain,
a policy file, the capability matrix, the cluster TLS cert log and the run logs —
and it published its result with two bare `write_text` calls straight onto
`<workdir>/.sdd/evidence/soc2/`:

```python
md_path.write_text(markdown, encoding="utf-8")
manifest_path.write_text(json.dumps(manifest, ...), encoding="utf-8")
```

Two failure windows follow from that, both in the location consumers read:

- `write_text` truncates the destination before writing, so a crash mid-write
  leaves a torn or empty file where a complete pack used to be.
- A failure between the two calls leaves a **new** markdown beside a **stale or
  missing** manifest — a pack that describes one generation and indexes another.

The module already had the single-file fix available and unused
(`core/persistence/atomic_write.py`), but a per-file atomic write alone does not
close the second window: the pack is two files that only mean anything together.
An auditor, a CI artefact collector or a GRC sync job reading that directory
needs the guarantee that what they pick up is a complete generation or the
previous complete generation, never a generation caught mid-write.

## How

`_publish_pack` (private, in `audit_pack.py`) does the staging:

1. Serialise the manifest and content-address the pair
   (`sha256(markdown + manifest)`); the scratch directory is
   `<output_dir>/.staging-<digest16>.<pid>.<rand>` — inside the output directory
   so promotion is a same-filesystem rename, pid/random-suffixed so two
   concurrent runs of different generations cannot share a scratch slot.
2. Write both files there with `write_atomic_text` (temp + fsync + replace, so
   each staged file is itself durable).
3. Only then `promote_atomic` each file onto its published path.
4. `finally:` remove the scratch directory, so a failed run leaves no residue.

Any failure before step 3 — evidence resolution, rendering, manifest
serialisation, either staged write — leaves the published path byte-for-byte as
it was.

`promote_atomic(staged_path, path)` is `os.replace` plus the directory fsync that
`write_atomic_bytes` already does, so a reader holding `path` sees either the
previous file or the new one.

**Open decision from the issue — the unit of promotion.** The issue left open
whether to promote the containing directory (one rename for the whole pack) or
the two files individually. This PR promotes the two files. Renaming a directory
over `target_dir` is not available here: `target_dir` is shared — it accumulates
one pack per `period_label` — so a directory-level swap would delete every other
period's pack, and `os.replace` refuses a non-empty destination directory anyway.
Moving the pack into a per-period subdirectory would fix that but changes the
published paths in `AuditPackResult` and for every existing reader, which is a
larger change than this issue asks for. The residual window is therefore two
consecutive rename syscalls after all I/O is durable, and each rename is itself
atomic: a reader can in principle catch a new markdown beside the previous
manifest, but never a torn file and never a partially written one. That is a
strictly narrower window than the two full file writes it replaces.

One deliberate behaviour preservation: `write_atomic_text` stages at owner-only
`0o600`, correct for `.sdd/runtime/` state but a silent narrowing for a published
evidence pack that `write_text` created with the ordinary default. Both staged
files are chmod-ed to `0o644` before promotion, pinned by test 7.

## Tests

New file `tests/unit/security/test_audit_pack_staged_write.py` (idiom:
`tests/unit/test_soc2_report.py`). Every test drives the real
`generate_audit_pack` against real directories; the fault is injected at the
manifest-serialisation stage, which on an unfixed tree runs *after* the markdown
has already been written to the published path.

1. `test_killed_run_between_stages_leaves_published_path_unchanged` —
   **load-bearing**. A run that dies between stages publishes nothing.
   Failed before the change: the published directory held the markdown while the
   manifest was never written.
2. `test_failed_run_is_a_clean_noop_for_consumers` — a failed re-generation
   leaves the previous complete pack byte-identical. Failed before the change:
   the markdown had already been overwritten with the new generation.
3. `test_publish_replaces_the_file_by_rename_so_readers_never_see_truncation` —
   a second run swaps the directory entry instead of truncating in place
   (inode identity changes). Failed before the change: same inode, i.e. the
   destination was truncated with a reader potentially holding it.
4. `test_resumed_run_produces_byte_identical_artefact_to_uninterrupted_run` —
   re-running after an interrupted run reproduces the uninterrupted pack exactly.
   Guards the new mechanism: an interrupted run must leave nothing behind that
   perturbs the next one.
5. `test_successful_run_leaves_no_staging_residue_in_published_directory` — after
   a successful run the published directory contains exactly the two pack files,
   and the published markdown hashes equal to the rendered body. Guards the new
   mechanism against leaking its scratch directory to consumers.
6. `test_promote_atomic_swaps_the_directory_entry_and_consumes_the_staged_file`
   (in `tests/unit/test_atomic_write.py`) — the new primitive's own contract.
7. `test_published_pack_is_readable_the_way_a_direct_write_left_it` — staging
   does not change who can read the published pack.

Tests 1–3 fail on `main` for the reasons stated above; 4, 5 and 7 pass on `main`
and exist to hold the new mechanism honest.

Verification run:

- `uv run python scripts/run_tests.py --parallel 2 -x tests/unit/security/test_audit_pack_staged_write.py tests/unit/test_atomic_write.py tests/unit/test_soc2_report.py tests/unit/test_soc2_export.py tests/integration/test_soc2_real_evidence.py tests/property/test_atomic_write_properties.py tests/property/test_lineage_eu_bughunt.py` — all green.
- `--affected origin/main` selects 1136 files (`atomic_write` is imported very
  broadly), well past what is sensible to run locally, so the local run was the
  tests of both changed modules plus every test file that imports them
  (14 files, all green). CI runs the full suite.
- `uv run ruff check src/` and `ruff format --check` on the changed files: clean.
- `uv run pyright` on both changed modules reports the same two pre-existing
  errors as on `main` (`audit_pack.py` resolver code, untouched here) and no new
  ones.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes (no new diagnostics; two pre-existing
      `audit_pack.py` errors are unchanged from `main`)
- [x] `uv run python scripts/run_tests.py -x` passes (scoped as described above)
- [x] New code has type hints

### Documentation duty

- [x] User-visible README section updated — N/A, no user-visible surface change
      (same CLI, same output paths, same bytes)
- [x] `docs/operations/<area>.md` updated — N/A, no operator-facing change
- [x] `docs/api/` schema regenerated if a public surface changed — N/A, no schema
- [x] `uv run bernstein agents-md sync` run — run; it produced no changes
- [x] Tests cover the documented behaviour

Part of #5123

## Remaining

- **Slice 3** — `--from-stage <n>` / `--reuse-artifacts`: persist per-stage
  artefacts so a re-run can skip evidence sources that already resolved, and
  record both on the run. Named tests still open:
  `test_from_stage_flag_skips_already_resolved_sources`,
  `test_reuse_artifacts_substitutes_stored_stage_output`.
- **Slice 4** — apply the same staged-write shape to `core/compliance/pack.py`,
  which has the same defect in a different form: `build_pack` and `_seal_pack`
  open `zipfile.ZipFile(output_path, "w")` directly on the published path, so an
  interrupted seal leaves a truncated ZIP where a complete signed pack was.
