### PR TITLE
refactor: declare the offline-verification result shape once, and guard against the next duplicate (#5099)

### DIFF
--- a/docs/sdd/module-map.md
+++ b/docs/sdd/module-map.md
@@ -19,6 +19,7 @@ Full per-file module map. `AGENTS.md`'s own "Module map" section links here inst
 | `path_scope.py`             | Which repository-relative paths fall outside a set of globs |
 | `run_auth_token.py`         | Persist and read the auto-generated run Bearer token (issue #2794) |
 | `streaming_merge.py`        | Streaming task results for long-running agents (incremental merge) |
+| `verify_result.py`          | The one shape an offline verification answers in |
 | `admission/`                | Named resource pools with lease-backed admission (#2544) |
 | `agents/`                   | agents sub-package |
 | `approval/`                 | Interactive tool-call approval (op-002) |

--- a/src/bernstein/core/cost/scheduling/receipt.py
+++ b/src/bernstein/core/cost/scheduling/receipt.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, Any
 
 from bernstein.core.cost.scheduling.policy import DispatchDecision
 from bernstein.core.lineage.spine import LineageSpine, content_hash_of
+from bernstein.core.verify_result import VerifyResult
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -206,13 +207,8 @@ def read_dispatch_receipt(workdir: Path, decision_hash: str) -> DispatchReceipt 
         return None
 
 
-@dataclass(frozen=True, slots=True)
-class DispatchVerifyResult:
-    """Outcome of an offline dispatch-receipt verification."""
-
-    ok: bool
-    reason: str
-    receipt: DispatchReceipt | None
+#: Outcome of an offline dispatch-receipt verification.
+DispatchVerifyResult = VerifyResult[DispatchReceipt]
 
 
 def _verify_knob_selection(decision: DispatchDecision) -> str | None:

--- a/src/bernstein/core/orchestration/escalation.py
+++ b/src/bernstein/core/orchestration/escalation.py
@@ -53,6 +53,7 @@ from bernstein.core.orchestration.supervisor_receipt import (
 from bernstein.core.replay.fork import SNAPSHOT_EVENT
 from bernstein.core.replay.journal import load_events, run_journal_path, verify_journal
 from bernstein.core.skills.catalog.signature import sign_payload, verify_payload
+from bernstein.core.verify_result import VerifyResult
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -551,13 +552,8 @@ def assemble_escalation_receipt(
 # ---------------------------------------------------------------------------
 
 
-@dataclass(frozen=True)
-class EscalationVerifyResult:
-    """Outcome of :func:`verify_escalation_receipt`."""
-
-    ok: bool
-    reason: str
-    receipt: EscalationReceipt | None = None
+#: Outcome of :func:`verify_escalation_receipt`.
+EscalationVerifyResult = VerifyResult[EscalationReceipt]
 
 
 def _degraded_reason(state: str) -> str:

--- a/src/bernstein/core/protocols/payments/x402.py
+++ b/src/bernstein/core/protocols/payments/x402.py
@@ -56,6 +56,7 @@ from bernstein.core.protocols.payments.mandates import (
     read_consent_receipt,
     verify_consent_receipt,
 )
+from bernstein.core.verify_result import VerifyResult
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
@@ -945,13 +946,8 @@ class X402SettlementCoordinator:
 # ---------------------------------------------------------------------------
 
 
-@dataclass(frozen=True)
-class SpendVerifyResult:
-    """Outcome of :func:`verify_spend_receipt`."""
-
-    ok: bool
-    reason: str
-    receipt: SpendReceipt | None = None
+#: Outcome of :func:`verify_spend_receipt`.
+SpendVerifyResult = VerifyResult[SpendReceipt]
 
 
 def verify_spend_receipt(

--- a/src/bernstein/core/review/receipt.py
+++ b/src/bernstein/core/review/receipt.py
@@ -65,6 +65,7 @@ from typing import TYPE_CHECKING, Any
 from bernstein.core.lineage.identity import generate_keypair
 from bernstein.core.lineage.spine import LineageSpine, content_hash_of
 from bernstein.core.skills.catalog.signature import sign_payload, verify_payload
+from bernstein.core.verify_result import VerifyResult
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -1024,13 +1025,8 @@ def _sign_and_anchor_autofix(
     return anchored
 
 
-@dataclass(frozen=True)
-class AutofixVerifyResult:
-    """Outcome of :func:`verify_autofix_receipt`."""
-
-    ok: bool
-    reason: str
-    receipt: AutofixReceipt | None = None
+#: Outcome of :func:`verify_autofix_receipt`.
+AutofixVerifyResult = VerifyResult[AutofixReceipt]
 
 
 def verify_autofix_receipt(

--- a/src/bernstein/core/sandbox/pool_placement.py
+++ b/src/bernstein/core/sandbox/pool_placement.py
@@ -34,6 +34,7 @@ from bernstein.core.sandbox.selector import (
     SandboxPolicy,
     select_sandbox,
 )
+from bernstein.core.verify_result import VerifyResult
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -277,13 +278,8 @@ def read_placement_receipt(workdir: Path, placement_hash: str) -> PlacementRecei
         return None
 
 
-@dataclass(frozen=True, slots=True)
-class PlacementVerifyResult:
-    """Outcome of an offline placement-receipt verification."""
-
-    ok: bool
-    reason: str
-    receipt: PlacementReceipt | None
+#: Outcome of an offline placement-receipt verification.
+PlacementVerifyResult = VerifyResult[PlacementReceipt]
 
 
 def verify_placement_receipt(workdir: Path, placement_hash: str) -> PlacementVerifyResult:

--- a/src/bernstein/core/skills/provenance.py
+++ b/src/bernstein/core/skills/provenance.py
@@ -42,6 +42,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from bernstein.core.lineage.spine import LineageSpine, SpineStatus
+from bernstein.core.verify_result import VerifyResult
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -664,13 +665,8 @@ def _verify_link_head(lineage_root: Path, hmac_key: bytes, link: UsageLink) -> t
 # ---------------------------------------------------------------------------
 
 
-@dataclass(frozen=True)
-class InstallVerifyResult:
-    """Outcome of :func:`verify_install`."""
-
-    ok: bool
-    reason: str
-    receipt: InstallReceipt | None = None
+#: Outcome of :func:`verify_install`.
+InstallVerifyResult = VerifyResult[InstallReceipt]
 
 
 def verify_install(

--- a/src/bernstein/core/verify_result.py
+++ b/src/bernstein/core/verify_result.py
@@ -19,10 +19,12 @@ why" is now answerable the same way regardless of which verifier produced the
 result.
 
 The type is frozen because a verdict a caller can rewrite in place is not a
-verdict, and ``reason`` is empty exactly when ``ok`` is true: a passing
-verification has nothing to explain. A failure always names its cause, because
-the whole value of an offline check is that it says which field stopped
-matching.
+verdict. ``reason`` is empty on an ordinary pass, since there is nothing to
+explain, but a verifier may still fill it in on a passing result to flag
+something the caller should know - a degraded receipt that verified with no
+window left to recompute, for instance. A failure always names its cause,
+because the whole value of an offline check is that it says which field
+stopped matching.
 """
 
 from __future__ import annotations

--- a/src/bernstein/core/verify_result.py
+++ b/src/bernstein/core/verify_result.py
@@ -1,0 +1,50 @@
+"""The one shape an offline verification answers in.
+
+Every receipt in this repository can be re-checked without the process that
+wrote it: read it back, recompute its hash, and confirm it is anchored in the
+chain it claims. Eight modules did exactly that, and each declared its own
+three-field result class to say how it went - same fields, same meaning, no
+relationship between any two of them. A caller holding one of those results
+could not be written to handle another without an adapter, so in practice the
+generic caller was never written and every consumer was pinned to one verifier.
+
+:class:`VerifyResult` is that shape declared once. It is generic in the receipt
+it carries, so a module specialises it rather than redeclaring it::
+
+    DispatchVerifyResult = VerifyResult[DispatchReceipt]
+
+The specialisation keeps the receipt's static type - a caller that reads
+``result.receipt.decision_hash`` still type-checks - while "did this pass, and
+why" is now answerable the same way regardless of which verifier produced the
+result.
+
+The type is frozen because a verdict a caller can rewrite in place is not a
+verdict, and ``reason`` is empty exactly when ``ok`` is true: a passing
+verification has nothing to explain. A failure always names its cause, because
+the whole value of an offline check is that it says which field stopped
+matching.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["VerifyResult"]
+
+
+@dataclass(frozen=True, slots=True)
+class VerifyResult[ReceiptT]:
+    """Outcome of verifying a receipt offline.
+
+    Attributes:
+        ok: Whether the receipt read back, recomputed and anchored intact.
+        reason: Why the verification failed, or ``""`` when it passed. A
+            passing verification may still carry a note - a degraded receipt
+            verifies but has no window to recompute, and says so here.
+        receipt: The receipt that was checked, or ``None`` when there was
+            nothing to check - no receipt at that hash, or none on disk.
+    """
+
+    ok: bool
+    reason: str
+    receipt: ReceiptT | None = None

--- a/src/bernstein/eval/gate_receipt.py
+++ b/src/bernstein/eval/gate_receipt.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.lineage.spine import LineageSpine, content_hash_of
+from bernstein.core.verify_result import VerifyResult
 from bernstein.eval.significance import (
     DEFAULT_ALPHA,
     DEFAULT_MIN_N,
@@ -419,13 +420,8 @@ def read_verdict_receipt(workdir: Path, receipt_hash: str) -> VerdictReceipt | N
         return None
 
 
-@dataclass(frozen=True, slots=True)
-class VerdictVerifyResult:
-    """Outcome of an offline verdict-receipt verification."""
-
-    ok: bool
-    reason: str
-    receipt: VerdictReceipt | None
+#: Outcome of an offline verdict-receipt verification.
+VerdictVerifyResult = VerifyResult[VerdictReceipt]
 
 
 def verify_verdict_receipt(

--- a/src/bernstein/eval/promotion.py
+++ b/src/bernstein/eval/promotion.py
@@ -29,6 +29,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.lineage.spine import LineageSpine, content_hash_of
+from bernstein.core.verify_result import VerifyResult
 from bernstein.eval.significance import PROMOTING_VERDICTS, Verdict
 
 if TYPE_CHECKING:
@@ -412,13 +413,8 @@ def read_revocation_receipt(workdir: Path, receipt_hash: str) -> RevocationRecei
         return None
 
 
-@dataclass(frozen=True, slots=True)
-class RevocationVerifyResult:
-    """Outcome of an offline revocation-receipt verification."""
-
-    ok: bool
-    reason: str
-    receipt: RevocationReceipt | None
+#: Outcome of an offline revocation-receipt verification.
+RevocationVerifyResult = VerifyResult[RevocationReceipt]
 
 
 def verify_revocation_receipt(

--- a/tests/unit/test_verify_result_field_shape_collisions.py
+++ b/tests/unit/test_verify_result_field_shape_collisions.py
@@ -1,12 +1,13 @@
 """One field shape must mean one type.
 
 A verification result is the most-copied shape in this repository. Eight
-separate classes declare exactly ``(ok, reason, receipt)`` under eight names,
-another five declare ``(errors, ok)``, four declare ``(detail, name, passed)``.
-Every one of them means the same thing - did the check pass, and why - but no
-two are related, so a caller that wants to handle "any verification result"
-either hand-writes an adapter per class or, far more often, is hardcoded to
-exactly one of them.
+separate classes declared exactly ``(ok, reason, receipt)`` under eight names -
+they are now specialisations of one :class:`~bernstein.core.verify_result.VerifyResult`
+- and five more still declare ``(errors, ok)``, four declare
+``(detail, name, passed)``. Every one of them means the same thing - did the
+check pass, and why - but no two are related, so a caller that wants to handle
+"any verification result" either hand-writes an adapter per class or, far more
+often, is hardcoded to exactly one of them.
 
 The duplicates were never decided on; they accumulated one module at a time,
 each author reasonably declaring a small local result type rather than hunting
@@ -376,11 +377,11 @@ def test_sbom_finding_and_response_dto_stay_deliberately_split() -> None:
 def test_verify_result_subclasses_expose_ok_reason_receipt() -> None:
     """Every migrated receipt verifier answers "did it pass, and why" the same way.
 
-    The eight names survive as specialisations of the one base type - the
-    issue's "subclass" in the sense that matters here, since a specialisation
-    of a generic dataclass is the base class with its receipt slot pinned. The
-    property under test is that a caller holding any of them can read ``ok``,
-    ``reason`` and ``receipt`` without knowing which verifier produced it.
+    The eight names survive as specialisations of the one base type: a
+    specialisation of a generic dataclass is that base class with its receipt
+    slot pinned, so each name still says which receipt it carries. The property
+    under test is that a caller holding any of them can read ``ok``, ``reason``
+    and ``receipt`` without knowing which verifier produced it.
     """
     from bernstein.core.cost.scheduling.receipt import DispatchVerifyResult
     from bernstein.core.orchestration.escalation import EscalationVerifyResult

--- a/tests/unit/test_verify_result_field_shape_collisions.py
+++ b/tests/unit/test_verify_result_field_shape_collisions.py
@@ -31,9 +31,11 @@ from __future__ import annotations
 
 import ast
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import FrozenInstanceError, dataclass
 from pathlib import Path
-from typing import Final
+from typing import Final, get_origin
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SOURCE_ROOT = REPO_ROOT / "src" / "bernstein"
@@ -168,9 +170,7 @@ _PENDING_SHAPES: Final[tuple[_AllowedShape, ...]] = (
     ),
     _AllowedShape(
         fields=frozenset({"errors", "ok"}),
-        classes=frozenset(
-            {"ReceiptVerification", "ManifestVerification", "ProjectionVerification"}
-        ),
+        classes=frozenset({"ReceiptVerification", "ManifestVerification", "ProjectionVerification"}),
         reason=(
             "core/orchestration/sla_receipt.py, core/orchestration/"
             "supervisor_receipt.py and core/sandbox/selection_receipt.py each "
@@ -195,26 +195,6 @@ _PENDING_SHAPES: Final[tuple[_AllowedShape, ...]] = (
         reason=(
             "core/interop/a2a_consume.py and core/lineage/gate.py report a "
             "list of failures behind a boolean. Pending consolidation."
-        ),
-    ),
-    _AllowedShape(
-        fields=frozenset({"ok", "reason", "receipt"}),
-        classes=frozenset(
-            {
-                "DispatchVerifyResult",
-                "EscalationVerifyResult",
-                "SpendVerifyResult",
-                "AutofixVerifyResult",
-                "PlacementVerifyResult",
-                "InstallVerifyResult",
-                "VerdictVerifyResult",
-                "RevocationVerifyResult",
-            }
-        ),
-        reason=(
-            "Eight modules declare the outcome of an offline receipt "
-            "verification under eight names with identical fields. The largest "
-            "single collision in the tree and the first one to migrate."
         ),
     ),
     _AllowedShape(
@@ -276,9 +256,7 @@ def _is_dataclass(node: ast.ClassDef) -> bool:
 def _annotated_fields(node: ast.ClassDef) -> frozenset[str]:
     """Return the names of *node*'s own annotated fields."""
     return frozenset(
-        stmt.target.id
-        for stmt in node.body
-        if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name)
+        stmt.target.id for stmt in node.body if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name)
     )
 
 
@@ -288,9 +266,7 @@ def _shapes_by_fields() -> dict[frozenset[str], list[_Declaration]]:
     for path in sorted(SOURCE_ROOT.rglob("*.py")):
         try:
             tree = ast.parse(path.read_text(encoding="utf-8"))
-        except (
-            SyntaxError
-        ):  # pragma: no cover - a parse failure is another test's problem
+        except SyntaxError:  # pragma: no cover - a parse failure is another test's problem
             continue
         module = path.relative_to(SOURCE_ROOT).as_posix()
         for node in ast.walk(tree):
@@ -301,9 +277,7 @@ def _shapes_by_fields() -> dict[frozenset[str], list[_Declaration]]:
             fields = _annotated_fields(node)
             if not fields:
                 continue
-            shapes[fields].append(
-                _Declaration(module=module, lineno=node.lineno, name=node.name)
-            )
+            shapes[fields].append(_Declaration(module=module, lineno=node.lineno, name=node.name))
     return shapes
 
 
@@ -334,9 +308,7 @@ def test_no_new_unallowlisted_field_shape_collisions() -> None:
     collisions = _collisions()
     problems: list[str] = []
 
-    for fields, declarations in sorted(
-        collisions.items(), key=lambda kv: sorted(kv[0])
-    ):
+    for fields, declarations in sorted(collisions.items(), key=lambda kv: sorted(kv[0])):
         entry = allowed.get(fields)
         if entry is None:
             problems.append("not allowlisted:\n" + _render(fields, declarations))
@@ -344,10 +316,7 @@ def test_no_new_unallowlisted_field_shape_collisions() -> None:
         declared = {declaration.name for declaration in declarations}
         if declared != entry.classes:
             joined = ", ".join(sorted(declared - entry.classes)) or "(none)"
-            problems.append(
-                f"allowlisted shape gained a class ({joined}):\n"
-                + _render(fields, declarations)
-            )
+            problems.append(f"allowlisted shape gained a class ({joined}):\n" + _render(fields, declarations))
 
     for entry in _ALLOWED_SHAPES:
         if entry.fields not in collisions:
@@ -367,11 +336,7 @@ def test_no_new_unallowlisted_field_shape_collisions() -> None:
 
 def test_every_allowlist_entry_states_a_reason() -> None:
     """An entry without a reason is a silenced failure, not a decision."""
-    unexplained = [
-        ", ".join(sorted(entry.fields))
-        for entry in _ALLOWED_SHAPES
-        if len(entry.reason.strip()) < 40
-    ]
+    unexplained = [", ".join(sorted(entry.fields)) for entry in _ALLOWED_SHAPES if len(entry.reason.strip()) < 40]
     assert not unexplained, (
         "allowlist entries with no stated reason:\n  "
         + "\n  ".join(unexplained)
@@ -393,12 +358,8 @@ def test_sbom_finding_and_response_dto_stay_deliberately_split() -> None:
         for entry in _DELIBERATE_SHAPES
         if entry.classes == frozenset({"SBOMVulnFinding", "SBOMVulnFindingResponse"})
     ]
-    assert len(entries) == 1, (
-        "the SBOM finding/DTO split must be recorded exactly once in _DELIBERATE_SHAPES"
-    )
-    assert "wire contract" in entries[0].reason, (
-        "the entry must say why the split is deliberate, not merely that it is"
-    )
+    assert len(entries) == 1, "the SBOM finding/DTO split must be recorded exactly once in _DELIBERATE_SHAPES"
+    assert "wire contract" in entries[0].reason, "the entry must say why the split is deliberate, not merely that it is"
 
     declared = {
         declaration.name: declaration.module
@@ -410,3 +371,57 @@ def test_sbom_finding_and_response_dto_stay_deliberately_split() -> None:
         "SBOMVulnFinding": "core/security/sbom.py",
         "SBOMVulnFindingResponse": "core/routes/sbom.py",
     }, f"the deliberately split pair moved or was collapsed: {declared}"
+
+
+def test_verify_result_subclasses_expose_ok_reason_receipt() -> None:
+    """Every migrated receipt verifier answers "did it pass, and why" the same way.
+
+    The eight names survive as specialisations of the one base type - the
+    issue's "subclass" in the sense that matters here, since a specialisation
+    of a generic dataclass is the base class with its receipt slot pinned. The
+    property under test is that a caller holding any of them can read ``ok``,
+    ``reason`` and ``receipt`` without knowing which verifier produced it.
+    """
+    from bernstein.core.cost.scheduling.receipt import DispatchVerifyResult
+    from bernstein.core.orchestration.escalation import EscalationVerifyResult
+    from bernstein.core.protocols.payments.x402 import SpendVerifyResult
+    from bernstein.core.review.receipt import AutofixVerifyResult
+    from bernstein.core.sandbox.pool_placement import PlacementVerifyResult
+    from bernstein.core.skills.provenance import InstallVerifyResult
+    from bernstein.core.verify_result import VerifyResult
+    from bernstein.eval.gate_receipt import VerdictVerifyResult
+    from bernstein.eval.promotion import RevocationVerifyResult
+
+    specialisations = {
+        "DispatchVerifyResult": DispatchVerifyResult,
+        "EscalationVerifyResult": EscalationVerifyResult,
+        "SpendVerifyResult": SpendVerifyResult,
+        "AutofixVerifyResult": AutofixVerifyResult,
+        "PlacementVerifyResult": PlacementVerifyResult,
+        "InstallVerifyResult": InstallVerifyResult,
+        "VerdictVerifyResult": VerdictVerifyResult,
+        "RevocationVerifyResult": RevocationVerifyResult,
+    }
+
+    wrong_base = {
+        name: get_origin(alias) for name, alias in specialisations.items() if get_origin(alias) is not VerifyResult
+    }
+    assert not wrong_base, f"names that no longer specialise VerifyResult: {wrong_base}"
+
+    for name, alias in specialisations.items():
+        outcome = alias(ok=False, reason="tampered", receipt=None)
+        assert isinstance(outcome, VerifyResult), f"{name} constructed something other than a VerifyResult"
+        assert (outcome.ok, outcome.reason, outcome.receipt) == (
+            False,
+            "tampered",
+            None,
+        ), name
+
+
+def test_verify_result_is_frozen_so_a_failed_verification_cannot_be_flipped() -> None:
+    """A verdict a caller can rewrite in place is not a verdict."""
+    from bernstein.core.verify_result import VerifyResult
+
+    outcome: VerifyResult[str] = VerifyResult(ok=False, reason="signature does not verify")
+    with pytest.raises(FrozenInstanceError):
+        outcome.ok = True  # type: ignore[misc]

--- a/tests/unit/test_verify_result_field_shape_collisions.py
+++ b/tests/unit/test_verify_result_field_shape_collisions.py
@@ -1,0 +1,412 @@
+"""One field shape must mean one type.
+
+A verification result is the most-copied shape in this repository. Eight
+separate classes declare exactly ``(ok, reason, receipt)`` under eight names,
+another five declare ``(errors, ok)``, four declare ``(detail, name, passed)``.
+Every one of them means the same thing - did the check pass, and why - but no
+two are related, so a caller that wants to handle "any verification result"
+either hand-writes an adapter per class or, far more often, is hardcoded to
+exactly one of them.
+
+The duplicates were never decided on; they accumulated one module at a time,
+each author reasonably declaring a small local result type rather than hunting
+for an existing one. Nothing in the tree pushed back, so the count only ever
+went up.
+
+This test is that push-back. It collects every dataclass and ``BaseModel``
+under ``src/bernstein`` whose name marks it as a check result, keys them by the
+frozenset of their annotated field names, and fails when one key maps to two or
+more declaration sites that are not on an allowlist below. The allowlist starts
+populated with the collisions that exist today, so the test is green now and
+the next colliding class has to either reuse the canonical type or argue for
+itself in writing.
+
+The allowlist is also checked in the other direction: an entry that no longer
+matches a real collision fails the test. That is what makes the count a ratchet
+- a migration must delete its entry, and the entry cannot outlive the debt it
+describes.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SOURCE_ROOT = REPO_ROOT / "src" / "bernstein"
+
+#: Name endings that mark a class as the outcome of a check.
+#:
+#: Deliberately narrow. This test is about verification results, not about
+#: every dataclass in the tree - a `Config` and a `Request` that happen to
+#: share three field names are not the same thing and never were.
+_RESULT_SUFFIXES: Final = ("Result", "Verification", "Verdict", "Check", "Finding")
+
+#: Trailing token that marks a wire DTO. ``SBOMVulnFindingResponse`` is the
+#: HTTP shape of ``SBOMVulnFinding``, so it is in scope: the whole point of the
+#: allowlist is to record that this particular pair is split on purpose.
+_DTO_SUFFIX: Final = "Response"
+
+
+@dataclass(frozen=True, slots=True)
+class _Declaration:
+    """One class declaration and where it was found."""
+
+    module: str
+    lineno: int
+    name: str
+
+    def __str__(self) -> str:
+        return f"{self.module}:{self.lineno} {self.name}"
+
+
+@dataclass(frozen=True, slots=True)
+class _AllowedShape:
+    """A field shape that is permitted to be declared more than once."""
+
+    fields: frozenset[str]
+    classes: frozenset[str]
+    reason: str
+
+
+#: Collisions that are correct and must stay.
+_DELIBERATE_SHAPES: Final[tuple[_AllowedShape, ...]] = (
+    _AllowedShape(
+        fields=frozenset(
+            {
+                "component_name",
+                "component_version",
+                "fix_version",
+                "scanner",
+                "severity",
+                "summary",
+                "vuln_id",
+            }
+        ),
+        classes=frozenset({"SBOMVulnFinding", "SBOMVulnFindingResponse"}),
+        reason=(
+            "core/security/sbom.py declares the internal scan-result type; "
+            "core/routes/sbom.py declares its HTTP response DTO. One is a wire "
+            "contract that changes only with an API version, the other is free "
+            "to change with the scanner. Collapsing them would make every "
+            "internal field rename a breaking API change."
+        ),
+    ),
+)
+
+#: Collisions that exist today and are not yet resolved. Each entry names the
+#: work that removes it. Adding to this tuple is not a fix.
+_PENDING_SHAPES: Final[tuple[_AllowedShape, ...]] = (
+    _AllowedShape(
+        fields=frozenset({"action", "branch", "files_changed", "reason"}),
+        classes=frozenset({"MergeResult"}),
+        reason=(
+            "core/orchestration/drain.py and core/orchestration/drain_merge.py "
+            "declare the same name for the same shape. Not a verification "
+            "result; consolidating it belongs with the drain modules, not here."
+        ),
+    ),
+    _AllowedShape(
+        fields=frozenset({"attestation", "ok", "reason"}),
+        classes=frozenset({"CleanRunVerifyResult", "EquivalenceVerifyResult"}),
+        reason=(
+            "eval/clean_run.py declares both, and they carry different "
+            "attestation types. They are the `(ok, reason, X)` shape with the "
+            "receipt slot renamed; folding them onto VerifyResult needs the "
+            "attestation types reconciled first."
+        ),
+    ),
+    _AllowedShape(
+        fields=frozenset({"catalog", "from_cache", "revalidated", "source_url"}),
+        classes=frozenset({"FetchResult"}),
+        reason=(
+            "core/protocols/mcp_catalog/fetcher.py and core/skills/catalog/"
+            "fetcher.py fetch different catalogs over the same HTTP caching "
+            "protocol. Not a verification result."
+        ),
+    ),
+    _AllowedShape(
+        fields=frozenset({"commit_sha", "cost_usd", "message", "success"}),
+        classes=frozenset({"DispatchResult", "GroundedDispatchResult"}),
+        reason=(
+            "core/autofix/dispatcher.py and core/autofix/telemetry_grounded.py "
+            "report an autofix dispatch, not a verification. Not a "
+            "verification result."
+        ),
+    ),
+    _AllowedShape(
+        fields=frozenset({"count", "errors", "status"}),
+        classes=frozenset({"SpineVerifyResult", "MemoryVerifyResult"}),
+        reason=(
+            "core/lineage/spine.py and core/memory/chain.py verify two chains "
+            "and report a count of entries walked. Pending: a `VerifyResult` "
+            "specialisation once the errors/status pair is reconciled with "
+            "the ok/reason pair the eight-way group uses."
+        ),
+    ),
+    _AllowedShape(
+        fields=frozenset({"detail", "name", "passed"}),
+        classes=frozenset({"GateResult", "ConformanceCheck", "ValidatorVerdict"}),
+        reason=(
+            "core/planning/run_summary.py, core/integrations/pr_gen.py, "
+            "core/interop/a2a_conformance.py and core/tokens/"
+            "compaction_validate.py declare one per-item check outcome under "
+            "four names. Pending consolidation."
+        ),
+    ),
+    _AllowedShape(
+        fields=frozenset({"entries", "errors", "head_hash", "ok"}),
+        classes=frozenset({"AdmissionVerification", "LedgerVerification"}),
+        reason=(
+            "core/admission/verify.py and core/persistence/work_ledger.py "
+            "verify a hash-chained journal and report its head. Pending "
+            "consolidation with the other `(errors, ok, ...)` verifications."
+        ),
+    ),
+    _AllowedShape(
+        fields=frozenset({"errors", "ok"}),
+        classes=frozenset(
+            {"ReceiptVerification", "ManifestVerification", "ProjectionVerification"}
+        ),
+        reason=(
+            "core/orchestration/sla_receipt.py, core/orchestration/"
+            "supervisor_receipt.py and core/sandbox/selection_receipt.py each "
+            "declare their own `ReceiptVerification`; core/lineage/c2pa.py and "
+            "core/observability/otel_projection.py declare the same shape "
+            "under two more names. Consolidating the receipt-side ones is part "
+            "of the receipt-protocol work, which owns the receipt fields."
+        ),
+    ),
+    _AllowedShape(
+        fields=frozenset({"errors", "ok", "verified_key_id"}),
+        classes=frozenset({"A2AReceiptVerification", "HeadSignatureVerification"}),
+        reason=(
+            "core/protocols/a2a/receipt.py and core/security/"
+            "audit_head_signature.py verify a signature and report which key "
+            "verified it. Pending consolidation."
+        ),
+    ),
+    _AllowedShape(
+        fields=frozenset({"failures", "ok"}),
+        classes=frozenset({"PolicyVerdict", "GateResult"}),
+        reason=(
+            "core/interop/a2a_consume.py and core/lineage/gate.py report a "
+            "list of failures behind a boolean. Pending consolidation."
+        ),
+    ),
+    _AllowedShape(
+        fields=frozenset({"ok", "reason", "receipt"}),
+        classes=frozenset(
+            {
+                "DispatchVerifyResult",
+                "EscalationVerifyResult",
+                "SpendVerifyResult",
+                "AutofixVerifyResult",
+                "PlacementVerifyResult",
+                "InstallVerifyResult",
+                "VerdictVerifyResult",
+                "RevocationVerifyResult",
+            }
+        ),
+        reason=(
+            "Eight modules declare the outcome of an offline receipt "
+            "verification under eight names with identical fields. The largest "
+            "single collision in the tree and the first one to migrate."
+        ),
+    ),
+    _AllowedShape(
+        fields=frozenset({"ok", "reason", "receipt", "status"}),
+        classes=frozenset({"RunGraphVerifyResult", "LadderVerifyResult"}),
+        reason=(
+            "core/lineage/run_graph.py and core/quality/verifier_ladder.py are "
+            "the eight-way `(ok, reason, receipt)` shape plus a status field. "
+            "They become `VerifyResult` subclasses that add `status` once the "
+            "two status vocabularies are reconciled."
+        ),
+    ),
+    _AllowedShape(
+        fields=frozenset({"passed", "task_id", "violations"}),
+        classes=frozenset({"PolicyCheckResult", "RuleEnforcerResult"}),
+        reason=(
+            "core/security/policy_engine.py and core/security/rule_enforcer.py "
+            "report per-task policy violations. Pending consolidation."
+        ),
+    ),
+)
+
+_ALLOWED_SHAPES: Final[tuple[_AllowedShape, ...]] = _DELIBERATE_SHAPES + _PENDING_SHAPES
+
+
+def _is_result_name(name: str) -> bool:
+    """Return whether *name* reads as the outcome of a check."""
+    stem = name.removesuffix(_DTO_SUFFIX)
+    return stem.endswith(_RESULT_SUFFIXES)
+
+
+def _base_names(node: ast.ClassDef) -> set[str]:
+    """Return the bare names of *node*'s bases, ignoring their qualifiers."""
+    names: set[str] = set()
+    for base in node.bases:
+        if isinstance(base, ast.Name):
+            names.add(base.id)
+        elif isinstance(base, ast.Attribute):
+            names.add(base.attr)
+    return names
+
+
+def _is_dataclass(node: ast.ClassDef) -> bool:
+    """Return whether *node* carries a ``@dataclass`` decorator."""
+    for decorator in node.decorator_list:
+        applied = decorator.func if isinstance(decorator, ast.Call) else decorator
+        name = (
+            applied.id
+            if isinstance(applied, ast.Name)
+            else applied.attr
+            if isinstance(applied, ast.Attribute)
+            else None
+        )
+        if name == "dataclass":
+            return True
+    return False
+
+
+def _annotated_fields(node: ast.ClassDef) -> frozenset[str]:
+    """Return the names of *node*'s own annotated fields."""
+    return frozenset(
+        stmt.target.id
+        for stmt in node.body
+        if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name)
+    )
+
+
+def _shapes_by_fields() -> dict[frozenset[str], list[_Declaration]]:
+    """Return every result-shaped declaration keyed by its field-name set."""
+    shapes: dict[frozenset[str], list[_Declaration]] = defaultdict(list)
+    for path in sorted(SOURCE_ROOT.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (
+            SyntaxError
+        ):  # pragma: no cover - a parse failure is another test's problem
+            continue
+        module = path.relative_to(SOURCE_ROOT).as_posix()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef) or not _is_result_name(node.name):
+                continue
+            if not (_is_dataclass(node) or "BaseModel" in _base_names(node)):
+                continue
+            fields = _annotated_fields(node)
+            if not fields:
+                continue
+            shapes[fields].append(
+                _Declaration(module=module, lineno=node.lineno, name=node.name)
+            )
+    return shapes
+
+
+def _collisions() -> dict[frozenset[str], list[_Declaration]]:
+    """Return the shapes declared at two or more distinct sites."""
+    return {
+        fields: sorted(declarations, key=lambda d: (d.module, d.lineno))
+        for fields, declarations in _shapes_by_fields().items()
+        if len({(d.module, d.name) for d in declarations}) > 1
+    }
+
+
+def _render(fields: frozenset[str], declarations: list[_Declaration]) -> str:
+    """Return a copy-pasteable description of one collision."""
+    joined = ", ".join(sorted(fields))
+    sites = "\n      ".join(str(d) for d in declarations)
+    return f"  ({joined})\n      {sites}"
+
+
+def test_no_new_unallowlisted_field_shape_collisions() -> None:
+    """A recurring field shape must be one type, not one type per module.
+
+    Load-bearing. Three ways to fail, and each one is a real regression:
+    a shape that recurs without an allowlist entry, a class that joins an
+    already-allowlisted shape, and an entry that outlived its collision.
+    """
+    allowed = {entry.fields: entry for entry in _ALLOWED_SHAPES}
+    collisions = _collisions()
+    problems: list[str] = []
+
+    for fields, declarations in sorted(
+        collisions.items(), key=lambda kv: sorted(kv[0])
+    ):
+        entry = allowed.get(fields)
+        if entry is None:
+            problems.append("not allowlisted:\n" + _render(fields, declarations))
+            continue
+        declared = {declaration.name for declaration in declarations}
+        if declared != entry.classes:
+            joined = ", ".join(sorted(declared - entry.classes)) or "(none)"
+            problems.append(
+                f"allowlisted shape gained a class ({joined}):\n"
+                + _render(fields, declarations)
+            )
+
+    for entry in _ALLOWED_SHAPES:
+        if entry.fields not in collisions:
+            problems.append(
+                "stale allowlist entry - this shape no longer collides, delete it:\n"
+                f"  ({', '.join(sorted(entry.fields))})"
+            )
+
+    assert not problems, (
+        "result-class field shapes are out of step with the allowlist:\n\n"
+        + "\n\n".join(problems)
+        + "\n\nDeclare the shape once and specialise it, or - if the split is "
+        "deliberate, as a wire DTO next to its internal type is - add an entry "
+        "to _DELIBERATE_SHAPES with the reason it must stay two types."
+    )
+
+
+def test_every_allowlist_entry_states_a_reason() -> None:
+    """An entry without a reason is a silenced failure, not a decision."""
+    unexplained = [
+        ", ".join(sorted(entry.fields))
+        for entry in _ALLOWED_SHAPES
+        if len(entry.reason.strip()) < 40
+    ]
+    assert not unexplained, (
+        "allowlist entries with no stated reason:\n  "
+        + "\n  ".join(unexplained)
+        + "\n\nThe reason is the whole value of the entry: it says whether the "
+        "split is deliberate or is debt someone still has to pay."
+    )
+
+
+def test_sbom_finding_and_response_dto_stay_deliberately_split() -> None:
+    """The one deliberate split keeps its reason and does not quietly vanish.
+
+    ``SBOMVulnFinding`` is what the scanner produces; ``SBOMVulnFindingResponse``
+    is what the HTTP route returns. They share a field set today and that is
+    correct - the wire shape is a contract with its own compatibility rules.
+    If someone collapses them to remove a duplicate, this test says why not.
+    """
+    entries = [
+        entry
+        for entry in _DELIBERATE_SHAPES
+        if entry.classes == frozenset({"SBOMVulnFinding", "SBOMVulnFindingResponse"})
+    ]
+    assert len(entries) == 1, (
+        "the SBOM finding/DTO split must be recorded exactly once in _DELIBERATE_SHAPES"
+    )
+    assert "wire contract" in entries[0].reason, (
+        "the entry must say why the split is deliberate, not merely that it is"
+    )
+
+    declared = {
+        declaration.name: declaration.module
+        for declarations in _collisions().values()
+        for declaration in declarations
+        if declaration.name in entries[0].classes
+    }
+    assert declared == {
+        "SBOMVulnFinding": "core/security/sbom.py",
+        "SBOMVulnFindingResponse": "core/routes/sbom.py",
+    }, f"the deliberately split pair moved or was collapsed: {declared}"


### PR DESCRIPTION
## What

Adds a guard test that fails when two verification-result classes declare the
same field shape under different names, and removes the largest existing
collision by declaring that shape once.

Two slices of #5099, in the order the issue lists them:

1. `tests/unit/test_verify_result_field_shape_collisions.py` collects every
   result-shaped dataclass and `BaseModel` under `src/bernstein`, keys them by
   their annotated field names, and fails on a shape declared at two or more
   sites without an allowlist entry. The allowlist is populated with the
   collisions that exist today, so the test is green now.
2. `src/bernstein/core/verify_result.py` declares `VerifyResult`, and the eight
   modules that each had their own `(ok, reason, receipt)` class now specialise
   it. That group's allowlist entry is deleted in the same commit.

Explicitly not in this PR:

- The remaining twelve allowlisted collisions. They stay on the allowlist with
  a stated reason each; see **Remaining**.
- What any individual verifier checks. Only the result *type* changes; every
  verification body, reason string and call site is untouched.
- The CLI `--json` shape for `verify` commands (#5103's scope).
- The receipt protocol and kind registry (#5096's scope).

## Why

Eight modules each declared a frozen dataclass with exactly `ok: bool`,
`reason: str`, `receipt: <SomeReceipt> | None` to report how an offline receipt
verification went — dispatch, escalation, spend, autofix, placement, install,
verdict, revocation. Same three fields, same meaning, and no relationship
between any two of them, so a caller holding one could not be written to handle
another without an adapter per class. In practice nobody writes that adapter:
every consumer is pinned to one verifier, and "did this pass, and why" is a
different question depending on which module answered it.

The duplicates were never decided on. Each was a reasonable local choice —
declaring a three-field result next to the verifier that returns it is cheaper
than finding an existing one — and nothing in the tree pushed back, so the count
only ever went up. Twelve other shapes are duplicated the same way, including
three modules that each declare their own `ReceiptVerification`.

The guard is the push-back. From here the duplicate count can be read down but
not silently up.

## How

**The guard.** An AST pass over `src/bernstein`, deliberately narrow: only
classes whose name ends in `Result`, `Verification`, `Verdict`, `Check` or
`Finding` (or the `Response` DTO of one) are in scope. A `Config` and a
`Request` that happen to share three field names are not the same thing and the
test does not claim they are.

The allowlist is split in two so the debt is visible: `_DELIBERATE_SHAPES` holds
splits that are correct and must stay, `_PENDING_SHAPES` holds collisions that
still have to be paid down. Every entry carries a reason, and a separate test
fails on an entry that does not state one.

It is checked in both directions, which is what makes it a ratchet rather than a
snapshot:

- a shape that recurs with no entry fails;
- a class that joins an already-allowlisted shape fails, so an existing entry
  cannot absorb a new duplicate;
- an entry whose collision is gone fails as stale, so a migration must delete
  its row and cannot leave a licence behind for the next author.

Both the second and third branches were exercised by hand before this was
committed.

**The base type — the open decision.** The issue leaves the choice of
`dataclass` / `Protocol` / `BaseModel` to the implementer. This PR uses a frozen
generic dataclass:

```python
@dataclass(frozen=True, slots=True)
class VerifyResult[ReceiptT]:
    ok: bool
    reason: str
    receipt: ReceiptT | None = None
```

- **Not a `Protocol`.** A protocol describes the shape without removing any of
  the eight declarations. The whole cost here is that the shape is declared
  eight times; a structural type leaves all eight standing.
- **Not a `BaseModel`.** All eight are plain frozen dataclasses today. Moving
  them to pydantic would add per-construction validation to a value type built
  on every verification call, for no property this issue asks for.
- **Generic, not a plain base with `receipt: object`.** The eight differ only in
  the receipt they carry. A type parameter keeps that: a caller reading
  `result.receipt.decision_hash` still type-checks.

Each module then specialises rather than redeclares:

```python
#: Outcome of an offline dispatch-receipt verification.
DispatchVerifyResult = VerifyResult[DispatchReceipt]
```

The eight public names, their `__all__` entries and every construction site are
unchanged; a specialisation of a generic dataclass is callable and constructs
the base. Four of the eight declared `receipt` with no default and four
defaulted it to `None`; the base takes the default, which every existing call
site already satisfies.

`pyright` on the nine touched modules reports the same 22 pre-existing
diagnostics as `origin/main` — no new ones, none on the changed lines.

## Tests

All in `tests/unit/test_verify_result_field_shape_collisions.py`. Each failed
before the change, for the reason given.

1. `test_no_new_unallowlisted_field_shape_collisions` — **load-bearing.** On an
   unmodified tree with an empty allowlist it fails listing 13 colliding shapes,
   the eight-way `(ok, reason, receipt)` group among them. Also verified by hand
   in its other two branches: dropping `RuleEnforcerResult` from its entry
   produced `allowlisted shape gained a class (RuleEnforcerResult)`, and a
   fabricated entry produced `stale allowlist entry`.
2. `test_every_allowlist_entry_states_a_reason` — an entry with no reason is a
   silenced failure, not a decision.
3. `test_sbom_finding_and_response_dto_stay_deliberately_split` — the one
   deliberate split keeps its reason, and both classes stay where they are.
   `SBOMVulnFinding` is what the scanner produces, `SBOMVulnFindingResponse` is
   the HTTP contract; collapsing them would make an internal field rename a
   breaking API change.
4. `test_verify_result_subclasses_expose_ok_reason_receipt` — each of the eight
   names resolves to a `VerifyResult` specialisation and constructs an instance
   whose `ok` / `reason` / `receipt` read the same way. Failed with
   `ModuleNotFoundError: No module named 'bernstein.core.verify_result'`.
5. `test_verify_result_is_frozen_so_a_failed_verification_cannot_be_flipped` — a
   verdict a caller can rewrite in place is not a verdict. Same failure before
   the change.

Also run green, since `--affected` selected only the new test file: the 40 test
files that import the nine touched modules or their importers — the skills
packaging/provenance/catalog suites, cost scheduling, review receipt, pool
placement, escalation, eval gate and promotion, x402, and
`tests/unit/test_orchestrator.py`. CI runs the full suite.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes — unchanged diagnostic count on the touched
      modules against `origin/main` (22 before, 22 after)
- [x] `uv run python scripts/run_tests.py -x` passes — run over the affected
      files rather than the whole suite, as noted above
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [ ] User-visible README section updated — N/A, internal type only
- [ ] `docs/operations/<area>.md` updated — N/A, no operator-visible behaviour
- [ ] `docs/api/` schema regenerated — N/A, no public HTTP or CLI surface changed
- [x] `uv run bernstein agents-md sync` run — added the `verify_result.py` row to
      `docs/sdd/module-map.md`
- [x] Tests cover the documented behaviour

Part of #5099

## Remaining

Slices 3 and 4 of the issue, plus the collisions the guard now holds in place.
Each is on the allowlist with the reason it is still there:

| Shape | Classes | Why not yet |
|---|---|---|
| `(errors, ok)` | `ReceiptVerification` ×3, `ManifestVerification`, `ProjectionVerification` | Slice 4. The receipt-side ones belong with #5096, which owns the receipt fields. |
| `(detail, name, passed)` | `GateResult` ×2, `ConformanceCheck`, `ValidatorVerdict` | Slice 3. |
| `(passed, task_id, violations)` | `PolicyCheckResult`, `RuleEnforcerResult` | Slice 3. |
| `(errors, ok, verified_key_id)` | `A2AReceiptVerification`, `HeadSignatureVerification` | Slice 3. |
| `(ok, reason, receipt, status)` | `RunGraphVerifyResult`, `LadderVerifyResult` | This group plus a `status` field; needs the two status vocabularies reconciled before it can subclass `VerifyResult`. |
| `(attestation, ok, reason)` | `CleanRunVerifyResult`, `EquivalenceVerifyResult` | Same shape with the receipt slot renamed; needs the attestation types reconciled. |
| `(count, errors, status)` | `SpineVerifyResult`, `MemoryVerifyResult` | Needs `errors`/`status` reconciled with the `ok`/`reason` pair. |
| `(entries, errors, head_hash, ok)` | `AdmissionVerification`, `LedgerVerification` | Follows the other `(errors, ok, …)` verifications. |
| `(failures, ok)` | `PolicyVerdict`, `GateResult` | Follows the same group. |
| `(action, branch, files_changed, reason)` | `MergeResult` ×2 | Not a verification result; belongs with the drain modules. |
| `(catalog, from_cache, revalidated, source_url)` | `FetchResult` ×2 | Not a verification result; two catalogs over one HTTP caching protocol. |
| `(commit_sha, cost_usd, message, success)` | `DispatchResult`, `GroundedDispatchResult` | Not a verification result. |

