### PR TITLE
lineage: project the ancestry DAG into PROV-O (#5039)

### DIFF
--- a/docs/release-notes/fragments/5039-prov-o-export.md
+++ b/docs/release-notes/fragments/5039-prov-o-export.md
@@ -1,0 +1,6 @@
+## PROV-O export for lineage v1 ancestry
+
+`bernstein lineage export-prov <artefact>` projects an artefact's
+`parent_hashes` ancestry from the v1 log into W3C PROV-O (PROV-JSON
+or Turtle). Deterministic: two exports of the same ancestry produce
+byte-identical output. (#5039)

--- a/src/bernstein/cli/commands/lineage_cmd.py
+++ b/src/bernstein/cli/commands/lineage_cmd.py
@@ -16,6 +16,11 @@ Two surfaces:
   above; preferred in scripts to avoid colliding with subcommand names.
 * ``bernstein lineage export <run_id> --format <csv|jsonld|html|openlineage>`` --
   produce a regulator-shaped artefact or OpenLineage JSONL projection (#4914).
+* ``bernstein lineage export-prov <artefact_path> --format <json|turtle>`` --
+  project an artefact's ``parent_hashes`` ancestry from the v1 log into
+  W3C PROV-O (#5039). A separate command from ``export`` above: this one
+  reads the content-addressed v1 log (``core/lineage/entry.py``) by
+  artefact path, not the run-id-keyed regulator store.
 * ``bernstein lineage verify <run_id>`` -- one-shot chain verification;
   exits 0 only when every record validates.
 
@@ -350,6 +355,71 @@ def chain_cmd(artefact_path: str, log_path: Path, cards_dir: Path) -> None:
     console.print(f"[green]chain OK[/green] ({len(entries)} entry(ies))")
     console.print(f"  open tips: {tips['open']}")
     console.print(f"  merged:    {tips['merged']}")
+
+
+@lineage_cmd.command(name="export-prov")
+@click.argument("artefact_path", required=True)
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["json", "turtle"], case_sensitive=False),
+    default="json",
+    show_default=True,
+    help="PROV-JSON or Turtle serialisation.",
+)
+@click.option(
+    "--log",
+    "log_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=Path(".sdd/lineage/log.jsonl"),
+    show_default=True,
+)
+@click.option(
+    "--output",
+    "-o",
+    "output_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Write to file instead of stdout.",
+)
+def export_prov_cmd(artefact_path: str, fmt: str, log_path: Path, output_path: Path | None) -> None:
+    """Export ARTEFACT_PATH's ancestry as a PROV-O document (issue #5039).
+
+    Walks the open tip for ARTEFACT_PATH and projects its full
+    ``parent_hashes`` ancestry into W3C PROV-O -- PROV-JSON by default,
+    Turtle with ``--format turtle``. Deterministic: re-running against
+    the same log produces byte-identical output.
+    """
+    import sys
+
+    from bernstein.cli.commands._lineage_v1_helpers import read_entries
+    from bernstein.core.lineage.prov_export import canonical_prov_json_bytes, project_prov_ancestry, to_turtle
+    from bernstein.core.lineage.tips import compute_tips
+
+    if not log_path.exists():
+        console.print(f"[yellow]No log at {log_path}[/yellow]")
+        sys.exit(1)
+
+    entries = read_entries(log_path)
+    tip_set = compute_tips(entries).get(artefact_path)
+    if not tip_set or not tip_set["open"]:
+        console.print(f"[yellow]No open tip for {artefact_path}[/yellow]")
+        sys.exit(1)
+    if len(tip_set["open"]) > 1:
+        console.print(
+            f"[red]{artefact_path} has {len(tip_set['open'])} open tips (unresolved fork).[/red] "
+            "Resolve with `bernstein lineage resolve` before exporting."
+        )
+        sys.exit(1)
+
+    doc = project_prov_ancestry(entries, root_entry_hash=tip_set["open"][0])
+    payload = canonical_prov_json_bytes(doc).decode("utf-8") if fmt.lower() == "json" else to_turtle(doc)
+
+    if output_path is None:
+        click.echo(payload)
+    else:
+        output_path.write_text(payload, encoding="utf-8")
+        console.print(f"[green]Wrote[/green] {len(payload)} byte(s) -> {output_path} [{fmt.lower()}]")
 
 
 @lineage_cmd.command(name="reindex")

--- a/src/bernstein/core/lineage/prov_export.py
+++ b/src/bernstein/core/lineage/prov_export.py
@@ -1,0 +1,501 @@
+"""PROV-O export: a deterministic projection of the lineage DAG (issue #5039).
+
+Bernstein's lineage v1 store (:mod:`bernstein.core.lineage.entry`,
+:mod:`bernstein.core.lineage.store`) is a content-addressed DAG: every
+:class:`~bernstein.core.lineage.entry.LineageEntry` names its own
+``content_hash`` and the ``parent_hashes`` of the entries it supersedes.
+That graph is provenance in everything but vocabulary -- W3C PROV-O is the
+vocabulary regulators, research-data systems, and archival tooling already
+read, and the tree carries no PROV export at all.
+
+This module makes the PROV-O export a **projection** of the lineage log
+rather than a hand-maintained parallel record, following the style of
+:mod:`bernstein.core.lineage.c2pa` and
+:mod:`bernstein.core.observability.otel_projection`:
+
+* Every PROV entity id embeds the artefact's ``content_hash``, so a
+  consumer holding the referenced bytes can verify the node is what it
+  claims.
+* ``parent_hashes`` become ``prov:wasDerivedFrom`` edges between entities;
+  ``attachment_digests`` become ``prov:used`` edges from the producing
+  activity onto an entity for each attached input.
+* :func:`project_prov_ancestry` is a pure function of the entries it is
+  given -- it never reads a clock, environment, or a random source, so two
+  exports of the same ancestry produce byte-identical PROV-JSON and Turtle.
+  Every relation id is a stable index over a sorted relation list rather
+  than a generated UUID, and the only timestamp in the document
+  (``prov:generatedAtTime`` / ``prov:endTime``) is derived from the
+  entry's own ``ts_ns``, never from the export's wall clock.
+
+Only entries reachable from the requested entry by walking ``parent_hashes``
+are exported: the ancestry of one artefact, not the whole log. Signing the
+export and validating it against the PROV-O ontology are later slices of
+issue #5039 (see the issue's slice list); this module produces the unsigned
+document those later slices will sign and validate.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.lineage.entry import LineageEntry, entry_hash
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+__all__ = [
+    "NS_BERNSTEIN",
+    "NS_PROV",
+    "NS_XSD",
+    "PROV_SCHEMA_VERSION",
+    "ProvActivity",
+    "ProvAgent",
+    "ProvDocument",
+    "ProvEntity",
+    "ProvExportError",
+    "ProvRelation",
+    "canonical_prov_json_bytes",
+    "project_prov_ancestry",
+    "to_prov_json",
+    "to_turtle",
+]
+
+#: Schema version of this projection envelope. Bumped on breaking changes to
+#: the exported document shape.
+PROV_SCHEMA_VERSION: str = "1.0.0"
+
+NS_PROV: str = "http://www.w3.org/ns/prov#"
+NS_XSD: str = "http://www.w3.org/2001/XMLSchema#"
+#: Namespace for the bernstein-specific extension attributes (e.g.
+#: ``trust_class``) that have no PROV core term -- see the issue's mapping
+#: table.
+NS_BERNSTEIN: str = "urn:bernstein:"
+
+
+class ProvExportError(RuntimeError):
+    """Raised when a PROV export cannot be built.
+
+    Raised by :func:`project_prov_ancestry` when the requested entry is not
+    among the supplied entries: the export is *unproducible* without the
+    entry it starts from, not merely empty.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Id derivation
+# ---------------------------------------------------------------------------
+
+
+def _entity_id(content_hash: str) -> str:
+    """Return the ``prov:Entity`` URI for an artefact version.
+
+    Embeds ``content_hash`` (already ``sha256:``-prefixed) so a verifier
+    holding the referenced bytes can confirm the node is what it claims.
+    """
+    return f"urn:bernstein:entity:{content_hash}"
+
+
+def _attachment_entity_id(digest_hex: str) -> str:
+    """Return the entity URI for an attached input, from its bare hex digest."""
+    return _entity_id(f"sha256:{digest_hex}")
+
+
+def _activity_id(entry_hash_str: str) -> str:
+    """Return the ``prov:Activity`` URI for the turn that produced one entry."""
+    return f"urn:bernstein:activity:{entry_hash_str}"
+
+
+def _agent_id(agent_id: str) -> str:
+    return f"urn:bernstein:agent:{agent_id}"
+
+
+def _model_agent_id(provider: str, model_requested: str) -> str:
+    return f"urn:bernstein:agent:model:{provider}:{model_requested}"
+
+
+def _iso_from_ts_ns(ts_ns: int) -> str:
+    """Return an xsd:dateTime string for a nanosecond epoch timestamp.
+
+    Built from integer division alone (no float arithmetic) so the same
+    ``ts_ns`` always renders to the same string regardless of platform. The
+    nanosecond remainder is kept as a 9-digit fractional-seconds suffix
+    instead of being rounded away, so the export loses no precision the
+    entry carried.
+    """
+    seconds, nanos = divmod(ts_ns, 1_000_000_000)
+    dt = datetime.fromtimestamp(seconds, tz=UTC)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S") + f".{nanos:09d}Z"
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ProvEntity:
+    """One ``prov:Entity``: an artefact version or an attached input."""
+
+    id: str
+    kind: str  # "artefact" | "attachment"
+    content_hash: str
+    artefact_path: str = ""
+    trust_class: str | None = None
+    sensitivity: str | None = None
+    generated_at_time: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class ProvActivity:
+    """One ``prov:Activity``: the turn that produced an entity."""
+
+    id: str
+    entry_hash: str
+    tool_call_id: str
+    span_id: str
+    ended_at_time: str
+
+
+@dataclass(frozen=True, slots=True)
+class ProvAgent:
+    """One ``prov:Agent``: the operator agent, or a model reference (#5037)."""
+
+    id: str
+    kind: str  # "operator" | "model"
+    label: str
+
+
+@dataclass(frozen=True, slots=True)
+class ProvRelation:
+    """One PROV relation between two of the ids above."""
+
+    kind: str  # "wasGeneratedBy" | "wasAssociatedWith" | "wasDerivedFrom" | "used"
+    subject: str
+    obj: str
+    role: str = ""
+
+
+@dataclass(slots=True)
+class ProvDocument:
+    """A PROV-O projection of one artefact's ancestry.
+
+    ``entities``/``activities``/``agents``/``relations`` are each sorted by
+    a stable key so two projections of the same ancestry -- regardless of
+    the order the source entries were supplied in -- produce the same
+    document.
+    """
+
+    schema_version: str
+    root_entity_id: str
+    entities: list[ProvEntity] = field(default_factory=list[ProvEntity])
+    activities: list[ProvActivity] = field(default_factory=list[ProvActivity])
+    agents: list[ProvAgent] = field(default_factory=list[ProvAgent])
+    relations: list[ProvRelation] = field(default_factory=list[ProvRelation])
+
+
+# ---------------------------------------------------------------------------
+# Ancestry closure
+# ---------------------------------------------------------------------------
+
+
+def _ancestry_closure(index: dict[str, LineageEntry], start_hash: str) -> list[str]:
+    """Return entry hashes reachable from ``start_hash`` via ``parent_hashes``.
+
+    A plain reachability walk over a set, so the result does not depend on
+    traversal order; sorted before return so two calls over the same index
+    return the identical list regardless of ``dict``/``set`` iteration order.
+    An entry named in ``parent_hashes`` but absent from ``index`` marks the
+    edge of the supplied window and is not followed further.
+    """
+    seen: set[str] = set()
+    frontier = [start_hash]
+    while frontier:
+        h = frontier.pop()
+        if h in seen:
+            continue
+        seen.add(h)
+        entry = index.get(h)
+        if entry is None:
+            continue
+        frontier.extend(entry.parent_hashes)
+    return sorted(seen)
+
+
+# ---------------------------------------------------------------------------
+# Projection
+# ---------------------------------------------------------------------------
+
+
+def project_prov_ancestry(entries: Sequence[LineageEntry], *, root_entry_hash: str) -> ProvDocument:
+    """Project the ancestry of one lineage entry into a PROV-O document.
+
+    Mapping (see issue #5039):
+
+    * artefact (``content_hash``, ``artefact_path``) -> ``prov:Entity``
+    * producing turn (``tool_call_id``, ``span_id``) -> ``prov:Activity``
+    * ``agent_id`` / ``agent_card_kid`` -> ``prov:Agent``,
+      ``prov:wasAssociatedWith``
+    * ``parent_hashes`` -> ``prov:wasDerivedFrom``
+    * ``attachment_digests`` -> ``prov:used``
+    * ``ts_ns`` -> ``prov:generatedAtTime`` / ``prov:endTime``
+    * ``model_ref`` -> a second ``prov:Agent``, ``prov:wasAssociatedWith``
+    * ``trust_class`` / ``sensitivity`` -> qualified ``bernstein:`` attributes
+
+    Args:
+        entries: Lineage entries to search. Only the transitive closure of
+            ``root_entry_hash`` over ``parent_hashes`` is exported; entries
+            outside that closure (other artefacts, other branches) are
+            ignored.
+        root_entry_hash: The entry hash naming the artefact version whose
+            ancestry is exported (e.g. the open tip of an artefact path,
+            from :func:`bernstein.core.lineage.tips.compute_tips`).
+
+    Returns:
+        A :class:`ProvDocument`. Pass it to :func:`to_prov_json` or
+        :func:`to_turtle`.
+
+    Raises:
+        ProvExportError: When ``root_entry_hash`` is not among ``entries``.
+            The export is unproducible without it, not merely empty.
+    """
+    index: dict[str, LineageEntry] = {entry_hash(e): e for e in entries}
+    if root_entry_hash not in index:
+        msg = f"no lineage entry with hash {root_entry_hash!r}; PROV export is unproducible without it"
+        raise ProvExportError(msg)
+
+    closure = _ancestry_closure(index, root_entry_hash)
+
+    entities: dict[str, ProvEntity] = {}
+    activities: dict[str, ProvActivity] = {}
+    agents: dict[str, ProvAgent] = {}
+    relations: list[ProvRelation] = []
+
+    for h in closure:
+        entry = index[h]
+        eid = _entity_id(entry.content_hash)
+        gen_time = _iso_from_ts_ns(entry.ts_ns)
+        if eid not in entities:
+            entities[eid] = ProvEntity(
+                id=eid,
+                kind="artefact",
+                content_hash=entry.content_hash,
+                artefact_path=entry.artefact_path,
+                trust_class=entry.trust_class,
+                sensitivity=entry.sensitivity,
+                generated_at_time=gen_time,
+            )
+
+        aid = _activity_id(h)
+        activities[aid] = ProvActivity(
+            id=aid,
+            entry_hash=h,
+            tool_call_id=entry.tool_call_id,
+            span_id=entry.span_id,
+            ended_at_time=gen_time,
+        )
+        relations.append(ProvRelation(kind="wasGeneratedBy", subject=eid, obj=aid))
+
+        agid = _agent_id(entry.agent_id)
+        agents.setdefault(agid, ProvAgent(id=agid, kind="operator", label=entry.agent_id))
+        relations.append(ProvRelation(kind="wasAssociatedWith", subject=aid, obj=agid, role="operator"))
+
+        if entry.model_ref is not None:
+            mid = _model_agent_id(entry.model_ref.provider, entry.model_ref.model_requested)
+            agents.setdefault(mid, ProvAgent(id=mid, kind="model", label=entry.model_ref.model_requested))
+            relations.append(ProvRelation(kind="wasAssociatedWith", subject=aid, obj=mid, role="model"))
+
+        for parent_hash in entry.parent_hashes:
+            parent_entry = index.get(parent_hash)
+            if parent_entry is None:
+                continue
+            peid = _entity_id(parent_entry.content_hash)
+            relations.append(ProvRelation(kind="wasDerivedFrom", subject=eid, obj=peid))
+
+        for digest in entry.attachment_digests or ():
+            ateid = _attachment_entity_id(digest)
+            entities.setdefault(
+                ateid,
+                ProvEntity(id=ateid, kind="attachment", content_hash=f"sha256:{digest}"),
+            )
+            relations.append(ProvRelation(kind="used", subject=aid, obj=ateid))
+
+    root_entity_id = _entity_id(index[root_entry_hash].content_hash)
+    ordered_relations = sorted(set(relations), key=lambda r: (r.kind, r.subject, r.obj, r.role))
+
+    return ProvDocument(
+        schema_version=PROV_SCHEMA_VERSION,
+        root_entity_id=root_entity_id,
+        entities=sorted(entities.values(), key=lambda e: e.id),
+        activities=sorted(activities.values(), key=lambda a: a.id),
+        agents=sorted(agents.values(), key=lambda a: a.id),
+        relations=ordered_relations,
+    )
+
+
+# ---------------------------------------------------------------------------
+# PROV-JSON serialisation
+# ---------------------------------------------------------------------------
+
+
+def _entity_attrs(e: ProvEntity) -> dict[str, Any]:
+    attrs: dict[str, Any] = {
+        "prov:type": f"bernstein:{e.kind}",
+        "bernstein:contentHash": e.content_hash,
+    }
+    if e.artefact_path:
+        attrs["bernstein:artefactPath"] = e.artefact_path
+    if e.generated_at_time:
+        attrs["prov:generatedAtTime"] = e.generated_at_time
+    if e.trust_class is not None:
+        attrs["bernstein:trustClass"] = e.trust_class
+    if e.sensitivity is not None:
+        attrs["bernstein:sensitivity"] = e.sensitivity
+    return attrs
+
+
+def _activity_attrs(a: ProvActivity) -> dict[str, Any]:
+    attrs: dict[str, Any] = {"bernstein:entryHash": a.entry_hash, "prov:endTime": a.ended_at_time}
+    if a.tool_call_id:
+        attrs["bernstein:toolCallId"] = a.tool_call_id
+    if a.span_id:
+        attrs["bernstein:spanId"] = a.span_id
+    return attrs
+
+
+def _agent_attrs(a: ProvAgent) -> dict[str, Any]:
+    return {"prov:type": f"bernstein:{a.kind}", "bernstein:label": a.label}
+
+
+def to_prov_json(doc: ProvDocument) -> dict[str, Any]:
+    """Render ``doc`` as a PROV-JSON document (W3C PROV-JSON).
+
+    Relation ids are ``_:<kind><index>`` over the document's already-sorted
+    relation list -- a stable position, not a generated identifier, so two
+    projections of the same ancestry emit the same ids.
+    """
+    entity = {e.id: _entity_attrs(e) for e in doc.entities}
+    activity = {a.id: _activity_attrs(a) for a in doc.activities}
+    agent = {a.id: _agent_attrs(a) for a in doc.agents}
+
+    was_generated_by: dict[str, Any] = {}
+    used: dict[str, Any] = {}
+    was_associated_with: dict[str, Any] = {}
+    was_derived_from: dict[str, Any] = {}
+
+    for index, r in enumerate(doc.relations):
+        rid = f"_:{r.kind}{index}"
+        if r.kind == "wasGeneratedBy":
+            was_generated_by[rid] = {"prov:entity": r.subject, "prov:activity": r.obj}
+        elif r.kind == "used":
+            used[rid] = {"prov:activity": r.subject, "prov:entity": r.obj}
+        elif r.kind == "wasAssociatedWith":
+            body: dict[str, Any] = {"prov:activity": r.subject, "prov:agent": r.obj}
+            if r.role:
+                body["prov:role"] = r.role
+            was_associated_with[rid] = body
+        elif r.kind == "wasDerivedFrom":
+            was_derived_from[rid] = {"prov:generatedEntity": r.subject, "prov:usedEntity": r.obj}
+
+    payload: dict[str, Any] = {
+        "schema_version": doc.schema_version,
+        "prefix": {"prov": NS_PROV, "xsd": NS_XSD, "bernstein": NS_BERNSTEIN},
+        "root_entity": doc.root_entity_id,
+        "entity": entity,
+        "activity": activity,
+        "agent": agent,
+    }
+    if was_generated_by:
+        payload["wasGeneratedBy"] = was_generated_by
+    if used:
+        payload["used"] = used
+    if was_associated_with:
+        payload["wasAssociatedWith"] = was_associated_with
+    if was_derived_from:
+        payload["wasDerivedFrom"] = was_derived_from
+    return payload
+
+
+def canonical_prov_json_bytes(doc: ProvDocument) -> bytes:
+    """Return deterministic PROV-JSON bytes: sorted keys, compact, UTF-8."""
+    return json.dumps(to_prov_json(doc), sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Turtle serialisation (slice 2, from the same ProvDocument intermediate)
+# ---------------------------------------------------------------------------
+
+
+def _turtle_literal(value: str) -> str:
+    """Escape a string for a Turtle quoted literal."""
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def _turtle_uri(value: str) -> str:
+    """Wrap a URI in angle brackets, escaping the characters Turtle forbids raw."""
+    return "<" + value.replace("\\", "%5C").replace(">", "%3E").replace(" ", "%20") + ">"
+
+
+def _turtle_block(subject: str, type_: str, predicates: list[tuple[str, str]]) -> str:
+    """Render one Turtle subject block: ``<subject> a type_ ; p1 o1 ; ... .``"""
+    lines = [f"{_turtle_uri(subject)} a {type_} ;"]
+    for i, (pred, obj) in enumerate(predicates):
+        suffix = " ." if i == len(predicates) - 1 else " ;"
+        lines.append(f"    {pred} {obj}{suffix}")
+    return "\n".join(lines)
+
+
+_RELATION_PREDICATE: dict[str, str] = {
+    "wasGeneratedBy": "prov:wasGeneratedBy",
+    "used": "prov:used",
+    "wasAssociatedWith": "prov:wasAssociatedWith",
+    "wasDerivedFrom": "prov:wasDerivedFrom",
+}
+
+
+def to_turtle(doc: ProvDocument) -> str:
+    """Render ``doc`` as Turtle, built from the same :class:`ProvDocument`
+    that :func:`to_prov_json` renders -- the two never diverge on what the
+    ancestry contains, only on syntax.
+    """
+    lines: list[str] = [
+        f"@prefix prov: <{NS_PROV}> .",
+        f"@prefix xsd: <{NS_XSD}> .",
+        f"@prefix bernstein: <{NS_BERNSTEIN}> .",
+        "",
+    ]
+
+    for e in doc.entities:
+        preds: list[tuple[str, str]] = [("bernstein:contentHash", f'"{_turtle_literal(e.content_hash)}"')]
+        if e.artefact_path:
+            preds.append(("bernstein:artefactPath", f'"{_turtle_literal(e.artefact_path)}"'))
+        if e.generated_at_time:
+            preds.append(("prov:generatedAtTime", f'"{e.generated_at_time}"^^xsd:dateTime'))
+        if e.trust_class is not None:
+            preds.append(("bernstein:trustClass", f'"{_turtle_literal(e.trust_class)}"'))
+        if e.sensitivity is not None:
+            preds.append(("bernstein:sensitivity", f'"{_turtle_literal(e.sensitivity)}"'))
+        lines.append(_turtle_block(e.id, "prov:Entity", preds))
+        lines.append("")
+
+    for a in doc.activities:
+        preds = [("bernstein:entryHash", f'"{_turtle_literal(a.entry_hash)}"')]
+        if a.tool_call_id:
+            preds.append(("bernstein:toolCallId", f'"{_turtle_literal(a.tool_call_id)}"'))
+        if a.span_id:
+            preds.append(("bernstein:spanId", f'"{_turtle_literal(a.span_id)}"'))
+        preds.append(("prov:endTime", f'"{a.ended_at_time}"^^xsd:dateTime'))
+        lines.append(_turtle_block(a.id, "prov:Activity", preds))
+        lines.append("")
+
+    for ag in doc.agents:
+        lines.append(_turtle_block(ag.id, "prov:Agent", [("bernstein:label", f'"{_turtle_literal(ag.label)}"')]))
+        lines.append("")
+
+    for r in doc.relations:
+        predicate = _RELATION_PREDICATE[r.kind]
+        lines.append(f"{_turtle_uri(r.subject)} {predicate} {_turtle_uri(r.obj)} .")
+
+    return "\n".join(lines).rstrip("\n") + "\n"

--- a/tests/unit/lineage/test_cli.py
+++ b/tests/unit/lineage/test_cli.py
@@ -166,6 +166,59 @@ def test_chain_unknown_artefact(tmp_path: Path) -> None:
     assert result.exit_code == 1
 
 
+# ── export-prov (issue #5039) ─────────────────────────────────────────────
+
+
+def test_export_prov_json_embeds_content_hash(tmp_path: Path) -> None:
+    root = _mk_entry("agent:a", "k1", "x.py", _h("1"), [], 1)
+    child = _mk_entry("agent:a", "k1", "x.py", _h("2"), [entry_hash(root)], 2)
+    log, _cards, *_ = _write_setup(tmp_path, [root, child])
+    runner = CliRunner()
+    result = runner.invoke(lineage_cmd, ["export-prov", "x.py", "--log", str(log)])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert _h("2") in json.dumps(payload)
+    assert _h("1") in json.dumps(payload)
+
+
+def test_export_prov_turtle_contains_derivation(tmp_path: Path) -> None:
+    root = _mk_entry("agent:a", "k1", "x.py", _h("1"), [], 1)
+    child = _mk_entry("agent:a", "k1", "x.py", _h("2"), [entry_hash(root)], 2)
+    log, _cards, *_ = _write_setup(tmp_path, [root, child])
+    runner = CliRunner()
+    result = runner.invoke(lineage_cmd, ["export-prov", "x.py", "--format", "turtle", "--log", str(log)])
+    assert result.exit_code == 0, result.output
+    assert "prov:wasDerivedFrom" in result.output
+
+
+def test_export_prov_unknown_artefact_exits_nonzero(tmp_path: Path) -> None:
+    g = _mk_entry("agent:a", "k1", "x.py", _h("1"), [], 1)
+    log, _cards, *_ = _write_setup(tmp_path, [g])
+    runner = CliRunner()
+    result = runner.invoke(lineage_cmd, ["export-prov", "other.py", "--log", str(log)])
+    assert result.exit_code == 1
+
+
+def test_export_prov_unresolved_fork_exits_nonzero(tmp_path: Path) -> None:
+    root = _mk_entry("agent:a", "k1", "x.py", _h("1"), [], 1)
+    fork_a = _mk_entry("agent:a", "k1", "x.py", _h("2"), [entry_hash(root)], 2)
+    fork_b = _mk_entry("agent:a", "k1", "x.py", _h("3"), [entry_hash(root)], 3)
+    log, _cards, *_ = _write_setup(tmp_path, [root, fork_a, fork_b])
+    runner = CliRunner()
+    result = runner.invoke(lineage_cmd, ["export-prov", "x.py", "--log", str(log)])
+    assert result.exit_code == 1
+
+
+def test_export_prov_writes_output_file(tmp_path: Path) -> None:
+    g = _mk_entry("agent:a", "k1", "x.py", _h("1"), [], 1)
+    log, _cards, *_ = _write_setup(tmp_path, [g])
+    out = tmp_path / "out.json"
+    runner = CliRunner()
+    result = runner.invoke(lineage_cmd, ["export-prov", "x.py", "--log", str(log), "--output", str(out)])
+    assert result.exit_code == 0, result.output
+    assert _h("1") in out.read_text()
+
+
 # ── reindex ─────────────────────────────────────────────────────────────────
 
 

--- a/tests/unit/lineage/test_prov_export.py
+++ b/tests/unit/lineage/test_prov_export.py
@@ -1,0 +1,197 @@
+"""Tests for the PROV-O export projection (issue #5039).
+
+Each test is named for the property it protects, per the issue's
+acceptance list. Tests 5 (ontology validation), 6 (round trip) and 7
+(export signature) belong to later slices of #5039 and are not covered
+here; see the PR body.
+"""
+
+from __future__ import annotations
+
+import re
+from unittest import mock
+
+import pytest
+
+from bernstein.core.lineage.entry import LineageEntry, ModelRef, entry_hash
+from bernstein.core.lineage.prov_export import (
+    ProvExportError,
+    canonical_prov_json_bytes,
+    project_prov_ancestry,
+    to_prov_json,
+    to_turtle,
+)
+
+
+def _h(seed: str) -> str:
+    return "sha256:" + (seed * 64)[:64]
+
+
+def _mk_entry(
+    *,
+    artefact_path: str = "x.py",
+    content_hash: str,
+    parent_hashes: list[str] | None = None,
+    agent_id: str = "agent:a",
+    ts_ns: int = 1_700_000_000_000_000_000,
+    attachment_digests: list[str] | None = None,
+    model_ref: ModelRef | None = None,
+    trust_class: str | None = None,
+) -> LineageEntry:
+    return LineageEntry(
+        v=1,
+        artefact_path=artefact_path,
+        artefact_kind="file",
+        content_hash=content_hash,
+        parent_hashes=parent_hashes or [],
+        agent_id=agent_id,
+        agent_card_kid="k1",
+        tool_call_id="tc-1",
+        span_id="span-1",
+        ts_ns=ts_ns,
+        operator_hmac="deadbeef" * 8,
+        attachment_digests=attachment_digests,
+        model_ref=model_ref,
+        trust_class=trust_class,
+    )
+
+
+# ── 1. determinism ───────────────────────────────────────────────────────────
+
+
+def test_prov_export_is_byte_identical_across_repeated_runs() -> None:
+    root = _mk_entry(content_hash=_h("1"))
+    child = _mk_entry(content_hash=_h("2"), parent_hashes=[entry_hash(root)])
+    entries = [root, child]
+
+    with mock.patch("time.time", return_value=1_000_000):
+        first = canonical_prov_json_bytes(project_prov_ancestry(entries, root_entry_hash=entry_hash(child)))
+    with mock.patch("time.time", return_value=2_000_000):
+        # Reversed input order must not change the output: the projection
+        # sorts entities/activities/agents/relations itself.
+        second = canonical_prov_json_bytes(
+            project_prov_ancestry(list(reversed(entries)), root_entry_hash=entry_hash(child))
+        )
+
+    assert first == second
+
+
+# ── 2. entity URI embeds the content hash ────────────────────────────────────
+
+
+def test_entity_uri_embeds_the_content_hash() -> None:
+    root = _mk_entry(content_hash=_h("1"))
+    doc = project_prov_ancestry([root], root_entry_hash=entry_hash(root))
+
+    assert doc.root_entity_id.endswith(_h("1"))
+    assert _h("1") in doc.root_entity_id
+
+    payload = to_prov_json(doc)
+    assert doc.root_entity_id in payload["entity"]
+
+
+# ── 3. parent_hashes -> wasDerivedFrom ───────────────────────────────────────
+
+
+def test_parent_hashes_become_was_derived_from_edges() -> None:
+    root = _mk_entry(content_hash=_h("1"))
+    child = _mk_entry(content_hash=_h("2"), parent_hashes=[entry_hash(root)])
+    doc = project_prov_ancestry([root, child], root_entry_hash=entry_hash(child))
+
+    derived = [r for r in doc.relations if r.kind == "wasDerivedFrom"]
+    assert len(derived) == 1
+    assert derived[0].subject == doc.root_entity_id
+    assert derived[0].obj.endswith(_h("1"))
+
+    payload = to_prov_json(doc)
+    assert "wasDerivedFrom" in payload
+    (rel,) = payload["wasDerivedFrom"].values()
+    assert rel["prov:generatedEntity"] == doc.root_entity_id
+    assert rel["prov:usedEntity"].endswith(_h("1"))
+
+
+def test_ancestry_omits_entries_outside_the_closure() -> None:
+    root = _mk_entry(content_hash=_h("1"))
+    child = _mk_entry(content_hash=_h("2"), parent_hashes=[entry_hash(root)])
+    unrelated = _mk_entry(artefact_path="other.py", content_hash=_h("9"))
+    doc = project_prov_ancestry([root, child, unrelated], root_entry_hash=entry_hash(child))
+
+    ids = {e.id for e in doc.entities}
+    assert not any(_h("9") in i for i in ids)
+    assert len(doc.entities) == 2
+
+
+# ── 4. attachment_digests -> used ────────────────────────────────────────────
+
+
+def test_attachment_digests_become_used_edges() -> None:
+    digest = "ab" * 32
+    root = _mk_entry(content_hash=_h("1"), attachment_digests=[digest])
+    doc = project_prov_ancestry([root], root_entry_hash=entry_hash(root))
+
+    used = [r for r in doc.relations if r.kind == "used"]
+    assert len(used) == 1
+    assert used[0].obj.endswith(f"sha256:{digest}")
+
+    payload = to_prov_json(doc)
+    assert "used" in payload
+    (rel,) = payload["used"].values()
+    assert rel["prov:entity"].endswith(f"sha256:{digest}")
+
+
+# ── 8. no export-time timestamps or generated identifiers ───────────────────
+
+
+def test_export_contains_no_export_time_timestamps_or_generated_identifiers() -> None:
+    root = _mk_entry(content_hash=_h("1"))
+    child = _mk_entry(content_hash=_h("2"), parent_hashes=[entry_hash(root)])
+    entries = [root, child]
+
+    with mock.patch("time.time", return_value=1_000_000):
+        first = canonical_prov_json_bytes(project_prov_ancestry(entries, root_entry_hash=entry_hash(child)))
+    with mock.patch("time.time", return_value=99_999_999):
+        second = canonical_prov_json_bytes(project_prov_ancestry(entries, root_entry_hash=entry_hash(child)))
+
+    # A wall-clock export timestamp would make these two diverge.
+    assert first == second
+
+    text = first.decode("utf-8")
+    assert "exported_at" not in text
+    assert "export_time" not in text
+    # No random/generated UUID (8-4-4-4-12 hex) anywhere in the document --
+    # every id is a stable index or a value copied from the entries.
+    uuid_pattern = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+    assert not uuid_pattern.search(text)
+
+
+# ── unproducible without the entry ───────────────────────────────────────────
+
+
+def test_missing_root_entry_raises_prov_export_error() -> None:
+    root = _mk_entry(content_hash=_h("1"))
+    with pytest.raises(ProvExportError):
+        project_prov_ancestry([root], root_entry_hash=_h("not-present"))
+
+
+# ── slice 2: Turtle, from the same intermediate ──────────────────────────────
+
+
+def test_turtle_embeds_content_hash_and_derivation() -> None:
+    root = _mk_entry(content_hash=_h("1"))
+    child = _mk_entry(content_hash=_h("2"), parent_hashes=[entry_hash(root)])
+    doc = project_prov_ancestry([root, child], root_entry_hash=entry_hash(child))
+
+    turtle = to_turtle(doc)
+    assert _h("1") in turtle
+    assert _h("2") in turtle
+    assert "prov:wasDerivedFrom" in turtle
+    assert "@prefix prov:" in turtle
+
+
+def test_turtle_is_byte_identical_across_repeated_runs() -> None:
+    root = _mk_entry(content_hash=_h("1"))
+    child = _mk_entry(content_hash=_h("2"), parent_hashes=[entry_hash(root)])
+    doc_a = project_prov_ancestry([root, child], root_entry_hash=entry_hash(child))
+    doc_b = project_prov_ancestry(list(reversed([root, child])), root_entry_hash=entry_hash(child))
+
+    assert to_turtle(doc_a) == to_turtle(doc_b)


### PR DESCRIPTION
## What

Adds a PROV-O projection of the lineage v1 ancestry DAG (issue #5039, slices 1 and 2):

- `bernstein.core.lineage.prov_export.project_prov_ancestry()` -- maps a `LineageEntry` ancestry (walked via `parent_hashes`) onto a `ProvDocument`: artefacts become `prov:Entity`, producing turns become `prov:Activity`, `agent_id`/`model_ref` become `prov:Agent`, `parent_hashes` become `prov:wasDerivedFrom`, `attachment_digests` become `prov:used`.
- `canonical_prov_json_bytes()` / `to_turtle()` -- render the same `ProvDocument` as PROV-JSON or Turtle, from one intermediate so the two formats never diverge on content.
- `bernstein lineage export-prov <artefact_path> [--format json|turtle]` -- CLI command that resolves the artefact's open tip in the v1 log and exports its ancestry.

This does not include:

- Ontology validation in CI (slice 3).
- The round-trip test (slice 4).
- Export signing over a chain head (slice 5).
- Run- and task-scoped exports (slice 6) -- only single-artefact ancestry, per slice 1's scope.

## Why

Lineage v1 is a content-addressed DAG with no export in a vocabulary outside tooling already reads (W3C PROV-O), even though the mapping from our fields to PROV terms is close to mechanical. Every export field is either copied from the entry or derived deterministically from `ts_ns`, so re-running the export against the same log produces byte-identical output -- there is nothing here that can drift between two operators exporting the same ancestry.

## How

`project_prov_ancestry()` takes a list of `LineageEntry` plus a root entry hash, walks `parent_hashes` reachability to the closure of entries relevant to that one artefact, and builds entity/activity/agent/relation collections keyed by content hash so repeated nodes across a graph collapse to one PROV entity. Every collection is sorted by a stable key before being placed on the `ProvDocument`, so supplying the same entries in a different order produces the same document. `to_prov_json()`/`to_turtle()` render that document; relation ids are stable indices over the document's already-sorted relation list rather than generated identifiers, so PROV-JSON output carries nothing export-time or random.

The CLI command reuses the v1 log reader (`_lineage_v1_helpers.read_entries`) and the existing tip projection (`core/lineage/tips.compute_tips`) to resolve "the ancestry of this artefact" to a single root entry hash, then calls the projection. It is a separate command from the existing `bernstein lineage export <run_id>` (kept as `export-prov` rather than added as a `--format` choice on `export`): that command reads a different, older lineage subsystem -- the run-id-keyed regulator/persistence store (`core/persistence/lineage.LineageReader`) -- and conflating the two under one flag would mean one command silently switching data sources depending on the format string. An artefact with more than one open tip (an unresolved fork) is rejected rather than guessed at.

## Tests

1. `test_prov_export_is_byte_identical_across_repeated_runs` -- **load-bearing**. Exports the same ancestry twice, with the input entry order reversed and the wall clock mocked to different values between runs, and asserts identical bytes. Fails on the pre-change tree because the module does not exist; once written, would fail if any collection were left in insertion order instead of sorted.
2. `test_entity_uri_embeds_the_content_hash` -- the root entity's PROV id and its JSON key both contain the artefact's `content_hash`.
3. `test_parent_hashes_become_was_derived_from_edges` -- a child's `parent_hashes` produces exactly one `wasDerivedFrom` relation to the parent's entity.
4. `test_ancestry_omits_entries_outside_the_closure` -- an unrelated artefact's entries never appear in the projected document.
5. `test_attachment_digests_become_used_edges` -- an entry's `attachment_digests` produce `used` relations to attachment entities.
6. `test_export_contains_no_export_time_timestamps_or_generated_identifiers` -- two exports under different mocked wall-clock values are byte-identical, and the output contains no `exported_at`/`export_time` key and no UUID-shaped string.
7. `test_missing_root_entry_raises_prov_export_error` -- a root hash absent from the supplied entries raises rather than returning an empty document.
8. `test_turtle_embeds_content_hash_and_derivation` / `test_turtle_is_byte_identical_across_repeated_runs` -- Turtle output carries the same content hashes and derivation edges as the JSON form, and is itself order-independent.
9. `test_export_prov_json_embeds_content_hash` / `test_export_prov_turtle_contains_derivation` / `test_export_prov_unknown_artefact_exits_nonzero` / `test_export_prov_unresolved_fork_exits_nonzero` / `test_export_prov_writes_output_file` -- CLI-level: both formats reach stdout/file correctly, an unknown artefact path and an unresolved fork both exit non-zero rather than exporting a guess.

Tests 1, 6 and 7 map to the issue's acceptance items 1 and 8; the issue's items 2-4 map to tests 2, 3 and 5 above (attachment digests). Acceptance items 5-7 (ontology validation, round trip, signature) are out of scope for this PR -- see slices 3, 4, 5 below.

All new tests fail on the pre-change tree (the module and command do not exist); confirmed by running them before either commit.

Ran, all green:
```
uv run python scripts/run_tests.py --parallel 2 -x tests/unit/lineage/test_prov_export.py tests/unit/lineage/test_cli.py tests/unit/test_lineage_v2_cli.py tests/unit/lineage/test_conflict_cli.py tests/unit/lineage/test_spine_cli.py
```
`--affected origin/main` found no affected tests (the new module has no tracked-diff importers yet); the command above covers every existing importer of `lineage_cmd.py` plus the new module's own tests. CI runs the full suite.

## Checklist

- [x] `uv run ruff check src/` -- clean on the changed files.
- [x] `uv run ruff format --check src/` -- clean on the changed files.
- [x] `uv run pyright src/` -- clean on both new/changed files; the 3 pre-existing errors in `lineage_cmd.py` (`merge_cmd`, unrelated to this change) are present on `main` too.
- [x] `uv run python scripts/run_tests.py -x <touched files>` -- all green (see Tests).
- [x] Type hints on all new public functions.
- [x] Docs: N/A -- no user-facing doc page describes `bernstein lineage` subcommands beyond the CLI's own `--help`, which is generated from the docstrings added here.
- [x] `bernstein agents-md sync` -- run; no output diff (no AGENTS.md/module-map entry covers per-subcommand CLI surface).

## Remaining

Slices 3-6 of issue #5039, in the order the issue lists them:

- Ontology validation of the PROV-JSON/Turtle output against the real PROV-O ontology in CI.
- The round-trip test (our graph -> PROV -> back -> same node/edge set).
- A signature over the export's canonical bytes plus the chain head it was taken at.
- Run- and task-scoped exports (this PR covers only a single artefact's ancestry).

Part of #5039
