### PR TITLE
fix(adapters): ScanResult carries the invocation that produced it

### DIFF
--- a/docs/release-notes/fragments/5151-scan-result-invocation-digest.md
+++ b/docs/release-notes/fragments/5151-scan-result-invocation-digest.md
@@ -1,0 +1,10 @@
+## Scan results record the invocation that produced them
+
+`ScanResult` now carries the invocation digest its adapter already computed,
+populated by the Nmap, Trivy and Gitleaks adapters. The digest previously
+lived only on the adapter instance, so a stored result could not say which
+scan produced it -- and Nmap builds its transcript from the hosts and ports it
+found, never the ones requested, so two empty scans of different targets were
+byte-identical. The scanner conformance harness checks the digest separately
+from the transcript, so a replay no longer passes on a transcript that matches
+for the wrong reason. (#5151)

--- a/src/bernstein/adapters/gitleaks.py
+++ b/src/bernstein/adapters/gitleaks.py
@@ -127,7 +127,7 @@ class GitleaksAdapter(ScannerAdapter):
             # SARIF snippets may contain secrets. Findings retain only a digest,
             # so the raw report should not outlive parsing.
             report_path.unlink(missing_ok=True)
-        return ScanResult(findings=findings)
+        return ScanResult(findings=findings, invocation_digest=self.last_invocation.argv_hash)
 
     def _resolve_config_path(self, scope: ScanScope, target: Path) -> Path | None:
         configured = scope.config.get("config_path")

--- a/src/bernstein/adapters/nmap.py
+++ b/src/bernstein/adapters/nmap.py
@@ -152,7 +152,11 @@ class NmapAdapter(ScannerAdapter):
             normalized = normalize_nmap_xml(report_path.read_bytes())
         finally:
             report_path.unlink(missing_ok=True)
-        return ScanResult(findings=list(normalized.findings), transcript=normalized.transcript)
+        return ScanResult(
+            findings=list(normalized.findings),
+            transcript=normalized.transcript,
+            invocation_digest=self.last_invocation.argv_hash,
+        )
 
 
 def _validate_scope(target: Path, scope: ScanScope) -> tuple[str, str]:

--- a/src/bernstein/adapters/scanner.py
+++ b/src/bernstein/adapters/scanner.py
@@ -121,11 +121,21 @@ class ScanResult:
             verify step can diff it.
         feed_digest: Optional digest of the recorded feed (used when determinism
             is ``feed_pinned``).  Empty when the adapter did not pin a feed.
+        invocation_digest: Semantic digest of the invocation that produced this
+            result.  Every adapter already computed one and assigned it only to
+            ``self.last_invocation`` - an attribute of the adapter INSTANCE - so
+            the object callers receive and store could not say which invocation
+            produced it.  That is load-bearing for an empty scan: nmap builds its
+            transcript from the hosts and ports it found, never from the ones
+            requested, so two scans of different targets that both find nothing
+            return byte-identical results.  Empty when the adapter records no
+            invocation provenance.
     """
 
     findings: list[Finding] = field(default_factory=list)
     transcript: str = ""
     feed_digest: str = ""
+    invocation_digest: str = ""
 
     def finding_hashes(self) -> list[str]:
         """Return the per-finding canonical hashes, sorted."""

--- a/src/bernstein/adapters/scanner_conformance.py
+++ b/src/bernstein/adapters/scanner_conformance.py
@@ -65,6 +65,12 @@ class ScannerTranscriptStep:
         expect_exception: Exception class name to expect, or None.
         expect_feed_digest: Expected feed digest when determinism is
             ``feed_pinned``, or None.
+        expected_invocation_digest: Expected invocation digest. A transcript can be
+            byte-identical across genuinely different invocations - nmap builds
+            its transcript from what it FOUND, so two scans of different targets
+            that both find nothing produce the same one - so pinning the
+            transcript alone cannot tell a faithful replay from a different scan
+            (#5151).
         expected_transcript: Expected transcript text when determinism is
             ``transcript_anchored``, or None.
     """
@@ -76,6 +82,7 @@ class ScannerTranscriptStep:
     expected_finding_hashes: list[str] | None = None
     expect_exception: str | None = None
     expect_feed_digest: str | None = None
+    expected_invocation_digest: str | None = None
     expected_transcript: str | None = None
 
     @classmethod
@@ -89,6 +96,7 @@ class ScannerTranscriptStep:
             expected_finding_hashes=raw.get("expected_finding_hashes"),
             expect_exception=raw.get("expect_exception"),
             expect_feed_digest=raw.get("expect_feed_digest"),
+            expected_invocation_digest=raw.get("expected_invocation_digest"),
             expected_transcript=raw.get("expected_transcript"),
         )
 
@@ -435,6 +443,20 @@ class ScannerConformanceHarness:
         if step.expected_transcript is not None and transcript != step.expected_transcript:
             passed = False
             message_parts.append("transcript_anchored tier: recorded transcript differs from the expected one")
+
+        # ... and the invocation that produced it must be the same invocation. Checked
+        # SEPARATELY from the transcript because the transcript cannot carry this: nmap
+        # records the hosts and ports it found, not the ones asked for, so a replay of a
+        # different target that also finds nothing matches byte for byte (#5151).
+        if (
+            step.expected_invocation_digest is not None
+            and scan_result.invocation_digest != step.expected_invocation_digest
+        ):
+            passed = False
+            message_parts.append(
+                "transcript_anchored tier: transcript matched but the invocation digest differs "
+                f"(expected {step.expected_invocation_digest!r}, got {scan_result.invocation_digest!r})"
+            )
 
         actual_hashes_str = ", ".join(actual_finding_hashes[:3]) if actual_finding_hashes else "(none)"
         expected_str = ", ".join(expected_hashes[:3]) if expected_hashes else "(none)"

--- a/src/bernstein/adapters/trivy.py
+++ b/src/bernstein/adapters/trivy.py
@@ -130,7 +130,11 @@ class TrivyAdapter(ScannerAdapter):
             findings = parse_trivy_sarif(report_path.read_bytes(), target_root=resolved_target)
         finally:
             report_path.unlink(missing_ok=True)
-        return ScanResult(findings=findings, feed_digest=db_identity)
+        return ScanResult(
+            findings=findings,
+            feed_digest=db_identity,
+            invocation_digest=self.last_invocation.argv_hash,
+        )
 
 
 def _validate_scope(target: Path, scope: ScanScope) -> str:

--- a/tests/unit/adapters/test_gitleaks_scanner.py
+++ b/tests/unit/adapters/test_gitleaks_scanner.py
@@ -234,3 +234,20 @@ def test_conformance_replays_two_identical_gitleaks_runs(tmp_path: Path) -> None
     assert result.adapter_name == "gitleaks"
     assert result.determinism_tier is DeterminismTier.DETERMINISTIC
     assert sum(call.args[0][1] == "dir" for call in run.call_args_list) == 2
+
+
+def test_scan_result_carries_the_invocation_digest(tmp_path: Path) -> None:
+    """The digest on the returned object is the one the adapter recorded (#5151)."""
+    target = tmp_path / "target"
+    target.mkdir()
+    adapter = GitleaksAdapter(config_path=_CONFIG)
+
+    with (
+        patch("bernstein.adapters.gitleaks.shutil.which", return_value="/usr/local/bin/gitleaks"),
+        patch("bernstein.adapters.gitleaks.subprocess.run", side_effect=_fake_gitleaks_run),
+    ):
+        result = adapter.scan(target, ScanScope(roots=(target,)), tmp_path / "work")
+
+    assert adapter.last_invocation is not None
+    assert result.invocation_digest == adapter.last_invocation.argv_hash
+    assert result.invocation_digest != ""

--- a/tests/unit/adapters/test_nmap_scanner.py
+++ b/tests/unit/adapters/test_nmap_scanner.py
@@ -245,3 +245,82 @@ def test_conformance_fails_when_the_expected_transcript_changes(tmp_path: Path) 
 
     assert not result.passed
     assert "recorded transcript differs" in result.step_results[0].message
+
+
+# ---------------------------------------------------------------------------
+# The stored result must say which invocation produced it (#5151)
+# ---------------------------------------------------------------------------
+
+_EMPTY_NMAP_XML = (
+    '<?xml version="1.0" encoding="UTF-8"?>'
+    '<nmaprun scanner="nmap" args="nmap" start="1735689600" version="7.991">'
+    '<runstats><finished time="1735689601" elapsed="1.00"/>'
+    '<hosts up="0" down="1" total="1"/></runstats></nmaprun>'
+)
+
+
+def _fake_nmap_run_empty():
+    """An nmap that finds nothing: host down, or nothing listening in range."""
+
+    def run(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if argv[1:] == ["--version"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="Nmap version 7.991 ( https://nmap.org )\n", stderr="")
+        Path(argv[argv.index("-oX") + 1]).write_text(_EMPTY_NMAP_XML, encoding="utf-8")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    return run
+
+
+def _empty_scan(target: str, ports: str, workdir: Path):
+    adapter = NmapAdapter()
+    with (
+        patch("bernstein.adapters.nmap.shutil.which", return_value="/usr/local/bin/nmap"),
+        patch("bernstein.adapters.nmap.subprocess.run", side_effect=_fake_nmap_run_empty()),
+    ):
+        return adapter, adapter.scan(Path(target), ScanScope(config={"ports": ports}), workdir)
+
+
+def test_empty_result_for_different_invocations_does_not_verify_as_the_same_result(
+    tmp_path: Path,
+) -> None:
+    """Two scans that find nothing must still be distinguishable.
+
+    `normalize_nmap_xml` builds its transcript from the hosts and ports nmap
+    REPORTED, never from the ones requested, so an empty scan's transcript is
+    byte-identical whatever was asked for. With the invocation hash living only
+    on the adapter instance, the two stored results were identical objects: a
+    scan of one target could verify as a scan of another.
+    """
+    _a, result_a = _empty_scan("127.0.0.1", "8765", tmp_path / "a")
+    _b, result_b = _empty_scan("10.0.0.1", "1-1024", tmp_path / "b")
+
+    # The premise: nothing else on the result tells them apart.
+    assert result_a.transcript == result_b.transcript
+    assert result_a.finding_hashes() == result_b.finding_hashes() == []
+
+    assert result_a.invocation_digest != result_b.invocation_digest
+
+
+def test_scan_result_carries_the_invocation_digest(tmp_path: Path) -> None:
+    """The digest on the returned object is the one the adapter recorded.
+
+    Asserted against `last_invocation` rather than against a literal: the point
+    is that the two agree, not what the hash happens to be.
+    """
+    adapter, result = _empty_scan("127.0.0.1", "8765", tmp_path / "work")
+    assert adapter.last_invocation is not None
+    assert result.invocation_digest == adapter.last_invocation.argv_hash
+    assert result.invocation_digest != ""
+
+
+def test_the_digest_follows_the_ports_asked_for_not_the_ports_found(tmp_path: Path) -> None:
+    """Same target, different port range, both empty - still two results.
+
+    The narrower half of the load-bearing case, and the one an operator hits:
+    re-running the same host over a wider range is the ordinary next step after
+    an empty scan.
+    """
+    _a, result_a = _empty_scan("127.0.0.1", "8765", tmp_path / "a")
+    _b, result_b = _empty_scan("127.0.0.1", "1-1024", tmp_path / "b")
+    assert result_a.transcript == result_b.transcript
+    assert result_a.invocation_digest != result_b.invocation_digest

--- a/tests/unit/adapters/test_trivy_scanner.py
+++ b/tests/unit/adapters/test_trivy_scanner.py
@@ -313,3 +313,23 @@ def test_conformance_replays_two_runs_with_the_same_db_pin(tmp_path: Path) -> No
     assert result.determinism_tier is DeterminismTier.FEED_PINNED
     assert [step.feed_digest for step in result.step_results] == [_DB_IDENTITY, _DB_IDENTITY]
     assert sum(call.args[0][1] == "filesystem" for call in run.call_args_list) == 2
+
+
+def test_scan_result_carries_the_invocation_digest(tmp_path: Path) -> None:
+    """The digest on the returned object is the one the adapter recorded (#5151).
+
+    Every adapter computed this and assigned it only to `self.last_invocation`, an
+    attribute of the adapter INSTANCE - so the object a caller stores could not say
+    which invocation produced it.
+    """
+    adapter = TrivyAdapter(cache_dir=tmp_path / "cache")
+    with (
+        patch("bernstein.adapters.trivy.shutil.which", return_value="/usr/local/bin/trivy"),
+        patch("bernstein.adapters.trivy._db_identity", return_value=_DB_IDENTITY),
+        patch("bernstein.adapters.trivy.subprocess.run", side_effect=_fake_trivy_run),
+    ):
+        result = adapter.scan(_TARGET, _scope(), tmp_path / "work")
+
+    assert adapter.last_invocation is not None
+    assert result.invocation_digest == adapter.last_invocation.argv_hash
+    assert result.invocation_digest != ""

--- a/tests/unit/test_scanner_conformance_harness.py
+++ b/tests/unit/test_scanner_conformance_harness.py
@@ -131,6 +131,47 @@ def test_replay_step_compares_the_pinned_transcript() -> None:
     assert "transcript differs" in result.message
 
 
+def test_conformance_transcript_anchored_check_uses_the_invocation_digest() -> None:
+    """A matching transcript is not enough: the invocation has to be the same one.
+
+    The transcript cannot carry this. Nmap records the hosts and ports it FOUND, never
+    the ones requested, so a replay of a different target that also finds nothing
+    matches byte for byte - and the replay passed on evidence that proved nothing
+    (#5151).
+    """
+    _reset(result=ScanResult(findings=[], transcript="t", invocation_digest="ran-something-else"))
+    step = ScannerTranscriptStep(expected_transcript="t", expected_invocation_digest="what-was-recorded")
+
+    result = ScannerConformanceHarness().replay_step(_RecordingScanner(), step, 0)
+
+    assert not result.passed
+    assert "invocation digest" in result.message
+
+
+def test_a_matching_invocation_digest_does_not_fail_the_replay() -> None:
+    """The over-correction guard: a faithful replay must still pass."""
+    _reset(result=ScanResult(findings=[], transcript="t", invocation_digest="the-same-one"))
+    step = ScannerTranscriptStep(expected_transcript="t", expected_invocation_digest="the-same-one")
+
+    result = ScannerConformanceHarness().replay_step(_RecordingScanner(), step, 0)
+
+    assert result.passed, result.message
+
+
+def test_a_transcript_pinned_without_an_invocation_digest_is_unchanged() -> None:
+    """Existing golden transcripts carry no digest and must keep passing.
+
+    The field is optional, so a recorded corpus predating it is not retroactively
+    failed for holding evidence it could not have had.
+    """
+    _reset(result=ScanResult(findings=[], transcript="t", invocation_digest="anything"))
+    step = ScannerTranscriptStep(expected_transcript="t")
+
+    result = ScannerConformanceHarness().replay_step(_RecordingScanner(), step, 0)
+
+    assert result.passed, result.message
+
+
 def test_replay_step_matches_an_expected_exception() -> None:
     _reset(raise_exc=RuntimeError)
     step = ScannerTranscriptStep(expect_exception="RuntimeError")


### PR DESCRIPTION
## What

`ScanResult.invocation_digest`, populated by all three adapters and checked by the conformance harness.

Fixes #5151.

## The open decision, and why I picked `invocation_digest`

You left the name open: reuse `argv_hash` for continuity, or something more general.

**`invocation_digest`**, because the field lives on the shared `ScanResult` contract rather than on any adapter's own provenance struct. `NmapInvocation`, `TrivyInvocation` and `GitleaksInvocation` keep `argv_hash` — that is literally what they hold, a hash over an argv — but the contract field is the *general* claim "this is which invocation produced this result", and a future adapter (an HTTP-API scanner, say) will have provenance with no argv in it. Naming the contract after one adapter's implementation is the kind of thing that reads fine now and is wrong the first time it does not fit.

## Why the empty case is load-bearing

`normalize_nmap_xml` builds its transcript from the hosts and ports nmap **reported**, never from the ones requested. So a scan that finds nothing — host down, filtered, nothing listening in range — produces a byte-identical transcript whatever was asked for.

The load-bearing test asserts that premise explicitly before asserting the fix:

```python
assert result_a.transcript == result_b.transcript
assert result_a.finding_hashes() == result_b.finding_hashes() == []
assert result_a.invocation_digest != result_b.invocation_digest
```

Without the first two lines it would pass for the wrong reason the day something else starts distinguishing them. Confirmed red before the change, along with the other two nmap cases.

I added a third: same target, **wider port range**, both empty. That is the narrower half and the one an operator actually hits — re-running the same host over a bigger range is the ordinary next step after an empty scan.

## Conformance

`expected_invocation_digest` is checked **separately** from `expected_transcript`, not folded into it, because the transcript cannot carry this — a replay that matched byte for byte was passing on evidence that proved nothing.

**Optional**, with a test pinning that: a golden corpus recorded before this field existed must not be retroactively failed for holding evidence it could not have had. There is also an over-correction guard that a faithful replay still passes.

## Verify

Your exact command:

```
scripts/run_tests.py -x tests/unit/adapters/test_scanner.py tests/unit/adapters/test_nmap_scanner.py \
  tests/unit/adapters/test_trivy_scanner.py tests/unit/adapters/test_gitleaks_scanner.py \
  tests/unit/test_scanner_conformance_harness.py
```
→ **91 passed** across the five files. `ruff check` on the five source files is clean.

Non-goals respected: no `finding` lineage kind, no transcript content changes, no fourth adapter.

## Checklist

- [x] `ruff check src/` and `ruff format --check` pass
- [ ] `pyright src/` — not run clean, and not by this change; repo-wide advisory scope is red on `main` (#4864). The diff adds one dataclass field and one optional step field.
- [x] `scripts/run_tests.py`: 91 passed
- [x] New code has type hints

### Documentation duty

- [x] README / `docs/operations/` — N/A, internal adapter contract
- [x] `docs/api/` — N/A, no public schema; both new fields are documented on their dataclasses where a caller meets them
- [x] `agents-md sync` — N/A, no new module
- [x] Tests cover the documented behaviour


---

## Maintainer addition

One file added on top of the above: `docs/release-notes/fragments/5151-scan-result-invocation-digest.md`. `ScanResult` is exported from `bernstein.adapters.__all__`, so the new field is a public-API addition and CONTRIBUTING asks for a fragment in the same change. No code was touched.
