### PR TITLE
docs: add GOVERNANCE, MAINTAINERS and SUPPORT

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,35 @@
+# Governance
+
+Bernstein is a single-maintainer project. [@chernistry](https://github.com/chernistry)
+holds the final call. This page states how that call gets made, so
+contributors do not have to infer it from the other files.
+
+**How decisions are made.** In the open, in issues and pull requests.
+There is no private channel where a proposal is really decided. The
+maintainer decides and the reasoning goes in the thread next to the
+decision — a "no" that does not say what would change it is an
+incomplete answer. Boundaries already settled live in
+[docs/scope.md](docs/scope.md), each pointing at the
+[decision record](docs/decisions/index.md) behind it.
+
+**Changes that need an issue first.** Agree on the design before writing
+code when the change touches the public API (CLI commands and flags, HTTP
+endpoints, the adapter ABC), a schema or on-disk format (`schemas/`,
+`proto/`, the `.sdd/` state layout), or a security boundary (auth, tokens,
+sandboxing, the audit chain, anything in the [SECURITY.md](SECURITY.md)
+in-scope table). State the problem, the option chosen, and what it costs.
+Everything else — bug fixes, docs, tests, a new adapter — goes straight
+to a pull request.
+
+**Becoming a maintainer.** Stewardship is earned by sustained merged work
+in one area, not by application; the mechanics are in
+[CONTRIBUTING.md](CONTRIBUTING.md#areas). Write access follows a stretch
+of established stewardship rather than arriving with it, because write
+here reaches the release workflows and their publishing credentials. The
+[CODEOWNERS](.github/CODEOWNERS) entry comes with the write grant, since
+GitHub only honors code owners who hold write.
+
+**Licensing.** Apache-2.0 ([LICENSE](LICENSE)); by contributing you agree
+your contributions are licensed under it. There is no CLA and no sign-off
+requirement — opening the pull request is the whole ceremony. The project
+name is not covered by the code grant, see [TRADEMARKS.md](TRADEMARKS.md).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,16 @@
+# Maintainers
+
+| Maintainer | Areas | Reach them at |
+|---|---|---|
+| [@chernistry](https://github.com/chernistry) | Everything: core orchestration, adapters, docs, packaging, CI | [Issues](https://github.com/sipyourdrink-ltd/bernstein/issues) and [Discussions](https://github.com/sipyourdrink-ltd/bernstein/discussions) |
+
+[.github/CODEOWNERS](.github/CODEOWNERS) is the authoritative per-path list
+and is what GitHub actually uses to route review. This table is the human
+summary; if the two disagree, CODEOWNERS wins.
+
+The areas open to stewardship are adapters, the web dashboard, the terminal
+UI, docs, and packaging — see [GOVERNANCE.md](GOVERNANCE.md) for how a name
+gets onto this table, and [CONTRIBUTING.md](CONTRIBUTING.md#areas) for the
+mechanics.
+
+Security reports do not go here. Use the channels in [SECURITY.md](SECURITY.md).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,31 @@
+# Support
+
+**Questions, ideas, "is this supposed to work like this?"** →
+[Discussions](https://github.com/sipyourdrink-ltd/bernstein/discussions).
+Q&A for usage questions, Ideas for proposals that are not yet a concrete
+change.
+
+**Bugs and concrete feature requests** →
+[Issues](https://github.com/sipyourdrink-ltd/bernstein/issues/new/choose),
+using the template that fits (blank issues are turned off on purpose). The
+bug template asks for a version, steps to reproduce, and a debug bundle,
+because that is what makes a report actionable; without them a report
+usually gets a question back instead of a fix. `bernstein debug-bundle`
+collects a redacted archive for you.
+
+**Security vulnerabilities** → not here. Follow
+[SECURITY.md](SECURITY.md) — email or a private advisory, never a public
+issue.
+
+**Response times.** Bernstein is maintained by one person, unpaid, alongside
+other work. Most issues get a first look within a few days; some take
+considerably longer, and a quiet thread means the queue is deep rather than
+that the report was dismissed. Security reports have their own stated bound
+of up to 90 days in [SECURITY.md](SECURITY.md). Nothing here is a
+service-level agreement.
+
+**What is not supported.** Third-party CLI agents themselves — if the agent
+misbehaves once it is running, that is a question for its vendor; if
+Bernstein spawns or parses it wrong, that is a bug here. Also out: debugging
+your own fork's modifications, private consulting, and anything covered by
+the out-of-scope table in [SECURITY.md](SECURITY.md).


### PR DESCRIPTION
Adds three root files that the repo did not have: GOVERNANCE.md, MAINTAINERS.md and SUPPORT.md.

Contributors currently have to infer how decisions get made, who owns an area, and where to ask a question by reading CONTRIBUTING.md, SECURITY.md and CODEOWNERS together and filling the gaps themselves.

Each file states only what the repo already does today and links to the file that is authoritative rather than restating it: GOVERNANCE points at docs/scope.md and the decision records, MAINTAINERS defers to .github/CODEOWNERS for per-path ownership, SUPPORT defers to SECURITY.md for vulnerabilities.

No behaviour change and no edits to existing files.

Checked locally with the typos spell check and the pre-commit markdown hooks.