### PR TITLE
fix(trackers): persist poll watermarks and bound the recovery poll (#5131)

### DIFF
--- a/docs/trackers/webhooks.md
+++ b/docs/trackers/webhooks.md
@@ -72,11 +72,35 @@ again.
 On boot the orchestrator may call
 `bernstein.core.trackers.webhook_receiver.replay_recent_via_poll` to
 catch events that the tracker tried to deliver while Bernstein was
-down. The helper runs a single poll, filters tickets older than the
-caller-supplied `last_processed_ts`, and feeds the rest into the same
-sink the webhook route uses. Adapters that do not populate
-`raw["updated_at"]` simply replay all open tickets, which is the safe
-default.
+down. The helper runs a single poll, skips tickets at or below the
+source's watermark, and feeds the rest into the same sink the webhook
+route uses. Adapters that do not populate `raw["updated_at"]` simply
+replay all open tickets, which is the safe default.
+
+The watermark lives in a `PollWatermarks` store: an append-only JSONL
+file, same shape as the replay ledger, read on construction and written
+back after a poll that ran to completion. A restart therefore resumes
+where the last poll stopped instead of replaying the same window. A
+poll cut short by the wall-clock bound leaves the watermark alone, so
+records it never reached are not skipped.
+
+Pass `newest_first=True` for adapters whose `pull_open_tickets` yields
+newest records first; the scan then stops at the first record at or
+below the watermark instead of paginating the whole open-ticket set.
+Left at the default the helper filters every record in Python, which is
+correct for any ordering but costs a full scan.
+
+`RateLimited` is retried with jittered backoff capped at
+`backoff_cap_s`; the retry restarts the poll from the top, which is
+safe when the sink upserts on the ticket id. `TicketUpsertSink` is the
+supplied implementation: it keys on `Ticket.id` so a retried poll
+replaces a record rather than appending a duplicate.
+
+`replay_recent_via_poll_all` drives several sources in one sweep. Each
+source polls inside its own `try`/`except`, so one unreachable resource
+type is recorded in `PollSweepResult.errors` and the sweep continues;
+`deadline_s` bounds the whole sweep so a single hung source cannot
+starve the ones behind it.
 
 ## Reverse-proxy setup
 

--- a/src/bernstein/core/trackers/webhook_receiver.py
+++ b/src/bernstein/core/trackers/webhook_receiver.py
@@ -21,8 +21,11 @@ Design notes:
   found in either causes a 200 OK no-op response so trackers do not
   retry indefinitely.
 * Recovery: ``replay_recent_via_poll`` runs a single poll at startup for
-  events newer than ``last_processed_ts`` so missed deliveries during
-  bernstein downtime are not lost.
+  events newer than a per-source watermark persisted by
+  ``PollWatermarks``, so missed deliveries during bernstein downtime are
+  not lost and a restart does not replay the same window again.
+  ``replay_recent_via_poll_all`` drives several sources under one
+  wall-clock bound with per-source error isolation.
 
 The module deliberately exposes small primitives.  The FastAPI route is
 in :mod:`bernstein.core.routes.tracker_webhooks` and is the only place
@@ -36,10 +39,11 @@ import hmac
 import json
 import logging
 import os
+import random
 import threading
 import time
 from collections import OrderedDict
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -47,7 +51,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 from bernstein.core.security.sanitize import sanitize_log
-from bernstein.core.trackers.contract import RoutingHint, Ticket
+from bernstein.core.trackers.contract import RateLimited, RoutingHint, Ticket
 from bernstein.core.webhook_signatures import verify_hmac_sha256
 
 logger = logging.getLogger(__name__)
@@ -532,7 +536,7 @@ def _gitlab_parse(headers: dict[str, str], payload: dict[str, Any]) -> TrackerEv
         issue_obj = payload.get("issue") or {}
         if not issue_obj:
             return None
-        attrs = {**issue_obj, **{"action": attrs.get("action", "commented")}}
+        attrs = {**issue_obj, "action": attrs.get("action", "commented")}
     iid = attrs.get("iid")
     project = payload.get("project") or {}
     project_path = str(project.get("path_with_namespace") or project.get("name") or "")
@@ -730,43 +734,339 @@ register_builtin_handlers()
 # ---------------------------------------------------------------------------
 
 
+def _ticket_updated_ts(ticket: Any) -> float | None:
+    """Return the ``updated_at`` claim on ``ticket`` as a float, if any."""
+
+    raw: dict[str, Any] = getattr(ticket, "raw", None) or {}
+    value: Any = raw.get("updated_at")
+    if value is None:
+        value = raw.get("updatedAt")
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _backoff_delay(
+    attempt: int,
+    *,
+    retry_after: float | None,
+    base_s: float,
+    cap_s: float,
+    jitter: Callable[[], float],
+) -> float:
+    """Return the equal-jitter wait for ``attempt`` (1-based), capped at ``cap_s``.
+
+    The tracker's own ``retry_after`` hint wins over the exponential
+    schedule when it supplies one, but is still clamped by ``cap_s`` so a
+    hostile or mistaken hint cannot park the poll for an hour.  Half the
+    budget is fixed and half is jittered, which keeps the wait strictly
+    positive while spreading retries from several sources apart.
+    """
+
+    hinted = retry_after is not None and retry_after > 0
+    target = float(retry_after or 0.0) if hinted else base_s * (2 ** (attempt - 1))
+    target = min(target, cap_s)
+    half = target / 2.0
+    return half + jitter() * half
+
+
+class PollWatermarks:
+    """Persisted per-source poll cursors.
+
+    Mirrors :class:`ReplayLedger`: an in-memory dict backed by an
+    append-only JSONL file that is read on construction, so a restart
+    resumes from where the last poll stopped instead of replaying the
+    same "recent" window.  The newest entry for a source wins on load.
+    Cursors only ever move forward, so an out-of-order write cannot
+    rewind a source and re-deliver records already handled.
+
+    Writes are best-effort in the same sense as the replay ledger: a
+    disk failure logs a warning and leaves the in-memory cursor in place
+    rather than aborting the poll.
+    """
+
+    def __init__(self, path: Path | None = None) -> None:
+        self._lock = threading.Lock()
+        self._marks: dict[str, float] = {}
+        self._path = path
+        self._load_from_disk()
+
+    def _load_from_disk(self) -> None:
+        if self._path is None or not self._path.exists():
+            return
+        try:
+            with self._path.open("r", encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entry = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    source = entry.get("source")
+                    ts = entry.get("ts")
+                    if not isinstance(source, str) or not isinstance(ts, (int, float)):
+                        continue
+                    self._marks[source] = float(ts)
+        except OSError as exc:
+            logger.warning("PollWatermarks: failed to load %s: %s", self._path, exc)
+
+    def get(self, source: str) -> float:
+        """Return the cursor for ``source``; ``0.0`` when nothing is recorded."""
+
+        with self._lock:
+            return self._marks.get(source, 0.0)
+
+    def advance(self, source: str, ts: float) -> bool:
+        """Move ``source``'s cursor to ``ts``.  Return ``True`` if it moved.
+
+        A ``ts`` at or below the recorded cursor is ignored so the cursor
+        is monotonic even when a poll observes records out of order.
+        """
+
+        ts_value = float(ts)
+        with self._lock:
+            if ts_value <= self._marks.get(source, 0.0):
+                return False
+            self._marks[source] = ts_value
+        if self._path is not None:
+            try:
+                self._path.parent.mkdir(parents=True, exist_ok=True)
+                with self._path.open("a", encoding="utf-8") as fh:
+                    fh.write(json.dumps({"source": source, "ts": ts_value}) + "\n")
+            except OSError as exc:
+                logger.warning("PollWatermarks: append failed for %s: %s", self._path, exc)
+        return True
+
+
+class TicketUpsertSink:
+    """Sink that upserts tickets on their stable tracker id.
+
+    A poll that is retried after a rate limit, or that overlaps a
+    webhook delivery, hands the same ticket id over more than once.
+    Keying on :attr:`Ticket.id` makes the far side idempotent: the later
+    record replaces the earlier one instead of appending a duplicate.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._by_id: dict[str, Ticket] = {}
+
+    def __call__(self, ticket: Ticket) -> None:
+        with self._lock:
+            self._by_id[ticket.id] = ticket
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._by_id)
+
+    @property
+    def tickets(self) -> list[Ticket]:
+        """Return the current record per stable id, in first-seen order."""
+
+        with self._lock:
+            return list(self._by_id.values())
+
+
+@dataclass(frozen=True)
+class PollSweepResult:
+    """Outcome of a poll sweep across several sources.
+
+    Attributes:
+        delivered: Ticket count handed to the sink, per source.
+        errors: ``"<ExceptionType>: <message>"`` per source that raised.
+            A source that fails is recorded here and the sweep carries on
+            with the remaining sources.
+        timed_out: Sources the wall-clock bound stopped, either before
+            their poll started or partway through it.
+    """
+
+    delivered: dict[str, int]
+    errors: dict[str, str]
+    timed_out: tuple[str, ...]
+
+
 def replay_recent_via_poll(
     adapter: Any,
     *,
-    last_processed_ts: float,
     sink: Callable[[Ticket], None],
+    last_processed_ts: float | None = None,
+    watermarks: PollWatermarks | None = None,
+    source: str | None = None,
+    newest_first: bool = False,
+    deadline: float | None = None,
+    max_attempts: int = 3,
+    backoff_base_s: float = 1.0,
+    backoff_cap_s: float = 60.0,
     now: Callable[[], float] | None = None,
+    sleep: Callable[[float], None] | None = None,
+    jitter: Callable[[], float] | None = None,
 ) -> int:
-    """Poll once and feed any ticket newer than ``last_processed_ts`` to ``sink``.
+    """Poll once and feed any ticket newer than the watermark to ``sink``.
 
     Used at process start to catch events that the tracker tried to
-    deliver while bernstein was down.  The tracker adapter's
-    ``pull_open_tickets`` already paginates the upstream API, so we just
-    iterate and filter by an ``updated_at`` claim on the raw payload -
-    adapters that do not populate that field simply replay all open
-    tickets, which is the safe default.
+    deliver while bernstein was down.
+
+    The watermark comes from ``watermarks`` (keyed by ``source``, or the
+    adapter's ``name``) and is written back after a poll that ran to
+    completion, so a restart resumes where the last poll stopped.  An
+    explicit ``last_processed_ts`` overrides the stored cursor for
+    callers that manage their own; passing neither replays every open
+    ticket, which stays the safe default.
+
+    Set ``newest_first`` when the adapter yields newest records first:
+    the scan then stops at the first record at or below the watermark
+    instead of paginating the whole open-ticket set.  Left ``False`` the
+    function filters every record in Python, which is correct for any
+    ordering but costs a full scan.
+
+    ``deadline`` is an absolute timestamp on the ``now`` clock.  A poll
+    the deadline cuts short does not advance the watermark, because the
+    records it never reached would otherwise be skipped forever.
+
+    :class:`~bernstein.core.trackers.contract.RateLimited` is retried up
+    to ``max_attempts`` times with jittered, capped backoff; the attempt
+    restarts the poll from the top, which is safe when ``sink`` upserts
+    on the ticket id (see :class:`TicketUpsertSink`).  The exception
+    propagates once the attempts are spent.
 
     Returns the number of tickets handed to ``sink``.
     """
 
-    del now  # reserved for clock injection in tests; currently unused
-    count = 0
     pull = getattr(adapter, "pull_open_tickets", None)
     if pull is None:
         return 0
-    for ticket in pull():
-        raw = getattr(ticket, "raw", None) or {}
-        ts_field = raw.get("updated_at") or raw.get("updatedAt")
-        if isinstance(ts_field, (int, float)) and ts_field <= last_processed_ts:
+
+    clock = now if now is not None else time.time
+    sleeper = sleep if sleep is not None else time.sleep
+    jitter_fn = jitter if jitter is not None else random.random
+    key = source or getattr(adapter, "name", None) or "default"
+
+    if last_processed_ts is not None:
+        floor = float(last_processed_ts)
+    elif watermarks is not None:
+        floor = watermarks.get(key)
+    else:
+        floor = 0.0
+
+    attempt = 0
+    while True:
+        count = 0
+        highest = floor
+        complete = True
+        try:
+            for ticket in pull():
+                if deadline is not None and clock() >= deadline:
+                    complete = False
+                    break
+                ts_field = _ticket_updated_ts(ticket)
+                if ts_field is not None and ts_field <= floor:
+                    if newest_first:
+                        break
+                    continue
+                sink(ticket)
+                count += 1
+                if ts_field is not None and ts_field > highest:
+                    highest = ts_field
+        except RateLimited as exc:
+            attempt += 1
+            if attempt >= max_attempts:
+                logger.warning(
+                    "poll recovery: %s rate limited after %d attempts",
+                    sanitize_log(key),
+                    attempt,
+                )
+                raise
+            sleeper(
+                _backoff_delay(
+                    attempt,
+                    retry_after=exc.retry_after,
+                    base_s=backoff_base_s,
+                    cap_s=backoff_cap_s,
+                    jitter=jitter_fn,
+                )
+            )
             continue
-        sink(ticket)
-        count += 1
+        break
+
+    if complete and watermarks is not None:
+        watermarks.advance(key, highest)
     return count
 
 
+def replay_recent_via_poll_all(
+    adapters: Mapping[str, Any],
+    *,
+    sink: Callable[[Ticket], None],
+    watermarks: PollWatermarks | None = None,
+    deadline_s: float | None = None,
+    newest_first: bool = False,
+    max_attempts: int = 3,
+    backoff_base_s: float = 1.0,
+    backoff_cap_s: float = 60.0,
+    now: Callable[[], float] | None = None,
+    sleep: Callable[[float], None] | None = None,
+    jitter: Callable[[], float] | None = None,
+) -> PollSweepResult:
+    """Poll every source in ``adapters``, isolating failures and slow sources.
+
+    Each source polls inside its own ``try``/``except`` so one broken or
+    unreachable resource type cannot abort the rest of the sweep; the
+    failure is recorded in :attr:`PollSweepResult.errors`.  ``deadline_s``
+    bounds the whole sweep rather than each source, so a single hung
+    source cannot starve the ones behind it - sources the bound stops are
+    listed in :attr:`PollSweepResult.timed_out` and keep their watermark.
+    """
+
+    clock = now if now is not None else time.time
+    deadline = clock() + deadline_s if deadline_s is not None else None
+
+    delivered: dict[str, int] = {}
+    errors: dict[str, str] = {}
+    timed_out: list[str] = []
+
+    for name, adapter in adapters.items():
+        if deadline is not None and clock() >= deadline:
+            delivered[name] = 0
+            timed_out.append(name)
+            continue
+        try:
+            delivered[name] = replay_recent_via_poll(
+                adapter,
+                sink=sink,
+                watermarks=watermarks,
+                source=name,
+                newest_first=newest_first,
+                deadline=deadline,
+                max_attempts=max_attempts,
+                backoff_base_s=backoff_base_s,
+                backoff_cap_s=backoff_cap_s,
+                now=clock,
+                sleep=sleep,
+                jitter=jitter,
+            )
+        except Exception as exc:  # one source must not sink the whole sweep
+            delivered[name] = 0
+            errors[name] = f"{type(exc).__name__}: {exc}"
+            logger.warning(
+                "poll recovery: source %s failed: %s",
+                sanitize_log(name),
+                sanitize_log(str(exc)),
+            )
+            continue
+        if deadline is not None and clock() >= deadline:
+            timed_out.append(name)
+
+    return PollSweepResult(delivered=delivered, errors=errors, timed_out=tuple(timed_out))
+
+
 __all__ = [
+    "PollSweepResult",
+    "PollWatermarks",
     "ReceiveResult",
     "ReplayLedger",
+    "TicketUpsertSink",
     "TrackerEvent",
     "WebhookConfig",
     "WebhookHandler",
@@ -776,4 +1076,5 @@ __all__ = [
     "register_builtin_handlers",
     "register_handler",
     "replay_recent_via_poll",
+    "replay_recent_via_poll_all",
 ]

--- a/tests/unit/trackers/test_webhook_receiver.py
+++ b/tests/unit/trackers/test_webhook_receiver.py
@@ -11,9 +11,12 @@ from typing import Any
 import pytest
 
 from bernstein.core.trackers import Ticket
+from bernstein.core.trackers.contract import RateLimited, TrackerUnavailable
 from bernstein.core.trackers.webhook_receiver import (
+    PollWatermarks,
     ReceiveResult,
     ReplayLedger,
+    TicketUpsertSink,
     TrackerEvent,
     WebhookConfig,
     WebhookHandler,
@@ -23,6 +26,7 @@ from bernstein.core.trackers.webhook_receiver import (
     register_builtin_handlers,
     register_handler,
     replay_recent_via_poll,
+    replay_recent_via_poll_all,
 )
 
 # ---------------------------------------------------------------------------
@@ -488,6 +492,256 @@ def test_replay_recent_via_poll_adapter_without_pull_returns_zero() -> None:
 
     n = replay_recent_via_poll(_NoPull(), last_processed_ts=0.0, sink=lambda t: None)
     assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# Persisted watermark, early exit, isolation, deadline, backoff, upsert
+# ---------------------------------------------------------------------------
+
+
+def _ticket(ident: str, ts: float | None = None, *, title: str = "t") -> Ticket:
+    raw: dict[str, Any] = {} if ts is None else {"updated_at": ts}
+    return Ticket(
+        id=ident,
+        external_url="",
+        title=title,
+        body="",
+        status="open",
+        raw=raw,
+    )
+
+
+class _RecordingAdapter:
+    """Adapter fixture that records which tickets each poll actually yielded."""
+
+    def __init__(self, tickets: list[Ticket], *, newest_first: bool = False) -> None:
+        self._tickets = list(tickets)
+        if newest_first:
+            self._tickets.sort(
+                key=lambda t: float(t.raw.get("updated_at", 0.0)),
+                reverse=True,
+            )
+        self.yielded: list[str] = []
+
+    def pull_open_tickets(self) -> Any:
+        for ticket in self._tickets:
+            self.yielded.append(ticket.id)
+            yield ticket
+
+
+class _Clock:
+    """Manually advanced clock so deadline tests stay deterministic."""
+
+    def __init__(self, start: float = 0.0) -> None:
+        self.t = start
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, delta: float) -> None:
+        self.t += delta
+
+
+def test_two_consecutive_polls_over_unchanged_fixture_fetch_zero_new_records_second_time(
+    tmp_path: Path,
+) -> None:
+    marks = PollWatermarks(tmp_path / "watermarks.jsonl")
+    fixture = [_ticket("A", 100.0), _ticket("B", 200.0)]
+    sink = TicketUpsertSink()
+
+    first = replay_recent_via_poll(_RecordingAdapter(fixture), sink=sink, source="jira", watermarks=marks)
+    assert first == 2
+
+    second = replay_recent_via_poll(_RecordingAdapter(fixture), sink=sink, source="jira", watermarks=marks)
+    assert second == 0
+    assert len(sink) == 2
+
+
+def test_watermark_persists_across_process_restart(tmp_path: Path) -> None:
+    path = tmp_path / "watermarks.jsonl"
+    replay_recent_via_poll(
+        _RecordingAdapter([_ticket("A", 100.0)]),
+        sink=lambda t: None,
+        source="jira",
+        watermarks=PollWatermarks(path),
+    )
+
+    reloaded = PollWatermarks(path)
+    assert reloaded.get("jira") == 100.0
+
+    delivered: list[Ticket] = []
+    n = replay_recent_via_poll(
+        _RecordingAdapter([_ticket("A", 100.0)]),
+        sink=delivered.append,
+        source="jira",
+        watermarks=reloaded,
+    )
+    assert n == 0
+    assert delivered == []
+
+
+def test_newest_first_stops_at_first_record_older_than_watermark(tmp_path: Path) -> None:
+    marks = PollWatermarks(tmp_path / "watermarks.jsonl")
+    marks.advance("jira", 150.0)
+    adapter = _RecordingAdapter(
+        [
+            _ticket("A", 100.0),
+            _ticket("B", 120.0),
+            _ticket("C", 200.0),
+            _ticket("D", 300.0),
+        ],
+        newest_first=True,
+    )
+
+    delivered: list[Ticket] = []
+    n = replay_recent_via_poll(
+        adapter,
+        sink=delivered.append,
+        source="jira",
+        watermarks=marks,
+        newest_first=True,
+    )
+
+    assert n == 2
+    assert [t.id for t in delivered] == ["D", "C"]
+    # The scan stops at the first record at or below the watermark; "A" is
+    # never pulled from the adapter at all.
+    assert adapter.yielded == ["D", "C", "B"]
+    assert marks.get("jira") == 300.0
+
+
+def test_one_resource_type_error_does_not_abort_the_others(tmp_path: Path) -> None:
+    class _Broken:
+        def pull_open_tickets(self) -> Any:
+            raise TrackerUnavailable("issues endpoint returned 503")
+
+    delivered: list[Ticket] = []
+    result = replay_recent_via_poll_all(
+        {"issues": _Broken(), "epics": _RecordingAdapter([_ticket("E-1", 10.0)])},
+        sink=delivered.append,
+        watermarks=PollWatermarks(tmp_path / "watermarks.jsonl"),
+    )
+
+    assert result.delivered["epics"] == 1
+    assert result.delivered["issues"] == 0
+    assert "issues" in result.errors
+    assert "TrackerUnavailable" in result.errors["issues"]
+    assert "epics" not in result.errors
+    assert [t.id for t in delivered] == ["E-1"]
+
+
+def test_poll_respects_wall_clock_bound(tmp_path: Path) -> None:
+    clock = _Clock()
+
+    class _SlowAdapter:
+        def __init__(self, tickets: list[Ticket], step: float) -> None:
+            self._tickets = tickets
+            self._step = step
+
+        def pull_open_tickets(self) -> Any:
+            for ticket in self._tickets:
+                clock.advance(self._step)
+                yield ticket
+
+    marks = PollWatermarks(tmp_path / "watermarks.jsonl")
+    slow = _SlowAdapter([_ticket("S-1", 10.0), _ticket("S-2", 20.0), _ticket("S-3", 30.0)], 6.0)
+    delivered: list[Ticket] = []
+
+    result = replay_recent_via_poll_all(
+        {"slow": slow, "second": _RecordingAdapter([_ticket("X-1", 1.0)])},
+        sink=delivered.append,
+        watermarks=marks,
+        deadline_s=10.0,
+        now=clock,
+    )
+
+    assert result.delivered["slow"] == 1
+    assert result.delivered["second"] == 0
+    assert result.timed_out == ("slow", "second")
+    assert result.errors == {}
+    # A poll the deadline cut short must not advance the watermark, or the
+    # records it never reached would be skipped forever.
+    assert marks.get("slow") == 0.0
+
+
+def test_rate_limited_response_backs_off_with_jitter_and_cap() -> None:
+    class _LimitedAdapter:
+        def __init__(self, failures: int) -> None:
+            self.calls = 0
+            self._failures = failures
+
+        def pull_open_tickets(self) -> Any:
+            self.calls += 1
+            if self.calls <= self._failures:
+                raise RateLimited("secondary rate limit", retry_after=600.0)
+            return iter([_ticket("A", 10.0)])
+
+    high_jitter: list[float] = []
+    adapter = _LimitedAdapter(3)
+    delivered: list[Ticket] = []
+    n = replay_recent_via_poll(
+        adapter,
+        sink=delivered.append,
+        max_attempts=4,
+        backoff_cap_s=5.0,
+        sleep=high_jitter.append,
+        jitter=lambda: 1.0,
+    )
+    assert n == 1
+    assert adapter.calls == 4
+    assert [t.id for t in delivered] == ["A"]
+
+    low_jitter: list[float] = []
+    replay_recent_via_poll(
+        _LimitedAdapter(3),
+        sink=lambda t: None,
+        max_attempts=4,
+        backoff_cap_s=5.0,
+        sleep=low_jitter.append,
+        jitter=lambda: 0.0,
+    )
+
+    # ``retry_after`` of 600s is clamped to the 5s cap, and the jitter term
+    # moves the wait within the cap rather than beyond it.
+    assert high_jitter == [5.0, 5.0, 5.0]
+    assert low_jitter == [2.5, 2.5, 2.5]
+    assert all(0.0 < wait <= 5.0 for wait in high_jitter + low_jitter)
+
+
+def test_rate_limit_gives_up_after_max_attempts() -> None:
+    class _AlwaysLimited:
+        def pull_open_tickets(self) -> Any:
+            raise RateLimited("still limited", retry_after=1.0)
+
+    with pytest.raises(RateLimited):
+        replay_recent_via_poll(
+            _AlwaysLimited(),
+            sink=lambda t: None,
+            max_attempts=2,
+            sleep=lambda _s: None,
+            jitter=lambda: 0.0,
+        )
+
+
+def test_sink_upserts_on_stable_id_not_duplicate_inserts(tmp_path: Path) -> None:
+    sink = TicketUpsertSink()
+    sink(_ticket("A", 100.0, title="first"))
+    sink(_ticket("A", 200.0, title="second"))
+    sink(_ticket("B", 100.0, title="other"))
+
+    assert len(sink) == 2
+    assert {t.id for t in sink.tickets} == {"A", "B"}
+    assert next(t for t in sink.tickets if t.id == "A").title == "second"
+
+    # A retried poll re-delivers the same ids; the far side keeps one record
+    # per stable id instead of appending duplicates.
+    marks = PollWatermarks(tmp_path / "watermarks.jsonl")
+    fixture = [_ticket("A", 300.0, title="third"), _ticket("C", 300.0)]
+    replay_recent_via_poll(_RecordingAdapter(fixture), sink=sink, source="s", watermarks=marks)
+    replay_recent_via_poll(_RecordingAdapter(fixture), sink=sink, source="s", watermarks=None)
+
+    assert len(sink) == 3
+    assert next(t for t in sink.tickets if t.id == "A").title == "third"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Rebuilds `replay_recent_via_poll` in `src/bernstein/core/trackers/webhook_receiver.py` so poll-based tracker recovery has a persisted cursor, an early exit, error isolation, a wall-clock bound, rate-limit backoff, and an id-keyed far side.

Added to the module:

| symbol | purpose |
|---|---|
| `PollWatermarks` | per-source cursor store; append-only JSONL, read on construction, monotonic |
| `TicketUpsertSink` | sink keyed on `Ticket.id`; a re-delivery replaces, never appends |
| `PollSweepResult` | per-source delivered counts, errors, and sources the deadline stopped |
| `replay_recent_via_poll_all` | multi-source sweep: per-source `try`/`except` under one deadline |

Explicitly **not** in this PR:

- The webhook push path (`WebhookReceiver.receive`, signature verification) is untouched.
- No adapter changes. `AbstractTrackerAdapter.pull_open_tickets` keeps its signature and no builtin adapter is edited.
- `RateLimited`'s definition in `contract.py` is unchanged; only whether the poll driver catches it.
- No orchestrator wiring. The helper had no production caller before this PR and still has none; it stays a primitive the boot path can adopt.

## Why

`replay_recent_via_poll` was the only poll-based recovery path and took `last_processed_ts` as a plain float the caller had to persist — and nothing did. A restart therefore re-fetched the same "recent" window every time, and the window only ever narrowed if some caller happened to remember the last timestamp itself.

Three further gaps in the same function made that replay expensive and fragile:

- It iterated every page `pull_open_tickets()` returned and filtered in Python, so the cost of "has anything changed?" scaled with the total open-ticket count rather than with the number of changes.
- There was no `try`/`except` around the pull at all, so one unreachable resource type aborted recovery for every other one.
- `RateLimited` already existed in `contract.py` with a `retry_after` hint, and nothing on this path caught it, backed off, or retried; a rate-limited tracker surfaced as an unhandled exception out of boot.

Finally, `sink` was a bare callback, so any re-delivery — a retried poll, or a poll overlapping a webhook delivery for the same ticket — wrote a duplicate downstream.

## How

**Watermark.** `PollWatermarks` mirrors the existing `ReplayLedger` shape in this module: an in-memory dict backed by an append-only JSONL file loaded on construction, newest entry per source wins, best-effort writes that log and continue on `OSError`. `advance()` only moves a cursor forward, so an out-of-order write cannot rewind a source. `replay_recent_via_poll` reads the cursor keyed by `source` (falling back to the adapter's `name`) and writes back the highest `updated_at` it observed — **only when the poll ran to completion**. A poll the deadline cut short leaves the cursor alone; advancing it would permanently skip the records the scan never reached. An explicit `last_processed_ts` still overrides the store, so the existing three tests keep passing unchanged.

**Newest-first — the open decision.** The issue left open whether newest-first should be requested from `pull_open_tickets` (an `AbstractTrackerAdapter` signature change touching every builtin adapter) or faked client-side by sorting after a full fetch. I took neither: `newest_first` is a driver-level flag on `replay_recent_via_poll`, defaulting to `False`. When an operator sets it for a source whose upstream query already returns newest-first, the scan breaks at the first record at or below the watermark and the pages behind it are never pulled — the real early-exit saving. Left at the default the function filters every record exactly as before, which is correct for any ordering. This keeps the adapter contract and every builtin adapter untouched (both listed as non-goals on the issue) while still buying the early exit where the ordering is known, and it leaves the wider interface decision to be made on its own evidence rather than as a side effect of this function.

**Isolation and deadline.** `replay_recent_via_poll_all` polls each source inside its own `try`/`except`; a failure is recorded as `"<Type>: <message>"` in `PollSweepResult.errors` and logged through `sanitize_log`, and the sweep continues. `deadline_s` is converted once to an absolute timestamp on the injected clock and bounds the whole sweep, not each source, so a hung source cannot starve the ones behind it. Sources the bound stops — whether before their poll started or partway through it — are listed in `timed_out` and keep their watermark.

**Backoff.** `RateLimited` is retried up to `max_attempts` with equal jitter: half the budget fixed, half jittered, so the wait is strictly positive and concurrent sources spread apart. The tracker's `retry_after` hint wins over the exponential schedule but is still clamped by `backoff_cap_s`, so a mistaken hint cannot park boot for an hour. The exception propagates once the attempts are spent, which is what puts a persistently limited source into `PollSweepResult.errors` instead of silently returning zero.

**Upsert.** A retried attempt restarts the poll from the top, which re-delivers the tickets the failed attempt already handed over. That is safe precisely because the far side is now keyed: `TicketUpsertSink` stores one record per `Ticket.id`, so a re-delivery replaces rather than appends. The retry and the upsert are the same design decision seen from two ends.

`sleep`, `jitter`, and `now` are injectable so the deadline and backoff contracts are tested against a scripted clock rather than wall time.

## Tests

All in `tests/unit/trackers/test_webhook_receiver.py`. On `main` every one of them fails at import: `PollWatermarks`, `TicketUpsertSink` and `replay_recent_via_poll_all` do not exist. Each was then re-checked individually by mutating the implementation back to the pre-PR behaviour and confirming that specific test — and only that test — goes red (mutation named in brackets).

1. `test_two_consecutive_polls_over_unchanged_fixture_fetch_zero_new_records_second_time` — **load-bearing**, the acceptance criterion. Two polls over an identical fixture; the second delivers zero. Red on `main` because the function cannot read a persisted cursor at all. [mutation: drop the watermark write-back → fails]
2. `test_watermark_persists_across_process_restart` — a second `PollWatermarks` over the same file reads back the cursor, and a poll against it delivers nothing. [same mutation → fails]
3. `test_newest_first_stops_at_first_record_older_than_watermark` — asserts on the fixture's record of what it actually yielded: the scan stops one record past the watermark and the oldest record is never pulled. [mutation: remove the early-exit `break` → fails]
4. `test_one_resource_type_error_does_not_abort_the_others` — a source raising `TrackerUnavailable` lands in `errors` while the following source still delivers.
5. `test_poll_respects_wall_clock_bound` — a clock the fixture advances as it yields; the slow source is truncated, the source behind it is skipped, both appear in `timed_out`, and the truncated source's watermark stays at `0.0`. [mutation: remove the in-loop deadline check → fails]
6. `test_rate_limited_response_backs_off_with_jitter_and_cap` — a `retry_after` of 600s clamped to a 5s cap; `jitter()==1.0` gives 5.0s waits and `jitter()==0.0` gives 2.5s, proving the jitter term moves the wait inside the cap rather than beyond it. [mutation: remove the cap → fails]
7. `test_sink_upserts_on_stable_id_not_duplicate_inserts` — same id twice keeps one record with the later payload, then a repeated poll re-delivers without growing the store. [mutation: key the sink on something other than `Ticket.id` → fails]
8. `test_rate_limit_gives_up_after_max_attempts` — the exception propagates once the attempts are spent, so a persistently limited source is reported rather than silently counted as zero.

The three pre-existing `replay_recent_via_poll` tests are unchanged and still pass.

Local runs (`--parallel 2`, isolated `XDG_*`):

- `uv run python scripts/run_tests.py --parallel 2 -x tests/unit/trackers/test_webhook_receiver.py` — 32 passed
- `--affected origin/main` expanded to effectively the whole suite locally, so instead: `uv run python scripts/run_tests.py --parallel 2 -x tests/unit/trackers/ tests/unit/test_issue_3166_unconfigured_subsystem_status.py tests/unit/test_sonar_copy_comprehensions.py` — 14 files, 294 passed. That covers the changed module and both importers of `webhook_receiver` in the tree. CI runs the full suite.
- `uv run ruff check src/` and `uv run ruff format --check src/` — clean
- `uv run pyright` on the changed module: 122 errors vs 126 on `main` for the same file, i.e. four fewer; the module is not in `pyrightconfig.strict.json`, which is the gating config

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes (advisory repo-wide run; the changed module reports four fewer errors than on `main` and is outside the gating `pyrightconfig.strict.json`)
- [x] `uv run python scripts/run_tests.py -x` passes (run scoped to the touched file plus `--affected origin/main`; CI runs the full suite)
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated — N/A, no README surface changes
- [x] `docs/operations/<area>.md` updated — `docs/trackers/webhooks.md` "Startup-poll recovery" rewritten for the watermark, early exit, backoff, upsert and sweep
- [x] `docs/api/` schema regenerated if a public surface changed — N/A, no HTTP surface changed
- [x] `uv run bernstein agents-md sync` run — run, produced no changes (no new module)
- [x] Tests cover the documented behaviour

Closes #5131
