### PR TITLE
fix: record which capability tokens the spawn decision evaluated (#5052)

### DIFF
--- a/docs/security/capability-matrix.md
+++ b/docs/security/capability-matrix.md
@@ -91,7 +91,7 @@ print(decision.reason)
 
 | Knob | Default | Controls |
 |---|--:|---|
-| `security.lethal_trifecta_enforcement` | `enforce` | `enforce` (refuse spawn + signed refusal audit event), `warn` (allow, warning recorded), `off` (allow). Every mode still records the evaluated chain in the per-spawn manifest under `.sdd/runtime/spawn_capabilities/`. |
+| `security.lethal_trifecta_enforcement` | `enforce` | `enforce` (refuse spawn + signed refusal audit event), `warn` (allow, warning recorded), `off` (allow). Every mode still writes a per-spawn manifest under `.sdd/runtime/spawn_capabilities/`, which separates the chain the decision saw (`evaluated`) from the tokens held out of it (`held_out`, each with a reason) - see [what the spawn decision covers](lethal-trifecta.md#what-the-spawn-decision-covers). |
 | `templates/capabilities/*.yaml` | three files: `adapters.yaml` (19 adapters), `mcp_tools.yaml`, `surfaces.yaml` | Capability declarations. |
 | Default for unknown tools | `frozenset(Capability)` (all three) | Fail-closed. |
 

--- a/docs/security/lethal-trifecta.md
+++ b/docs/security/lethal-trifecta.md
@@ -55,9 +55,12 @@ Three properties matter for a reviewer:
   spawner before any agent process starts. There is no agent prompt
   that could be talked out of it.
 - **Default-deny on unknown tools.** A tool not present in the registry
-  is treated as carrying all three capabilities. Missing metadata
-  fails closed - a custom plugin without a YAML declaration is denied,
-  not silently allowed.
+  is treated as carrying all three capabilities, so any chain that
+  includes it fails closed. At spawn time an undeclared tool is held
+  out of the decision rather than denying the spawn on its own (see
+  [what the spawn decision covers](#what-the-spawn-decision-covers));
+  `bernstein audit capabilities` replays the full recorded chain and
+  surfaces it.
 - **Bypass-immune in the policy graph.** The decision lands as
   `DecisionType.IMMUNE` with `bypass_immune=True` in
   [`policy_engine.py`](https://github.com/sipyourdrink-ltd/bernstein/blob/main/src/bernstein/core/security/policy_engine.py).
@@ -67,12 +70,40 @@ On refusal, two artefacts are persisted:
 
 | Artefact | Path | Contents |
 |---|---|---|
-| Spawn manifest | `.sdd/runtime/spawn_capabilities/<session_id>.json` | Tool chain, triggered capabilities, offending tool list, mode, decision |
+| Spawn manifest | `.sdd/runtime/spawn_capabilities/<session_id>.json` | Recorded chain (`tools`), the chain the decision saw (`evaluated`), the tokens held out and why (`held_out`), triggered capabilities, offending tool list, mode, decision |
 | Audit event | `.sdd/audit/` (HMAC-chained) | `event_type=capability_matrix_refusal` with role, reason, full chain |
 
 The audit event lands on the same HMAC chain as task-state transitions,
 so a SOC 2 / ISO 27001 reviewer can verify that no trifecta-prone agent
 ever spawned without a matching deny event.
+
+## What the spawn decision covers
+
+The chain recorded in the manifest is wider than the chain the spawn
+decision evaluates, so the manifest states both. `evaluated` is exactly
+the sequence handed to `CapabilityRegistry.evaluate_chain`; `held_out`
+lists every other recorded token with the reason it was held out.
+
+| `held_out` reason | Token | Why it is held out |
+|---|---|---|
+| `outer-envelope` | `adapter.<name>` | Every adapter row in `templates/capabilities/adapters.yaml` is tagged with all three capabilities by design - it describes the envelope a running CLI agent sits in, not a single call. Evaluating it would deny every spawn under `enforce`. |
+| `undeclared-tool` | any catalog tool with no registry row | Undeclared tools default to all three capabilities, so a single missing YAML row would block the spawn. They are recorded instead, and `bernstein audit capabilities` re-evaluates the full chain. |
+
+**The adapter envelope is out of scope for spawn-time enforcement.**
+Spawn-time enforcement answers one question: does the operator-declared
+inner tool set union the trifecta? The envelope is covered by three
+controls that act on the running agent rather than on the spawn:
+
+| Control | Where |
+|---|---|
+| Worker tool allowlist (T578) - narrows what the agent may call at all | `core/agents/spawner_warm_pool.py` (`build_tool_allowlist_env`) |
+| Per-agent credential scoping - narrows which secrets reach the process | [Credential scoping](credential-scoping.md) |
+| `bernstein audit capabilities` - replays `tools` from every manifest, envelope included, and exits non-zero on a violating chain | CLI |
+
+Widening the spawn gate to the envelope needs the first two controls to
+be readable at spawn time so a scoped adapter can be distinguished from
+an unscoped one. That is not in place today, which is why the boundary
+is recorded rather than enforced.
 
 ## Default capability matrix
 

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -381,6 +381,13 @@ def extract_error_aware_reason(log_text: str, max_chars: int = _FAILURE_REASON_M
 # straight into its cwd (issue #2793).
 _WRITE_BOUNDARY_ROLES = frozenset({"manager"})
 
+# Why a token recorded in a spawn-capability manifest was not part of the
+# chain handed to ``CapabilityRegistry.evaluate_chain``.  The manifest is
+# the artefact an auditor reads, so the held-out set carries its reason
+# rather than leaving it to be inferred from absence (issue #5052).
+_HELD_OUT_OUTER_ENVELOPE = "outer-envelope"
+_HELD_OUT_UNDECLARED = "undeclared-tool"
+
 
 def manager_write_boundary_error(
     role: str,
@@ -2258,6 +2265,27 @@ class AgentSpawner:
         declared_only = [t for t in catalog_tools if t in registry.tools]
         decision = registry.evaluate_chain(declared_only)
 
+        # The recorded chain is wider than the evaluated one: the adapter
+        # envelope is never fed to the gate (every adapter row carries all
+        # three capabilities, so it would deny every spawn) and undeclared
+        # catalog tools are dropped for the reason above.  Both omissions
+        # are deliberate, but a reader of the manifest must not have to
+        # infer them from absence - record each held-out token with why it
+        # was held out, and keep the evaluated set byte-equal to the chain
+        # the decision actually saw.
+        held_out: list[dict[str, str]] = []
+        accounted: set[str] = set(declared_only)
+        for token in chain:
+            if token in accounted:
+                continue
+            accounted.add(token)
+            held_out.append(
+                {
+                    "tool": token,
+                    "reason": (_HELD_OUT_OUTER_ENVELOPE if token == adapter_token else _HELD_OUT_UNDECLARED),
+                }
+            )
+
         runtime_dir = self._workdir / ".sdd" / "runtime" / "spawn_capabilities"
         try:
             runtime_dir.mkdir(parents=True, exist_ok=True)
@@ -2266,7 +2294,8 @@ class AgentSpawner:
                 "role": role,
                 "timestamp": datetime.now(UTC).isoformat(),
                 "tools": chain,
-                "evaluated": catalog_tools,
+                "evaluated": list(declared_only),
+                "held_out": held_out,
                 "triggered": sorted(c.value for c in decision.triggered),
                 "allowed": decision.allowed,
                 "reason": decision.reason,

--- a/tests/integration/test_capability_matrix_spawn_refusal.py
+++ b/tests/integration/test_capability_matrix_spawn_refusal.py
@@ -993,3 +993,160 @@ class TestScalarFrontmatterTrifectaEnforcement:
         )
 
         monkeypatch.undo()
+
+
+# ---------------------------------------------------------------------------
+# 10. Manifest fidelity - the record must not overstate what was enforced
+# ---------------------------------------------------------------------------
+
+
+class TestManifestRecordsWhatWasEvaluated:
+    """The spawn manifest records a wider chain than the decision saw.
+
+    ``_enforce_lethal_trifecta`` prepends the adapter envelope token and
+    drops every undeclared catalog tool before calling
+    ``evaluate_chain``.  Both omissions are deliberate, but the manifest
+    under ``.sdd/runtime/spawn_capabilities/`` is the artefact a reviewer
+    reads, so it has to say which tokens the verdict covers and why the
+    rest were held out.
+    """
+
+    @staticmethod
+    def _record_evaluate_chain(
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> list[list[str]]:
+        """Capture every tool sequence handed to ``evaluate_chain``."""
+        from bernstein.core.security.capability_matrix import CapabilityRegistry
+
+        calls: list[list[str]] = []
+        original = CapabilityRegistry.evaluate_chain
+
+        def _spy(
+            self: CapabilityRegistry,
+            tools: Any,
+            **kwargs: Any,
+        ) -> Any:
+            calls.append([str(t) for t in tools])
+            return original(self, tools, **kwargs)
+
+        monkeypatch.setattr(CapabilityRegistry, "evaluate_chain", _spy)
+        return calls
+
+    def test_manifest_evaluated_set_contains_only_tokens_passed_to_evaluate_chain(
+        self,
+        workdir: Path,
+        mock_adapter: MagicMock,
+        make_task: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """No token may be recorded as evaluated unless the decision saw it.
+
+        ``fs.unknown_probe`` is absent from the staged registry, so the
+        spawner filters it out of the evaluated chain.  Recording it as
+        evaluated would tell a reviewer the verdict covered a tool it
+        never looked at.
+        """
+        calls = self._record_evaluate_chain(monkeypatch)
+        catalog = _catalog_with(tools=["fs.read", "fs.unknown_probe"])
+        spawner = _build_spawner(workdir=workdir, adapter=mock_adapter, catalog=catalog)
+
+        session = spawner.spawn_for_tasks([make_task()])
+
+        manifest_path = workdir / ".sdd" / "runtime" / "spawn_capabilities" / f"{session.id}.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        seen: set[str] = {tool for call in calls for tool in call}
+        assert calls, "Expected the spawner to evaluate a chain"
+        assert set(manifest["evaluated"]) <= seen, (
+            "Manifest records tokens as evaluated that were never passed to "
+            f"evaluate_chain: {set(manifest['evaluated']) - seen}"
+        )
+
+    def test_adapter_envelope_is_recorded_as_held_out_with_a_reason(
+        self,
+        workdir: Path,
+        mock_adapter: MagicMock,
+        make_task: Any,
+    ) -> None:
+        """The adapter token is in the chain but outside the verdict."""
+        catalog = _catalog_with(tools=["fs.read"])
+        spawner = _build_spawner(workdir=workdir, adapter=mock_adapter, catalog=catalog)
+
+        session = spawner.spawn_for_tasks([make_task()])
+
+        manifest_path = workdir / ".sdd" / "runtime" / "spawn_capabilities" / f"{session.id}.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        held_out = {entry["tool"]: entry["reason"] for entry in manifest["held_out"]}
+        assert held_out.get("adapter.mockcli") == "outer-envelope", (
+            f"Adapter envelope missing from held_out with its reason: {manifest['held_out']}"
+        )
+        assert "adapter.mockcli" not in manifest["evaluated"]
+
+    def test_undeclared_catalog_tool_is_recorded_as_held_out_with_a_reason(
+        self,
+        workdir: Path,
+        mock_adapter: MagicMock,
+        make_task: Any,
+    ) -> None:
+        """A tool with no registry row is held out, and the record says so."""
+        catalog = _catalog_with(tools=["fs.read", "fs.unknown_probe"])
+        spawner = _build_spawner(workdir=workdir, adapter=mock_adapter, catalog=catalog)
+
+        session = spawner.spawn_for_tasks([make_task()])
+
+        manifest_path = workdir / ".sdd" / "runtime" / "spawn_capabilities" / f"{session.id}.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        held_out = {entry["tool"]: entry["reason"] for entry in manifest["held_out"]}
+        assert held_out.get("fs.unknown_probe") == "undeclared-tool", (
+            f"Undeclared tool missing from held_out with its reason: {manifest['held_out']}"
+        )
+        assert "fs.read" in manifest["evaluated"]
+
+    def test_evaluated_and_held_out_partition_the_recorded_chain(
+        self,
+        workdir: Path,
+        mock_adapter: MagicMock,
+        make_task: Any,
+    ) -> None:
+        """Every recorded token is accounted for, exactly once."""
+        catalog = _catalog_with(tools=["fs.read", "git.commit", "fs.unknown_probe"])
+        spawner = _build_spawner(workdir=workdir, adapter=mock_adapter, catalog=catalog)
+
+        session = spawner.spawn_for_tasks([make_task()])
+
+        manifest_path = workdir / ".sdd" / "runtime" / "spawn_capabilities" / f"{session.id}.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        evaluated = set(manifest["evaluated"])
+        held_out = {entry["tool"] for entry in manifest["held_out"]}
+        assert not (evaluated & held_out), f"Token recorded as both evaluated and held out: {evaluated & held_out}"
+        assert evaluated | held_out == set(manifest["tools"]), (
+            "evaluated + held_out must cover the recorded chain exactly; "
+            f"missing={set(manifest['tools']) - (evaluated | held_out)} "
+            f"extra={(evaluated | held_out) - set(manifest['tools'])}"
+        )
+
+    def test_recorded_chain_split_does_not_change_the_enforcement_outcome(
+        self,
+        workdir: Path,
+        mock_adapter: MagicMock,
+        make_task: Any,
+    ) -> None:
+        """Splitting the record leaves both verdicts where they were.
+
+        A chain that spawns today still spawns even though the adapter
+        envelope carries all three capabilities, and a declared trifecta
+        is still refused.
+        """
+        safe_catalog = _catalog_with(tools=["fs.read", "git.commit", "fs.unknown_probe"])
+        safe_spawner = _build_spawner(workdir=workdir, adapter=mock_adapter, catalog=safe_catalog)
+        session = safe_spawner.spawn_for_tasks([make_task(task_id="T-safe")])
+        manifest = json.loads(
+            (workdir / ".sdd" / "runtime" / "spawn_capabilities" / f"{session.id}.json").read_text(encoding="utf-8")
+        )
+        assert manifest["allowed"] is True
+
+        mock_adapter.spawn.reset_mock()
+        trifecta_catalog = _catalog_with(tools=["fs.read", "web.fetch", "github.post_comment"])
+        trifecta_spawner = _build_spawner(workdir=workdir, adapter=mock_adapter, catalog=trifecta_catalog)
+        with pytest.raises(SpawnError, match="lethal trifecta"):
+            trifecta_spawner.spawn_for_tasks([make_task(task_id="T-trifecta")])
+        mock_adapter.spawn.assert_not_called()


### PR DESCRIPTION
## What

The spawn-capability manifest under `.sdd/runtime/spawn_capabilities/<session_id>.json` now records the chain the lethal-trifecta decision actually evaluated, separately from the tokens that were held out of it, with a reason on each held-out token. The enforcement verdict is unchanged.

**In scope**
- `evaluated` in the manifest is byte-equal to the sequence handed to `CapabilityRegistry.evaluate_chain`.
- New `held_out` list: `{"tool": ..., "reason": ...}`, reasons `outer-envelope` (the `adapter.<name>` token) and `undeclared-tool` (a catalog tool with no registry row).
- `docs/security/lethal-trifecta.md` states that the adapter envelope is out of scope for spawn-time enforcement and names the controls that cover it.

**Explicitly not in scope**
- No change to which capabilities any adapter is tagged with.
- No change to the enforcement outcome of any existing configuration.
- No unification of the three copies of this check (`spawner_core.py`, `capability_matrix.record_spawn_capabilities`, `adapters/clm.py`) — separate slice.
- `tools` in the manifest is unchanged, so `bernstein audit capabilities` keeps replaying the full chain, envelope included.

## Why

`_enforce_lethal_trifecta` builds `chain = [adapter_token, *catalog_tools]`, evaluates `declared_only` (catalog tools that have a registry row — so the adapter token and every undeclared tool are dropped), and then writes `chain` as `tools` and `catalog_tools` as `evaluated`.

Both omissions are deliberate. Every row in `templates/capabilities/adapters.yaml` carries all three capabilities because the adapter row describes the envelope a running CLI agent sits in, not a single call; feeding it into `evaluate_chain` under `enforce` would deny every spawn. Undeclared tools default to all three for the same fail-closed reason, so a single missing YAML row would block a spawn.

What was wrong is the record, not the verdict: the manifest is the artefact a reviewer reads, and it listed under `evaluated` tools that the decision never saw. Recorded evidence and enforced decision must not diverge silently.

## How

In `src/bernstein/core/agents/spawner_core.py`, after `evaluate_chain`, the recorded chain is partitioned: tokens in `declared_only` go to `evaluated`, every other token in `chain` goes to `held_out` with `outer-envelope` for the adapter token and `undeclared-tool` otherwise. The two reasons are module constants. The partition walks `chain` and skips tokens already accounted for, so `evaluated` and `held_out` are disjoint and together cover `tools` exactly, even if a catalog entry repeats a token.

**The open decision, and how it went.** The issue left open whether the envelope should be evaluated when the operator has scoped the adapter. This PR documents it as out of scope for spawn-time enforcement instead. Conditioning the gate on "the operator has scoped this adapter" would change the verdict for some existing configurations, which the acceptance criteria rule out, and neither the worker tool allowlist (T578, built at spawn in `spawner_warm_pool.py`) nor per-agent credential scoping is readable at the point the trifecta check runs — there is nothing to condition on today. The docs now name the three controls that do cover the envelope: the worker tool allowlist, per-agent credential scoping, and `bernstein audit capabilities`, which replays `tools` from every manifest with the envelope included and exits non-zero on a violating chain.

## Tests

All in `tests/integration/test_capability_matrix_spawn_refusal.py`, class `TestManifestRecordsWhatWasEvaluated`, driving the real `AgentSpawner.spawn_for_tasks` path.

1. `test_manifest_evaluated_set_contains_only_tokens_passed_to_evaluate_chain` — **load-bearing.** Spies on `CapabilityRegistry.evaluate_chain` and asserts the manifest's `evaluated` set is a subset of the tokens actually passed to it. Failed before the change: `Manifest records tokens as evaluated that were never passed to evaluate_chain: {'fs.unknown_probe'}`.
2. `test_adapter_envelope_is_recorded_as_held_out_with_a_reason` — the `adapter.<name>` token appears in `held_out` with `reason == "outer-envelope"` and never in `evaluated`. Failed before with `KeyError: 'held_out'`.
3. `test_undeclared_catalog_tool_is_recorded_as_held_out_with_a_reason` — a catalog tool with no registry row appears in `held_out` with `reason == "undeclared-tool"`, while a declared sibling is in `evaluated`. Failed before with `KeyError: 'held_out'`.
4. `test_evaluated_and_held_out_partition_the_recorded_chain` — the two sets are disjoint and their union equals `tools`, so no recorded token is unaccounted for. Failed before with `KeyError: 'held_out'`.
5. `test_recorded_chain_split_does_not_change_the_enforcement_outcome` — a chain that spawns today still spawns despite the all-three envelope, and a declared trifecta is still refused before `adapter.spawn()`. This is the no-regression guard for the "no change to the default enforcement outcome" criterion; it passes both before and after, which is the property it is there to protect.

Verification run: `run_tests.py --parallel 2 -x` green on `tests/integration/test_capability_matrix_spawn_refusal.py` (24 passed), plus `tests/unit/test_capability_matrix.py`, `tests/unit/test_capability_matrix_adversarial.py`, `tests/property/test_capability_matrix_bughunt.py`, `tests/unit/test_policy_engine_trifecta.py`, `tests/unit/test_spawner_capability_routing.py`, `tests/unit/test_docs_capability_reachability.py`, `tests/unit/test_adapter_clm.py`, `tests/integration/test_soc2_real_evidence.py`, and the docs-drift trio (`test_docs_url_hygiene.py`, `test_docs_prose_cli_drift.py`, `test_docs_drift_deleted_sources.py`) — all green. `--affected origin/main` selects 343 files because `spawner_core.py` is imported broadly, so the run above targets the touched module's own tests and the tests of its capability-matrix importers instead; CI runs the full suite. `uv run pyright src/bernstein/core/agents/spawner_core.py` reports the same 1170 pre-existing errors as `origin/main` and none in the changed range.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes (no new errors on the changed file; count identical to `origin/main`)
- [x] `uv run python scripts/run_tests.py -x` passes (targeted selection, see Tests)
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [ ] User-visible README section updated — N/A, no user-visible surface changed
- [x] `docs/operations/<area>.md` updated — `docs/security/lethal-trifecta.md` and `docs/security/capability-matrix.md`
- [ ] `docs/api/` schema regenerated if a public surface changed — N/A, no public API changed
- [ ] `uv run bernstein agents-md sync` — N/A, no new module
- [x] Tests cover the documented behaviour

Closes #5052
