### PR TITLE
feat: pin manifest for plugins and skills with parse-time rejection of floating versions (#5089)

### DIFF
--- a/docs/reference/cli/verify.md
+++ b/docs/reference/cli/verify.md
@@ -2,13 +2,14 @@
 
 `bernstein verify` is a command group: two run-receipt subcommands
 (`run` and `receipt`, issue #2924), the verifier-ladder subcommand
-(`ladder`, issue #2927), plus five legacy verification modes —
+(`ladder`, issue #2927), the plugin/skill pin subcommand (`pins`,
+issue #5089), plus five legacy verification modes —
 air-gap wheelhouse signatures, WAL hash-chain integrity,
 execution-determinism fingerprints, lesson-memory provenance, and formal
 property checks. The legacy modes live on the default `legacy` subcommand:
 any invocation whose first token is not `run` / `receipt` / `ladder` /
-`legacy` routes there, so pre-group invocations keep their exact behaviour
-and exit codes.
+`pins` / `legacy` routes there, so pre-group invocations keep their exact
+behaviour and exit codes.
 Each legacy mode is selected by its own flag (or a positional argument for
 wheelhouse mode); passing more than one runs all of them and combines their
 exit codes with bitwise OR.
@@ -22,6 +23,7 @@ Merkle-sealed audit trail, see [`bernstein audit verify`](../../security/audit-l
 bernstein verify run <run-id> --signing-key-path key.pem    # build the signed run receipt
 bernstein verify receipt <path> [--public-key pub.pem]      # verify a receipt offline (0/1/2)
 bernstein verify ladder <receipt-hash>                      # re-derive a verifier-ladder receipt (0/1/2)
+bernstein verify pins --manifest pins.yaml --loaded loaded.json  # check the loaded set against the pins (0/1/2)
 bernstein verify <wheelhouse-path>                          # air-gap wheelhouse signatures
 bernstein verify --wal-integrity <run-id>                   # WAL hash-chain check
 bernstein verify --determinism <run-id>                     # print execution fingerprint
@@ -35,8 +37,8 @@ Running the bare command with no arguments prints a usage hint and returns
 without error.
 
 One routing edge: a wheelhouse directory literally named `run`, `receipt`,
-`ladder`, or `legacy` shadows the positional mode — spell it `./run` or use
-`bernstein verify legacy <path>`.
+`ladder`, `pins`, or `legacy` shadows the positional mode — spell it `./run`
+or use `bernstein verify legacy <path>`.
 
 ## Run receipts
 
@@ -117,6 +119,57 @@ substrate no tier can be confirmed to have run.
 | 2 | Re-derivation or spine-anchor mismatch (tamper). |
 
 Architecture: [verifier ladder](../../sdd/verifier-ladder.md).
+
+## Pinned plugins and skills (`verify pins`)
+
+Checks the plugin and skill set an install actually loaded against the
+install-wide pin manifest (issue #5089). The manifest is a governed
+allow-list, not an install log: it names every plugin and skill the install
+*may* load, each at an exact version and content address, plus the sources
+each environment may load them from.
+
+```yaml
+# pins.yaml
+version: 1
+environments:
+  production:
+    allowed_sources:
+      - "github://acme/plugins"
+plugins:
+  - name: audit-logger
+    version: "2.0.0"                     # exact; "latest" or "^2.0" is rejected at parse time
+    content_hash: "sha256:<64 hex>"
+    source: "github://acme/plugins"
+skills:
+  - name: code-review
+    version: "1.2.0"
+    content_hash: "sha256:<64 hex>"
+    source: "github://acme/plugins"
+```
+
+A floating specifier — `latest`, `*`, `^1.2.0`, `1.2`, a branch name — fails
+the parse rather than surviving as a warning, so an install can never drift
+onto whatever `latest` resolves to on a given day. A `content_hash` that is
+not a full `sha256:<64 hex>` address, and a `source` no environment lists,
+fail the parse for the same reason.
+
+`--loaded` takes a JSON list of the resolved components
+(`kind`, `name`, `version`, `content_hash`, `source`); `--environment` names
+the environment whose `allowed_sources` gate them. The command prints one
+line per divergence — presence in either direction, version, content hash,
+and source — so a single run names every drifted entry rather than the
+first. `--json` emits the same list machine-readably alongside the exit
+code.
+
+The source check is independent of version and hash: a component pulled from
+a source the environment does not allow is reported even when its bytes match
+the pin exactly.
+
+| Exit code | Meaning |
+|---|---|
+| 0 | Every loaded component matches its pin. |
+| 1 | The manifest or the loaded set could not be read or failed validation. |
+| 2 | At least one entry drifted. |
 
 ## Legacy modes
 
@@ -201,5 +254,7 @@ Every verification command in Bernstein follows a strict exit-code contract. The
 
 `src/bernstein/cli/commands/verify_cmd.py` (command group);
 `src/bernstein/core/replay/run_receipt.py` (receipt build + offline verify);
-`src/bernstein/core/quality/verifier_ladder.py` (ladder receipts).
+`src/bernstein/core/quality/verifier_ladder.py` (ladder receipts);
+`src/bernstein/core/plugins_core/plugin_pin_manifest.py` (pin manifest,
+verify, and idempotent apply).
 

--- a/docs/release-notes/fragments/5089-plugin-pin-manifest.md
+++ b/docs/release-notes/fragments/5089-plugin-pin-manifest.md
@@ -1,0 +1,13 @@
+## `bernstein verify pins` checks the loaded plugin/skill set against a pinned manifest
+
+An install-wide pin manifest now names every plugin and skill the install may
+load, each at an exact version and content address, together with the sources
+each environment may load them from. A floating specifier — `latest`, `*`,
+`^1.2.0`, `1.2` — fails the parse instead of surviving as a warning, so an
+install cannot drift onto whatever `latest` resolves to on a given day.
+
+`bernstein verify pins --manifest <file> --loaded <file> [--environment NAME]`
+prints one line per divergence in presence, version, content hash, or source
+and exits 2 on any drift. Applying the manifest rewrites its state file only
+when it differs and appends a decision record carrying the manifest hash
+before and after on every apply, no-ops included (#5089).

--- a/src/bernstein/cli/commands/verify_cmd.py
+++ b/src/bernstein/cli/commands/verify_cmd.py
@@ -1524,3 +1524,114 @@ def verify_ladder_cmd(receipt_hash: str, workdir: str) -> None:
     console.print(f"  [red]![/red] {result.reason}")
     console.print()
     raise SystemExit(2)
+
+
+@verify_cmd.command("pins")
+@click.option(
+    "--manifest",
+    "manifest_path",
+    required=True,
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="Install-wide pin manifest listing every plugin and skill this install may load.",
+)
+@click.option(
+    "--loaded",
+    "loaded_path",
+    required=True,
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="JSON list of the resolved components: kind, name, version, content_hash, source.",
+)
+@click.option(
+    "--environment",
+    "environment",
+    default=None,
+    help="Environment whose allowed_sources gate the loaded sources. Omit to skip the source check.",
+)
+@click.option(
+    "--json", "as_json", is_flag=True, default=False, help="Emit the drift list as JSON alongside the exit code."
+)
+def verify_pins_cmd(
+    manifest_path: Path,
+    loaded_path: Path,
+    environment: str | None,
+    as_json: bool,
+) -> None:
+    """Verify the loaded plugin/skill set against the pin manifest.
+
+    The manifest is a governed allow-list: each entry names an exact
+    version, a content address, and the source it may come from. Every
+    divergence is printed -- presence in either direction, version,
+    content hash, and a source the environment does not allow -- so one
+    run names all of them rather than the first.
+
+    \b
+    Exit codes:
+      0  every loaded component matches its pin
+      1  the manifest or the loaded set could not be read
+      2  at least one entry drifted
+    """
+    from bernstein.core.plugins_core.plugin_pin_manifest import (
+        PinManifestError,
+        load_pin_manifest,
+        loaded_components_from_json,
+        verify_pinned_set,
+    )
+
+    try:
+        manifest = load_pin_manifest(manifest_path)
+        loaded = loaded_components_from_json(_json.loads(loaded_path.read_text(encoding="utf-8")))
+    except PinManifestError as exc:
+        for err in exc.errors:
+            console.print(f"[red]![/red] {err}")
+        raise SystemExit(1) from None
+    except (OSError, _json.JSONDecodeError) as exc:
+        console.print(f"[red]Failed to read the loaded set: {exc}[/red]")
+        raise SystemExit(1) from None
+
+    result = verify_pinned_set(manifest, loaded, environment=environment)
+
+    if as_json:
+        console.print_json(
+            data={
+                "ok": result.ok,
+                "manifest_hash": manifest.manifest_hash(),
+                "checked": result.checked,
+                "drifts": [
+                    {
+                        "kind": d.kind,
+                        "name": d.name,
+                        "reason": d.reason,
+                        "expected": d.expected,
+                        "actual": d.actual,
+                    }
+                    for d in result.drifts
+                ],
+            }
+        )
+        raise SystemExit(result.exit_code)
+
+    console.print()
+    if result.ok:
+        console.print(
+            Panel(
+                "[bold green]Pin manifest: VERIFIED[/bold green]",
+                border_style="green",
+                expand=False,
+            )
+        )
+        console.print(f"  [dim]{result.checked} component(s) match manifest {manifest.manifest_hash()}[/dim]")
+        console.print()
+        raise SystemExit(0)
+
+    for line in result.render_lines():
+        console.print(f"  [red]![/red] {line}", overflow="fold", soft_wrap=False)
+    console.print()
+    console.print(
+        Panel(
+            f"[bold red]Pin manifest: DRIFTED ({len(result.drifts)} entry/entries)[/bold red]",
+            border_style="red",
+            expand=False,
+        )
+    )
+    console.print()
+    raise SystemExit(result.exit_code)

--- a/src/bernstein/core/plugins_core/plugin_manifest.py
+++ b/src/bernstein/core/plugins_core/plugin_manifest.py
@@ -39,6 +39,9 @@ _MAX_STRING_LENGTH = 1024
 #: Max number of hooks/tools/skills a plugin can declare.
 _MAX_DECLARATIONS = 100
 
+#: Exact ``MAJOR.MINOR.PATCH`` version - no ranges, no partials, no moving tags.
+_SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
 
 @dataclass(frozen=True)
 class PluginManifest:
@@ -112,6 +115,17 @@ def _validate_plugin_name(name: str) -> list[str]:
     return errors
 
 
+def is_exact_semver(version: str) -> bool:
+    """Return True when *version* is an exact ``MAJOR.MINOR.PATCH`` string.
+
+    Exactness is the whole point: a range (``^1.2.0``), a partial version
+    (``1.2``) or a moving tag (``latest``) all fail, so a caller pinning a
+    version can tell an exact pin from a floating one without re-deriving
+    the rule.
+    """
+    return bool(_SEMVER_RE.match(version))
+
+
 def _validate_semver(version: str) -> list[str]:
     """Validate semantic versioning format (``MAJOR.MINOR.PATCH``)."""
     errors: list[str] = []
@@ -119,8 +133,7 @@ def _validate_semver(version: str) -> list[str]:
         errors.append("Plugin version is required")
         return errors
 
-    semver_re = re.compile(r"^\d+\.\d+\.\d+$")
-    if not semver_re.match(version):
+    if not is_exact_semver(version):
         errors.append(f"Plugin version '{version}' must follow semver (e.g. '1.0.0').")
 
     return errors

--- a/src/bernstein/core/plugins_core/plugin_pin_manifest.py
+++ b/src/bernstein/core/plugins_core/plugin_pin_manifest.py
@@ -1,0 +1,832 @@
+"""Install-wide pin manifest for plugins and skills (issue #5089).
+
+``plugin_reconciler`` removes what a marketplace stopped listing; the
+catalog lockfile records what *was* installed. Neither answers the
+governing question an operator actually has: *is what this install loads
+exactly what it was allowed to load?* This module adds the missing
+document -- one version-controlled allow-list naming every plugin and
+skill, each at an exact version and content address, plus the sources
+each environment may load them from.
+
+Three properties make the manifest worth having:
+
+* **No floating pins.** A specifier like ``latest``, ``^1.2.0`` or ``1.2``
+  is rejected when the manifest is parsed, not warned about at load time.
+  The rejection mirrors
+  :func:`~bernstein.core.plugins_core.plugin_manifest._validate_semver`,
+  raised to the install-wide level: the manifest names an exact byte, so
+  an install can never silently drift onto whatever ``latest`` resolves to
+  on a given day.
+
+* **Divergence is enumerable.** :func:`verify_pinned_set` compares a
+  resolved set against the manifest and returns one
+  :class:`PinDrift` per divergence in presence, version, content hash, or
+  source -- so a caller can print every drifted entry rather than the
+  first one.
+
+* **Applying is idempotent and recorded.** :func:`apply_pin_manifest`
+  writes the manifest's canonical bytes to
+  ``.sdd/plugins/pins/applied.json`` only when they differ, and appends a
+  :class:`PinApplyRecord` carrying the manifest hash before and after to
+  ``.sdd/plugins/pins/decisions.jsonl`` on *every* apply, no-ops included.
+
+Scope: this module does not resolve the loaded set itself. Callers pass
+the resolved plugins and skills in as :class:`LoadedComponent` values.
+
+One manifest, not two
+---------------------
+
+Plugins and skills live in separate subsystems with separate lockfiles,
+but the allow-list is deliberately a single document covering both. The
+question it answers is install-wide, so it needs a single answer and a
+single hash: a decision record that says "the install moved from manifest
+hash A to hash B" is only meaningful if one hash covers everything the
+install may load. Two parallel files would give two hashes, two apply
+ledgers, and no single value to compare.
+
+Usage::
+
+    from bernstein.core.plugins_core.plugin_pin_manifest import (
+        load_pin_manifest,
+        verify_pinned_set,
+    )
+
+    manifest = load_pin_manifest(workdir / ".bernstein" / "pins.yaml")
+    result = verify_pinned_set(manifest, resolved, environment="production")
+    if not result.ok:
+        for line in result.render_lines():
+            print(line)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+from bernstein.core.plugins_core.plugin_manifest import is_exact_semver
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Component kind for an entry under the manifest's ``plugins:`` key.
+PIN_KIND_PLUGIN = "plugin"
+
+#: Component kind for an entry under the manifest's ``skills:`` key.
+PIN_KIND_SKILL = "skill"
+
+#: The two component kinds, in the order they are read from the manifest.
+PIN_KINDS: tuple[str, str] = (PIN_KIND_PLUGIN, PIN_KIND_SKILL)
+
+#: Manifest schema version this parser understands.
+PIN_MANIFEST_VERSION = 1
+
+#: Path of the applied-state file and the apply ledger, under the project root.
+PIN_STATE_SUBPATH: tuple[str, ...] = (".sdd", "plugins", "pins")
+
+#: Filename of the canonical applied manifest state.
+PIN_APPLIED_FILENAME = "applied.json"
+
+#: Filename of the append-only apply ledger.
+PIN_DECISIONS_FILENAME = "decisions.jsonl"
+
+#: Exit code :func:`PinVerifyResult.exit_code` returns when anything drifted.
+PIN_VERIFY_DRIFT_EXIT = 2
+
+#: Component names: alphanumeric plus hyphen, underscore and dot.
+_PIN_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$")
+
+#: A pinned content address is a full SHA-256 digest, never a prefix.
+_CONTENT_HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+#: Reasons a :class:`PinDrift` can carry, in the order they are checked.
+DRIFT_ENVIRONMENT = "environment"
+DRIFT_UNPINNED = "unpinned"
+DRIFT_ABSENT = "absent"
+DRIFT_VERSION = "version"
+DRIFT_CONTENT_HASH = "content_hash"
+DRIFT_SOURCE = "source"
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class PinManifestError(Exception):
+    """Raised when a pin manifest fails to parse or validate.
+
+    Attributes:
+        errors: Every individual validation failure, so an operator fixing
+            the manifest sees all of them in one pass.
+    """
+
+    def __init__(self, errors: list[str]) -> None:
+        self.errors = errors
+        super().__init__(
+            f"Pin manifest validation failed ({len(errors)} error(s)):\n" + "\n".join(f"  - {e}" for e in errors),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PinEntry:
+    """One pinned plugin or skill.
+
+    Attributes:
+        kind: :data:`PIN_KIND_PLUGIN` or :data:`PIN_KIND_SKILL`.
+        name: Component name, unique within its kind.
+        version: Exact ``MAJOR.MINOR.PATCH`` version; never a range.
+        content_hash: Content address (``sha256:<64 hex>``) of the tree the
+            install is allowed to load.
+        source: Marketplace or repository the component may come from.
+    """
+
+    kind: str
+    name: str
+    version: str
+    content_hash: str
+    source: str
+
+    def to_dict(self) -> dict[str, str]:
+        """Serialise to a JSON-friendly dict."""
+        return {
+            "kind": self.kind,
+            "name": self.name,
+            "version": self.version,
+            "content_hash": self.content_hash,
+            "source": self.source,
+        }
+
+
+@dataclass(frozen=True)
+class PinEnvironment:
+    """The sources one environment may load pinned components from.
+
+    Attributes:
+        name: Environment name, e.g. ``production``.
+        allowed_sources: Sources permitted in this environment. A component
+            from any other source is rejected by :func:`verify_pinned_set`
+            regardless of its version or content hash.
+    """
+
+    name: str
+    allowed_sources: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-friendly dict."""
+        return {"name": self.name, "allowed_sources": list(self.allowed_sources)}
+
+
+@dataclass(frozen=True)
+class PinManifest:
+    """The parsed install-wide allow-list.
+
+    Entries and environments are stored sorted, so two manifests listing
+    the same pins in a different file order share one manifest hash.
+    """
+
+    version: int
+    entries: tuple[PinEntry, ...]
+    environments: tuple[PinEnvironment, ...]
+
+    def to_canonical_bytes(self) -> bytes:
+        """Serialise to canonical JSON bytes -- the hashed artifact."""
+        return json.dumps(
+            {
+                "version": self.version,
+                "environments": [e.to_dict() for e in self.environments],
+                "entries": [e.to_dict() for e in self.entries],
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+
+    def manifest_hash(self) -> str:
+        """Return the manifest's content address (``sha256:<hex>``)."""
+        return content_address(self.to_canonical_bytes())
+
+    def entry(self, kind: str, name: str) -> PinEntry | None:
+        """Return the pin for ``(kind, name)``, or ``None`` when unpinned."""
+        for candidate in self.entries:
+            if candidate.kind == kind and candidate.name == name:
+                return candidate
+        return None
+
+    def environment(self, name: str) -> PinEnvironment | None:
+        """Return the named environment, or ``None`` when it is not declared."""
+        for candidate in self.environments:
+            if candidate.name == name:
+                return candidate
+        return None
+
+    def allowed_sources(self, name: str) -> frozenset[str]:
+        """Return the sources ``name`` allows; empty when it is not declared."""
+        env = self.environment(name)
+        return frozenset(env.allowed_sources) if env is not None else frozenset()
+
+
+@dataclass(frozen=True)
+class LoadedComponent:
+    """One plugin or skill the install actually resolved.
+
+    The resolved set is supplied by the caller; recording it at spawn time
+    is a separate concern and is not implemented here.
+    """
+
+    kind: str
+    name: str
+    version: str
+    content_hash: str
+    source: str
+
+
+@dataclass(frozen=True)
+class PinDrift:
+    """One divergence between the loaded set and the manifest.
+
+    Attributes:
+        kind: Component kind, or ``""`` when the drift is not about one
+            component (an undeclared environment, for instance).
+        name: Component name, or ``""`` as above.
+        reason: One of :data:`DRIFT_ENVIRONMENT`, :data:`DRIFT_UNPINNED`,
+            :data:`DRIFT_ABSENT`, :data:`DRIFT_VERSION`,
+            :data:`DRIFT_CONTENT_HASH`, :data:`DRIFT_SOURCE`.
+        expected: What the manifest allows.
+        actual: What was loaded.
+    """
+
+    kind: str
+    name: str
+    reason: str
+    expected: str
+    actual: str
+
+    def describe(self) -> str:
+        """Return a single operator-readable line naming this divergence."""
+        subject = f"{self.kind}/{self.name}" if self.kind and self.name else "manifest"
+        return f"{subject}: {self.reason} (expected {self.expected!r}, loaded {self.actual!r})"
+
+
+@dataclass(frozen=True)
+class PinVerifyResult:
+    """The outcome of comparing a loaded set against the manifest."""
+
+    drifts: tuple[PinDrift, ...]
+    checked: int
+
+    @property
+    def ok(self) -> bool:
+        """True when nothing diverged."""
+        return not self.drifts
+
+    @property
+    def exit_code(self) -> int:
+        """``0`` when clean, :data:`PIN_VERIFY_DRIFT_EXIT` otherwise."""
+        return 0 if self.ok else PIN_VERIFY_DRIFT_EXIT
+
+    def render_lines(self) -> list[str]:
+        """Return one line per drifted entry, in a stable order."""
+        return [d.describe() for d in self.drifts]
+
+
+@dataclass(frozen=True)
+class PinApplyRecord:
+    """The decision record written by one :func:`apply_pin_manifest` call.
+
+    Attributes:
+        timestamp: Caller-supplied integer timestamp, so identical fixtures
+            produce byte-identical ledger lines.
+        manifest_hash_before: Content address of the previously applied
+            manifest; ``""`` on the first apply.
+        manifest_hash_after: Content address of the manifest now applied.
+        changed: False when the apply was a no-op -- the recorded evidence
+            that applying twice changed nothing.
+        entry_count: Number of pinned components in the applied manifest.
+    """
+
+    timestamp: int
+    manifest_hash_before: str
+    manifest_hash_after: str
+    changed: bool
+    entry_count: int
+
+    def to_canonical_bytes(self) -> bytes:
+        """Serialise to one canonical JSON line (without the newline)."""
+        return json.dumps(
+            {
+                "timestamp": self.timestamp,
+                "manifest_hash_before": self.manifest_hash_before,
+                "manifest_hash_after": self.manifest_hash_after,
+                "changed": self.changed,
+                "entry_count": self.entry_count,
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+
+    @classmethod
+    def from_dict(cls, row: dict[str, Any]) -> PinApplyRecord:
+        """Rebuild a record from one parsed ledger line."""
+        return cls(
+            timestamp=int(row["timestamp"]),
+            manifest_hash_before=str(row["manifest_hash_before"]),
+            manifest_hash_after=str(row["manifest_hash_after"]),
+            changed=bool(row["changed"]),
+            entry_count=int(row["entry_count"]),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Hashing
+# ---------------------------------------------------------------------------
+
+
+def content_address(payload: bytes) -> str:
+    """Return ``sha256:<hex>`` over *payload*."""
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+
+def _validate_pinned_version(version: str, label: str) -> list[str]:
+    """Reject anything that is not an exact ``MAJOR.MINOR.PATCH`` version.
+
+    Delegates the format check to
+    :func:`~bernstein.core.plugins_core.plugin_manifest.is_exact_semver` --
+    the same rule the per-plugin manifest applies -- and restates the
+    failure at the install-manifest level, naming the entry so an operator
+    can find it in a long manifest.
+    """
+    if not is_exact_semver(version):
+        shown = version if version else "<empty>"
+        return [
+            f"{label}: version {shown!r} is not an exact pin. "
+            "The manifest must name a MAJOR.MINOR.PATCH version (e.g. '1.0.0'); "
+            "floating specifiers such as 'latest', '*', '^1.2.0' or '1.2' are rejected."
+        ]
+    return []
+
+
+def _parse_environments(raw: Any) -> tuple[list[PinEnvironment], list[str]]:
+    """Parse the ``environments:`` mapping into sorted environments."""
+    errors: list[str] = []
+    if not isinstance(raw, dict):
+        return [], ["environments: must be a mapping of environment name to {allowed_sources: [...]}"]
+
+    mapping = cast("dict[str, Any]", raw)
+    if not mapping:
+        return [], ["environments: at least one environment must be declared"]
+
+    environments: list[PinEnvironment] = []
+    for name in sorted(mapping):
+        body: Any = mapping[name]
+        if not isinstance(body, dict):
+            errors.append(f"environments.{name}: must be a mapping with an 'allowed_sources' list")
+            continue
+        sources_raw: Any = cast("dict[str, Any]", body).get("allowed_sources", [])
+        if not isinstance(sources_raw, list):
+            errors.append(f"environments.{name}.allowed_sources: must be a list of source identifiers")
+            continue
+        sources = [str(s).strip() for s in cast("list[Any]", sources_raw) if str(s).strip()]
+        if not sources:
+            errors.append(f"environments.{name}.allowed_sources: must list at least one source")
+            continue
+        environments.append(PinEnvironment(name=name, allowed_sources=tuple(sorted(set(sources)))))
+
+    return environments, errors
+
+
+def _parse_entry(item: Any, kind: str, index: int, known_sources: frozenset[str]) -> tuple[PinEntry | None, list[str]]:
+    """Parse and validate one ``plugins:``/``skills:`` entry."""
+    label = f"{kind}s[{index}]"
+    if not isinstance(item, dict):
+        return None, [f"{label}: must be a mapping with name, version, content_hash and source"]
+
+    row = cast("dict[str, Any]", item)
+    name = str(row.get("name", "")).strip()
+    label = f"{label} {name!r}" if name else label
+
+    errors: list[str] = []
+    if not name:
+        errors.append(f"{label}: name is required")
+    elif not _PIN_NAME_RE.match(name):
+        errors.append(
+            f"{label}: name contains invalid characters; only alphanumerics, '.', '-' and '_' are allowed",
+        )
+
+    version = str(row.get("version", "")).strip()
+    errors.extend(_validate_pinned_version(version, label))
+
+    content_hash = str(row.get("content_hash", "")).strip()
+    if not _CONTENT_HASH_RE.match(content_hash):
+        errors.append(
+            f"{label}: content_hash {content_hash or '<empty>'!r} must be a full content address "
+            "of the form 'sha256:<64 lowercase hex chars>'",
+        )
+
+    source = str(row.get("source", "")).strip()
+    if not source:
+        errors.append(f"{label}: source is required; a pin names where the component may come from")
+    elif source not in known_sources:
+        errors.append(
+            f"{label}: source {source!r} is not listed in allowed_sources of any environment, "
+            "so no environment could ever load it",
+        )
+
+    if errors:
+        return None, errors
+    return PinEntry(kind=kind, name=name, version=version, content_hash=content_hash, source=source), []
+
+
+def parse_pin_manifest(data: Any) -> PinManifest:
+    """Parse and validate an install-wide pin manifest mapping.
+
+    Every entry must carry an exact version and a full content address, and
+    must come from a source some environment allows. Validation is
+    exhaustive: all failures are collected and reported together.
+
+    Args:
+        data: The parsed manifest document (a mapping).
+
+    Returns:
+        The validated :class:`PinManifest`.
+
+    Raises:
+        PinManifestError: When the document is not a mapping, declares an
+            unsupported schema version, or holds any invalid entry --
+            including a floating or ``latest`` version specifier.
+    """
+    if not isinstance(data, dict):
+        raise PinManifestError(["pin manifest must be a mapping"])
+
+    doc = cast("dict[str, Any]", data)
+    errors: list[str] = []
+
+    raw_version: Any = doc.get("version", PIN_MANIFEST_VERSION)
+    try:
+        schema_version = int(raw_version)
+    except (TypeError, ValueError):
+        schema_version = -1
+    if schema_version != PIN_MANIFEST_VERSION:
+        errors.append(
+            f"version: unsupported pin manifest schema version {raw_version!r}; expected {PIN_MANIFEST_VERSION}"
+        )
+        schema_version = PIN_MANIFEST_VERSION
+
+    environments, env_errors = _parse_environments(doc.get("environments"))
+    errors.extend(env_errors)
+    known_sources = frozenset(s for env in environments for s in env.allowed_sources)
+
+    entries: list[PinEntry] = []
+    seen: set[tuple[str, str]] = set()
+    for kind in PIN_KINDS:
+        raw_list: Any = doc.get(f"{kind}s", [])
+        if raw_list is None:
+            continue
+        if not isinstance(raw_list, list):
+            errors.append(f"{kind}s: must be a list of pinned entries")
+            continue
+        for index, item in enumerate(cast("list[Any]", raw_list)):
+            entry, entry_errors = _parse_entry(item, kind, index, known_sources)
+            errors.extend(entry_errors)
+            if entry is None:
+                continue
+            key = (entry.kind, entry.name)
+            if key in seen:
+                errors.append(f"{kind}s[{index}] {entry.name!r}: duplicate pin for the same {kind}")
+                continue
+            seen.add(key)
+            entries.append(entry)
+
+    if errors:
+        raise PinManifestError(errors)
+
+    return PinManifest(
+        version=schema_version,
+        entries=tuple(sorted(entries, key=lambda e: (e.kind, e.name))),
+        environments=tuple(sorted(environments, key=lambda e: e.name)),
+    )
+
+
+def load_pin_manifest(path: Path) -> PinManifest:
+    """Load and validate the pin manifest at *path* (YAML or JSON).
+
+    Raises:
+        PinManifestError: When the file is missing, unreadable, unparseable,
+            or fails validation.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PinManifestError([f"cannot read pin manifest {path}: {exc}"]) from None
+
+    raw: Any
+    try:
+        import yaml
+
+        raw = yaml.safe_load(text)
+    except ImportError:
+        try:
+            raw = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise PinManifestError([f"cannot parse pin manifest {path}: {exc}"]) from None
+    except Exception as exc:  # pragma: no cover - yaml raises its own error tree
+        raise PinManifestError([f"cannot parse pin manifest {path}: {exc}"]) from None
+
+    return parse_pin_manifest(raw)
+
+
+def loaded_components_from_json(raw: Any) -> list[LoadedComponent]:
+    """Build a resolved set from a parsed JSON list of component records.
+
+    Raises:
+        PinManifestError: When the document is not a list of mappings, or a
+            record is missing a field, or names an unknown kind.
+    """
+    if not isinstance(raw, list):
+        raise PinManifestError(["loaded set must be a JSON list of component records"])
+
+    errors: list[str] = []
+    loaded: list[LoadedComponent] = []
+    for index, item in enumerate(cast("list[Any]", raw)):
+        if not isinstance(item, dict):
+            errors.append(f"loaded[{index}]: must be a mapping")
+            continue
+        row = cast("dict[str, Any]", item)
+        kind = str(row.get("kind", "")).strip()
+        if kind not in PIN_KINDS:
+            errors.append(f"loaded[{index}]: kind {kind!r} must be one of {list(PIN_KINDS)}")
+            continue
+        name = str(row.get("name", "")).strip()
+        if not name:
+            errors.append(f"loaded[{index}]: name is required")
+            continue
+        loaded.append(
+            LoadedComponent(
+                kind=kind,
+                name=name,
+                version=str(row.get("version", "")).strip(),
+                content_hash=str(row.get("content_hash", "")).strip(),
+                source=str(row.get("source", "")).strip(),
+            )
+        )
+
+    if errors:
+        raise PinManifestError(errors)
+    return loaded
+
+
+# ---------------------------------------------------------------------------
+# Verify
+# ---------------------------------------------------------------------------
+
+
+def verify_pinned_set(
+    manifest: PinManifest,
+    loaded: Sequence[LoadedComponent],
+    *,
+    environment: str | None = None,
+) -> PinVerifyResult:
+    """Compare a resolved set against *manifest* and enumerate every drift.
+
+    Presence is checked in both directions: a component that is loaded but
+    unpinned is drift, and so is a pinned component the install did not
+    load -- both mean the running install is not the one that was pinned.
+
+    Source is checked independently of version and content hash, so a
+    component pulled from a source *environment* does not allow is
+    reported even when its bytes match the pin exactly.
+
+    Args:
+        manifest: The parsed allow-list.
+        loaded: The components the install actually resolved.
+        environment: Environment whose ``allowed_sources`` gate the loaded
+            sources. When omitted, the source check is skipped.
+
+    Returns:
+        A :class:`PinVerifyResult`; ``exit_code`` is non-zero on any drift.
+    """
+    allowed: frozenset[str] | None = None
+    if environment is not None:
+        if manifest.environment(environment) is None:
+            return PinVerifyResult(
+                drifts=(
+                    PinDrift(
+                        kind="",
+                        name="",
+                        reason=DRIFT_ENVIRONMENT,
+                        expected=", ".join(e.name for e in manifest.environments),
+                        actual=environment,
+                    ),
+                ),
+                checked=0,
+            )
+        allowed = manifest.allowed_sources(environment)
+
+    drifts: list[PinDrift] = []
+    seen: set[tuple[str, str]] = set()
+
+    for component in sorted(loaded, key=lambda c: (c.kind, c.name)):
+        seen.add((component.kind, component.name))
+        pin = manifest.entry(component.kind, component.name)
+        if pin is None:
+            drifts.append(
+                PinDrift(
+                    kind=component.kind,
+                    name=component.name,
+                    reason=DRIFT_UNPINNED,
+                    expected="",
+                    actual=component.version,
+                )
+            )
+            continue
+        if component.version != pin.version:
+            drifts.append(
+                PinDrift(
+                    kind=component.kind,
+                    name=component.name,
+                    reason=DRIFT_VERSION,
+                    expected=pin.version,
+                    actual=component.version,
+                )
+            )
+        if component.content_hash != pin.content_hash:
+            drifts.append(
+                PinDrift(
+                    kind=component.kind,
+                    name=component.name,
+                    reason=DRIFT_CONTENT_HASH,
+                    expected=pin.content_hash,
+                    actual=component.content_hash,
+                )
+            )
+        if allowed is not None and component.source not in allowed:
+            drifts.append(
+                PinDrift(
+                    kind=component.kind,
+                    name=component.name,
+                    reason=DRIFT_SOURCE,
+                    expected=", ".join(sorted(allowed)),
+                    actual=component.source,
+                )
+            )
+
+    for pin in manifest.entries:
+        if (pin.kind, pin.name) not in seen:
+            drifts.append(
+                PinDrift(
+                    kind=pin.kind,
+                    name=pin.name,
+                    reason=DRIFT_ABSENT,
+                    expected=pin.version,
+                    actual="",
+                )
+            )
+
+    return PinVerifyResult(drifts=tuple(drifts), checked=len(loaded))
+
+
+# ---------------------------------------------------------------------------
+# Apply
+# ---------------------------------------------------------------------------
+
+
+def pin_state_dir(workdir: Path) -> Path:
+    """Return the directory holding the applied state and the apply ledger."""
+    return workdir.joinpath(*PIN_STATE_SUBPATH)
+
+
+def _write_atomic(path: Path, payload: bytes) -> None:
+    """Write *payload* to *path* via a sibling temp file and one rename."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_bytes(payload)
+    tmp.replace(path)
+
+
+def apply_pin_manifest(manifest: PinManifest, *, workdir: Path, timestamp: int) -> PinApplyRecord:
+    """Apply *manifest* to *workdir* and record the decision.
+
+    The applied state is the manifest's canonical bytes. A second apply of
+    the same manifest rewrites nothing, so the state file stays
+    byte-identical, and the returned record carries ``changed=False`` with
+    equal before and after hashes. Every apply -- no-ops included -- appends
+    one line to the apply ledger, so the ledger is a complete history of
+    what the install was told to allow.
+
+    Args:
+        manifest: The manifest to apply.
+        workdir: Project root; state lands under ``.sdd/plugins/pins/``.
+        timestamp: Integer timestamp recorded on the decision record.
+
+    Returns:
+        The :class:`PinApplyRecord` that was appended to the ledger.
+    """
+    applied_path = pin_state_dir(workdir) / PIN_APPLIED_FILENAME
+    payload = manifest.to_canonical_bytes()
+
+    before = ""
+    if applied_path.is_file():
+        before = content_address(applied_path.read_bytes())
+
+    after = content_address(payload)
+    changed = before != after
+    if changed:
+        _write_atomic(applied_path, payload)
+
+    record = PinApplyRecord(
+        timestamp=timestamp,
+        manifest_hash_before=before,
+        manifest_hash_after=after,
+        changed=changed,
+        entry_count=len(manifest.entries),
+    )
+    _append_apply_record(workdir, record)
+    return record
+
+
+def _append_apply_record(workdir: Path, record: PinApplyRecord) -> None:
+    """Append one canonical JSON line to the apply ledger."""
+    path = pin_state_dir(workdir) / PIN_DECISIONS_FILENAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("ab") as fh:
+        fh.write(record.to_canonical_bytes() + b"\n")
+
+
+def read_apply_records(workdir: Path) -> list[PinApplyRecord]:
+    """Return every apply decision record for *workdir*, oldest first.
+
+    Malformed lines are skipped and logged; a truncated tail must not hide
+    the applies that were recorded correctly.
+    """
+    path = pin_state_dir(workdir) / PIN_DECISIONS_FILENAME
+    if not path.is_file():
+        return []
+
+    records: list[PinApplyRecord] = []
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            row: Any = json.loads(line)
+            if not isinstance(row, dict):
+                raise TypeError("record must be a mapping")
+            records.append(PinApplyRecord.from_dict(cast("dict[str, Any]", row)))
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+            log.warning("plugin_pin_manifest: malformed apply record at %s:%d: %s", path, lineno, exc)
+    return records
+
+
+__all__ = [
+    "DRIFT_ABSENT",
+    "DRIFT_CONTENT_HASH",
+    "DRIFT_ENVIRONMENT",
+    "DRIFT_SOURCE",
+    "DRIFT_UNPINNED",
+    "DRIFT_VERSION",
+    "PIN_APPLIED_FILENAME",
+    "PIN_DECISIONS_FILENAME",
+    "PIN_KINDS",
+    "PIN_KIND_PLUGIN",
+    "PIN_KIND_SKILL",
+    "PIN_MANIFEST_VERSION",
+    "PIN_STATE_SUBPATH",
+    "PIN_VERIFY_DRIFT_EXIT",
+    "LoadedComponent",
+    "PinApplyRecord",
+    "PinDrift",
+    "PinEntry",
+    "PinEnvironment",
+    "PinManifest",
+    "PinManifestError",
+    "PinVerifyResult",
+    "apply_pin_manifest",
+    "content_address",
+    "load_pin_manifest",
+    "loaded_components_from_json",
+    "parse_pin_manifest",
+    "pin_state_dir",
+    "read_apply_records",
+    "verify_pinned_set",
+]

--- a/tests/unit/test_plugin_pin_manifest.py
+++ b/tests/unit/test_plugin_pin_manifest.py
@@ -1,0 +1,399 @@
+"""Tests for the install-wide plugin/skill pin manifest (issue #5089).
+
+The manifest is a governed allow-list: it names every plugin and skill the
+install may load, each at an exact version and content address, plus the
+sources each environment may load them from. These tests protect four
+properties:
+
+1. A floating version specifier is rejected when the manifest is parsed,
+   not warned about later.
+2. Both plugins and skills carry an exact version and a content hash.
+3. ``bernstein verify pins`` exits non-zero and prints every drifted entry.
+4. Applying the manifest twice is idempotent and each apply appends a
+   decision record carrying the manifest hash before and after.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.plugins_core.plugin_pin_manifest import (
+    PIN_KIND_PLUGIN,
+    PIN_KIND_SKILL,
+    LoadedComponent,
+    PinManifestError,
+    apply_pin_manifest,
+    load_pin_manifest,
+    parse_pin_manifest,
+    read_apply_records,
+    verify_pinned_set,
+)
+
+_PLUGIN_HASH = "sha256:" + "a" * 64
+_SKILL_HASH = "sha256:" + "b" * 64
+
+
+def _manifest_mapping() -> dict[str, object]:
+    """A minimal well-formed manifest covering one plugin and one skill."""
+    return {
+        "version": 1,
+        "environments": {
+            "production": {"allowed_sources": ["github://acme/plugins"]},
+        },
+        "plugins": [
+            {
+                "name": "audit-logger",
+                "version": "2.0.0",
+                "content_hash": _PLUGIN_HASH,
+                "source": "github://acme/plugins",
+            }
+        ],
+        "skills": [
+            {
+                "name": "code-review",
+                "version": "1.2.0",
+                "content_hash": _SKILL_HASH,
+                "source": "github://acme/plugins",
+            }
+        ],
+    }
+
+
+def _loaded_set() -> list[LoadedComponent]:
+    """The resolved set that exactly matches :func:`_manifest_mapping`."""
+    return [
+        LoadedComponent(
+            kind=PIN_KIND_PLUGIN,
+            name="audit-logger",
+            version="2.0.0",
+            content_hash=_PLUGIN_HASH,
+            source="github://acme/plugins",
+        ),
+        LoadedComponent(
+            kind=PIN_KIND_SKILL,
+            name="code-review",
+            version="1.2.0",
+            content_hash=_SKILL_HASH,
+            source="github://acme/plugins",
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 1. Parse-time rejection of floating versions (load-bearing)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "floating",
+    ["latest", "*", "^1.2.0", "~1.2.0", ">=1.0.0", "1.2", "1.2.x", "main", ""],
+)
+def test_manifest_rejects_floating_or_latest_version_at_parse_time(floating: str) -> None:
+    """A non-exact version must fail the parse, not survive it as a warning."""
+    data = _manifest_mapping()
+    plugins = data["plugins"]
+    assert isinstance(plugins, list)
+    entry = plugins[0]
+    assert isinstance(entry, dict)
+    entry["version"] = floating
+
+    with pytest.raises(PinManifestError) as excinfo:
+        parse_pin_manifest(data)
+
+    assert any("audit-logger" in err for err in excinfo.value.errors)
+    assert any("version" in err for err in excinfo.value.errors)
+
+
+def test_manifest_rejects_a_floating_skill_version_too() -> None:
+    """The rejection is a property of every entry, not only of plugins."""
+    data = _manifest_mapping()
+    skills = data["skills"]
+    assert isinstance(skills, list)
+    entry = skills[0]
+    assert isinstance(entry, dict)
+    entry["version"] = "latest"
+
+    with pytest.raises(PinManifestError) as excinfo:
+        parse_pin_manifest(data)
+
+    assert any("code-review" in err for err in excinfo.value.errors)
+
+
+def test_manifest_rejects_a_content_hash_that_is_not_a_sha256_address() -> None:
+    """A pin without a full ``sha256:<64 hex>`` address is not a pin."""
+    data = _manifest_mapping()
+    plugins = data["plugins"]
+    assert isinstance(plugins, list)
+    entry = plugins[0]
+    assert isinstance(entry, dict)
+    entry["content_hash"] = "sha256:deadbeef"
+
+    with pytest.raises(PinManifestError) as excinfo:
+        parse_pin_manifest(data)
+
+    assert any("content_hash" in err for err in excinfo.value.errors)
+
+
+def test_manifest_rejects_a_source_no_environment_allows() -> None:
+    """An entry whose source is listed by no environment cannot be loaded anywhere."""
+    data = _manifest_mapping()
+    plugins = data["plugins"]
+    assert isinstance(plugins, list)
+    entry = plugins[0]
+    assert isinstance(entry, dict)
+    entry["source"] = "github://someone-else/plugins"
+
+    with pytest.raises(PinManifestError) as excinfo:
+        parse_pin_manifest(data)
+
+    assert any("source" in err for err in excinfo.value.errors)
+
+
+# ---------------------------------------------------------------------------
+# 2. Coverage: every plugin and skill, exact version, content hash
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_lists_every_plugin_and_skill_with_exact_version_and_content_hash(tmp_path: Path) -> None:
+    """One manifest carries both subsystems; each entry is exactly pinned."""
+    path = tmp_path / "pins.yaml"
+    path.write_text(json.dumps(_manifest_mapping()), encoding="utf-8")
+
+    manifest = load_pin_manifest(path)
+
+    kinds = {(e.kind, e.name) for e in manifest.entries}
+    assert kinds == {(PIN_KIND_PLUGIN, "audit-logger"), (PIN_KIND_SKILL, "code-review")}
+    for entry in manifest.entries:
+        assert entry.version.count(".") == 2
+        assert entry.content_hash.startswith("sha256:")
+        assert len(entry.content_hash) == len("sha256:") + 64
+        assert entry.source
+    assert manifest.allowed_sources("production") == frozenset({"github://acme/plugins"})
+
+
+def test_manifest_hash_is_stable_across_entry_order(tmp_path: Path) -> None:
+    """The manifest hash addresses content, not the order it was written in."""
+    forward = _manifest_mapping()
+    reversed_data = _manifest_mapping()
+    plugins = reversed_data["plugins"]
+    skills = reversed_data["skills"]
+    assert isinstance(plugins, list)
+    assert isinstance(skills, list)
+    plugins.append(
+        {
+            "name": "aaa-first",
+            "version": "0.1.0",
+            "content_hash": "sha256:" + "c" * 64,
+            "source": "github://acme/plugins",
+        }
+    )
+    forward_plugins = forward["plugins"]
+    assert isinstance(forward_plugins, list)
+    forward_plugins.insert(
+        0,
+        {
+            "name": "aaa-first",
+            "version": "0.1.0",
+            "content_hash": "sha256:" + "c" * 64,
+            "source": "github://acme/plugins",
+        },
+    )
+
+    assert parse_pin_manifest(forward).manifest_hash() == parse_pin_manifest(reversed_data).manifest_hash()
+
+
+# ---------------------------------------------------------------------------
+# 3. verify: non-zero exit, every drifted entry printed
+# ---------------------------------------------------------------------------
+
+
+def test_verify_reports_no_drift_when_the_loaded_set_matches_the_manifest() -> None:
+    result = verify_pinned_set(parse_pin_manifest(_manifest_mapping()), _loaded_set(), environment="production")
+    assert result.ok
+    assert result.drifts == ()
+
+
+def test_verify_exits_nonzero_and_prints_each_drifted_entry_on_divergence(tmp_path: Path) -> None:
+    """Three independent divergences must all reach the operator's terminal."""
+    from click.testing import CliRunner
+
+    from bernstein.cli.commands.verify_cmd import verify_cmd
+
+    manifest_path = tmp_path / "pins.yaml"
+    manifest_path.write_text(json.dumps(_manifest_mapping()), encoding="utf-8")
+
+    loaded_path = tmp_path / "loaded.json"
+    loaded_path.write_text(
+        json.dumps(
+            [
+                # version drift
+                {
+                    "kind": PIN_KIND_PLUGIN,
+                    "name": "audit-logger",
+                    "version": "2.0.1",
+                    "content_hash": _PLUGIN_HASH,
+                    "source": "github://acme/plugins",
+                },
+                # content-hash drift
+                {
+                    "kind": PIN_KIND_SKILL,
+                    "name": "code-review",
+                    "version": "1.2.0",
+                    "content_hash": "sha256:" + "f" * 64,
+                    "source": "github://acme/plugins",
+                },
+                # presence drift: loaded but not pinned at all
+                {
+                    "kind": PIN_KIND_PLUGIN,
+                    "name": "smuggled",
+                    "version": "9.9.9",
+                    "content_hash": "sha256:" + "e" * 64,
+                    "source": "github://acme/plugins",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(
+        verify_cmd,
+        [
+            "pins",
+            "--manifest",
+            str(manifest_path),
+            "--loaded",
+            str(loaded_path),
+            "--environment",
+            "production",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "audit-logger" in result.output
+    assert "code-review" in result.output
+    assert "smuggled" in result.output
+
+
+def test_verify_exits_zero_when_the_loaded_set_matches(tmp_path: Path) -> None:
+    from click.testing import CliRunner
+
+    from bernstein.cli.commands.verify_cmd import verify_cmd
+
+    manifest_path = tmp_path / "pins.yaml"
+    manifest_path.write_text(json.dumps(_manifest_mapping()), encoding="utf-8")
+    loaded_path = tmp_path / "loaded.json"
+    loaded_path.write_text(
+        json.dumps(
+            [
+                {
+                    "kind": c.kind,
+                    "name": c.name,
+                    "version": c.version,
+                    "content_hash": c.content_hash,
+                    "source": c.source,
+                }
+                for c in _loaded_set()
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(
+        verify_cmd,
+        ["pins", "--manifest", str(manifest_path), "--loaded", str(loaded_path), "--environment", "production"],
+    )
+
+    assert result.exit_code == 0, result.output
+
+
+def test_verify_rejects_a_component_from_a_source_the_environment_does_not_allow() -> None:
+    """An unlisted source fails regardless of a matching version and hash."""
+    manifest = parse_pin_manifest(_manifest_mapping())
+    loaded = _loaded_set()
+    loaded[0] = LoadedComponent(
+        kind=PIN_KIND_PLUGIN,
+        name="audit-logger",
+        version="2.0.0",
+        content_hash=_PLUGIN_HASH,
+        source="github://mirror/plugins",
+    )
+
+    result = verify_pinned_set(manifest, loaded, environment="production")
+
+    assert not result.ok
+    assert result.exit_code != 0
+    reasons = {d.reason for d in result.drifts}
+    assert "source" in reasons
+
+
+def test_verify_reports_a_pinned_entry_that_is_not_loaded() -> None:
+    """Presence divergence runs both ways: pinned-but-absent is drift too."""
+    manifest = parse_pin_manifest(_manifest_mapping())
+    result = verify_pinned_set(manifest, _loaded_set()[:1], environment="production")
+
+    assert not result.ok
+    assert any(d.name == "code-review" and d.reason == "absent" for d in result.drifts)
+
+
+def test_verify_rejects_an_unknown_environment_name() -> None:
+    manifest = parse_pin_manifest(_manifest_mapping())
+    result = verify_pinned_set(manifest, _loaded_set(), environment="staging")
+
+    assert not result.ok
+    assert any(d.reason == "environment" for d in result.drifts)
+
+
+# ---------------------------------------------------------------------------
+# 4. Idempotent apply with a before/after decision record
+# ---------------------------------------------------------------------------
+
+
+def test_apply_manifest_twice_is_idempotent_with_decision_record_hash_before_and_after(tmp_path: Path) -> None:
+    manifest = parse_pin_manifest(_manifest_mapping())
+
+    first = apply_pin_manifest(manifest, workdir=tmp_path, timestamp=1_000)
+    applied_after_first = (tmp_path / ".sdd" / "plugins" / "pins" / "applied.json").read_bytes()
+
+    second = apply_pin_manifest(manifest, workdir=tmp_path, timestamp=2_000)
+    applied_after_second = (tmp_path / ".sdd" / "plugins" / "pins" / "applied.json").read_bytes()
+
+    # Idempotent: the applied state is byte-identical and unchanged.
+    assert applied_after_first == applied_after_second
+    assert first.changed is True
+    assert second.changed is False
+
+    # Every apply carries the manifest hash before and after.
+    assert first.manifest_hash_before == ""
+    assert first.manifest_hash_after == manifest.manifest_hash()
+    assert second.manifest_hash_before == manifest.manifest_hash()
+    assert second.manifest_hash_after == manifest.manifest_hash()
+
+    # Every apply -- including the no-op -- appends a decision record.
+    records = read_apply_records(tmp_path)
+    assert len(records) == 2
+    assert [r.manifest_hash_before for r in records] == ["", manifest.manifest_hash()]
+    assert [r.manifest_hash_after for r in records] == [manifest.manifest_hash()] * 2
+
+
+def test_apply_records_a_changed_manifest_hash_when_the_pins_move(tmp_path: Path) -> None:
+    """A real change records the prior hash, so drift has a before value."""
+    first_manifest = parse_pin_manifest(_manifest_mapping())
+    apply_pin_manifest(first_manifest, workdir=tmp_path, timestamp=1_000)
+
+    data = _manifest_mapping()
+    plugins = data["plugins"]
+    assert isinstance(plugins, list)
+    entry = plugins[0]
+    assert isinstance(entry, dict)
+    entry["version"] = "2.0.1"
+    second_manifest = parse_pin_manifest(data)
+
+    record = apply_pin_manifest(second_manifest, workdir=tmp_path, timestamp=2_000)
+
+    assert record.changed is True
+    assert record.manifest_hash_before == first_manifest.manifest_hash()
+    assert record.manifest_hash_after == second_manifest.manifest_hash()
+    assert record.manifest_hash_before != record.manifest_hash_after


### PR DESCRIPTION
## What

Adds an install-wide pin manifest for plugins and skills, a `verify` verb that
compares a loaded set against it, and an idempotent apply that records the
manifest hash before and after.

**In scope**

- `src/bernstein/core/plugins_core/plugin_pin_manifest.py` — the manifest
  schema, parser, verifier and apply path.
- `bernstein verify pins` — prints every drifted entry, exits non-zero on drift.
- `is_exact_semver` in `plugin_manifest.py` — the exact-version rule promoted
  from a private regex to a shared predicate, so the per-plugin validator and
  the install-wide manifest apply one rule rather than two copies of it.
- `docs/reference/cli/verify.md` + a release-notes fragment.

**Explicitly not in scope**

- Recording the resolved plugin/skill set at spawn time (#4986). `verify pins`
  takes the loaded set as input — a `--loaded` JSON file on the CLI, a
  `Sequence[LoadedComponent]` in the library. Wiring it to a live resolver is
  #4986's job.
- Signature verification of third-party skills (#2899).
- Auto-remediation. Drift is reported and exits non-zero; nothing is removed or
  reinstalled. The marketplace-delisting removal in `plugin_reconciler.py` is
  untouched.
- No new manifest is generated from an installed tree; the manifest is
  version-controlled by the operator.

## Why

`plugin_reconciler.reconcile_plugins` only removes what a marketplace stopped
listing, and `core/skills/catalog/lockfile.py` records what *was* installed.
Neither answers the question an operator running a compliance-sensitive install
actually has: is what this install loads exactly what it was allowed to load?

The content-hash primitives were already there — `tree_content_hash`
(`core/skills/packaging.py:137`) and the inline per-skill `content_hash` in
`serialize_skill_discovery_index` — but nothing compared either against a
document of what the install may load, because no such document existed.
`PluginManifest` validates one plugin's own self-declared fields; it is not an
allow-list.

The concrete failure this closes: a version specifier like `latest` or `^1.2.0`
lets an install resolve to different bytes on different days with nothing in
the tree recording that it moved. Rejecting the specifier at parse time means
the manifest names an exact byte, and `verify` either proves the running
install matches it or says exactly where it diverged.

## How

**One manifest, not two** (the open decision in the issue). Plugins and skills
keep their separate subsystems and separate lockfiles, but the allow-list is a
single document covering both, with one `plugins:` list and one `skills:` list
sharing one entry schema. The reason is the decision record: "the install moved
from manifest hash A to hash B" is only a meaningful statement if one hash
covers everything the install may load. Two parallel files would give two
hashes, two apply ledgers, and no single value to compare — and `verify` would
have to be run twice to answer one question.

```yaml
version: 1
environments:
  production:
    allowed_sources: ["github://acme/plugins"]
plugins:
  - name: audit-logger
    version: "2.0.0"
    content_hash: "sha256:<64 hex>"
    source: "github://acme/plugins"
skills:
  - name: code-review
    version: "1.2.0"
    content_hash: "sha256:<64 hex>"
    source: "github://acme/plugins"
```

- **Parse-time rejection.** `_validate_pinned_version` calls `is_exact_semver`
  and raises `PinManifestError` naming the entry. `latest`, `*`, `^1.2.0`,
  `~1.2.0`, `>=1.0.0`, `1.2`, `1.2.x`, a branch name and an empty string all
  fail. A `content_hash` that is not a full `sha256:<64 hex>` address, and a
  `source` no environment lists, fail the same way. All errors are collected
  and reported together.
- **Manifest hash.** Entries and environments are stored sorted, so the hash
  addresses content rather than file order.
- **Verify.** `verify_pinned_set` returns one `PinDrift` per divergence.
  Presence is checked in both directions — loaded-but-unpinned and
  pinned-but-absent both mean the running install is not the pinned one. The
  source check (from the issue comment) is independent of version and hash, so
  a component pulled from a source the environment does not allow is reported
  even when its bytes match the pin exactly. An `--environment` the manifest
  does not declare is itself drift rather than a silently empty allow-set.
- **Apply.** `apply_pin_manifest` writes the manifest's canonical bytes to
  `.sdd/plugins/pins/applied.json` only when they differ (atomic temp-file
  rename), so a second apply leaves the file byte-identical. Every apply,
  no-ops included, appends one canonical-JSON `PinApplyRecord` carrying
  `manifest_hash_before` / `manifest_hash_after` / `changed` to
  `.sdd/plugins/pins/decisions.jsonl`, so the ledger is a complete history of
  what the install was told to allow, and a no-op is recorded as a no-op rather
  than being invisible.

## Tests

`tests/unit/test_plugin_pin_manifest.py`, 22 tests. The whole file failed on
the unmodified tree at collection — `plugin_pin_manifest` did not exist — and
each test below was additionally checked against the specific defect it names.

1. **`test_manifest_rejects_floating_or_latest_version_at_parse_time`** —
   **load-bearing.** Parametrised over nine specifiers. Verified by
   disabling only the version check on the finished tree: 10 tests go red,
   the rest stay green. This is the criterion most likely to be implemented as
   a warning; the test only passes if the parse raises.
2. `test_manifest_rejects_a_floating_skill_version_too` — the rule is a
   property of every entry, not only of plugins.
3. `test_manifest_rejects_a_content_hash_that_is_not_a_sha256_address` — a
   truncated digest is not a pin.
4. `test_manifest_rejects_a_source_no_environment_allows` — an entry no
   environment could ever load fails at parse, not at verify.
5. `test_manifest_lists_every_plugin_and_skill_with_exact_version_and_content_hash`
   — one manifest carries both subsystems; every entry has an exact version, a
   full content address and a source.
6. `test_manifest_hash_is_stable_across_entry_order` — the hash addresses
   content, so a reordered file is the same manifest.
7. `test_verify_reports_no_drift_when_the_loaded_set_matches_the_manifest`.
8. **`test_verify_exits_nonzero_and_prints_each_drifted_entry_on_divergence`** —
   drives the real CLI through `CliRunner` with three independent divergences
   (version, content hash, unpinned component) and asserts all three names
   reach the output, not just the first.
9. `test_verify_exits_zero_when_the_loaded_set_matches` — the exit code is
   load-bearing in both directions.
10. `test_verify_rejects_a_component_from_a_source_the_environment_does_not_allow`
    — version and hash match exactly; the unlisted source still fails.
11. `test_verify_reports_a_pinned_entry_that_is_not_loaded` — presence
    divergence runs both ways.
12. `test_verify_rejects_an_unknown_environment_name` — an undeclared
    environment must not read as an empty allow-set that passes everything.
13. **`test_apply_manifest_twice_is_idempotent_with_decision_record_hash_before_and_after`**
    — compares the applied file's bytes across two applies, asserts
    `changed` flips to False, and asserts both applies appended a record with
    the before/after hashes.
14. `test_apply_records_a_changed_manifest_hash_when_the_pins_move` — a real
    change records the prior hash, so drift has a before value to compare.

Also run green: `tests/unit/test_plugin_manifest.py` (31),
`tests/unit/test_plugin_reconciler.py` (23),
`tests/unit/test_verify_run_receipt_cmd.py` (22).

## Checklist

- [x] `uv run ruff check src/` — clean on the changed files.
- [x] `uv run ruff format --check src/` — clean on the changed files.
- [x] `uv run pyright src/bernstein/core/plugins_core/plugin_pin_manifest.py
      src/bernstein/core/plugins_core/plugin_manifest.py` — 0 errors.
      `verify_cmd.py` is unchanged at 108 pre-existing errors on `main` and 108
      after this change.
- [x] `uv run python scripts/run_tests.py --parallel 2 -x <files>` — green.
- [x] `--affected origin/main` selected 202 files; run in full: 200 passed.
      The two that did not are environment-bound, not caused by this change —
      `tests/unit/test_doctor.py` hit the runner's 300s per-file cap under load
      and passes in 298s when run alone, and
      `tests/unit/cli/test_run_banner.py::test_bare_invocation_prints_banner_when_splash_disabled`
      fails the same way on an unmodified `origin/main` worktree on this
      machine (`_splash_future.result(timeout=10)` in `cli/main.py:841` times
      out when the box is loaded).
- [x] Type hints on every new function and dataclass field.
- [x] Docs: `docs/reference/cli/verify.md` gains a `verify pins` section, the
      usage block, the routing-edge note and the source list; a release-notes
      fragment is added at `docs/release-notes/fragments/5089-plugin-pin-manifest.md`.
- [x] `uv run bernstein agents-md sync` — no tracked changes.
- [ ] `README.md` — N/A, no README-level surface changed.
- [ ] `docs/api/` schemas — N/A, no HTTP API surface changed.
- [ ] `docs/contributing/testing.md` — N/A, no new test layer.
- [ ] Schema or data migration — N/A, no existing on-disk format changed.

Part of #5089

## Remaining

- Slice 2 is complete as a comparison, but the loaded set it compares is
  supplied by the caller. Wiring it to the resolved set recorded at spawn time
  waits on #4986; until that lands, `verify pins` reads `--loaded` from a file.
- No startup hook calls `verify_pinned_set`. `reconcile_plugins` still runs the
  marketplace pass alone; enforcing pins during startup is a separate change
  once the resolved set exists.
