### PR TITLE
feat(govern): anchor the audit report as a chain-verifiable artefact (#5077)

### DIFF
--- a/docs/release-notes/fragments/5077-govern-audit-report-anchor.md
+++ b/docs/release-notes/fragments/5077-govern-audit-report-anchor.md
@@ -1,0 +1,5 @@
+## The govern audit report is a chain-anchored artefact
+
+A governance audit report is now an artefact rather than a printout. Its canonical bytes are a deterministic function of the findings it carries, so its sha256 identifies a posture: two audits over an unchanged install produce byte-identical reports. That identity is anchored in the lineage spine over exactly those bytes, the way a governance decision is, and `bernstein audit verify` gained a `Govern Audit Reports` pillar that re-derives the anchor offline — an edited stored report matches no spine entry and fails verification instead of reading as a different posture. A report also records the anchor of the inventory it audited, so "audited what was enumerated on that date" is one chain walk, and `diff_reports` computes drift between two stored reports — only findings whose verdict or evidence hash changed — without re-running any check.
+
+(#5077)

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -353,6 +353,13 @@ def verify_cmd(
     if not _verify_run_artifacts():
         failed_pillars.append("Run Artifacts")
 
+    # Govern audit reports are a further integrity pillar: a report identifies
+    # a posture by the hash of its canonical bytes, so an edited stored report
+    # must fail verify rather than read as a different posture (#5077).
+    # Orthogonal to both the HMAC chain and the Merkle seal.
+    if not _verify_audit_reports():
+        failed_pillars.append("Govern Audit Reports")
+
     # Tournament selection receipts are a further integrity pillar: a tampered
     # score or a hand-picked winner must fail verify exactly like a tampered
     # chain entry (#2353). Orthogonal to both HMAC chain and Merkle seal.
@@ -1512,6 +1519,55 @@ def _verify_run_artifacts() -> bool:
     console.print(Panel("[bold red]Run Artifact Verification FAILED[/bold red]", border_style="red", expand=False))
     for result in failures:
         console.print(f"  [red]![/red] task {result.task_id} key={result.key} v{result.version}: {result.reason}")
+    return False
+
+
+def _verify_audit_reports() -> bool:
+    """Verify every stored govern-audit report and print results. Returns True if valid.
+
+    A report identifies a posture by the sha256 of its canonical bytes, so a
+    flipped byte in a stored report matches no spine entry and makes
+    ``bernstein audit verify`` fail with the report named -- exactly like a
+    tampered chain entry (#5077). When no reports exist the check is a silent
+    no-op.
+    """
+    from bernstein.core.govern.audit_report import verify_all_audit_reports
+
+    # AUDIT_DIR is ``.sdd/audit``; the project root is two levels up. Reports
+    # live under ``<root>/.sdd/lineage/govern-audit/reports``.
+    workdir = AUDIT_DIR.parent.parent
+
+    key = _verify_key("Govern audit report")
+    if key is None:
+        return True
+
+    results = verify_all_audit_reports(workdir, hmac_key=key)
+    if not results:
+        return True  # no audit reports recorded; nothing to verify
+
+    failures = [r for r in results if not r.ok]
+    console.print()
+    if not failures:
+        console.print(
+            Panel(
+                "[bold green]Govern Audit Report Verification Passed[/bold green]",
+                border_style="green",
+                expand=False,
+            )
+        )
+        table = Table(show_header=False, box=None, padding=(0, 2))
+        table.add_column("Key", style="dim", no_wrap=True, min_width=14)
+        table.add_column("Value")
+        table.add_row("Reports", str(len(results)))
+        console.print(table)
+        return True
+
+    console.print(
+        Panel("[bold red]Govern Audit Report Verification FAILED[/bold red]", border_style="red", expand=False)
+    )
+    for result in failures:
+        anchor = result.report.journal_entry_hash if result.report is not None else "?"
+        console.print(f"  [red]![/red] report anchor={anchor or '(unanchored)'}: {result.reason}")
     return False
 
 

--- a/src/bernstein/core/govern/audit_report.py
+++ b/src/bernstein/core/govern/audit_report.py
@@ -1,0 +1,493 @@
+"""The ``govern audit`` report as a chain-anchored artefact (issue #5077).
+
+A report is not a printout of what a run happened to observe. Its canonical
+bytes are a deterministic function of the findings it carries, so its sha256
+identifies a posture: two audits over an unchanged install produce the same
+bytes and therefore the same identity.
+
+That identity is anchored in the lineage spine over exactly those bytes, the
+way :class:`~bernstein.core.security.governance.GovernanceDecision` is -- the
+report's ``journal_entry_hash`` is the spine entry hash over its canonical
+bytes. A stored report whose bytes were edited no longer hashes to any spine
+entry, so tampering makes it *unverifiable* rather than merely different.
+
+Because both audits are anchored artefacts, "what changed since the last
+audit" is :func:`diff_reports` over two stored reports -- a comparison of two
+hashes, not a re-run of the checks.
+
+The report envelope deliberately does not define what a check is. Findings are
+carried as the serialised records their producers emit; this module requires
+only that each record carries a unique ``id`` (so the drift diff is
+well-defined) and reads ``verdict`` and ``evidence`` when computing drift.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, cast
+
+from bernstein.core.lineage.spine import LineageSpine, content_hash_of
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Version stamped into every report preimage. Bump only on a wire-format change.
+GOVERN_AUDIT_SCHEMA_VERSION = 1
+
+#: The spine run id every audit report anchors to. One run id keeps successive
+#: audits on one chain, so a drift comparison is a single chain walk.
+GOVERN_AUDIT_RUN_ID = "govern-audit"
+
+#: Actor recorded on the spine entry that anchors a report.
+GOVERN_AUDIT_ACTOR = "bernstein.govern.audit"
+
+#: Model string recorded on report spine entries (no model runs at audit time;
+#: the field is part of the spine schema).
+_GOVERN_AUDIT_MODEL = "none"
+
+#: Sub-path (relative to the audit run's spine dir) the persisted reports land
+#: in, colocated with the spine so the artefact and its anchor share one root.
+_REPORT_SUBPATH = ("reports",)
+
+
+def _canonical_bytes(payload: Any) -> bytes:
+    """Return canonical JSON bytes (sorted keys, minimal separators, UTF-8)."""
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _sha256(payload: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_bytes(payload)).hexdigest()
+
+
+def _finding_id(finding: dict[str, Any]) -> str:
+    """Return *finding*'s stable id, rejecting a record that has none."""
+    raw = finding.get("id")
+    if not isinstance(raw, str) or not raw:
+        raise ValueError("every audit finding must carry a non-empty string finding id")
+    return raw
+
+
+def evidence_hash(finding: dict[str, Any]) -> str:
+    """Return the content hash of *finding*'s evidence list.
+
+    Shape-agnostic: whatever the producer records under ``evidence`` is hashed
+    canonically, so drift detects a re-read that returned different bytes
+    without this module knowing how evidence is spelled.
+    """
+    return _sha256(finding.get("evidence", []))
+
+
+@dataclass(frozen=True, slots=True)
+class FindingDrift:
+    """One finding whose verdict or evidence differs between two reports.
+
+    Attributes:
+        finding_id: The stable finding id that drifted.
+        change: ``verdict`` when the verdict differs (checked first, so a
+            finding that changed both is reported as a verdict change),
+            ``evidence`` when only the evidence hash differs, ``appeared`` when
+            the id is new in the later report, ``disappeared`` when it is gone.
+        before_verdict: The earlier verdict (empty when the finding appeared).
+        after_verdict: The later verdict (empty when the finding disappeared).
+        before_evidence_hash: Hash of the earlier evidence (empty when appeared).
+        after_evidence_hash: Hash of the later evidence (empty when disappeared).
+    """
+
+    finding_id: str
+    change: str
+    before_verdict: str = ""
+    after_verdict: str = ""
+    before_evidence_hash: str = ""
+    after_evidence_hash: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the serialised drift row."""
+        return {
+            "finding_id": self.finding_id,
+            "change": self.change,
+            "before_verdict": self.before_verdict,
+            "after_verdict": self.after_verdict,
+            "before_evidence_hash": self.before_evidence_hash,
+            "after_evidence_hash": self.after_evidence_hash,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AuditReport:
+    """One ``govern audit`` run, as an anchored artefact.
+
+    ``journal_entry_hash`` anchors the report in the lineage spine over the
+    report's canonical bytes -- its chain-verifiable identity. It is not part
+    of those bytes, exactly as on ``GovernanceDecision``.
+
+    Attributes:
+        findings: The serialised finding records this audit produced. Order is
+            the producer's business: the canonical form sorts them by id, so a
+            registry that enumerates checks in a different order still emits
+            byte-identical bytes.
+        timestamp: Integer timestamp; caller-chosen but stable so identical
+            fixtures anchor byte-identically.
+        inventory_hash: Content hash of the inventory this audit ran over
+            (empty when the audit was not scoped to one).
+        inventory_anchor: The spine entry hash anchoring that inventory, so
+            "audited what was enumerated on that date" is one chain walk.
+        journal_entry_hash: The lineage-spine entry hash anchoring this report.
+            Empty until :func:`anchor_audit_report` records it.
+    """
+
+    findings: tuple[dict[str, Any], ...]
+    timestamp: int
+    inventory_hash: str = ""
+    inventory_anchor: str = ""
+    journal_entry_hash: str = ""
+
+    def _canonical_findings(self) -> list[dict[str, Any]]:
+        """Return the findings in canonical order, rejecting duplicate ids."""
+        seen: set[str] = set()
+        for finding in self.findings:
+            fid = _finding_id(finding)
+            if fid in seen:
+                raise ValueError(f"duplicate finding id in audit report: {fid}")
+            seen.add(fid)
+        return sorted(self.findings, key=_finding_id)
+
+    def _binding(self) -> dict[str, Any]:
+        """Return the anchored binding (everything except the anchor itself)."""
+        return {
+            "v": GOVERN_AUDIT_SCHEMA_VERSION,
+            "findings": self._canonical_findings(),
+            "timestamp": self.timestamp,
+            "inventory_hash": self.inventory_hash,
+            "inventory_anchor": self.inventory_anchor,
+        }
+
+    def to_canonical_bytes(self) -> bytes:
+        """Serialise the binding to canonical JSON bytes (spine-hashed)."""
+        return _canonical_bytes(self._binding())
+
+    def report_hash(self) -> str:
+        """Return the ``sha256:``-prefixed identity of this posture."""
+        return "sha256:" + hashlib.sha256(self.to_canonical_bytes()).hexdigest()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the serialised report, anchor included."""
+        return self._binding() | {"journal_entry_hash": self.journal_entry_hash}
+
+    @classmethod
+    def from_dict(cls, row: dict[str, Any]) -> AuditReport:
+        """Rebuild a report from a serialised row."""
+        raw_findings: object = row.get("findings") or []
+        if not isinstance(raw_findings, list):
+            raise ValueError("audit report findings must be a list")
+        rows = cast("list[dict[str, Any]]", raw_findings)
+        return cls(
+            findings=tuple(dict(f) for f in rows),
+            timestamp=int(row["timestamp"]),
+            inventory_hash=str(row.get("inventory_hash", "")),
+            inventory_anchor=str(row.get("inventory_anchor", "")),
+            journal_entry_hash=str(row.get("journal_entry_hash", "")),
+        )
+
+    def finding_by_id(self, finding_id: str) -> dict[str, Any] | None:
+        """Return the finding record with *finding_id*, or ``None``."""
+        for finding in self.findings:
+            if finding.get("id") == finding_id:
+                return finding
+        return None
+
+
+def diff_reports(before: AuditReport, after: AuditReport) -> tuple[FindingDrift, ...]:
+    """Return the findings that drifted between two anchored reports.
+
+    Drift is a comparison of two artefacts, never a re-run: a finding appears
+    only when its verdict or the hash of the evidence it read changed, or when
+    the id entered or left the check set. A report emitted at a later timestamp
+    over an unchanged install produces no drift rows.
+
+    Rows are ordered by finding id so two operators holding the same pair of
+    reports print the same list.
+    """
+    before_map = {_finding_id(f): f for f in before.findings}
+    after_map = {_finding_id(f): f for f in after.findings}
+
+    drift: list[FindingDrift] = []
+    for fid in sorted(before_map.keys() | after_map.keys()):
+        old = before_map.get(fid)
+        new = after_map.get(fid)
+        if old is None and new is not None:
+            drift.append(
+                FindingDrift(
+                    finding_id=fid,
+                    change="appeared",
+                    after_verdict=str(new.get("verdict", "")),
+                    after_evidence_hash=evidence_hash(new),
+                )
+            )
+            continue
+        if new is None and old is not None:
+            drift.append(
+                FindingDrift(
+                    finding_id=fid,
+                    change="disappeared",
+                    before_verdict=str(old.get("verdict", "")),
+                    before_evidence_hash=evidence_hash(old),
+                )
+            )
+            continue
+        if old is None or new is None:  # pragma: no cover - both sides present here
+            continue
+        old_verdict, new_verdict = str(old.get("verdict", "")), str(new.get("verdict", ""))
+        old_evidence, new_evidence = evidence_hash(old), evidence_hash(new)
+        if old_verdict == new_verdict and old_evidence == new_evidence:
+            continue
+        drift.append(
+            FindingDrift(
+                finding_id=fid,
+                change="verdict" if old_verdict != new_verdict else "evidence",
+                before_verdict=old_verdict,
+                after_verdict=new_verdict,
+                before_evidence_hash=old_evidence,
+                after_evidence_hash=new_evidence,
+            )
+        )
+    return tuple(drift)
+
+
+# ---------------------------------------------------------------------------
+# Persistence (colocated with the audit spine)
+# ---------------------------------------------------------------------------
+
+
+def reports_dir(lineage_root: Path) -> Path:
+    """Return the directory holding persisted audit reports."""
+    return lineage_root / GOVERN_AUDIT_RUN_ID / _REPORT_SUBPATH[0]
+
+
+def _report_filename(report: AuditReport, seq: int) -> str:
+    """Return a stable, ordered artefact filename for *report*.
+
+    ``seq`` is a zero-padded monotonic index so reports sort in emit order, and
+    the report-hash fragment keeps names distinct within a timestamp.
+    """
+    digest = report.report_hash()
+    frag = digest[7:23] if digest.startswith("sha256:") else digest[:16]
+    return f"{seq:06d}-{frag}.json"
+
+
+def _next_seq(out_dir: Path) -> int:
+    """Return the next zero-based emit index for *out_dir* (append order)."""
+    if not out_dir.is_dir():
+        return 0
+    return sum(1 for _ in out_dir.glob("*.json"))
+
+
+def anchor_audit_report(
+    *,
+    lineage_root: Path,
+    hmac_key: bytes,
+    report: AuditReport,
+) -> AuditReport:
+    """Anchor *report* in the audit spine and persist it. Returns the anchored copy.
+
+    The report's canonical bytes are what the spine hashes, so the returned
+    record's ``journal_entry_hash`` is the spine entry hash over exactly those
+    bytes.
+    """
+    out_dir = reports_dir(lineage_root)
+    filename = _report_filename(report, _next_seq(out_dir))
+    artifact_path = "/".join((*_REPORT_SUBPATH, filename))
+
+    anchor = LineageSpine(lineage_root, run_id=GOVERN_AUDIT_RUN_ID, hmac_key=hmac_key).record(
+        artifact_path=artifact_path,
+        content=report.to_canonical_bytes(),
+        actor=GOVERN_AUDIT_ACTOR,
+        step_id=report.report_hash(),
+        model=_GOVERN_AUDIT_MODEL,
+        timestamp=report.timestamp,
+    )
+    anchored = AuditReport(
+        findings=report.findings,
+        timestamp=report.timestamp,
+        inventory_hash=report.inventory_hash,
+        inventory_anchor=report.inventory_anchor,
+        journal_entry_hash=anchor,
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / filename).write_text(
+        json.dumps(anchored.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True),
+        encoding="utf-8",
+    )
+    return anchored
+
+
+def read_audit_reports(lineage_root: Path) -> list[AuditReport]:
+    """Load every persisted audit report (append order)."""
+    out_dir = reports_dir(lineage_root)
+    if not out_dir.is_dir():
+        return []
+    reports: list[AuditReport] = []
+    for path in sorted(out_dir.glob("*.json")):
+        try:
+            reports.append(AuditReport.from_dict(json.loads(path.read_bytes())))
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+            logger.warning("govern audit: malformed report at %s", path)
+            continue
+    return reports
+
+
+def read_audit_report(lineage_root: Path, report_hash: str) -> AuditReport | None:
+    """Return the stored report whose canonical bytes hash to *report_hash*.
+
+    The lookup recomputes each stored report's hash rather than trusting a
+    filename, so a report is addressable only by the posture it actually
+    records: edited bytes address nothing and this returns ``None``.
+
+    *report_hash* may be the full ``sha256:``-prefixed digest or a bare hex
+    prefix of at least eight characters.
+    """
+    wanted = report_hash.removeprefix("sha256:").strip().lower()
+    if len(wanted) < 8:
+        return None
+    for report in read_audit_reports(lineage_root):
+        try:
+            digest = report.report_hash().removeprefix("sha256:")
+        except ValueError:
+            continue
+        if digest.startswith(wanted):
+            return report
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Offline verification
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class AuditReportVerifyResult:
+    """Outcome of verifying one stored audit report.
+
+    Attributes:
+        ok: True only when the spine is intact, the report's canonical bytes
+            are anchored in it, the recorded anchor is that entry, and any
+            named inventory anchor is an entry on the same chain.
+        reason: Why verification failed (empty when ``ok``).
+        report: The report that was checked, when one was loaded.
+    """
+
+    ok: bool
+    reason: str = ""
+    report: AuditReport | None = None
+    errors: tuple[str, ...] = field(default_factory=tuple)
+
+
+def _recompute_anchor(spine: LineageSpine, canonical: bytes) -> str | None:
+    """Return the spine entry hash whose content matches ``canonical`` bytes."""
+    want = content_hash_of(canonical)
+    for entry in spine.iter_entries():
+        if entry.content_hash == want:
+            return entry.entry_hash
+    return None
+
+
+def verify_audit_report(
+    *,
+    lineage_root: Path,
+    hmac_key: bytes,
+    report: AuditReport,
+) -> AuditReportVerifyResult:
+    """Prove offline that *report* is the artefact the chain anchored.
+
+    Recomputes, from the stored report and the spine alone:
+
+    * the whole audit spine;
+    * the spine entry whose content hash is the report's canonical bytes -- a
+      byte-flipped report matches no entry and is unverifiable, not merely
+      different;
+    * the recorded ``journal_entry_hash`` against that entry;
+    * the named ``inventory_anchor``, when present, as an entry on the same
+      chain, so a report cannot claim an inventory the chain never saw.
+    """
+    spine = LineageSpine(lineage_root, run_id=GOVERN_AUDIT_RUN_ID, hmac_key=hmac_key)
+    spine_result = spine.verify()
+    if not spine_result.ok:
+        return AuditReportVerifyResult(
+            ok=False,
+            reason=f"govern-audit spine failed verification ({spine_result.status.value})",
+            report=report,
+        )
+
+    try:
+        canonical = report.to_canonical_bytes()
+    except ValueError as exc:
+        return AuditReportVerifyResult(ok=False, reason=f"report is malformed ({exc})", report=report)
+
+    recomputed = _recompute_anchor(spine, canonical)
+    if recomputed is None:
+        return AuditReportVerifyResult(
+            ok=False,
+            reason="report is not anchored in the govern-audit spine",
+            report=report,
+        )
+    if recomputed != report.journal_entry_hash:
+        return AuditReportVerifyResult(
+            ok=False,
+            reason="recorded journal_entry_hash does not match the spine anchor over the report bytes",
+            report=report,
+        )
+
+    if report.inventory_anchor:
+        anchors = {entry.entry_hash for entry in spine.iter_entries()}
+        if report.inventory_anchor not in anchors:
+            return AuditReportVerifyResult(
+                ok=False,
+                reason="referenced inventory anchor is not an entry on the govern-audit spine",
+                report=report,
+            )
+
+    return AuditReportVerifyResult(ok=True, report=report)
+
+
+def verify_all_audit_reports(workdir: Path, *, hmac_key: bytes) -> list[AuditReportVerifyResult]:
+    """Verify every stored audit report under ``workdir/.sdd/lineage``.
+
+    Used by ``bernstein audit verify`` so a tampered posture report is detected
+    exactly like a tampered chain entry. Returns one result per stored report
+    (empty list when no reports exist).
+    """
+    lineage_root = workdir / ".sdd" / "lineage"
+    out_dir = reports_dir(lineage_root)
+    if not out_dir.is_dir():
+        return []
+    results: list[AuditReportVerifyResult] = []
+    for path in sorted(out_dir.glob("*.json")):
+        try:
+            report = AuditReport.from_dict(json.loads(path.read_bytes()))
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+            results.append(AuditReportVerifyResult(ok=False, reason=f"malformed report at {path.name}"))
+            continue
+        results.append(verify_audit_report(lineage_root=lineage_root, hmac_key=hmac_key, report=report))
+    return results
+
+
+__all__ = [
+    "GOVERN_AUDIT_ACTOR",
+    "GOVERN_AUDIT_RUN_ID",
+    "GOVERN_AUDIT_SCHEMA_VERSION",
+    "AuditReport",
+    "AuditReportVerifyResult",
+    "FindingDrift",
+    "anchor_audit_report",
+    "diff_reports",
+    "evidence_hash",
+    "read_audit_report",
+    "read_audit_reports",
+    "reports_dir",
+    "verify_all_audit_reports",
+    "verify_audit_report",
+]

--- a/tests/unit/core/govern/test_audit_report_anchor.py
+++ b/tests/unit/core/govern/test_audit_report_anchor.py
@@ -1,0 +1,320 @@
+"""The govern audit report is a chain-anchored artefact (issue #5077).
+
+The report is not a printout: its canonical bytes are deterministic, its
+sha256 identifies a posture, it is anchored in the lineage spine over exactly
+those bytes the way ``GovernanceDecision`` is, and drift between two audits is
+a comparison of two anchored artefacts rather than a re-run.
+
+Each test names the property it protects:
+
+1. two audits over an unchanged install produce byte-identical reports;
+2. a changed verdict changes the report hash;
+3. the producer's finding order does not change the report bytes;
+4. an anchored report verifies offline against the spine;
+5. a byte-flipped stored report is unverifiable, not merely different;
+6. a forged ``journal_entry_hash`` fails verification;
+7. drift lists only findings whose verdict or evidence changed;
+8. drift names an appeared and a disappeared finding;
+9. a report references the anchor of the inventory it audited;
+10. duplicate finding ids are rejected, so the diff stays well-defined;
+11. ``bernstein audit verify`` fails when a stored report is tampered.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.govern.audit_report import (
+    GOVERN_AUDIT_RUN_ID,
+    AuditReport,
+    anchor_audit_report,
+    diff_reports,
+    read_audit_report,
+    reports_dir,
+    verify_audit_report,
+)
+
+_KEY = b"k" * 32
+
+
+def _lineage_root(tmp_path: Path) -> Path:
+    return tmp_path / ".sdd" / "lineage"
+
+
+def _finding(
+    finding_id: str,
+    *,
+    verdict: str = "measured",
+    passed: bool = True,
+    evidence: list[dict[str, str]] | None = None,
+) -> dict[str, Any]:
+    """Build one serialised finding record as a check producer would emit it."""
+    return {
+        "id": finding_id,
+        "area": finding_id.split("-")[0].lower(),
+        "verdict": verdict,
+        "passed": passed,
+        "summary": f"summary for {finding_id}",
+        "remediation": f"remediate {finding_id}",
+        "evidence": evidence
+        if evidence is not None
+        else [{"locator": f"config/{finding_id}.yaml", "sha256": "a" * 64}],
+    }
+
+
+def _report(findings: list[dict[str, Any]], *, timestamp: int = 1_700_000_000, **kwargs: Any) -> AuditReport:
+    return AuditReport(findings=tuple(findings), timestamp=timestamp, **kwargs)
+
+
+# --------------------------------------------------------------------------- 1
+
+
+def test_two_audits_over_an_unchanged_install_produce_identical_report_bytes() -> None:
+    first = _report([_finding("MDL-001"), _finding("OBS-004", verdict="declared", passed=False)])
+    second = _report([_finding("MDL-001"), _finding("OBS-004", verdict="declared", passed=False)])
+
+    assert first.to_canonical_bytes() == second.to_canonical_bytes()
+    assert first.report_hash() == second.report_hash()
+
+
+# --------------------------------------------------------------------------- 2
+
+
+def test_report_hash_changes_when_a_finding_verdict_changes() -> None:
+    before = _report([_finding("MDL-001", verdict="measured")])
+    after = _report([_finding("MDL-001", verdict="not_measurable")])
+
+    assert before.report_hash() != after.report_hash()
+
+
+# --------------------------------------------------------------------------- 3
+
+
+def test_producer_finding_order_does_not_change_the_report_bytes() -> None:
+    forward = _report([_finding("MDL-001"), _finding("OBS-004"), _finding("CHG-002")])
+    shuffled = _report([_finding("CHG-002"), _finding("MDL-001"), _finding("OBS-004")])
+
+    assert forward.to_canonical_bytes() == shuffled.to_canonical_bytes()
+
+
+# --------------------------------------------------------------------------- 4
+
+
+def test_anchored_report_verifies_offline_against_the_spine(tmp_path: Path) -> None:
+    root = _lineage_root(tmp_path)
+    anchored = anchor_audit_report(
+        lineage_root=root,
+        hmac_key=_KEY,
+        report=_report([_finding("MDL-001"), _finding("OBS-004")]),
+    )
+
+    assert anchored.journal_entry_hash
+    result = verify_audit_report(lineage_root=root, hmac_key=_KEY, report=anchored)
+    assert result.ok, result.reason
+
+    # The stored copy round-trips to the same artefact, and its sha256 is the
+    # posture identity used to address it later.
+    stored = read_audit_report(root, anchored.report_hash())
+    assert stored is not None
+    assert stored.to_canonical_bytes() == anchored.to_canonical_bytes()
+    assert stored.journal_entry_hash == anchored.journal_entry_hash
+
+
+# --------------------------------------------------------------------------- 5
+
+
+def test_byte_flipped_stored_report_is_unverifiable_not_merely_different(tmp_path: Path) -> None:
+    root = _lineage_root(tmp_path)
+    anchored = anchor_audit_report(
+        lineage_root=root,
+        hmac_key=_KEY,
+        report=_report([_finding("MDL-001", verdict="measured", passed=False)]),
+    )
+
+    path = next(iter(sorted(reports_dir(root).glob("*.json"))))
+    row = json.loads(path.read_text(encoding="utf-8"))
+    row["findings"][0]["passed"] = True
+    path.write_text(json.dumps(row, ensure_ascii=False, separators=(",", ":"), sort_keys=True), encoding="utf-8")
+
+    tampered = read_audit_report(root, anchored.report_hash())
+    # The stored bytes no longer address the posture they claim to be.
+    assert tampered is None
+
+    stored_rows = [AuditReport.from_dict(json.loads(p.read_bytes())) for p in sorted(reports_dir(root).glob("*.json"))]
+    assert len(stored_rows) == 1
+    result = verify_audit_report(lineage_root=root, hmac_key=_KEY, report=stored_rows[0])
+    assert not result.ok
+    assert "not anchored" in result.reason
+
+
+# --------------------------------------------------------------------------- 6
+
+
+def test_report_with_a_forged_journal_entry_hash_fails_verification(tmp_path: Path) -> None:
+    root = _lineage_root(tmp_path)
+    anchored = anchor_audit_report(
+        lineage_root=root,
+        hmac_key=_KEY,
+        report=_report([_finding("MDL-001")]),
+    )
+    forged = AuditReport(
+        findings=anchored.findings,
+        timestamp=anchored.timestamp,
+        inventory_hash=anchored.inventory_hash,
+        inventory_anchor=anchored.inventory_anchor,
+        journal_entry_hash="sha256:" + "0" * 64,
+    )
+
+    result = verify_audit_report(lineage_root=root, hmac_key=_KEY, report=forged)
+    assert not result.ok
+    assert "journal_entry_hash" in result.reason
+
+
+# --------------------------------------------------------------------------- 7
+
+
+def test_drift_lists_only_findings_whose_verdict_or_evidence_changed() -> None:
+    before = _report(
+        [
+            _finding("MDL-001"),
+            _finding("OBS-004"),
+            _finding("CHG-002"),
+        ]
+    )
+    after = _report(
+        [
+            # unchanged
+            _finding("MDL-001"),
+            # verdict changed
+            _finding("OBS-004", verdict="not_measurable", passed=False),
+            # evidence changed, verdict identical
+            _finding("CHG-002", evidence=[{"locator": "config/CHG-002.yaml", "sha256": "b" * 64}]),
+        ],
+        timestamp=1_700_009_999,
+    )
+
+    drift = diff_reports(before, after)
+    assert [d.finding_id for d in drift] == ["CHG-002", "OBS-004"]
+    assert [d.change for d in drift] == ["evidence", "verdict"]
+    # A changed timestamp alone is not drift: MDL-001 read the same evidence and
+    # returned the same verdict, so it does not appear.
+    assert "MDL-001" not in {d.finding_id for d in drift}
+
+
+# --------------------------------------------------------------------------- 8
+
+
+def test_drift_names_an_appeared_and_a_disappeared_finding() -> None:
+    before = _report([_finding("MDL-001"), _finding("OBS-004")])
+    after = _report([_finding("MDL-001"), _finding("CHG-002")])
+
+    drift = {d.finding_id: d.change for d in diff_reports(before, after)}
+    assert drift == {"CHG-002": "appeared", "OBS-004": "disappeared"}
+
+
+# --------------------------------------------------------------------------- 9
+
+
+def test_report_references_the_anchor_of_the_inventory_it_audited(tmp_path: Path) -> None:
+    root = _lineage_root(tmp_path)
+    from bernstein.core.govern.inventory_models import Inventory, Surface
+    from bernstein.core.lineage.spine import LineageSpine
+
+    inventory = Inventory(
+        surfaces=(Surface(surface="agent:claude-code", observed_value="2.1.0", evidence_ref="fs:~/.claude"),)
+    )
+    inventory_bytes = json.dumps(inventory.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode(
+        "utf-8"
+    )
+    inventory_anchor = LineageSpine(root, run_id=GOVERN_AUDIT_RUN_ID, hmac_key=_KEY).record(
+        artifact_path="inventory.json",
+        content=inventory_bytes,
+        actor="bernstein.govern",
+        step_id=inventory.content_hash(),
+        model="none",
+        timestamp=1_700_000_000,
+    )
+
+    anchored = anchor_audit_report(
+        lineage_root=root,
+        hmac_key=_KEY,
+        report=_report(
+            [_finding("MDL-001")],
+            inventory_hash=inventory.content_hash(),
+            inventory_anchor=inventory_anchor,
+        ),
+    )
+
+    # One chain walk answers "audited what was enumerated on that date": the
+    # report's own anchor, and the inventory anchor it names, are entries in
+    # the same spine.
+    result = verify_audit_report(lineage_root=root, hmac_key=_KEY, report=anchored)
+    assert result.ok, result.reason
+
+    entries = {e.entry_hash for e in LineageSpine(root, run_id=GOVERN_AUDIT_RUN_ID, hmac_key=_KEY).iter_entries()}
+    assert anchored.inventory_anchor in entries
+    assert anchored.journal_entry_hash in entries
+
+
+def test_report_naming_an_inventory_anchor_absent_from_the_spine_fails_verification(tmp_path: Path) -> None:
+    root = _lineage_root(tmp_path)
+    anchored = anchor_audit_report(
+        lineage_root=root,
+        hmac_key=_KEY,
+        report=_report(
+            [_finding("MDL-001")],
+            inventory_hash="sha256:" + "c" * 64,
+            inventory_anchor="sha256:" + "d" * 64,
+        ),
+    )
+
+    result = verify_audit_report(lineage_root=root, hmac_key=_KEY, report=anchored)
+    assert not result.ok
+    assert "inventory" in result.reason
+
+
+# --------------------------------------------------------------------------- 10
+
+
+def test_duplicate_finding_ids_are_rejected() -> None:
+    with pytest.raises(ValueError, match="duplicate finding id"):
+        _report([_finding("MDL-001"), _finding("MDL-001", verdict="declared")]).to_canonical_bytes()
+
+
+def test_finding_without_an_id_is_rejected() -> None:
+    with pytest.raises(ValueError, match="finding id"):
+        _report([{"verdict": "measured", "evidence": []}]).to_canonical_bytes()
+
+
+# --------------------------------------------------------------------------- 11
+
+
+def test_audit_verify_fails_when_a_stored_report_is_tampered(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from bernstein.cli.commands import audit_cmd
+
+    monkeypatch.setattr(audit_cmd, "AUDIT_DIR", tmp_path / ".sdd" / "audit")
+    monkeypatch.setattr("bernstein.core.security.audit.load_audit_key", lambda *a, **k: _KEY)
+
+    root = _lineage_root(tmp_path)
+    anchor_audit_report(lineage_root=root, hmac_key=_KEY, report=_report([_finding("MDL-001")]))
+    assert audit_cmd._verify_audit_reports() is True
+
+    path = next(iter(sorted(reports_dir(root).glob("*.json"))))
+    row = json.loads(path.read_text(encoding="utf-8"))
+    row["findings"][0]["summary"] = "rewritten after the fact"
+    path.write_text(json.dumps(row, ensure_ascii=False, separators=(",", ":"), sort_keys=True), encoding="utf-8")
+
+    assert audit_cmd._verify_audit_reports() is False
+
+
+def test_audit_verify_is_a_silent_no_op_without_reports(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from bernstein.cli.commands import audit_cmd
+
+    monkeypatch.setattr(audit_cmd, "AUDIT_DIR", tmp_path / ".sdd" / "audit")
+    monkeypatch.setattr("bernstein.core.security.audit.load_audit_key", lambda *a, **k: _KEY)
+
+    assert audit_cmd._verify_audit_reports() is True


### PR DESCRIPTION
## What

Makes a `govern audit` report an artefact instead of a printout.

`bernstein.core.govern.audit_report` defines the report envelope: deterministic
canonical bytes, a `sha256:` identity over those bytes, an anchor in the lineage
spine over exactly those bytes, offline verification, and a drift diff between
two stored reports. `bernstein audit verify` gains a `Govern Audit Reports`
pillar so a tampered stored report fails verification exactly like a tampered
chain entry.

**This PR explicitly does not:**

- define what a check is, or add any check producer — that is slice 1 (#5072),
  which is not on `main`. The envelope carries findings as the serialised
  records their producers emit and requires only a unique `id`;
- add the `govern audit` command or its `--since` flag: there is no `govern
  audit` command on `main` to hang a flag on. The diff itself
  (`diff_reports`) and hash-addressing (`read_audit_report`) are implemented
  and tested here, so the flag is a wiring change once #5072 lands;
- change any existing verification pillar, output format, or default.

**Open decision, decided here.** Acceptance criterion 5 says a report
"references the inventory's anchor". The choice was whether the referenced
anchor may live on any spine or must live on the audit spine. This PR requires
it on the same `govern-audit` chain and fails verification otherwise, because
the criterion asks for *one chain walk*: an anchor on a foreign chain would
need a second key and a second verification pass to mean anything, and an
unchecked anchor string would let a report claim an inventory the chain never
saw.

## Why

`bernstein audit verify` can already prove that a decision, a receipt, a grant
chain and a run artefact are what the chain recorded. An assessment of an
install's posture had no such standing: it existed only as terminal output, so
"has anything changed since the last audit" could only be answered by re-running
every check and eyeballing the difference, and an edited saved report read as a
different posture rather than as a broken one.

Anchoring the report closes both gaps at once. Because the bytes are
deterministic, two audits over an unchanged install produce the same bytes and
therefore the same identity, so drift is a comparison of two stored artefacts
rather than a re-run. Because the anchor is over exactly those bytes, an edited
report matches no spine entry and is unverifiable.

## How

- `AuditReport` binds a schema version, the findings in canonical order (sorted
  by finding id, duplicates rejected), an integer timestamp, and the audited
  inventory's content hash and anchor. `to_canonical_bytes()` is sorted-key,
  minimal-separator UTF-8 JSON; `report_hash()` is the sha256 of those bytes.
  `journal_entry_hash` is not part of the preimage, exactly as on
  `GovernanceDecision`.
- `anchor_audit_report()` records those canonical bytes on the `govern-audit`
  spine via `LineageSpine.record` and persists the anchored report next to the
  spine. One run id keeps successive audits on one chain, so a drift comparison
  is a single chain walk.
- `verify_audit_report()` re-derives everything offline from the stored report
  and the spine: the spine verifies; some entry's content hash equals the
  report's canonical bytes; the recorded anchor is that entry; a named
  inventory anchor is an entry on the same chain.
- `read_audit_report()` addresses a stored report by recomputing each stored
  report's hash rather than trusting a filename, so edited bytes address
  nothing.
- `diff_reports()` returns one row per finding whose verdict or evidence hash
  changed, or that entered or left the check set, ordered by finding id. A
  later timestamp alone is not drift.
- `audit_cmd._verify_audit_reports()` runs the new verification over every
  stored report and adds `Govern Audit Reports` to the failed-pillar list. It is
  a silent no-op when no reports exist and skips (like the other pillars) when
  no audit key can be loaded — verification never mints key material.

## Tests

`tests/unit/core/govern/test_audit_report_anchor.py` (14 tests). Every one of
them failed on the unmodified tree with
`ModuleNotFoundError: No module named 'bernstein.core.govern.audit_report'`
(verified by restoring `src/` to `origin/main` and running the file).

1. `test_two_audits_over_an_unchanged_install_produce_identical_report_bytes` —
   the bytes are deterministic, so the sha256 identifies a posture.
2. `test_report_hash_changes_when_a_finding_verdict_changes` — a different
   posture is a different identity.
3. `test_producer_finding_order_does_not_change_the_report_bytes` — the
   enumeration order of a check registry cannot change the identity.
4. `test_anchored_report_verifies_offline_against_the_spine` — the anchored
   report verifies from the spine alone and round-trips through storage.
5. `test_byte_flipped_stored_report_is_unverifiable_not_merely_different` —
   **load-bearing.** A flipped byte in a stored report addresses nothing and
   matches no spine entry; verification fails with "not anchored" instead of
   reporting a different posture.
6. `test_report_with_a_forged_journal_entry_hash_fails_verification` — the
   recorded anchor is checked against the recomputed one, not trusted.
7. `test_drift_lists_only_findings_whose_verdict_or_evidence_changed` — drift is
   a comparison, not a re-run; a changed timestamp alone produces no rows.
8. `test_drift_names_an_appeared_and_a_disappeared_finding` — a check entering
   or leaving the set is drift too.
9. `test_report_references_the_anchor_of_the_inventory_it_audited` — the report
   anchor and the inventory anchor are entries on one chain.
10. `test_report_naming_an_inventory_anchor_absent_from_the_spine_fails_verification`
    — a report cannot claim an inventory the chain never saw.
11. `test_duplicate_finding_ids_are_rejected` — the diff stays well-defined.
12. `test_finding_without_an_id_is_rejected` — same property, missing id.
13. `test_audit_verify_fails_when_a_stored_report_is_tampered` — the new
    `bernstein audit verify` pillar fails on a tampered stored report.
14. `test_audit_verify_is_a_silent_no_op_without_reports` — installs with no
    audit reports are unaffected.

Also run green locally (`--parallel 2`): `tests/unit/cli/test_audit_cmd_paths.py`,
`test_audit_verify_active.py`, `test_audit_verify_cards.py`,
`test_audit_verify_gates_cmd.py`, `test_audit_verify_grants.py`,
`test_audit_verify_is_read_only.py`, `tests/unit/test_audit_verify_summary_panel.py`,
`tests/unit/test_audit_verify_receipt_cmd.py`,
`tests/unit/test_verification_exit_codes.py`,
`tests/unit/core/govern/test_models.py` — the importers of the two touched
modules. The full `--affected origin/main` selection did not finish inside the
local time budget on a shared machine, so the importer set above was run
instead; CI runs the full suite.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes — 0 errors on
      `src/bernstein/core/govern/audit_report.py`; `audit_cmd.py` carries
      pre-existing findings and none fall in the added lines
- [x] `uv run python scripts/run_tests.py -x` passes (targeted files above)
- [x] New code has type hints

### Documentation duty

- [ ] User-visible README section updated — N/A (no new command or flag)
- [ ] `docs/operations/<area>.md` updated — N/A (no operator surface changes
      until the `govern audit` command lands in #5072)
- [ ] `docs/api/` schema regenerated — N/A (no public HTTP or config schema
      changed)
- [x] `uv run bernstein agents-md sync` run — produced no changes
- [x] Tests cover the documented behaviour
- [x] Release-note fragment added:
      `docs/release-notes/fragments/5077-govern-audit-report-anchor.md`

Part of #5077

## Remaining

- `govern audit --since <report-hash>` — the drift view as a CLI flag. Blocked
  on #5072, which introduces the `govern audit` command. `diff_reports()` and
  `read_audit_report()` here are the two primitives it needs.
- Populating `inventory_hash` / `inventory_anchor` from a real
  `govern inventory` run (#4973); the envelope carries and verifies both fields,
  but nothing produces a report yet.
