### PR TITLE
feat: govern inventory selector grammar and typed target-resolution API (#5116)

### DIFF
--- a/src/bernstein/core/govern/selector.py
+++ b/src/bernstein/core/govern/selector.py
@@ -1,0 +1,426 @@
+"""Selector grammar and typed resolution API for the govern inventory.
+
+A selector is a chain of ``key value`` filters over the attributes of the
+governed inventory. Every consumer that needs a target subset -- an audit pass,
+a scheduler, a reconcile lane -- resolves it through :func:`resolve_targets`,
+so "what does this selector actually match" is answered by running it rather
+than by reading one ad hoc filter implementation per consumer.
+
+Grammar (tokens, never a shell string)::
+
+    kind bucket region ~^us- group {prod,staging}
+
+* ``key value``      -- exact match on any value of the attribute
+* ``key ~regex``     -- :mod:`re` search against any value
+* ``key {a,b,c}``    -- membership in a declared set
+* ``key \\literal``   -- exact match, escaping a leading ``~``, ``{`` or ``\\``
+* ``@alias``         -- expands to the filter pairs declared for it as data
+
+Two attribute keys are reserved and always present on a resolved node: ``id``
+(the node identifier) and ``group`` (its group memberships), so a selector can
+name a group without the store needing a matching attribute.
+
+Group membership is an edge. Values attached to a group resolve onto its
+members; a value declared on the node itself overrides the group's. Two groups
+carrying different values for the same key, with no node-level value to settle
+it, are a :class:`GroupConflictError` rather than a silent precedence rule --
+a precedence rule would make the match set readable only from this module's
+source, which is the failure mode this API exists to remove.
+
+Ordering is by node identifier, so two operators running the same selector
+against the same store get the same result to diff or script against.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from enum import StrEnum
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping, Sequence
+    from pathlib import Path
+
+#: Attribute keys the resolver always fills in, shadowing any stored attribute.
+RESERVED_KEYS = ("id", "group")
+
+_FIELD_RE = re.compile(r"%([A-Za-z_][A-Za-z0-9_.\-]*)")
+
+
+class SelectorError(Exception):
+    """Base class for every selector failure."""
+
+
+class SelectorSyntaxError(SelectorError):
+    """A selector, alias table or projection template is malformed."""
+
+
+class GroupConflictError(SelectorError):
+    """Two groups carry different values for one key and no node value settles it."""
+
+
+def _freeze(values: Mapping[str, Sequence[str]]) -> Mapping[str, tuple[str, ...]]:
+    """Return an immutable view of *values* with tuple-valued entries."""
+    return MappingProxyType({str(k): tuple(str(v) for v in vs) for k, vs in values.items()})
+
+
+@dataclass(frozen=True, slots=True)
+class InventoryNode:
+    """One selectable entity in the governed inventory.
+
+    Attributes:
+        node_id: Stable identifier of the node (ARN, repo name, path).
+        attributes: Discovered attributes; every attribute is multi-valued.
+        groups: Group identifiers this node is an edge to.
+    """
+
+    node_id: str
+    attributes: Mapping[str, tuple[str, ...]] = field(default_factory=dict[str, tuple[str, ...]])
+    groups: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "attributes", _freeze(self.attributes))
+        object.__setattr__(self, "groups", tuple(self.groups))
+
+
+@dataclass(frozen=True, slots=True)
+class InventoryGroup:
+    """Values attached to a group, inherited by its members.
+
+    Attributes:
+        group_id: Stable identifier of the group.
+        values: Attribute values every member inherits unless it declares its own.
+    """
+
+    group_id: str
+    values: Mapping[str, tuple[str, ...]] = field(default_factory=dict[str, tuple[str, ...]])
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "values", _freeze(self.values))
+
+
+@dataclass(frozen=True, slots=True)
+class InventoryStore:
+    """The nodes and groups a selector queries.
+
+    Attributes:
+        nodes: Every discovered node. Declaration order does not affect results.
+        groups: Every declared group.
+    """
+
+    nodes: tuple[InventoryNode, ...] = ()
+    groups: tuple[InventoryGroup, ...] = ()
+
+    def group(self, group_id: str) -> InventoryGroup | None:
+        """Look up a group by identifier."""
+        for g in self.groups:
+            if g.group_id == group_id:
+                return g
+        return None
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedNode:
+    """A node with its group inheritance already applied.
+
+    Attributes:
+        node_id: Stable identifier of the node.
+        attributes: Effective attributes, including the reserved keys.
+    """
+
+    node_id: str
+    attributes: Mapping[str, tuple[str, ...]]
+
+    def values(self, key: str) -> tuple[str, ...]:
+        """Return the effective values for *key*, empty when it is not set."""
+        return self.attributes.get(key, ())
+
+
+class FilterKind(StrEnum):
+    """How a filter compares its value against an attribute."""
+
+    EXACT = "exact"
+    REGEX = "regex"
+    SET = "set"
+
+
+@dataclass(frozen=True, slots=True)
+class Filter:
+    """One ``key value`` term of a selector.
+
+    Attributes:
+        key: Attribute key the term applies to.
+        kind: Comparison performed against the attribute's values.
+        literal: The exact value, for :attr:`FilterKind.EXACT`.
+        members: The declared set, for :attr:`FilterKind.SET`.
+        pattern: The compiled expression, for :attr:`FilterKind.REGEX`.
+    """
+
+    key: str
+    kind: FilterKind
+    literal: str = ""
+    members: tuple[str, ...] = ()
+    pattern: re.Pattern[str] | None = None
+
+    @classmethod
+    def parse(cls, key: str, token: str) -> Filter:
+        """Build a filter for *key* from one value *token*.
+
+        Raises:
+            SelectorSyntaxError: If the token is an unusable regex or set.
+        """
+        if not key:
+            raise SelectorSyntaxError("selector filter key must not be empty")
+        if token.startswith("\\"):
+            return cls(key=key, kind=FilterKind.EXACT, literal=token[1:])
+        if token.startswith("~"):
+            try:
+                pattern = re.compile(token[1:])
+            except re.error as exc:
+                raise SelectorSyntaxError(f"invalid regex for key {key!r}: {token[1:]!r} ({exc})") from exc
+            return cls(key=key, kind=FilterKind.REGEX, pattern=pattern)
+        if token.startswith("{") and token.endswith("}"):
+            members = tuple(sorted({p.strip() for p in token[1:-1].split(",") if p.strip()}))
+            if not members:
+                raise SelectorSyntaxError(f"empty set for key {key!r}")
+            return cls(key=key, kind=FilterKind.SET, members=members)
+        return cls(key=key, kind=FilterKind.EXACT, literal=token)
+
+    def matches(self, values: Sequence[str]) -> bool:
+        """True when any of *values* satisfies this term."""
+        if self.kind is FilterKind.EXACT:
+            return self.literal in values
+        if self.kind is FilterKind.SET:
+            return any(v in self.members for v in values)
+        pattern = self.pattern
+        return pattern is not None and any(pattern.search(v) for v in values)
+
+
+@dataclass(frozen=True, slots=True)
+class AliasTable:
+    """Short selector names expanding to filter pairs, declared as data.
+
+    Attributes:
+        aliases: Mapping of alias name to the tokens it expands to.
+    """
+
+    aliases: Mapping[str, tuple[str, ...]]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "aliases", _freeze(self.aliases))
+
+    @classmethod
+    def empty(cls) -> AliasTable:
+        """An alias table declaring nothing."""
+        return cls(aliases={})
+
+    @classmethod
+    def from_directory(cls, directory: Path) -> AliasTable:
+        """Load every ``*.json`` alias file in *directory*, in name order.
+
+        Each file declares ``{"aliases": {"<name>": ["key", "value", ...]}}``.
+        An operator extends the vocabulary by adding a file; no code changes.
+
+        Raises:
+            SelectorError: If *directory* does not exist.
+            SelectorSyntaxError: If a file is malformed or redeclares an alias.
+        """
+        if not directory.is_dir():
+            raise SelectorError(f"alias directory not found: {directory}")
+        collected: dict[str, tuple[str, ...]] = {}
+        declared_in: dict[str, str] = {}
+        for path in sorted(directory.glob("*.json")):
+            try:
+                loaded: object = json.loads(path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError as exc:
+                raise SelectorSyntaxError(f"alias file {path.name} is not valid JSON: {exc}") from exc
+            if not isinstance(loaded, dict):
+                raise SelectorSyntaxError(f"alias file {path.name} must declare an 'aliases' object")
+            declared: object = cast("dict[str, Any]", loaded).get("aliases")
+            if not isinstance(declared, dict):
+                raise SelectorSyntaxError(f"alias file {path.name} must declare an 'aliases' object")
+            for raw_name, raw_tokens in cast("dict[str, Any]", declared).items():
+                name = str(raw_name)
+                if not isinstance(raw_tokens, list) or not all(
+                    isinstance(t, str) for t in cast("list[Any]", raw_tokens)
+                ):
+                    raise SelectorSyntaxError(f"alias {name!r} in {path.name} must expand to a list of tokens")
+                if name in collected:
+                    raise SelectorSyntaxError(f"alias {name!r} declared twice: {declared_in[name]} and {path.name}")
+                collected[name] = tuple(str(t) for t in cast("list[Any]", raw_tokens))
+                declared_in[name] = path.name
+        return cls(aliases=collected)
+
+
+@dataclass(frozen=True, slots=True)
+class Selector:
+    """A chain of filters resolved against an :class:`InventoryStore`.
+
+    Attributes:
+        filters: The terms, in the order they were written.
+    """
+
+    filters: tuple[Filter, ...]
+
+    @classmethod
+    def parse(cls, tokens: Sequence[str], *, aliases: AliasTable | None = None) -> Selector:
+        """Build a selector from *tokens*, expanding any ``@alias`` first.
+
+        Args:
+            tokens: Argv-style tokens. A single string is rejected: it is also a
+                sequence of its characters, and accepting it would reintroduce
+                the shell-string path this API exists to remove.
+            aliases: Alias declarations available to the expansion.
+
+        Raises:
+            TypeError: If *tokens* is a string.
+            SelectorSyntaxError: On an unknown alias, an alias cycle, an odd
+                token count or an unusable filter value.
+        """
+        if isinstance(tokens, str | bytes):
+            raise TypeError("Selector.parse takes a sequence of tokens, not a string; split at the source instead")
+        expanded = _expand_aliases(tokens, aliases, ())
+        if len(expanded) % 2 != 0:
+            raise SelectorSyntaxError(f"selector needs an even number of tokens, got {len(expanded)}: {expanded}")
+        terms = tuple(Filter.parse(expanded[i], expanded[i + 1]) for i in range(0, len(expanded), 2))
+        return cls(filters=terms)
+
+    def matches(self, node: ResolvedNode) -> bool:
+        """True when *node* satisfies every term."""
+        return all(term.matches(node.values(term.key)) for term in self.filters)
+
+
+def _expand_aliases(
+    tokens: Iterable[str],
+    aliases: AliasTable | None,
+    stack: tuple[str, ...],
+) -> list[str]:
+    """Replace every ``@name`` token with the tokens declared for it."""
+    out: list[str] = []
+    for token in tokens:
+        if not token.startswith("@"):
+            out.append(token)
+            continue
+        name = token[1:]
+        if aliases is None or name not in aliases.aliases:
+            raise SelectorSyntaxError(f"unknown alias: {name!r}")
+        if name in stack:
+            raise SelectorSyntaxError(f"alias cycle: {' -> '.join([*stack, name])}")
+        out.extend(_expand_aliases(aliases.aliases[name], aliases, (*stack, name)))
+    return out
+
+
+@dataclass(frozen=True, slots=True)
+class Projection:
+    """A ``%field %field`` template rendered once per matched node.
+
+    Attributes:
+        template: The template as written.
+        fields: The referenced field names, in declaration order.
+    """
+
+    template: str
+    fields: tuple[str, ...]
+
+    @classmethod
+    def parse(cls, template: str) -> Projection:
+        """Build a projection from *template*.
+
+        Raises:
+            SelectorSyntaxError: If the template references no field.
+        """
+        names = _FIELD_RE.findall(template)
+        if not names:
+            raise SelectorSyntaxError(f"projection template references no %field: {template!r}")
+        ordered: list[str] = []
+        for name in names:
+            if name not in ordered:
+                ordered.append(name)
+        return cls(template=template, fields=tuple(ordered))
+
+    def render(self, node: ResolvedNode) -> str:
+        """Render one line for *node*; an unset field renders empty."""
+        return _FIELD_RE.sub(lambda m: _render_value(node, m.group(1)), self.template)
+
+    def project(self, node: ResolvedNode) -> dict[str, str]:
+        """Return only the projected fields of *node*, for JSON output."""
+        return {name: _render_value(node, name) for name in self.fields}
+
+
+def _render_value(node: ResolvedNode, key: str) -> str:
+    """Render the effective values of *key* as one comma-joined string."""
+    return ",".join(node.values(key))
+
+
+def resolve_targets(store: InventoryStore, selector: Selector) -> tuple[ResolvedNode, ...]:
+    """Resolve *selector* against *store*, ordered by node identifier.
+
+    Args:
+        store: The inventory to query.
+        selector: The parsed filter chain.
+
+    Returns:
+        The matching nodes with group inheritance applied, sorted by
+        ``node_id`` so the same selector over the same store is byte-identical
+        across runs and across stores that serialized their rows differently.
+
+    Raises:
+        SelectorError: If a node is an edge to a group the store does not declare.
+        GroupConflictError: If two groups disagree on a key the node does not set.
+    """
+    resolved = [_resolve_node(store, node) for node in store.nodes]
+    matched = [node for node in resolved if selector.matches(node)]
+    return tuple(sorted(matched, key=lambda n: n.node_id))
+
+
+def _resolve_node(store: InventoryStore, node: InventoryNode) -> ResolvedNode:
+    """Apply group inheritance and the reserved keys to one node."""
+    effective: dict[str, tuple[str, ...]] = dict(node.attributes)
+    inherited: dict[str, list[tuple[str, tuple[str, ...]]]] = {}
+
+    for group_id in sorted(set(node.groups)):
+        group = store.group(group_id)
+        if group is None:
+            raise SelectorError(f"node {node.node_id!r} is a member of undeclared group {group_id!r}")
+        for key, values in group.values.items():
+            if key in node.attributes or key in RESERVED_KEYS:
+                # A value declared on the node itself wins outright, so groups
+                # that disagree about it are not a conflict.
+                continue
+            inherited.setdefault(key, []).append((group_id, values))
+
+    for key in sorted(inherited):
+        contributions = inherited[key]
+        distinct = {values for _, values in contributions}
+        if len(distinct) > 1:
+            detail = ", ".join(f"{gid}={'/'.join(values)}" for gid, values in contributions)
+            raise GroupConflictError(
+                f"node {node.node_id!r} inherits conflicting values for {key!r} ({detail}); "
+                f"declare {key!r} on the node to settle it"
+            )
+        effective[key] = contributions[0][1]
+
+    effective["id"] = (node.node_id,)
+    effective["group"] = tuple(sorted(set(node.groups)))
+    return ResolvedNode(node_id=node.node_id, attributes=_freeze(effective))
+
+
+__all__ = [
+    "RESERVED_KEYS",
+    "AliasTable",
+    "Filter",
+    "FilterKind",
+    "GroupConflictError",
+    "InventoryGroup",
+    "InventoryNode",
+    "InventoryStore",
+    "Projection",
+    "ResolvedNode",
+    "Selector",
+    "SelectorError",
+    "SelectorSyntaxError",
+    "resolve_targets",
+]

--- a/tests/unit/core/govern/test_selector.py
+++ b/tests/unit/core/govern/test_selector.py
@@ -1,0 +1,309 @@
+"""Tests for the govern inventory selector grammar and typed resolution API."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.govern.selector import (
+    AliasTable,
+    GroupConflictError,
+    InventoryGroup,
+    InventoryNode,
+    InventoryStore,
+    Projection,
+    Selector,
+    SelectorError,
+    SelectorSyntaxError,
+    resolve_targets,
+)
+
+_SELECTOR_MODULE = "bernstein.core.govern.selector"
+
+
+def _store() -> InventoryStore:
+    """A small fixture store: five nodes, three groups, one per-node override."""
+    return InventoryStore(
+        nodes=(
+            InventoryNode(
+                node_id="arn:aws:s3:::logs",
+                attributes={
+                    "kind": ("bucket",),
+                    "region": ("us-east-1",),
+                    "tier": ("cold", "archive"),
+                    "retention": ("365d",),
+                },
+                groups=("prod",),
+            ),
+            InventoryNode(
+                node_id="arn:aws:s3:::assets",
+                attributes={"kind": ("bucket",), "region": ("us-west-2",)},
+                groups=("prod",),
+            ),
+            InventoryNode(
+                node_id="arn:aws:iam::role/deploy",
+                attributes={"kind": ("role",), "region": ("global",)},
+                groups=("prod", "privileged"),
+            ),
+            InventoryNode(
+                node_id="arn:aws:s3:::scratch",
+                attributes={"kind": ("bucket",), "region": ("eu-central-1",), "retention": ("7d",)},
+                groups=("dev",),
+            ),
+            InventoryNode(
+                node_id="arn:aws:s3:::backup",
+                attributes={"kind": ("bucket",), "region": ("us-east-1",)},
+                groups=(),
+            ),
+        ),
+        groups=(
+            InventoryGroup(group_id="prod", values={"retention": ("90d",), "env": ("production",)}),
+            InventoryGroup(group_id="dev", values={"env": ("development",)}),
+            InventoryGroup(group_id="privileged", values={"review": ("two-person",)}),
+        ),
+    )
+
+
+class TestDeterminism:
+    """The same selector over the same store returns the same ordered result."""
+
+    def test_same_selector_same_store_same_order(self) -> None:
+        store = _store()
+        selector = Selector.parse(["kind", "bucket"])
+
+        first = resolve_targets(store, selector)
+        second = resolve_targets(store, selector)
+        # A store whose nodes were declared in a different order must not
+        # reorder the result: the order is a property of the selector, not of
+        # how the store happened to serialize its rows.
+        shuffled = InventoryStore(nodes=tuple(reversed(store.nodes)), groups=tuple(reversed(store.groups)))
+        third = resolve_targets(shuffled, selector)
+
+        ids = [n.node_id for n in first]
+        assert ids == [n.node_id for n in second]
+        assert ids == [n.node_id for n in third]
+        assert ids == sorted(ids)
+        assert ids == [
+            "arn:aws:s3:::assets",
+            "arn:aws:s3:::backup",
+            "arn:aws:s3:::logs",
+            "arn:aws:s3:::scratch",
+        ]
+
+
+class TestFilterChain:
+    """Successive ``key value`` filters: exact, regex and set membership."""
+
+    def test_selector_chain_matches_exact_regex_and_set(self) -> None:
+        store = _store()
+        selector = Selector.parse(
+            [
+                "kind",
+                "bucket",  # exact
+                "region",
+                "~^us-",  # regex
+                "group",
+                "{prod,staging}",  # set membership
+            ]
+        )
+
+        matched = [n.node_id for n in resolve_targets(store, selector)]
+
+        # backup is us-east-1 but in no group; scratch is in dev and eu-central-1.
+        assert matched == ["arn:aws:s3:::assets", "arn:aws:s3:::logs"]
+
+    def test_filter_matches_any_value_of_a_multi_valued_attribute(self) -> None:
+        store = _store()
+        matched = [n.node_id for n in resolve_targets(store, Selector.parse(["tier", "archive"]))]
+        assert matched == ["arn:aws:s3:::logs"]
+
+    def test_escaped_value_is_matched_literally(self) -> None:
+        store = InventoryStore(
+            nodes=(InventoryNode(node_id="n1", attributes={"pattern": ("~^us-",)}, groups=()),),
+            groups=(),
+        )
+        assert [n.node_id for n in resolve_targets(store, Selector.parse(["pattern", r"\~^us-"]))] == ["n1"]
+
+    def test_odd_token_count_is_a_syntax_error(self) -> None:
+        with pytest.raises(SelectorSyntaxError):
+            Selector.parse(["kind", "bucket", "region"])
+
+    def test_unknown_alias_is_a_syntax_error(self) -> None:
+        with pytest.raises(SelectorSyntaxError):
+            Selector.parse(["@nosuchalias"], aliases=AliasTable.empty())
+
+
+class TestAliases:
+    """Aliases are declared as data, not code."""
+
+    def test_alias_expands_to_declared_filter_pairs(self, tmp_path: Path) -> None:
+        (tmp_path / "site.json").write_text(
+            json.dumps({"aliases": {"us-buckets": ["kind", "bucket", "region", "~^us-"]}}),
+            encoding="utf-8",
+        )
+        aliases = AliasTable.from_directory(tmp_path)
+        store = _store()
+
+        via_alias = resolve_targets(store, Selector.parse(["@us-buckets"], aliases=aliases))
+        written_out = resolve_targets(store, Selector.parse(["kind", "bucket", "region", "~^us-"]))
+
+        assert [n.node_id for n in via_alias] == [n.node_id for n in written_out]
+        assert [n.node_id for n in via_alias] == [
+            "arn:aws:s3:::assets",
+            "arn:aws:s3:::backup",
+            "arn:aws:s3:::logs",
+        ]
+
+    def test_alias_cycle_is_rejected(self, tmp_path: Path) -> None:
+        (tmp_path / "loop.json").write_text(
+            json.dumps({"aliases": {"a": ["@b"], "b": ["@a"]}}),
+            encoding="utf-8",
+        )
+        aliases = AliasTable.from_directory(tmp_path)
+        with pytest.raises(SelectorSyntaxError, match="cycle"):
+            Selector.parse(["@a"], aliases=aliases)
+
+    def test_alias_declared_twice_in_a_directory_is_rejected(self, tmp_path: Path) -> None:
+        (tmp_path / "a.json").write_text(json.dumps({"aliases": {"prod": ["env", "production"]}}), encoding="utf-8")
+        (tmp_path / "b.json").write_text(json.dumps({"aliases": {"prod": ["env", "prod"]}}), encoding="utf-8")
+        with pytest.raises(SelectorSyntaxError, match="prod"):
+            AliasTable.from_directory(tmp_path)
+
+
+class TestGroupEdges:
+    """Group membership is an edge; group values resolve onto members."""
+
+    def test_group_value_resolves_to_members_with_override(self) -> None:
+        store = _store()
+        resolved = {n.node_id: n for n in resolve_targets(store, Selector.parse(["group", "prod"]))}
+
+        # assets declares no retention, so it inherits the prod group's value.
+        assert resolved["arn:aws:s3:::assets"].attributes["retention"] == ("90d",)
+        # logs declares its own, which wins over the group-level value.
+        assert resolved["arn:aws:s3:::logs"].attributes["retention"] == ("365d",)
+        # scratch is not in prod, so it is not in this result at all.
+        assert "arn:aws:s3:::scratch" not in resolved
+
+    def test_selector_matches_an_inherited_group_value(self) -> None:
+        store = _store()
+        matched = [n.node_id for n in resolve_targets(store, Selector.parse(["env", "production"]))]
+        assert matched == [
+            "arn:aws:iam::role/deploy",
+            "arn:aws:s3:::assets",
+            "arn:aws:s3:::logs",
+        ]
+
+    def test_conflicting_group_values_without_override_are_rejected(self) -> None:
+        store = InventoryStore(
+            nodes=(InventoryNode(node_id="n1", attributes={}, groups=("left", "right")),),
+            groups=(
+                InventoryGroup(group_id="left", values={"retention": ("7d",)}),
+                InventoryGroup(group_id="right", values={"retention": ("90d",)}),
+            ),
+        )
+        with pytest.raises(GroupConflictError) as excinfo:
+            resolve_targets(store, Selector.parse(["id", "n1"]))
+        message = str(excinfo.value)
+        assert "n1" in message
+        assert "retention" in message
+        assert "left" in message
+        assert "right" in message
+
+    def test_membership_in_an_undeclared_group_is_rejected(self) -> None:
+        store = InventoryStore(
+            nodes=(InventoryNode(node_id="n1", attributes={}, groups=("ghost",)),),
+            groups=(),
+        )
+        with pytest.raises(SelectorError, match="ghost"):
+            resolve_targets(store, Selector.parse(["id", "n1"]))
+
+    def test_node_override_resolves_a_group_conflict(self) -> None:
+        store = InventoryStore(
+            nodes=(InventoryNode(node_id="n1", attributes={"retention": ("30d",)}, groups=("left", "right")),),
+            groups=(
+                InventoryGroup(group_id="left", values={"retention": ("7d",)}),
+                InventoryGroup(group_id="right", values={"retention": ("90d",)}),
+            ),
+        )
+        resolved = resolve_targets(store, Selector.parse(["id", "n1"]))
+        assert resolved[0].attributes["retention"] == ("30d",)
+
+
+class TestProjection:
+    """``%field %field`` renders one line per match; JSON carries only those fields."""
+
+    def test_projection_renders_template_line_and_json_fields(self) -> None:
+        store = _store()
+        matched = resolve_targets(store, Selector.parse(["group", "dev"]))
+        projection = Projection.parse("%id in %region keeps %retention")
+
+        assert [projection.render(n) for n in matched] == ["arn:aws:s3:::scratch in eu-central-1 keeps 7d"]
+        assert [projection.project(n) for n in matched] == [
+            {"id": "arn:aws:s3:::scratch", "region": "eu-central-1", "retention": "7d"}
+        ]
+
+    def test_projection_of_a_missing_field_is_empty_not_an_error(self) -> None:
+        store = _store()
+        matched = resolve_targets(store, Selector.parse(["id", "arn:aws:s3:::backup"]))
+        projection = Projection.parse("%id|%retention")
+        assert projection.render(matched[0]) == "arn:aws:s3:::backup|"
+        assert projection.project(matched[0]) == {"id": "arn:aws:s3:::backup", "retention": ""}
+
+    def test_projection_without_a_field_is_a_syntax_error(self) -> None:
+        with pytest.raises(SelectorSyntaxError):
+            Projection.parse("no fields here")
+
+
+class TestTypedCallSites:
+    """Consumers resolve targets through the typed API, never a built string."""
+
+    def test_call_sites_use_typed_api_not_raw_strings(self) -> None:
+        # A bare string is also a Sequence[str] -- of its characters -- so
+        # accepting one would silently parse "kind bucket" into per-character
+        # filters. Rejecting it is what keeps the shell-string path structurally
+        # unavailable to every consumer.
+        with pytest.raises(TypeError):
+            Selector.parse("kind bucket")  # type: ignore[arg-type]
+
+        src_root = Path(__file__).resolve().parents[4] / "src" / "bernstein"
+        assert src_root.is_dir(), src_root
+
+        offenders: list[str] = []
+        for path in sorted(src_root.rglob("*.py")):
+            source = path.read_text(encoding="utf-8")
+            if _SELECTOR_MODULE not in source:
+                continue
+            tree = ast.parse(source, filename=str(path))
+            for call in (n for n in ast.walk(tree) if isinstance(n, ast.Call)):
+                if not _is_selector_entry_point(call.func):
+                    continue
+                for arg in [*call.args, *(kw.value for kw in call.keywords)]:
+                    if _is_constructed_string(arg):
+                        offenders.append(f"{path}:{call.lineno} builds a selector argument as a string")
+        assert offenders == []
+
+
+def _is_selector_entry_point(func: ast.expr) -> bool:
+    """True when *func* names one of the typed resolution entry points."""
+    if isinstance(func, ast.Name):
+        return func.id == "resolve_targets"
+    if isinstance(func, ast.Attribute):
+        owner = func.value
+        if func.attr == "resolve_targets":
+            return True
+        return func.attr == "parse" and isinstance(owner, ast.Name) and owner.id in {"Selector", "Projection"}
+    return False
+
+
+def _is_constructed_string(node: ast.expr) -> bool:
+    """True when *node* is a string assembled at the call site."""
+    if isinstance(node, ast.JoinedStr):
+        return True
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add | ast.Mod):
+        return isinstance(node.left, ast.Constant) and isinstance(node.left.value, str)
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+        return node.func.attr in {"format", "join"}
+    return False


### PR DESCRIPTION
## What

Adds `src/bernstein/core/govern/selector.py`: one selector grammar and one typed
resolution API for picking a target subset out of the governed inventory.

In scope (all four slices of the issue, as a library):

1. **Selector grammar** — successive `key value` filters over any discovered
   attribute: exact, `~regex`, `{a,b,c}` set membership, `\literal` escape.
2. **Aliases as data** — `@name` expands to declared filter pairs, loaded from a
   directory of JSON files an operator can extend without a code change.
3. **Projection** — `Projection.parse("%id %region")` renders one line per match
   (`render`) and returns only the projected fields (`project`) for JSON output.
4. **Group membership as an edge** — group values resolve onto members, a
   per-node value overrides the group's.

Explicitly not in scope:

- The inventory store itself. `InventoryStore` here is the typed fixture shape
  the selector queries; the real store lands in #5082 / #5083 / #5129.
- Any CLI flag or command. No consumer exists yet, so nothing is wired.
- Write operations. This is read/resolve only.
- `src/bernstein/core/fleet/bulk.py`. `select_projects` stays as it is: it
  resolves live fleet projects, a different entity type, and the issue asks for
  the two to stay parallel.

## Why

The only "resolve a target subset from a string" mechanism in the tree today is
`select_projects` in `src/bernstein/core/fleet/bulk.py:78`, which takes one
`cost>5`-style expression against three fixed fields of a fleet project. On the
govern side there is no filtering at all — `Inventory.get_surface`
(`src/bernstein/core/govern/inventory_models.py:91`) is an exact-id lookup.

Every surface that will need a target subset — an audit pass over selected
targets, a scheduler, a reconcile lane — would otherwise grow its own filter,
and "what does this selector actually match" would then be answerable only by
reading N filter implementations. One typed API makes it answerable by running
the selector. Sorting the result by node identifier means two operators running
the same selector against the same store get the same output to diff or script
against, regardless of the order the store happened to serialize its rows in.

## How

- `Selector.parse(tokens)` takes argv-style tokens, never a string. A string is
  also a sequence — of its characters — so accepting one would silently parse
  `"kind bucket"` into per-character filters and re-open the shell-string path;
  it raises `TypeError` instead. Consumers split at their own boundary
  (`typer` variadic arguments give a token tuple directly).
- `Filter.parse` classifies one value token into exact / regex / set, compiling
  the regex once at parse time so a malformed pattern fails at parse, not per
  node.
- `AliasTable.from_directory` reads `*.json` in name order; an alias declared in
  two files is rejected naming both, so the table does not depend on read order.
  Expansion is recursive with cycle detection.
- `resolve_targets` resolves each node's effective attributes (own values, then
  inherited group values), filters, and returns the matches sorted by
  `node_id`. Two reserved keys are always present: `id` and `group`, so a
  selector can name a group without the store carrying a matching attribute.

**Decision left open by the issue — a node in two groups with conflicting
values.** A node value always wins outright, so that case is only reachable when
the node declares nothing for the key. There, `resolve_targets` raises
`GroupConflictError` naming the node, the key and each contributing group,
rather than applying a precedence rule. A precedence rule would make the match
set readable only from this module's source, which is the failure mode the issue
exists to remove; the error tells the operator exactly which node to annotate to
settle it.

**What felt speculative**, as the issue asks: with no caller yet (#5090, #5118,
#5121 do not exist), two shapes are guesses that a first real consumer should be
allowed to change — (a) attributes are multi-valued everywhere, which is right
for tags but adds a tuple to every single-valued read; (b) `Projection.project`
joins multi-valued fields with `,` into a string rather than emitting a JSON
list, chosen so `render` and `project` cannot disagree. Both are internal to
this module and cheap to revisit.

## Tests

`tests/unit/core/govern/test_selector.py`, 18 tests. All of them failed before
the change for the same reason — the module did not exist, so the file failed
collection with `ImportError`. Confirmed on the unmodified tree.

1. `test_same_selector_same_store_same_order` — **load-bearing.** The same
   selector twice, and against a store with its nodes and groups declared in
   reverse, yields one identical sorted list. Re-verified as load-bearing by
   dropping the sort in `resolve_targets`: this test fails, the other 17 pass.
2. `test_selector_chain_matches_exact_regex_and_set` — one selector combining
   all three filter kinds.
3. `test_filter_matches_any_value_of_a_multi_valued_attribute`
4. `test_escaped_value_is_matched_literally` — `\~^us-` matches the literal.
5. `test_odd_token_count_is_a_syntax_error`
6. `test_unknown_alias_is_a_syntax_error`
7. `test_alias_expands_to_declared_filter_pairs` — an alias defined as data
   resolves to the same result as writing out its filter pairs.
8. `test_alias_cycle_is_rejected`
9. `test_alias_declared_twice_in_a_directory_is_rejected`
10. `test_group_value_resolves_to_members_with_override` — a per-node value wins
    over the group-level value; a non-member does not appear.
11. `test_selector_matches_an_inherited_group_value`
12. `test_conflicting_group_values_without_override_are_rejected`
13. `test_membership_in_an_undeclared_group_is_rejected`
14. `test_node_override_resolves_a_group_conflict`
15. `test_projection_renders_template_line_and_json_fields`
16. `test_projection_of_a_missing_field_is_empty_not_an_error`
17. `test_projection_without_a_field_is_a_syntax_error`
18. `test_call_sites_use_typed_api_not_raw_strings` — structural. Asserts
    `Selector.parse` rejects a string (fails on an unmodified tree today), then
    walks every `src/bernstein` module that imports this one and fails any call
    to `resolve_targets`, `Selector.parse` or `Projection.parse` whose argument
    is an f-string, a `+`/`%` string, or a `.format()`/`.join()` result. There
    are no such consumers yet, so today the walk is empty; it is written to
    catch the first one that lands.

Verification run in an isolated `XDG_*` environment:

- `uv run python scripts/run_tests.py --parallel 2 -x tests/unit/core/govern/test_selector.py tests/unit/core/govern/test_models.py` — 61 passed.
- `uv run python scripts/run_tests.py --parallel 2 --affected origin/main` — 50 files
  selected. 49 green; `tests/unit/test_orchestrator.py` hit the harness's 300s
  per-file cap on a loaded machine and was re-run on its own: 228 passed in
  234s. It does not import the added module.
- `uv run ruff check src/` and `uv run ruff format --check` — clean.
- `uv run pyright src/bernstein/core/govern/selector.py` — 0 errors.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes (checked for the added module)
- [x] `uv run python scripts/run_tests.py -x` passes (affected selection, 50 files; CI runs the full suite)
- [x] New code has type hints

### Documentation duty

- [x] User-visible README section updated — N/A, no user-visible surface: this
      adds a library module with no CLI flag or command behind it yet.
- [x] `docs/operations/<area>.md` updated — N/A, nothing to operate until a
      consumer wires it.
- [x] `docs/api/` schema regenerated if a public surface changed — N/A, no HTTP
      or serialized schema changes.
- [x] `uv run bernstein agents-md sync` — N/A, no documented public surface
      changed; the module is not re-exported from `bernstein.core.govern`.
- [x] Tests cover the documented behaviour — the grammar, alias, projection and
      group rules in the module docstring each have a test above.

Part of #5116

## Remaining

- The `--json` half of acceptance item 2. `Projection.project` returns exactly
  the projected fields, but there is no command to hang a `--json` flag on yet;
  it wires up with the first consumer (#5090 `govern audit --targets`).
- Pointing the selector at the real inventory store. `InventoryStore` here is
  the typed shape the selector queries; #5082 / #5083 / #5129 build the store it
  should read from.
- Acceptance item 4 is guarded but not yet exercised: no consumer resolves
  targets through this API today, so `test_call_sites_use_typed_api_not_raw_strings`
  passes over an empty set of call sites until the first one lands.
