### PR TITLE
test(trackers): drive a synthetic transaction through a real adapter (#5124)

### DIFF
--- a/docs/trackers/contract.md
+++ b/docs/trackers/contract.md
@@ -154,6 +154,47 @@ present in `bernstein.yaml`, the command reports `status: skipped` with
 the missing-argument error rather than failing. This makes the same
 invocation safe to run in ephemeral CI environments.
 
+## Synthetic transaction
+
+`bernstein trackers test` proves an adapter is *reachable*. It does not
+prove it is right: a status id can map to the wrong workflow state and a
+comment can land on the wrong field while the smoke test stays green.
+
+`bernstein.core.trackers.synthetic` drives the stronger check. It creates
+one throwaway entity through the adapter, runs an ordered list of
+validator callables against it, and lets the last validator delete it and
+assert absence:
+
+```python
+from bernstein.core.trackers.synthetic import run_synthetic_transaction
+
+report = run_synthetic_transaction(adapter)
+raise SystemExit(report.exit_code)
+```
+
+Each validator prints one verdict line (`PASS` / `FAIL` / `SKIP`) and
+`report.exit_code` is non-zero if any validator failed. A validator that
+does not apply to an adapter raises `ValidatorSkipped`; a skip is not a
+failure. Adding a check is appending one callable to
+`DEFAULT_VALIDATORS`, with the deleting validator staying last.
+
+Every entity is titled with a deterministic, date-derived marker
+(`bernstein-synthetic-<tracker>-<YYYYMMDD>`). Trackers assign their own
+ids, so the marker -- not the id -- is what a re-run can predict: two runs
+on the same UTC day compute the same marker, so a run that aborts halfway
+leaves a leftover the next run recognises and sweeps.
+
+Hosting a throwaway entity is optional, and deliberately not part of
+`AbstractTrackerAdapter`: the hot path never creates or deletes tickets,
+and a general-purpose delete on the shared contract would be reachable by
+accident. An adapter opts in by implementing three methods --
+`create_probe_ticket`, `find_probe_tickets`, `delete_probe_ticket` --
+where the delete reads the entity back and refuses any whose title does
+not carry the marker. Adapters that do not implement them are refused
+with `SyntheticProbeUnsupported`; the runner has no per-adapter branch.
+
+`GitLabAdapter` is the reference implementation.
+
 ## Reference fake
 
 `tests/fixtures/trackers/in_memory_tracker.py` ships a deterministic

--- a/src/bernstein/core/trackers/builtin/gitlab_adapter.py
+++ b/src/bernstein/core/trackers/builtin/gitlab_adapter.py
@@ -33,7 +33,7 @@ import os
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import quote
 
 if TYPE_CHECKING:
@@ -50,9 +50,11 @@ from bernstein.core.trackers.contract import (
     RateLimited,
     RoutingHint,
     Ticket,
+    TrackerError,
     TrackerUnavailable,
     TransitionResult,
 )
+from bernstein.core.trackers.synthetic import probe_body, probe_title
 
 logger = logging.getLogger(__name__)
 
@@ -351,6 +353,54 @@ class GitLabAdapter(AbstractTrackerAdapter):
             etag=None,
         )
 
+    # -- synthetic-transaction probe ----------------------------------------
+    #
+    # GitLab is the reference probe implementation: a free-tier or
+    # self-hosted project is the lowest-friction throwaway target of the
+    # built-in adapters, and issue create/delete are plain REST calls on
+    # the same ``_request`` path the hot-path methods already use, so the
+    # probe exercises the adapter's real transport, auth and error
+    # mapping rather than a side channel.
+
+    def create_probe_ticket(self, marker: str) -> str:
+        """Create a throwaway issue titled with ``marker``; return its iid."""
+        payload = {"title": probe_title(marker), "description": probe_body(marker)}
+        data = _as_row(self._request("POST", f"/projects/{self._project_segment}/issues", json=payload))
+        iid = data.get("iid")
+        if iid is None:
+            msg = f"GitLab did not return an iid for the synthetic issue {marker!r}"
+            raise TrackerUnavailable(msg)
+        return str(iid)
+
+    def find_probe_tickets(self, marker: str) -> tuple[str, ...]:
+        """Return the iids of every issue whose title carries ``marker``.
+
+        Searches every state, not just ``opened``: a probe run transitions
+        its entity before deleting it, and a tracker that closes on
+        transition must not hide the leftover from the next run's sweep.
+        """
+        rows = _as_rows(
+            self._request(
+                "GET",
+                f"/projects/{self._project_segment}/issues",
+                params={"search": marker, "in": "title", "state": "all", "per_page": 100},
+            )
+        )
+        # GitLab's ``search`` is fuzzy; re-check the marker client-side so a
+        # near-miss never becomes a delete target.
+        return tuple(
+            str(row["iid"]) for row in rows if row.get("iid") is not None and marker in str(row.get("title") or "")
+        )
+
+    def delete_probe_ticket(self, ticket_id: str, marker: str) -> None:
+        """Delete ``ticket_id``, refusing any issue whose title lacks ``marker``."""
+        data = _as_row(self._request("GET", f"/projects/{self._project_segment}/issues/{ticket_id}"))
+        title = str(data.get("title") or "")
+        if marker not in title:
+            msg = f"GitLab issue {ticket_id} does not carry the synthetic marker {marker!r}; refusing to delete it."
+            raise TrackerError(msg)
+        self._request("DELETE", f"/projects/{self._project_segment}/issues/{ticket_id}")
+
     # -- internals ----------------------------------------------------------
 
     def _idempotency_headers(self, key: str | None) -> dict[str, str]:
@@ -469,6 +519,20 @@ class GitLabAdapter(AbstractTrackerAdapter):
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _as_row(payload: Any) -> dict[str, Any]:
+    """Normalise a decoded JSON payload into an object row (empty when it is not one)."""
+    if isinstance(payload, dict):
+        return cast("dict[str, Any]", payload)
+    return {}
+
+
+def _as_rows(payload: Any) -> list[dict[str, Any]]:
+    """Normalise a decoded JSON payload into a list of object rows."""
+    if not isinstance(payload, list):
+        return []
+    return [cast("dict[str, Any]", item) for item in cast("list[Any]", payload) if isinstance(item, dict)]
 
 
 def _looks_like_rate_limit(response: Any) -> bool:

--- a/src/bernstein/core/trackers/synthetic.py
+++ b/src/bernstein/core/trackers/synthetic.py
@@ -1,0 +1,494 @@
+"""Synthetic transaction: one throwaway entity, one ordered validator list.
+
+``bernstein trackers test`` proves an adapter is *reachable* -- it
+constructs the adapter and lists open tickets. That is the ceiling of
+today's coverage, and it is not enough: an adapter can be up, authorised
+and still wrong (a status id that maps to the wrong workflow state, a
+comment that lands on the wrong field, a ``pull_open_tickets`` that
+returns zero rows because a filter silently excludes everything).
+
+This module drives the cheapest honest proof instead. It creates one
+throwaway entity through the adapter itself, runs an ordered list of
+validator callables against it, and lets the last validator delete it and
+assert absence. Every entity carries a deterministic, date-derived marker
+so a run that aborts halfway leaves a leftover the *next* run on the same
+day recognises and sweeps, rather than a growing pile of orphans.
+
+Shape
+-----
+
+* :func:`synthetic_marker` -- the deterministic id scheme.
+* :class:`SyntheticProbeAdapter` -- the three optional operations an
+  adapter must expose to host a throwaway entity. Adapters that do not
+  expose them are refused with :class:`SyntheticProbeUnsupported`; the
+  runner never grows a per-adapter branch.
+* :data:`DEFAULT_VALIDATORS` -- the shared ordered list. Adding a check
+  is appending one callable.
+* :func:`run_synthetic_transaction` -- the runner. Returns a
+  :class:`SyntheticTransactionReport` whose ``exit_code`` is non-zero if
+  any validator failed, and which prints one verdict line per validator.
+
+A validator is a plain callable taking a :class:`SyntheticContext`. It
+signals failure by raising (any exception; the runner records the
+exception class so a :class:`~bernstein.core.trackers.contract.RateLimited`
+is distinguishable from a
+:class:`~bernstein.core.trackers.contract.TrackerUnavailable` or a plain
+assertion) and signals "not applicable to this adapter" by raising
+:class:`ValidatorSkipped`. A skip is not a failure.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
+
+from bernstein.core.trackers.contract import TrackerError
+
+if TYPE_CHECKING:
+    from typing import TextIO
+
+    from bernstein.core.trackers.contract import AbstractTrackerAdapter
+
+__all__ = [
+    "DEFAULT_VALIDATORS",
+    "PROBE_OPERATIONS",
+    "SYNTHETIC_MARKER_PREFIX",
+    "SyntheticContext",
+    "SyntheticProbeAdapter",
+    "SyntheticProbeUnsupported",
+    "SyntheticTransactionReport",
+    "Validator",
+    "ValidatorSkipped",
+    "ValidatorVerdict",
+    "add_comment_replay_with_the_same_key_is_accepted",
+    "add_comment_returns_a_comment_id",
+    "attach_blob_or_declares_unsupported",
+    "claim_ticket_or_declares_unsupported",
+    "delete_removes_the_synthetic_entity",
+    "probe_body",
+    "probe_title",
+    "pull_open_tickets_finds_the_synthetic_entity",
+    "run_synthetic_transaction",
+    "synthetic_marker",
+    "transition_reports_the_requested_status",
+]
+
+
+#: Prefix every synthetic entity's title carries. Operators grepping their
+#: tracker for orphaned probe entities search for this.
+SYNTHETIC_MARKER_PREFIX = "bernstein-synthetic"
+
+#: The three optional adapter operations a synthetic transaction needs.
+PROBE_OPERATIONS: tuple[str, ...] = (
+    "create_probe_ticket",
+    "find_probe_tickets",
+    "delete_probe_ticket",
+)
+
+_OUTCOME_PREFIX = {"passed": "PASS", "failed": "FAIL", "skipped": "SKIP"}
+
+
+# ---------------------------------------------------------------------------
+# Deterministic identity
+# ---------------------------------------------------------------------------
+
+
+def synthetic_marker(tracker_name: str, *, day: dt.date | None = None) -> str:
+    """Return the deterministic marker for ``tracker_name`` on ``day``.
+
+    The marker is date-derived at day granularity, which is what makes a
+    re-run collide with its own leftovers: two runs on the same UTC day
+    compute the same marker, so the second finds and sweeps whatever the
+    first left behind. Trackers assign their own entity ids, so the
+    marker -- not the id -- is the thing the runner can predict.
+
+    Args:
+        tracker_name: The adapter's ``name`` attribute.
+        day: UTC day to derive from; defaults to today in UTC.
+
+    Returns:
+        ``bernstein-synthetic-<tracker>-<YYYYMMDD>``.
+    """
+    stamp = (day or dt.datetime.now(dt.UTC).date()).strftime("%Y%m%d")
+    return f"{SYNTHETIC_MARKER_PREFIX}-{tracker_name}-{stamp}"
+
+
+def probe_title(marker: str) -> str:
+    """Return the title a synthetic entity is created with."""
+    return f"{marker} (bernstein adapter contract probe)"
+
+
+def probe_body(marker: str) -> str:
+    """Return the description a synthetic entity is created with."""
+    return (
+        "Throwaway entity created by the bernstein adapter contract test.\n\n"
+        f"Marker: {marker}\n\n"
+        "It is deleted by the last validator of the run that created it. "
+        "If you are reading this, a run aborted midway; the next run on "
+        "the same UTC day sweeps it, or you can delete it by hand."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Probe surface
+# ---------------------------------------------------------------------------
+
+
+class SyntheticProbeUnsupported(TrackerError):
+    """Raised when an adapter cannot host a throwaway entity."""
+
+
+class ValidatorSkipped(Exception):
+    """Raised by a validator that does not apply to this adapter."""
+
+
+@runtime_checkable
+class SyntheticProbeAdapter(Protocol):
+    """Optional adapter surface the synthetic transaction drives.
+
+    Deliberately separate from
+    :class:`~bernstein.core.trackers.contract.AbstractTrackerAdapter`:
+    the hot path never creates or deletes tickets, and a general-purpose
+    ``delete_ticket`` on the shared contract would be a destructive
+    operation every caller could reach by accident. These three carry
+    "probe" in their names and every implementation refuses an entity
+    whose title does not carry the marker.
+    """
+
+    def create_probe_ticket(self, marker: str) -> str:
+        """Create a throwaway entity titled with ``marker``; return its id."""
+        ...
+
+    def find_probe_tickets(self, marker: str) -> tuple[str, ...]:
+        """Return the ids of every entity whose title carries ``marker``."""
+        ...
+
+    def delete_probe_ticket(self, ticket_id: str, marker: str) -> None:
+        """Delete ``ticket_id``, refusing it if its title lacks ``marker``."""
+        ...
+
+
+@dataclass(frozen=True)
+class SyntheticContext:
+    """What a validator is handed.
+
+    Attributes:
+        adapter: The adapter under test, on its normal contract surface.
+        probe: The same object, viewed through the probe surface.
+        ticket_id: Tracker-assigned id of the entity created for this run.
+        marker: The deterministic marker this run's entity carries.
+    """
+
+    adapter: AbstractTrackerAdapter
+    probe: SyntheticProbeAdapter
+    ticket_id: str
+    marker: str
+
+
+#: A validator is a plain callable. It raises to fail and raises
+#: :class:`ValidatorSkipped` to opt out on adapters it does not apply to.
+type Validator = Callable[[SyntheticContext], None]
+
+
+# ---------------------------------------------------------------------------
+# Verdicts and report
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ValidatorVerdict:
+    """The outcome of one validator.
+
+    Attributes:
+        name: The validator callable's ``__name__``.
+        outcome: ``"passed"``, ``"failed"`` or ``"skipped"``.
+        detail: Human-readable reason; empty for a plain pass.
+        error_kind: Exception class name for a failure -- ``RateLimited``,
+            ``TrackerUnavailable``, ``OptimisticConcurrencyError`` and
+            ``IdempotencyConflict`` are distinguishable here rather than
+            flattened into one "it broke".
+    """
+
+    name: str
+    outcome: str
+    detail: str = ""
+    error_kind: str | None = None
+
+
+@dataclass(frozen=True)
+class SyntheticTransactionReport:
+    """The result of one synthetic transaction.
+
+    Attributes:
+        tracker: Adapter name.
+        marker: Deterministic marker used for this run.
+        ticket_id: Id of the entity created, or ``None`` if creation failed.
+        leftovers_cleaned: Number of same-marker entities swept before the
+            run created its own.
+        verdicts: One verdict per validator, in the order they ran.
+        lines: Exactly the lines the runner printed.
+    """
+
+    tracker: str
+    marker: str
+    ticket_id: str | None
+    leftovers_cleaned: int
+    verdicts: tuple[ValidatorVerdict, ...]
+    lines: tuple[str, ...]
+
+    @property
+    def failures(self) -> tuple[ValidatorVerdict, ...]:
+        """Verdicts that failed. A skip is not a failure."""
+        return tuple(v for v in self.verdicts if v.outcome == "failed")
+
+    @property
+    def ok(self) -> bool:
+        """True when no validator failed."""
+        return not self.failures
+
+    @property
+    def exit_code(self) -> int:
+        """``0`` when every validator passed or skipped, ``1`` otherwise."""
+        return 0 if self.ok else 1
+
+    def render_lines(self) -> list[str]:
+        """Return the printed lines, for callers that captured no stream."""
+        return list(self.lines)
+
+
+# ---------------------------------------------------------------------------
+# The shared validator list
+# ---------------------------------------------------------------------------
+
+
+def pull_open_tickets_finds_the_synthetic_entity(ctx: SyntheticContext) -> None:
+    """The hot path returns the entity that was just created."""
+    for ticket in ctx.adapter.pull_open_tickets({}):
+        if ticket.id == ctx.ticket_id:
+            return
+    msg = f"pull_open_tickets did not return the entity {ctx.ticket_id} it should see as open"
+    raise AssertionError(msg)
+
+
+def add_comment_returns_a_comment_id(ctx: SyntheticContext) -> None:
+    """A comment lands and the tracker hands back an id for it."""
+    result = ctx.adapter.add_comment(
+        ctx.ticket_id,
+        f"{ctx.marker}: adapter contract probe comment.",
+        idempotency_key=f"{ctx.marker}-comment",
+    )
+    if result.ticket_id != ctx.ticket_id:
+        msg = f"add_comment reported ticket {result.ticket_id!r}, expected {ctx.ticket_id!r}"
+        raise AssertionError(msg)
+    if not result.comment_id:
+        msg = "add_comment returned an empty comment_id"
+        raise AssertionError(msg)
+
+
+def add_comment_replay_with_the_same_key_is_accepted(ctx: SyntheticContext) -> None:
+    """Replaying an identical comment does not blow up on the idempotency key.
+
+    Trackers differ on whether they honour the key; what must never
+    happen is the replay erroring out, because the orchestrator retries
+    comments after a transport failure it cannot distinguish from a
+    write that already landed.
+    """
+    result = ctx.adapter.add_comment(
+        ctx.ticket_id,
+        f"{ctx.marker}: adapter contract probe comment.",
+        idempotency_key=f"{ctx.marker}-comment",
+    )
+    if not result.comment_id:
+        msg = "replayed add_comment returned an empty comment_id"
+        raise AssertionError(msg)
+
+
+def transition_reports_the_requested_status(ctx: SyntheticContext) -> None:
+    """A transition reports back the status it was asked for."""
+    status_id = f"{ctx.marker}-done"
+    result = ctx.adapter.transition(
+        ctx.ticket_id,
+        status_id,
+        idempotency_key=f"{ctx.marker}-transition",
+    )
+    if result.ticket_id != ctx.ticket_id:
+        msg = f"transition reported ticket {result.ticket_id!r}, expected {ctx.ticket_id!r}"
+        raise AssertionError(msg)
+    if result.new_status != status_id:
+        msg = f"transition reported status {result.new_status!r}, expected {status_id!r}"
+        raise AssertionError(msg)
+
+
+def claim_ticket_or_declares_unsupported(ctx: SyntheticContext) -> None:
+    """Claiming succeeds, or the adapter says it does not support claiming."""
+    try:
+        result = ctx.adapter.claim_ticket(ctx.ticket_id, f"{ctx.marker}-agent")
+    except NotImplementedError as exc:
+        raise ValidatorSkipped(str(exc) or "claim_ticket not supported") from exc
+    if not result.claimed:
+        msg = f"claim_ticket refused the freshly created entity {ctx.ticket_id}"
+        raise AssertionError(msg)
+
+
+def attach_blob_or_declares_unsupported(ctx: SyntheticContext) -> None:
+    """Attaching succeeds, or the adapter says it does not support attaching."""
+    try:
+        result = ctx.adapter.attach_blob(
+            ctx.ticket_id,
+            ctx.marker.encode("utf-8"),
+            "text/plain",
+            idempotency_key=f"{ctx.marker}-attach",
+        )
+    except NotImplementedError as exc:
+        raise ValidatorSkipped(str(exc) or "attach_blob not supported") from exc
+    if not result.attachment_id:
+        msg = "attach_blob returned an empty attachment_id"
+        raise AssertionError(msg)
+
+
+def delete_removes_the_synthetic_entity(ctx: SyntheticContext) -> None:
+    """The entity is deleted and no longer findable. Always runs last."""
+    ctx.probe.delete_probe_ticket(ctx.ticket_id, ctx.marker)
+    remaining = ctx.probe.find_probe_tickets(ctx.marker)
+    if remaining:
+        msg = f"entities still carry marker {ctx.marker!r} after delete: {remaining}"
+        raise AssertionError(msg)
+
+
+#: The shared ordered list. Adding a check is appending one callable; the
+#: deleting validator stays last.
+DEFAULT_VALIDATORS: tuple[Validator, ...] = (
+    pull_open_tickets_finds_the_synthetic_entity,
+    add_comment_returns_a_comment_id,
+    add_comment_replay_with_the_same_key_is_accepted,
+    transition_reports_the_requested_status,
+    claim_ticket_or_declares_unsupported,
+    attach_blob_or_declares_unsupported,
+    delete_removes_the_synthetic_entity,
+)
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+def _resolve_probe(adapter: AbstractTrackerAdapter) -> SyntheticProbeAdapter:
+    """Return ``adapter`` viewed as a probe host, or refuse it by name."""
+    missing = [op for op in PROBE_OPERATIONS if not callable(getattr(adapter, op, None))]
+    if missing:
+        name = getattr(adapter, "name", type(adapter).__name__)
+        msg = (
+            f"Tracker {name!r} cannot host a synthetic transaction: "
+            f"missing {', '.join(missing)}. Implement the probe surface on "
+            "the adapter to bring it under the contract test."
+        )
+        raise SyntheticProbeUnsupported(msg)
+    return cast("SyntheticProbeAdapter", adapter)
+
+
+def _entities(count: int) -> str:
+    """Pluralise an entity count for the printed sweep lines."""
+    return f"{count} entity" if count == 1 else f"{count} entities"
+
+
+def _verdict_line(verdict: ValidatorVerdict) -> str:
+    prefix = _OUTCOME_PREFIX.get(verdict.outcome, "????")
+    suffix = f"  {verdict.detail}" if verdict.detail else ""
+    return f"{prefix} {verdict.name}{suffix}"
+
+
+def run_synthetic_transaction(
+    adapter: AbstractTrackerAdapter,
+    *,
+    validators: Sequence[Validator] = DEFAULT_VALIDATORS,
+    day: dt.date | None = None,
+    stream: TextIO | None = None,
+) -> SyntheticTransactionReport:
+    """Drive one throwaway entity through ``adapter`` and report per validator.
+
+    Sweeps same-day leftovers, creates the entity, runs every validator in
+    order (a failure does not abort the run, so the deleting validator
+    still gets to clean up), then sweeps anything that still carries the
+    marker so nothing leaks either way.
+
+    Args:
+        adapter: The adapter under test. Must expose
+            :data:`PROBE_OPERATIONS`.
+        validators: Ordered validator callables; defaults to
+            :data:`DEFAULT_VALIDATORS`.
+        day: UTC day the marker derives from; defaults to today.
+        stream: Where verdict lines are written; defaults to stdout.
+
+    Returns:
+        A :class:`SyntheticTransactionReport`. Callers that need a process
+        exit status use ``report.exit_code``.
+
+    Raises:
+        SyntheticProbeUnsupported: When ``adapter`` cannot host a
+            throwaway entity.
+    """
+    probe = _resolve_probe(adapter)
+    out = sys.stdout if stream is None else stream
+    tracker = getattr(adapter, "name", type(adapter).__name__)
+    marker = synthetic_marker(tracker, day=day)
+
+    lines: list[str] = []
+
+    def emit(line: str) -> None:
+        lines.append(line)
+        print(line, file=out)
+
+    emit(f"probe {tracker} marker={marker}")
+
+    leftovers = probe.find_probe_tickets(marker)
+    for stale in leftovers:
+        probe.delete_probe_ticket(stale, marker)
+    if leftovers:
+        emit(f"swept {_entities(len(leftovers))} left by an earlier run")
+
+    ticket_id = probe.create_probe_ticket(marker)
+    ctx = SyntheticContext(adapter=adapter, probe=probe, ticket_id=ticket_id, marker=marker)
+
+    verdicts: list[ValidatorVerdict] = []
+    for validator in validators:
+        name = getattr(validator, "__name__", repr(validator))
+        try:
+            validator(ctx)
+        except ValidatorSkipped as exc:
+            verdict = ValidatorVerdict(name=name, outcome="skipped", detail=str(exc))
+        except Exception as exc:  # the runner reports failures, it does not classify them
+            verdict = ValidatorVerdict(
+                name=name,
+                outcome="failed",
+                detail=str(exc),
+                error_kind=type(exc).__name__,
+            )
+        else:
+            verdict = ValidatorVerdict(name=name, outcome="passed")
+        verdicts.append(verdict)
+        emit(_verdict_line(verdict))
+
+    stragglers = probe.find_probe_tickets(marker)
+    for stale in stragglers:
+        probe.delete_probe_ticket(stale, marker)
+    if stragglers:
+        emit(f"warn: swept {_entities(len(stragglers))} no validator deleted")
+
+    failed = sum(1 for v in verdicts if v.outcome == "failed")
+    skipped = sum(1 for v in verdicts if v.outcome == "skipped")
+    passed = len(verdicts) - failed - skipped
+    outcome = "ok" if failed == 0 else "failed"
+    emit(f"result {outcome}: {passed} passed, {skipped} skipped, {failed} failed")
+
+    return SyntheticTransactionReport(
+        tracker=tracker,
+        marker=marker,
+        ticket_id=ticket_id,
+        leftovers_cleaned=len(leftovers),
+        verdicts=tuple(verdicts),
+        lines=tuple(lines),
+    )

--- a/tests/fixtures/trackers/in_memory_tracker.py
+++ b/tests/fixtures/trackers/in_memory_tracker.py
@@ -39,9 +39,11 @@ from bernstein.core.trackers.contract import (
     OptimisticConcurrencyError,
     RateLimited,
     Ticket,
+    TrackerError,
     TrackerUnavailable,
     TransitionResult,
 )
+from bernstein.core.trackers.synthetic import probe_body, probe_title
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -237,6 +239,28 @@ class InMemoryTracker(AbstractTrackerAdapter):
                 "sha": _digest(blob),
             }
         return AttachResult(attachment_id=attachment_id, ticket_id=ticket_id)
+
+    # ---- Synthetic-transaction probe -------------------------------------
+
+    def create_probe_ticket(self, marker: str) -> str:
+        """Create a throwaway ticket titled with ``marker``; return its id."""
+        return self.seed(probe_title(marker), probe_body(marker)).id
+
+    def find_probe_tickets(self, marker: str) -> tuple[str, ...]:
+        """Return the ids of every ticket whose title carries ``marker``.
+
+        Scans every status, not just ``open``: the probe transitions its
+        entity before deleting it.
+        """
+        return tuple(t.id for t in self._tickets.values() if marker in t.title)
+
+    def delete_probe_ticket(self, ticket_id: str, marker: str) -> None:
+        """Delete ``ticket_id``, refusing any ticket whose title lacks ``marker``."""
+        ticket = self._require_ticket(ticket_id)
+        if marker not in ticket.title:
+            msg = f"Ticket {ticket_id} does not carry the synthetic marker {marker!r}; refusing to delete it."
+            raise TrackerError(msg)
+        del self._tickets[ticket_id]
 
     # ---- Internals -------------------------------------------------------
 

--- a/tests/integration/trackers/test_adapter_contract.py
+++ b/tests/integration/trackers/test_adapter_contract.py
@@ -1,0 +1,490 @@
+"""Adapter contract test: one synthetic transaction, many adapters.
+
+Drives a throwaway entity with a deterministic, date-derived id through a
+real :class:`~bernstein.core.trackers.contract.AbstractTrackerAdapter`
+implementation, runs the shared ordered validator list against it, and
+lets the last validator delete it and assert absence.
+
+Two adapters are exercised here:
+
+* :class:`~tests.fixtures.trackers.in_memory_tracker.InMemoryTracker` --
+  the canonical reference implementation of the contract.
+* :class:`~bernstein.core.trackers.builtin.gitlab_adapter.GitLabAdapter`
+  -- a real HTTP adapter, driven against a stateful GitLab API double so
+  the transport, auth headers, pagination and error mapping in the
+  adapter all run for real without needing sandbox credentials.
+
+The same ``DEFAULT_VALIDATORS`` list runs against both, and the
+registry-driven test at the bottom asserts every registered adapter is
+reachable by the same runner.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import io
+import json
+import re
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import pytest
+import respx
+
+from bernstein.core.trackers.builtin.gitlab_adapter import (
+    DEFAULT_GITLAB_URL,
+    GITLAB_API_PATH,
+    GitLabAdapter,
+    GitLabConfig,
+)
+from bernstein.core.trackers.contract import (
+    AbstractTrackerAdapter,
+    CommentResult,
+    Ticket,
+    TrackerError,
+    TransitionResult,
+)
+from bernstein.core.trackers.registry import get_registry
+from bernstein.core.trackers.synthetic import (
+    DEFAULT_VALIDATORS,
+    PROBE_OPERATIONS,
+    SyntheticProbeUnsupported,
+    ValidatorSkipped,
+    run_synthetic_transaction,
+    synthetic_marker,
+)
+from tests.fixtures.trackers.in_memory_tracker import InMemoryTracker
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from bernstein.core.trackers.synthetic import SyntheticContext
+
+PROBE_DAY = dt.date(2026, 3, 4)
+PROJECT = "my-group/my-project"
+
+
+# ---------------------------------------------------------------------------
+# GitLab API double
+# ---------------------------------------------------------------------------
+
+
+class _FakeGitLab:
+    """Minimal stateful GitLab Issues API used by the respx transport.
+
+    Implements only the six endpoints the synthetic transaction touches:
+    create, list-open, search-by-title, note, label update, delete.
+    """
+
+    def __init__(self) -> None:
+        self.issues: dict[int, dict[str, Any]] = {}
+        self.notes: list[dict[str, Any]] = []
+        self._next_iid = 1
+        self.deleted: list[int] = []
+
+    # -- routing ----------------------------------------------------------
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        method = request.method
+        prefix = f"{GITLAB_API_PATH}/projects/"
+        if not path.startswith(prefix):  # pragma: no cover - defensive
+            return httpx.Response(404, json={"message": "404 Not Found"})
+        rest = path[len(prefix) :]
+        # rest looks like "<project>/issues[/<iid>[/notes]]"; the project
+        # segment may itself contain a slash once httpx decodes ``%2F``, so
+        # split on the first "/issues" rather than the first "/".
+        cut = rest.find("/issues")
+        if cut == -1:  # pragma: no cover - defensive
+            return httpx.Response(404, json={"message": "404 Not Found"})
+        tail = rest[cut + 1 :]
+        if method == "POST" and tail == "issues":
+            return self._create(request)
+        if method == "GET" and tail == "issues":
+            return self._list(request)
+        match = re.fullmatch(r"issues/(\d+)", tail)
+        if match is not None:
+            iid = int(match.group(1))
+            if method == "PUT":
+                return self._update(iid, request)
+            if method == "DELETE":
+                return self._delete(iid)
+            if method == "GET":
+                return self._get(iid)
+        match = re.fullmatch(r"issues/(\d+)/notes", tail)
+        if match is not None and method == "POST":
+            return self._note(int(match.group(1)), request)
+        return httpx.Response(404, json={"message": "404 Not Found"})  # pragma: no cover
+
+    def seed_issue(self, title: str) -> int:
+        """Insert an unrelated, operator-owned issue and return its iid."""
+        iid = self._next_iid
+        self._next_iid += 1
+        self.issues[iid] = {
+            "id": 1000 + iid,
+            "iid": iid,
+            "project_id": 7,
+            "title": title,
+            "description": "",
+            "labels": [],
+            "state": "opened",
+            "web_url": f"https://gitlab.com/{PROJECT}/-/issues/{iid}",
+            "assignee": None,
+        }
+        return iid
+
+    # -- endpoints --------------------------------------------------------
+
+    def _create(self, request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content or b"{}")
+        iid = self._next_iid
+        self._next_iid += 1
+        issue = {
+            "id": 1000 + iid,
+            "iid": iid,
+            "project_id": 7,
+            "title": str(payload.get("title") or ""),
+            "description": str(payload.get("description") or ""),
+            "labels": [lab for lab in str(payload.get("labels") or "").split(",") if lab],
+            "state": "opened",
+            "web_url": f"https://gitlab.com/{PROJECT}/-/issues/{iid}",
+            "assignee": None,
+        }
+        self.issues[iid] = issue
+        return httpx.Response(201, json=issue)
+
+    def _list(self, request: httpx.Request) -> httpx.Response:
+        params = request.url.params
+        state = params.get("state")
+        search = params.get("search")
+        page = int(params.get("page") or 1)
+        rows = list(self.issues.values())
+        if state and state != "all":
+            rows = [r for r in rows if r["state"] == state]
+        if search:
+            field = "title" if params.get("in") == "title" else "description"
+            rows = [r for r in rows if search in r[field]]
+        # Single-page responses are enough for the probe; page 2+ is empty
+        # so the adapter's pagination loop terminates.
+        if page > 1:
+            rows = []
+        return httpx.Response(200, json=rows)
+
+    def _get(self, iid: int) -> httpx.Response:
+        issue = self.issues.get(iid)
+        if issue is None:
+            return httpx.Response(404, json={"message": "404 Issue Not Found"})
+        return httpx.Response(200, json=issue)
+
+    def _update(self, iid: int, request: httpx.Request) -> httpx.Response:
+        issue = self.issues.get(iid)
+        if issue is None:  # pragma: no cover - defensive
+            return httpx.Response(404, json={"message": "404 Issue Not Found"})
+        payload = json.loads(request.content or b"{}")
+        labels = set(issue["labels"])
+        for lab in str(payload.get("remove_labels") or "").split(","):
+            labels.discard(lab)
+        for lab in str(payload.get("add_labels") or "").split(","):
+            if lab:
+                labels.add(lab)
+        issue["labels"] = sorted(labels)
+        return httpx.Response(200, json=issue)
+
+    def _delete(self, iid: int) -> httpx.Response:
+        if iid not in self.issues:
+            return httpx.Response(404, json={"message": "404 Issue Not Found"})
+        del self.issues[iid]
+        self.deleted.append(iid)
+        return httpx.Response(204)
+
+    def _note(self, iid: int, request: httpx.Request) -> httpx.Response:
+        if iid not in self.issues:  # pragma: no cover - defensive
+            return httpx.Response(404, json={"message": "404 Issue Not Found"})
+        payload = json.loads(request.content or b"{}")
+        note = {
+            "id": 500 + len(self.notes),
+            "body": str(payload.get("body") or ""),
+            "issue_iid": iid,
+            "idempotency_key": request.headers.get("Idempotency-Key"),
+        }
+        self.notes.append(note)
+        return httpx.Response(201, json=note)
+
+
+@pytest.fixture
+def gitlab_probe(monkeypatch: pytest.MonkeyPatch) -> Iterator[tuple[GitLabAdapter, _FakeGitLab]]:
+    """Yield a real ``GitLabAdapter`` wired to a stateful API double."""
+    monkeypatch.setenv("GITLAB_PROBE_TOKEN", "glpat-test")
+    fake = _FakeGitLab()
+    with respx.mock(base_url=DEFAULT_GITLAB_URL, assert_all_called=False) as mock:
+        mock.route().mock(side_effect=fake.handler)
+        adapter = GitLabAdapter(
+            config=GitLabConfig(
+                project_id_or_path=PROJECT,
+                token_env="GITLAB_PROBE_TOKEN",
+            ),
+        )
+        try:
+            yield adapter, fake
+        finally:
+            adapter.close()
+
+
+# ---------------------------------------------------------------------------
+# 1. Deterministic id + create/delete round trip (load-bearing)
+# ---------------------------------------------------------------------------
+
+
+def test_synthetic_transaction_creates_and_deletes_with_deterministic_id(
+    gitlab_probe: tuple[GitLabAdapter, _FakeGitLab],
+) -> None:
+    """A real adapter creates, drives, and deletes a dated throwaway entity."""
+    adapter, fake = gitlab_probe
+    marker = synthetic_marker("gitlab", day=PROBE_DAY)
+
+    assert marker == "bernstein-synthetic-gitlab-20260304"
+    assert synthetic_marker("gitlab", day=PROBE_DAY) == marker
+
+    report = run_synthetic_transaction(adapter, day=PROBE_DAY, stream=io.StringIO())
+
+    assert report.marker == marker
+    assert report.ticket_id is not None
+    assert report.exit_code == 0, report.render_lines()
+    # The entity really existed on the tracker side and is gone afterwards.
+    assert fake.deleted == [int(report.ticket_id)]
+    assert fake.issues == {}
+    assert adapter.find_probe_tickets(marker) == ()
+    # The last validator is the one that deleted it.
+    assert report.verdicts[-1].name == "delete_removes_the_synthetic_entity"
+    assert report.verdicts[-1].outcome == "passed"
+
+
+def test_synthetic_transaction_round_trips_the_in_memory_reference() -> None:
+    """The same runner drives the canonical reference implementation."""
+    adapter = InMemoryTracker()
+    report = run_synthetic_transaction(adapter, day=PROBE_DAY, stream=io.StringIO())
+
+    assert report.marker == "bernstein-synthetic-in_memory-20260304"
+    assert report.exit_code == 0, report.render_lines()
+    assert adapter.find_probe_tickets(report.marker) == ()
+
+
+# ---------------------------------------------------------------------------
+# 2. Re-runs collide with their own leftovers
+# ---------------------------------------------------------------------------
+
+
+def test_rerun_collides_with_own_leftover_and_cleans_it() -> None:
+    """A leftover from an aborted run on the same day is swept, not duplicated."""
+    adapter = InMemoryTracker()
+    marker = synthetic_marker(adapter.name, day=PROBE_DAY)
+    leftover = adapter.create_probe_ticket(marker)
+    assert adapter.find_probe_tickets(marker) == (leftover,)
+
+    report = run_synthetic_transaction(adapter, day=PROBE_DAY, stream=io.StringIO())
+
+    assert report.leftovers_cleaned == 1
+    assert report.ticket_id != leftover
+    assert report.exit_code == 0, report.render_lines()
+    # Nothing leaks: neither the leftover nor this run's entity survives.
+    assert adapter.find_probe_tickets(marker) == ()
+
+
+def test_rerun_on_the_same_day_leaves_nothing_behind() -> None:
+    """Two consecutive runs on the same day end with an empty tracker."""
+    adapter = InMemoryTracker()
+    marker = synthetic_marker(adapter.name, day=PROBE_DAY)
+
+    first = run_synthetic_transaction(adapter, day=PROBE_DAY, stream=io.StringIO())
+    second = run_synthetic_transaction(adapter, day=PROBE_DAY, stream=io.StringIO())
+
+    assert first.exit_code == 0
+    assert second.exit_code == 0
+    assert second.leftovers_cleaned == 0
+    assert adapter.find_probe_tickets(marker) == ()
+
+
+# ---------------------------------------------------------------------------
+# 3./4. Runner contract: exit code and printed verdicts
+# ---------------------------------------------------------------------------
+
+
+def _always_fails(ctx: SyntheticContext) -> None:
+    """Validator that always fails; used to probe the runner's exit code."""
+    msg = f"deliberate failure on {ctx.ticket_id}"
+    raise AssertionError(msg)
+
+
+def _always_skips(ctx: SyntheticContext) -> None:
+    """Validator that always records a skip."""
+    del ctx
+    raise ValidatorSkipped("not applicable here")
+
+
+def test_validator_runner_exits_nonzero_on_any_failure() -> None:
+    """One failing validator makes the whole run non-zero, and cleanup still runs."""
+    adapter = InMemoryTracker()
+    validators = (_always_skips, _always_fails, *DEFAULT_VALIDATORS)
+
+    report = run_synthetic_transaction(
+        adapter,
+        validators=validators,
+        day=PROBE_DAY,
+        stream=io.StringIO(),
+    )
+
+    assert report.exit_code == 1
+    assert not report.ok
+    outcomes = {v.name: v.outcome for v in report.verdicts}
+    assert outcomes["_always_skips"] == "skipped"
+    assert outcomes["_always_fails"] == "failed"
+    # A skip is not a failure.
+    assert [v.name for v in report.failures] == ["_always_fails"]
+    # The failure did not abort the run: the deleting validator still ran.
+    assert outcomes["delete_removes_the_synthetic_entity"] == "passed"
+    assert adapter.find_probe_tickets(report.marker) == ()
+
+
+def test_validator_runner_records_the_error_taxonomy_of_a_failure() -> None:
+    """A failing validator's verdict names the tracker error class, not just 'failed'."""
+    adapter = InMemoryTracker()
+
+    def _raises_tracker_error(ctx: SyntheticContext) -> None:
+        del ctx
+        msg = "upstream said no"
+        raise TrackerError(msg)
+
+    report = run_synthetic_transaction(
+        adapter,
+        validators=(_raises_tracker_error, *DEFAULT_VALIDATORS),
+        day=PROBE_DAY,
+        stream=io.StringIO(),
+    )
+
+    verdict = next(v for v in report.verdicts if v.name == "_raises_tracker_error")
+    assert verdict.error_kind == "TrackerError"
+    assert "upstream said no" in verdict.detail
+
+
+def test_validator_runner_prints_each_validators_verdict() -> None:
+    """Every validator, in order, gets exactly one printed verdict line."""
+    adapter = InMemoryTracker()
+    stream = io.StringIO()
+    validators = (_always_skips, *DEFAULT_VALIDATORS)
+
+    report = run_synthetic_transaction(
+        adapter,
+        validators=validators,
+        day=PROBE_DAY,
+        stream=stream,
+    )
+
+    printed = stream.getvalue().splitlines()
+    verdict_lines = [line for line in printed if line.startswith(("PASS", "FAIL", "SKIP"))]
+    assert len(verdict_lines) == len(validators)
+    assert [line.split()[1] for line in verdict_lines] == [v.__name__ for v in validators]
+    assert verdict_lines[0].startswith("SKIP")
+    assert report.render_lines() == printed
+
+
+# ---------------------------------------------------------------------------
+# 5. The same list runs against every registered adapter
+# ---------------------------------------------------------------------------
+
+
+def _builtin_names() -> list[str]:
+    """Registered built-in adapter names, read from the registry itself."""
+    return [entry.name for entry in get_registry() if entry.source == "builtin"]
+
+
+class _ProbelessAdapter(AbstractTrackerAdapter):
+    """A contract-complete adapter that cannot host a throwaway entity."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def pull_open_tickets(self, filter: dict[str, Any] | None = None) -> Iterator[Ticket]:
+        del filter
+        return iter(())
+
+    def add_comment(self, ticket_id: str, body: str, *, idempotency_key: str | None = None) -> CommentResult:
+        del body, idempotency_key
+        return CommentResult(comment_id="c", ticket_id=ticket_id)
+
+    def transition(
+        self,
+        ticket_id: str,
+        status_id: str,
+        *,
+        idempotency_key: str | None = None,
+        etag: str | None = None,
+    ) -> TransitionResult:
+        del idempotency_key, etag
+        return TransitionResult(ticket_id=ticket_id, new_status=status_id)
+
+
+@pytest.mark.parametrize("tracker_name", _builtin_names())
+def test_same_validator_list_runs_against_every_builtin_adapter(
+    tracker_name: str,
+    gitlab_probe: tuple[GitLabAdapter, _FakeGitLab],
+) -> None:
+    """One validator list covers every registered adapter, with no per-adapter branch.
+
+    An adapter that declares the probe surface is driven through the full
+    ``DEFAULT_VALIDATORS`` list; one that does not is refused by name with
+    :class:`SyntheticProbeUnsupported`. A newly registered adapter joins
+    this parametrization automatically instead of needing its own file.
+    """
+    entry = get_registry().get(tracker_name)
+    supports_probe = all(hasattr(entry.factory, op) for op in PROBE_OPERATIONS)
+
+    if supports_probe:
+        # GitLab is the reference probe implementation for this slice.
+        assert tracker_name == "gitlab"
+        adapter, _fake = gitlab_probe
+        report = run_synthetic_transaction(adapter, day=PROBE_DAY, stream=io.StringIO())
+        assert [v.name for v in report.verdicts] == [v.__name__ for v in DEFAULT_VALIDATORS]
+        assert report.exit_code == 0, report.render_lines()
+        return
+
+    with pytest.raises(SyntheticProbeUnsupported) as excinfo:
+        run_synthetic_transaction(_ProbelessAdapter(tracker_name), day=PROBE_DAY, stream=io.StringIO())
+    assert tracker_name in str(excinfo.value)
+
+
+def test_at_least_one_builtin_adapter_declares_the_probe_surface() -> None:
+    """Guards the parametrized test above against silently covering nothing."""
+    supported = [
+        entry.name
+        for entry in get_registry()
+        if entry.source == "builtin" and all(hasattr(entry.factory, op) for op in PROBE_OPERATIONS)
+    ]
+    assert supported == ["gitlab"]
+
+
+# ---------------------------------------------------------------------------
+# Destructive-operation guard
+# ---------------------------------------------------------------------------
+
+
+def test_delete_probe_ticket_refuses_a_ticket_without_the_synthetic_marker(
+    gitlab_probe: tuple[GitLabAdapter, _FakeGitLab],
+) -> None:
+    """``delete_probe_ticket`` never deletes a ticket it did not create."""
+    adapter, fake = gitlab_probe
+    iid = fake.seed_issue("A real operator ticket")
+
+    with pytest.raises(TrackerError, match="does not carry the synthetic marker"):
+        adapter.delete_probe_ticket(str(iid), synthetic_marker("gitlab", day=PROBE_DAY))
+
+    assert fake.deleted == []
+    assert iid in fake.issues
+
+
+def test_in_memory_delete_probe_ticket_refuses_an_unmarked_ticket() -> None:
+    """The reference implementation carries the same guard."""
+    adapter = InMemoryTracker()
+    ticket = adapter.seed("A real operator ticket")
+
+    with pytest.raises(TrackerError, match="does not carry the synthetic marker"):
+        adapter.delete_probe_ticket(ticket.id, synthetic_marker("in_memory", day=PROBE_DAY))


### PR DESCRIPTION
## What

Adds a synthetic-transaction contract test for tracker adapters: one throwaway entity with a deterministic, date-derived id is created through a real adapter, an ordered list of validator callables runs against it, and the last validator deletes it and asserts absence.

New surface:

| what | where |
|---|---|
| id scheme, verdicts, report, validator list, runner | `src/bernstein/core/trackers/synthetic.py` |
| reference probe implementation | `GitLabAdapter.create_probe_ticket` / `find_probe_tickets` / `delete_probe_ticket` |
| same three methods on the reference fake | `tests/fixtures/trackers/in_memory_tracker.py` |
| the contract test | `tests/integration/trackers/test_adapter_contract.py` |

Explicitly **not** in this PR: live tracker credentials in CI; a `bernstein trackers` subcommand that fronts the runner; probe implementations for the other eight built-in adapters; webhook/polling ingestion.

## Why

`bernstein trackers test <name>` (`src/bernstein/cli/commands/trackers_cmd.py:163`) is the ceiling of today's coverage: it constructs the adapter and calls `pull_open_tickets` once. That proves the process reaches the tracker and auth succeeded. It does not prove the adapter is right — a status id can map to the wrong workflow state, a comment can land on the wrong field, and `pull_open_tickets` returning zero rows because a filter silently excludes everything is indistinguishable from a quiet backlog. Nine adapters implement `AbstractTrackerAdapter` and nothing drives a real entity through the contract surface end to end.

Running one identical validator list against every implementation is what keeps this an adapter *contract* test instead of nine bespoke smoke tests that drift apart.

## How

**Deterministic identity.** Trackers assign their own entity ids, so the runner cannot predict an id — it predicts a *marker*: `bernstein-synthetic-<tracker>-<YYYYMMDD>`, at UTC-day granularity. Two runs on the same day compute the same marker, so a run that aborts halfway leaves a leftover the next run recognises and sweeps. The runner sweeps before creating and again after the validators, so nothing accumulates on either path.

**Validators.** A validator is a plain callable taking a `SyntheticContext`. It fails by raising and opts out by raising `ValidatorSkipped`; a skip is not a failure. Adding a check is appending one callable to `DEFAULT_VALIDATORS`, with the deleting validator last. A failure does not abort the run, precisely so the deleting validator still gets to clean up. Each verdict records the exception class, so `RateLimited`, `TrackerUnavailable`, `OptimisticConcurrencyError` and `IdempotencyConflict` stay distinguishable rather than flattened into one "it broke". `report.exit_code` is non-zero if any validator failed, and one `PASS`/`FAIL`/`SKIP` line is printed per validator.

**Create/delete is deliberately not on `AbstractTrackerAdapter`.** The hot path never creates or deletes tickets, and a general-purpose `delete_ticket` on the shared contract would be a destructive operation every caller could reach by accident. Instead an adapter opts in by implementing three probe-named methods, and each `delete_probe_ticket` reads the entity back and refuses any whose title does not carry the run's marker. Adapters that do not implement them are refused with `SyntheticProbeUnsupported`, so the runner never grows a per-adapter branch.

**Open decision, decided: GitLab is the reference implementation.** The issue left the first adapter open, keyed on lowest-friction sandbox setup. GitLab wins on three counts: the instance is self-hostable *and* has a free tier, so a throwaway project needs no vendor negotiation; issue create and delete are plain REST calls on the same `_request` path the hot-path methods already use, so the probe exercises the adapter's real transport, auth headers and error mapping rather than a side channel; and `GITLAB_URL` already redirects the adapter at a local instance. The in-memory reference fake implements the same three methods so the runner's own semantics are provable without any network.

The GitLab probe searches `state=all`, not `opened`: the run transitions its entity before deleting it, and a tracker that closes on transition must not be able to hide a leftover from the next run's sweep.

## Tests

`tests/integration/trackers/test_adapter_contract.py`. Each failed on the unmodified tree — collection aborted with `ModuleNotFoundError: No module named 'bernstein.core.trackers.synthetic'`, because no runner and no create/delete round-trip exist anywhere on `main`.

1. `test_synthetic_transaction_creates_and_deletes_with_deterministic_id` — **load-bearing.** Drives a real `GitLabAdapter` against a stateful GitLab API double: asserts the marker is date-derived and stable across calls, that the entity really existed on the tracker side, that the tracker recorded exactly one delete, and that the last verdict is the deleting validator's.
2. `test_synthetic_transaction_round_trips_the_in_memory_reference` — the same runner drives the canonical reference implementation.
3. `test_rerun_collides_with_own_leftover_and_cleans_it` — a leftover from an aborted run on the same day is swept, a fresh entity is used, and nothing survives.
4. `test_rerun_on_the_same_day_leaves_nothing_behind` — two consecutive runs end with an empty tracker and no second sweep.
5. `test_validator_runner_exits_nonzero_on_any_failure` — one failing validator makes the run non-zero, a skip does not, and the failure does not stop the deleting validator from running.
6. `test_validator_runner_records_the_error_taxonomy_of_a_failure` — the verdict names the tracker error class, not just "failed".
7. `test_validator_runner_prints_each_validators_verdict` — exactly one verdict line per validator, in order, and `render_lines()` reproduces what was printed.
8. `test_same_validator_list_runs_against_every_builtin_adapter` — parametrized off the registry. The probe-capable adapter is driven through the full `DEFAULT_VALIDATORS` list and its verdict names must match that list exactly; every other adapter is refused by name through the one shared code path. A newly registered adapter joins this parametrization without a new test file.
9. `test_at_least_one_builtin_adapter_declares_the_probe_surface` — guards test 8 against silently covering nothing.
10. `test_delete_probe_ticket_refuses_a_ticket_without_the_synthetic_marker` — the GitLab delete refuses an operator-owned issue and deletes nothing.
11. `test_in_memory_delete_probe_ticket_refuses_an_unmarked_ticket` — the reference implementation carries the same guard.

Locally green: `tests/integration/trackers/test_adapter_contract.py` (19 passed) and all of `tests/unit/trackers/` (13 files), plus every test module that imports the touched modules — `tests/unit/core/trackers/test_linear.py`, `tests/unit/cost/test_ticket_cap.py`, `tests/unit/lineage/test_tracker_audit.py`, `tests/unit/odata/test_odata_writeback.py`, `tests/unit/orchestration/test_tracker_pipeline.py`, `tests/unit/test_pipeline_sweep.py`. `--affected origin/main` did not finish inside the local time budget, so the selection above was derived from the importers of the changed modules; CI runs the full suite.

## Checklist

- [x] `uv run ruff check src/` — clean
- [x] `uv run ruff format --check` on the changed files — clean
- [x] `uv run pyright src/bernstein/core/trackers/synthetic.py` — 0 errors; `gitlab_adapter.py` stays at its pre-existing 11-error baseline (the new code adds none)
- [x] `uv run python scripts/run_tests.py --parallel 2 -x <files>` — green
- [x] Type hints on every new function and dataclass field
- [x] Documentation duty: `docs/trackers/contract.md` gains a "Synthetic transaction" section covering the runner, the id scheme and the optional probe surface
- [x] `uv run bernstein agents-md sync` — no tracked file changed
- [x] `uv run python scripts/check_docs_drift.py` — no drift
- [x] README / translations — N/A (untouched)
- [x] Release notes — N/A (no operator-visible CLI or config change in this slice)

Part of #5124

## Remaining

- Probe implementations for the other eight built-in adapters (`jira_cloud`, `jira_dc`, `github_projects_v2`, `clickup`, `asana`, `plane`, `linear`, `servicenow`). Each is one adapter-local change; the validator list and runner do not move.
- Wiring sandbox credentials so the runner executes against live instances, skipped where credentials are absent — the issue lists this as a per-adapter follow-up.
- An operator entry point (`bernstein trackers probe <name>`) fronting `run_synthetic_transaction` and returning its exit code.
