### PR TITLE
secrets: broker an operator's own secret store behind one contract (#4984)

### DIFF
--- a/docs/operations/secrets.md
+++ b/docs/operations/secrets.md
@@ -316,6 +316,76 @@ Same three providers, different lifecycle. The injector is for
 Use the injector when you want an agent to have a database password
 or a cloud role for the lifetime of one task and never see it again.
 
+### Broker-side stores: `core/security/external_secret_store.py`
+
+Both integration points above copy a value out of the operator's store
+and into Bernstein. The broker
+(`core/security/secrets_broker.py`) takes the opposite approach: the
+operator's store stays the only place the value lives, and Bernstein
+keeps the authorization record.
+
+Configure it as a broker backend:
+
+```yaml
+secrets_broker:
+  backend: external
+  backend_settings:
+    store_name: acme       # a registered store
+    # any further keys are forwarded to that store's factory
+```
+
+A spec then names a secret by opaque reference, never by value:
+
+```yaml
+secret_name: acme:prod/db-password
+```
+
+The `acme` half selects the store; the rest is store-native (a Vault
+path, an ARN, a resource id) and Bernstein never interprets it.
+
+On every mint the broker asks the store three things, in order:
+
+1. `resolve(path)` - non-secret facts: which store holds it, its
+   store-native version or lease id, whether it is revoked, and any
+   store-imposed expiry.
+2. `report_revocation(path, upstream_id=...)` - revoking in your own
+   store is what stops Bernstein minting. There is no separate
+   revocation list to keep in step.
+3. `mint_credential(path, audience=..., ttl_seconds=...)` - a
+   short-lived credential. A store may return a shorter expiry than
+   asked for and the broker caps the token to it, so a broker token
+   never outlives the credential behind it.
+
+What reaches the grant chain is the grant, the store identity, the
+audience and the expiry. The credential value is held in the broker's
+in-process registry for the token's lifetime and is dropped on
+revocation. Grant enforcement is unchanged: without a verifying grant
+the broker refuses, and the store is never called.
+
+Binding a credential for one step:
+
+```python
+with broker.bind_scoped(
+    secret_name="acme:prod/db-password",
+    task_id=task.id,
+    env_var="DATABASE_PASSWORD",
+    grant=grant,
+) as token:
+    run_step(token)
+# DATABASE_PASSWORD is gone here - or back to whatever you had set
+# under that name - and the token is revoked.
+```
+
+#### Registering a store
+
+No concrete store ships built in. A store implements
+`ExternalSecretStore` and registers under a name, either through the
+`provide_secret_store` plugin hook or, in-process, through
+`register_secret_store()`. Because stores register from outside,
+`bernstein.core` never imports a vendor SDK -
+`tests/unit/security/test_core_vendor_sdk_imports.py` fails the build
+if it gains one.
+
 ---
 
 ## `.env` file conventions
@@ -443,6 +513,9 @@ blast radius.
 | HMAC audit log                | `src/bernstein/core/security/vault/audit.py`                       |
 | Startup secret-manager loader | `src/bernstein/core/security/secrets.py`                           |
 | Spawn-time injector           | `src/bernstein/core/security/vault_injector.py`                    |
+| Secrets broker                | `src/bernstein/core/security/secrets_broker.py`                    |
+| External-store contract       | `src/bernstein/core/security/external_secret_store.py`             |
+| External-store registry       | `src/bernstein/core/security/secret_store_registry.py`             |
 | Env-var filter for spawns     | `src/bernstein/adapters/env_isolation.py` (see `env-isolation.md`) |
 
 ---

--- a/docs/release-notes/fragments/4984-external-secret-stores.md
+++ b/docs/release-notes/fragments/4984-external-secret-stores.md
@@ -1,0 +1,5 @@
+## Broker an operator's own secret store instead of copying secrets into ours
+
+The secrets broker now treats an external secret store as a backend behind one contract: resolve a named secret, mint a short-lived credential, report a revocation. A spec names a secret by opaque reference (`<store>:<store-native path>`), the store keeps the value, and the grant chain records the grant, the identity of the issuing store, the audience and the expiry — never the value. Revoking the secret upstream is what stops Bernstein minting, so there is no second revocation list to keep in step. Stores register through a plugin hook (`provide_secret_store`), so no vendor SDK import lands in `bernstein.core`; a static check fails the build if one does. `SecretsBroker.bind_scoped()` binds a minted token into the environment for the duration of one step and removes it — or restores the operator's own value — on the way out.
+
+(#4984)

--- a/src/bernstein/core/identity/grants.py
+++ b/src/bernstein/core/identity/grants.py
@@ -565,9 +565,19 @@ class GrantLedger:
         task_id: str = "",
         secret_name: str = "",
         audience: str = "",
+        store: str = "",
         created: int | None = None,
     ) -> GrantReceipt:
-        """Append a ``grant_exchanged`` record binding a minted ``token_id`` to a grant."""
+        """Append a ``grant_exchanged`` record binding a minted ``token_id`` to a grant.
+
+        Args:
+            store: Identity of the external secret store that issued the
+                credential behind the token, when one did. It is written into
+                the existing signed ``reason`` field as ``store:<id>`` rather
+                than as a new field, so records written before external stores
+                existed keep verifying against the same signed body. The store
+                identity is non-secret; the credential value is never recorded.
+        """
         return self._append(
             run_id=run_id,
             kind=GRANT_EXCHANGED,
@@ -578,7 +588,7 @@ class GrantLedger:
             expiry=0,
             capability_ceiling=(),
             token_id=token_id,
-            reason="",
+            reason=f"store:{store}" if store else "",
             created=created,
         )
 

--- a/src/bernstein/core/security/external_secret_store.py
+++ b/src/bernstein/core/security/external_secret_store.py
@@ -1,0 +1,195 @@
+"""Contract for external secret stores used as broker backends (issue #4984).
+
+Why this exists
+===============
+
+Operators running compliance-sensitive workflows already have a secret store,
+already audit it, and already have policy attached to it. Copying secrets into
+a second store to run Bernstein means governing two stores instead of one.
+
+So the broker treats an operator's own store as a backend behind one contract:
+
+* :meth:`ExternalSecretStore.resolve` -- resolve a named secret to *non-secret*
+  facts about it (which store holds it, its store-native version or lease id,
+  whether it is revoked).
+* :meth:`ExternalSecretStore.mint_credential` -- mint a short-lived credential.
+* :meth:`ExternalSecretStore.report_revocation` -- report whether the upstream
+  secret or credential has been revoked.
+
+What is recorded, and what is not
+=================================
+
+The credential *value* never enters the grant chain. What
+:mod:`bernstein.core.identity.grants` records is the grant, the identity of the
+store that issued the credential, the audience, and the expiry. Bernstein is
+not a secret store that gained connectors; it is the authorization record that
+can prove which task held which credential power over which window, whichever
+store issued it.
+
+Naming
+======
+
+A spec names a secret by opaque reference -- ``"<store>:<store-native path>"``
+-- never by value. :class:`SecretRef` is that reference; the ``path`` half is
+opaque to Bernstein and is interpreted only by the store that owns it.
+
+No vendor SDKs in core
+======================
+
+``bernstein.core`` implements the contract and nothing else. A store that needs
+a vendor SDK ships as a plugin registered through
+:mod:`bernstein.core.security.secret_store_registry`; the SDK import lives in
+the plugin, never here.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+__all__ = [
+    "REFERENCE_SEPARATOR",
+    "ExternalCredential",
+    "ExternalSecretStore",
+    "ExternalStoreError",
+    "SecretDescriptor",
+    "SecretRef",
+]
+
+#: Separates the store identity from the store-native path in a reference.
+REFERENCE_SEPARATOR = ":"
+
+
+class ExternalStoreError(Exception):
+    """Raised when an external store cannot serve a contract call.
+
+    The broker translates this into a
+    :class:`~bernstein.core.security.secrets_broker.SecretsBrokerError` so
+    callers see one error type regardless of which backend is configured.
+    """
+
+
+@dataclass(frozen=True)
+class SecretRef:
+    """Opaque reference naming one secret inside one external store.
+
+    Attributes:
+        store: Registered store identity (the registry name).
+        path: Store-native name -- a Vault path, an ARN, a resource id.
+            Bernstein never interprets it.
+    """
+
+    store: str
+    path: str
+
+    @classmethod
+    def parse(cls, reference: str) -> SecretRef:
+        """Parse ``"<store>:<path>"``.
+
+        Raises:
+            ExternalStoreError: When the reference names no store. Failing
+                closed matters here: a bare name would otherwise be resolved
+                against whichever store happened to be configured.
+        """
+        store, sep, path = reference.partition(REFERENCE_SEPARATOR)
+        if not sep or not store or not path:
+            raise ExternalStoreError(f"secret reference {reference!r} must be '<store>{REFERENCE_SEPARATOR}<path>'")
+        return cls(store=store, path=path)
+
+    def __str__(self) -> str:
+        return f"{self.store}{REFERENCE_SEPARATOR}{self.path}"
+
+
+@dataclass(frozen=True)
+class SecretDescriptor:
+    """Non-secret facts about a named secret. Never carries a value.
+
+    Attributes:
+        store_id: Identity of the store that holds the secret. This is what
+            the grant chain records alongside the grant.
+        upstream_id: Store-native version, lease, or generation id. Non-secret
+            by construction; it is what a later revocation check refers to.
+        revoked: Whether the store reports the secret as revoked.
+        expires_at: Store-imposed expiry as epoch seconds; ``0`` means the
+            store imposes none and the broker TTL governs.
+    """
+
+    store_id: str
+    upstream_id: str = ""
+    revoked: bool = False
+    expires_at: float = 0.0
+
+
+@dataclass(frozen=True, repr=False)
+class ExternalCredential:
+    """A short-lived credential a store minted for one task.
+
+    ``repr`` is redacted so a credential that reaches a log line or a
+    traceback does not carry its own value.
+
+    Attributes:
+        value: The credential. Held in the broker's in-process registry for
+            the token's lifetime and never persisted or recorded.
+        expires_at: Store-imposed expiry as epoch seconds; ``0`` means none.
+        upstream_id: Store-native lease or version id for revocation checks.
+        audience: The audience the store issued the credential for, when the
+            store scopes credentials itself.
+    """
+
+    value: str
+    expires_at: float = 0.0
+    upstream_id: str = ""
+    audience: str = ""
+
+    def __repr__(self) -> str:
+        return (
+            f"ExternalCredential(value=<redacted len={len(self.value)}>, "
+            f"expires_at={self.expires_at!r}, upstream_id={self.upstream_id!r}, "
+            f"audience={self.audience!r})"
+        )
+
+
+class ExternalSecretStore(ABC):
+    """One operator secret store, behind three verbs.
+
+    Implementations live outside ``bernstein.core`` -- in an adapter or a
+    plugin -- so a vendor SDK never becomes a core import. Every method may
+    raise :class:`ExternalStoreError`; the broker records the refusal against
+    the grant chain and raises its own error type.
+    """
+
+    #: Stable identity recorded in the grant chain beside the grant.
+    store_id: str = ""
+
+    @abstractmethod
+    def resolve(self, path: str) -> SecretDescriptor:
+        """Return non-secret facts about the secret at ``path``.
+
+        Raises:
+            ExternalStoreError: When the store holds no such secret.
+        """
+
+    @abstractmethod
+    def mint_credential(self, path: str, *, audience: str, ttl_seconds: int) -> ExternalCredential:
+        """Mint a short-lived credential for the secret at ``path``.
+
+        Args:
+            path: Store-native name.
+            audience: The downstream target the credential is for; stores that
+                scope credentials themselves should honour it.
+            ttl_seconds: The lifetime the broker asked for. A store may return
+                a shorter expiry; the broker caps the token to whichever is
+                sooner. It must not return a longer one.
+
+        Raises:
+            ExternalStoreError: When the store refuses to mint.
+        """
+
+    @abstractmethod
+    def report_revocation(self, path: str, *, upstream_id: str) -> bool:
+        """Return ``True`` when the upstream secret or credential is revoked.
+
+        Called before every mint, so revoking in the operator's own store is
+        what stops Bernstein minting -- no separate revocation list to keep in
+        step.
+        """

--- a/src/bernstein/core/security/secret_store_registry.py
+++ b/src/bernstein/core/security/secret_store_registry.py
@@ -1,0 +1,296 @@
+"""Registry of external secret-store backends (issue #4984).
+
+Adding a store must not require a patch to ``bernstein.core``. Stores come
+from two sources, mirroring the tracker-adapter registry
+(:mod:`bernstein.core.trackers.registry`) so store authors follow a contract
+they already know:
+
+1. **Plugin-contributed stores** discovered via the ``provide_secret_store``
+   pluggy hookspec. A store that needs a vendor SDK ships this way, keeping
+   the SDK import out of core.
+2. **Programmatic registrations** through :func:`register_secret_store`, used
+   by tests, in-process fakes, and third parties that load a store without
+   pluggy.
+
+No store ships built in: each concrete store is its own slice on top of the
+contract in :mod:`bernstein.core.security.external_secret_store`.
+
+The registry stores construction factories only. Instantiation -- with a base
+URL, a role, a mount, whatever the store needs -- is the caller's job.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from bernstein.core.security.external_secret_store import ExternalSecretStore
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "DuplicateSecretStoreError",
+    "SecretStoreFactory",
+    "SecretStoreRegistration",
+    "SecretStoreRegistry",
+    "discover_plugin_secret_stores",
+    "get_registry",
+    "register_secret_store",
+    "reset_registry_for_tests",
+]
+
+
+class SecretStoreFactory(Protocol):
+    """Callable that constructs an :class:`ExternalSecretStore`."""
+
+    def __call__(self, **kwargs: Any) -> ExternalSecretStore:
+        """Construct a store with the supplied configuration."""
+
+
+class DuplicateSecretStoreError(ValueError):
+    """Raised when two stores register under the same name."""
+
+
+@dataclass(frozen=True)
+class SecretStoreRegistration:
+    """A single registered external secret store.
+
+    Attributes:
+        name: Store identity used in a secret reference (``"<name>:<path>"``).
+        factory: Callable that constructs the store.
+        summary: One-line human-readable description.
+        source: ``"plugin"`` or ``"programmatic"``; labels where it came from.
+        provenance: Plugin name or module path, recorded so an operator can
+            tell which code is holding their credentials.
+    """
+
+    name: str
+    factory: SecretStoreFactory
+    summary: str = ""
+    source: str = "programmatic"
+    provenance: str | None = None
+
+
+class SecretStoreRegistry:
+    """In-process registry of external secret-store factories.
+
+    Not a singleton by design: tests build isolated instances. Module-level
+    helpers wrap a process-wide default reached through :func:`get_registry`.
+    """
+
+    def __init__(self) -> None:
+        self._entries: dict[str, SecretStoreRegistration] = {}
+
+    def register(
+        self,
+        name: str,
+        factory: SecretStoreFactory,
+        *,
+        summary: str = "",
+        source: str = "programmatic",
+        provenance: str | None = None,
+        overwrite: bool = False,
+    ) -> SecretStoreRegistration:
+        """Register ``factory`` under ``name``.
+
+        Raises:
+            DuplicateSecretStoreError: When ``name`` is taken and
+                ``overwrite`` is False. Silently letting a second store claim
+                a name would repoint an operator's secrets without a trace.
+        """
+        if name in self._entries and not overwrite:
+            existing = self._entries[name]
+            msg = (
+                f"Secret store {name!r} is already registered "
+                f"(source={existing.source}, provenance={existing.provenance!r}). "
+                "Pass overwrite=True to replace it."
+            )
+            raise DuplicateSecretStoreError(msg)
+        entry = SecretStoreRegistration(
+            name=name,
+            factory=factory,
+            summary=summary,
+            source=source,
+            provenance=provenance,
+        )
+        self._entries[name] = entry
+        return entry
+
+    def unregister(self, name: str) -> None:
+        """Remove ``name`` from the registry (no-op if absent)."""
+        self._entries.pop(name, None)
+
+    def get(self, name: str) -> SecretStoreRegistration:
+        """Return the registration for ``name``.
+
+        Raises:
+            KeyError: When no store is registered under ``name``.
+        """
+        try:
+            return self._entries[name]
+        except KeyError as exc:
+            known = ", ".join(sorted(self._entries)) or "(none)"
+            raise KeyError(f"Unknown secret store {name!r}. Registered: {known}.") from exc
+
+    def create(self, name: str, **kwargs: Any) -> ExternalSecretStore:
+        """Construct a store instance, forwarding ``kwargs`` to its factory."""
+        return self.get(name).factory(**kwargs)
+
+    def names(self) -> tuple[str, ...]:
+        """Return registered names, plugin entries before programmatic ones."""
+        priority = {"plugin": 0, "programmatic": 1}
+
+        def sort_key(item: tuple[str, SecretStoreRegistration]) -> tuple[int, str]:
+            return (priority.get(item[1].source, 2), item[0])
+
+        return tuple(name for name, _ in sorted(self._entries.items(), key=sort_key))
+
+    def __iter__(self) -> Iterator[SecretStoreRegistration]:
+        for name in self.names():
+            yield self._entries[name]
+
+    def __contains__(self, name: object) -> bool:
+        return isinstance(name, str) and name in self._entries
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+
+# ---------------------------------------------------------------------------
+# Process-wide default registry
+# ---------------------------------------------------------------------------
+
+_registry: SecretStoreRegistry | None = None
+
+
+def get_registry() -> SecretStoreRegistry:
+    """Return the process-wide default registry, creating it on first use."""
+    global _registry
+    if _registry is None:
+        _registry = SecretStoreRegistry()
+    return _registry
+
+
+def reset_registry_for_tests() -> None:
+    """Clear the process-wide registry (test helper only)."""
+    global _registry
+    _registry = None
+
+
+def register_secret_store(
+    name: str,
+    factory: SecretStoreFactory,
+    *,
+    summary: str = "",
+    source: str = "programmatic",
+    provenance: str | None = None,
+    overwrite: bool = False,
+) -> SecretStoreRegistration:
+    """Register ``factory`` on the process-wide default registry."""
+    return get_registry().register(
+        name,
+        factory,
+        summary=summary,
+        source=source,
+        provenance=provenance,
+        overwrite=overwrite,
+    )
+
+
+def discover_plugin_secret_stores(plugin_manager: Any | None = None) -> int:
+    """Populate the registry with plugin-contributed stores.
+
+    Calls ``provide_secret_store`` on every loaded plugin that implements it
+    and registers each returned :class:`SecretStoreRegistration` (or
+    ``(name, factory)`` tuple).
+
+    Args:
+        plugin_manager: Optional explicit manager; defaults to the
+            orchestrator's via ``bernstein.plugins.manager.get_plugin_manager``.
+
+    Returns:
+        Number of stores newly registered.
+    """
+    pm = plugin_manager
+    if pm is None:
+        try:
+            from bernstein.plugins.manager import get_plugin_manager
+
+            pm = get_plugin_manager()
+        except Exception as exc:  # pragma: no cover - defensive
+            log.warning("Could not obtain plugin manager: %s", exc)
+            return 0
+
+    registry = get_registry()
+    inner_pm = getattr(pm, "_pm", None)
+    if inner_pm is None:
+        log.debug("Plugin manager has no inner pluggy manager; skipping discovery.")
+        return 0
+
+    added = 0
+    for plugin_name in getattr(pm, "_registered_names", []):
+        plugin = inner_pm.get_plugin(plugin_name)
+        if plugin is None or not hasattr(plugin, "provide_secret_store"):
+            continue
+        try:
+            result = plugin.provide_secret_store()
+        except Exception as exc:
+            log.warning("Plugin %r provide_secret_store raised: %s", plugin_name, exc)
+            continue
+        added += _register_plugin_result(registry, plugin_name, result)
+    return added
+
+
+def _register_plugin_result(registry: SecretStoreRegistry, plugin_name: str, result: Any) -> int:
+    """Register one plugin's return value; returns how many entries landed."""
+    if result is None:
+        return 0
+    items = result if isinstance(result, list) else [result]
+    count = 0
+    for raw in items:
+        registration = _coerce_registration(raw, plugin_name)
+        if registration is None:
+            continue
+        try:
+            registry.register(
+                registration.name,
+                registration.factory,
+                summary=registration.summary,
+                source="plugin",
+                provenance=registration.provenance or plugin_name,
+                overwrite=False,
+            )
+            count += 1
+        except DuplicateSecretStoreError as exc:
+            log.warning(
+                "Plugin %r tried to register duplicate secret store %r: %s",
+                plugin_name,
+                registration.name,
+                exc,
+            )
+    return count
+
+
+def _coerce_registration(raw: Any, plugin_name: str) -> SecretStoreRegistration | None:
+    """Normalise a plugin-supplied registration into a dataclass."""
+    if isinstance(raw, SecretStoreRegistration):
+        return raw
+    if isinstance(raw, tuple) and len(raw) == 2:
+        name, factory = raw
+        if isinstance(name, str) and callable(factory):
+            return SecretStoreRegistration(
+                name=name,
+                factory=factory,
+                source="plugin",
+                provenance=plugin_name,
+            )
+    log.warning(
+        "Plugin %r provide_secret_store returned unrecognised value %r; ignoring.",
+        plugin_name,
+        raw,
+    )
+    return None

--- a/src/bernstein/core/security/secrets_broker.py
+++ b/src/bernstein/core/security/secrets_broker.py
@@ -43,6 +43,17 @@ Six backends ship in this module: ``vault``, ``aws_secretsmanager``,
 ``read(secret_name) -> raw_value``. Network backends are imported lazily so
 the module loads without optional dependencies installed.
 
+A seventh backend, ``external``, is the operator's own secret store behind
+:class:`~bernstein.core.security.external_secret_store.ExternalSecretStore`.
+Instead of copying secrets into a store of ours, the broker resolves a named
+secret in theirs, asks it to mint a short-lived credential, and refuses to
+mint again once that store reports the secret revoked. The credential value
+never enters the audit chain: what the chain records is the grant, the
+identity of the store that issued the credential, the audience, and the
+expiry. Concrete stores are plugins registered through
+:mod:`~bernstein.core.security.secret_store_registry`, so a vendor SDK import
+never lands in ``bernstein.core``.
+
 Audit log
 =========
 
@@ -70,11 +81,21 @@ import subprocess
 import threading
 import time
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, MutableMapping
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
+
+from bernstein.core.security.external_secret_store import (
+    ExternalCredential,
+    ExternalStoreError,
+    SecretDescriptor,
+    SecretRef,
+)
+
+if TYPE_CHECKING:
+    from bernstein.core.security.external_secret_store import ExternalSecretStore
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +104,7 @@ __all__ = [
     "AuditSink",
     "AwsSecretsManagerBackend",
     "BrokerConfig",
+    "ExternalStoreBackend",
     "FileEncryptedBackend",
     "GcpSecretManagerBackend",
     "LinuxKeyringBackend",
@@ -100,6 +122,7 @@ __all__ = [
 ]
 
 BackendName = Literal[
+    "external",
     "vault",
     "aws_secretsmanager",
     "gcp_secret_manager",
@@ -467,6 +490,83 @@ class FileEncryptedBackend(SecretsBackend):
             return []
 
 
+class ExternalStoreBackend(SecretsBackend):
+    """The operator's own secret store, behind the external-store contract.
+
+    Configure as ``backend: external`` with
+    ``backend_settings: {store_name: "<registered name>"}``; any further
+    settings are forwarded to the store's factory. Tests and in-process
+    wiring may pass an already-constructed ``store`` instead.
+
+    Store construction is deferred to first use, so a name that no plugin
+    registered fails at mint time with a message naming what *is* registered,
+    rather than minting against some other store or failing at import.
+
+    ``secret_name`` here is an opaque reference -- ``"<store>:<path>"`` -- and
+    the ``path`` half is interpreted only by the store that owns it.
+    """
+
+    name = "external"
+
+    def __init__(
+        self,
+        *,
+        store: ExternalSecretStore | None = None,
+        store_name: str = "",
+        **store_settings: Any,
+    ) -> None:
+        self._store = store
+        self._store_name = store_name or (str(getattr(store, "store_id", "")) if store is not None else "")
+        self._store_settings = store_settings
+
+    @property
+    def store_name(self) -> str:
+        """Name this backend answers for, and the store half of a reference."""
+        return self._store_name
+
+    def store(self) -> ExternalSecretStore:
+        """Return the store, constructing it from the registry on first use."""
+        if self._store is None:
+            from bernstein.core.security.secret_store_registry import get_registry
+
+            try:
+                self._store = get_registry().create(self._store_name, **self._store_settings)
+            except KeyError as exc:
+                raise SecretsBrokerError(str(exc)) from exc
+        return self._store
+
+    def _path(self, secret_name: str) -> str:
+        """Split ``secret_name`` into its store-native path, checking the store."""
+        ref = SecretRef.parse(secret_name)
+        if self._store_name and ref.store != self._store_name:
+            raise SecretsBrokerError(
+                f"secret reference {secret_name!r} names store {ref.store!r}, "
+                f"but this backend serves {self._store_name!r}"
+            )
+        return ref.path
+
+    def describe(self, secret_name: str) -> SecretDescriptor:
+        """Return the store's non-secret facts about ``secret_name``."""
+        return self.store().resolve(self._path(secret_name))
+
+    def report_revocation(self, secret_name: str, *, upstream_id: str) -> bool:
+        """Ask the store whether the upstream secret or credential is revoked."""
+        return self.store().report_revocation(self._path(secret_name), upstream_id=upstream_id)
+
+    def issue(self, secret_name: str, *, audience: str, ttl_seconds: int) -> ExternalCredential:
+        """Ask the store to mint a short-lived credential."""
+        return self.store().mint_credential(self._path(secret_name), audience=audience, ttl_seconds=ttl_seconds)
+
+    def read(self, secret_name: str) -> str:
+        """Return a credential value for callers that only hold the thin API.
+
+        The broker itself goes through :meth:`describe` / :meth:`issue` so the
+        revocation check and the store-reported expiry are honoured; this
+        method exists because every backend implements ``read``.
+        """
+        return self.issue(secret_name, audience="", ttl_seconds=_DEFAULT_TTL_SECONDS).value
+
+
 # ---------------------------------------------------------------------------
 # Broker config
 # ---------------------------------------------------------------------------
@@ -678,12 +778,30 @@ class SecretsBroker:
                 expires_override = float(grant_expiry)
 
         ttl = self._resolve_ttl(secret_name, ttl_seconds)
-        raw_value = self._backend.read(secret_name)
+        store_id = ""
+        store_expiry: float | None = None
+        if isinstance(self._backend, ExternalStoreBackend):
+            raw_value, store_id, store_expiry = self._issue_external(
+                self._backend,
+                secret_name=secret_name,
+                task_id=task_id,
+                audience=audience,
+                ttl_seconds=ttl,
+                run_id=grant_run_id or task_id,
+                grant_id=grant_id,
+            )
+        else:
+            raw_value = self._backend.read(secret_name)
         token_id = _new_token_id()
         token_value = _new_token_value()
         now = self._clock()
         expires_at = expires_override if expires_override is not None else now + ttl
-        effective_ttl = int(expires_at - now) if expires_override is not None else ttl
+        # A store that issues a shorter-lived credential than we asked for caps
+        # the token: the broker must never outlive the credential behind it.
+        if store_expiry is not None and store_expiry < expires_at:
+            expires_at = store_expiry
+        unbounded = expires_override is None and store_expiry is None
+        effective_ttl = ttl if unbounded else int(expires_at - now)
         token = MintedToken(
             token_id=token_id,
             value=token_value,
@@ -715,6 +833,7 @@ class SecretsBroker:
                 task_id=task_id,
                 secret_name=secret_name,
                 audience=audience,
+                store=store_id,
             )
         self._emit(
             AuditEvent(
@@ -749,6 +868,62 @@ class SecretsBroker:
         try:
             yield token
         finally:
+            self.revoke(token.token_id, reason="scope-exit")
+
+    @contextmanager
+    def bind_scoped(
+        self,
+        *,
+        secret_name: str,
+        task_id: str,
+        env_var: str,
+        ttl_seconds: int | None = None,
+        grant: Any = None,
+        run_id: str | None = None,
+        env: MutableMapping[str, str] | None = None,
+    ) -> Generator[MintedToken, None, None]:
+        """Bind a minted token into ``env`` for the duration of one step.
+
+        A spec names a secret by opaque reference; the value is bound into the
+        environment only for the block. On the way out the variable is removed
+        -- or restored to whatever the operator had set under that name -- and
+        the token is revoked, which also drops the backing credential from the
+        broker registry. An environment dump before the block and after it
+        finds the bound value in neither.
+
+        Args:
+            secret_name: Backing-store name or, for the ``external`` backend,
+                a ``"<store>:<path>"`` reference.
+            task_id: Task that owns the token.
+            env_var: Variable name to bind under.
+            ttl_seconds: Lifetime override, as for :meth:`mint`.
+            grant: Grant authorizing the mint, as for :meth:`mint`.
+            run_id: Run scope for chain-anchored refusals, as for :meth:`mint`.
+            env: Mapping to bind into. Defaults to :data:`os.environ`.
+
+        Yields:
+            The :class:`MintedToken` bound under ``env_var``.
+        """
+        if not env_var:
+            raise SecretsBrokerError("env_var must not be empty")
+        target: MutableMapping[str, str] = os.environ if env is None else env
+        token = self.mint(
+            secret_name=secret_name,
+            task_id=task_id,
+            ttl_seconds=ttl_seconds,
+            grant=grant,
+            run_id=run_id,
+        )
+        had_previous = env_var in target
+        previous = target.get(env_var, "")
+        target[env_var] = token.value
+        try:
+            yield token
+        finally:
+            if had_previous:
+                target[env_var] = previous
+            else:
+                target.pop(env_var, None)
             self.revoke(token.token_id, reason="scope-exit")
 
     def resolve(self, token_value: str, *, audience: str | None = None) -> str:
@@ -850,6 +1025,9 @@ class SecretsBroker:
             if reg is None or reg.revoked:
                 return False
             reg.revoked = True
+            # A revoked token's backing credential has no further use; dropping
+            # it keeps a bound value from outliving the step that bound it.
+            reg.raw_value = ""
             deferred = AuditEvent(
                 kind="revoke",
                 token_id=token_id,
@@ -880,6 +1058,7 @@ class SecretsBroker:
                 if reg.revoked or reg.token.task_id != task_id:
                     continue
                 reg.revoked = True
+                reg.raw_value = ""
                 deferred.append(
                     AuditEvent(
                         kind="revoke",
@@ -1004,6 +1183,54 @@ class SecretsBroker:
             return False, "not_active"
         return True, "ok"
 
+    # -- external stores (issue #4984) --------------------------------------
+
+    def _issue_external(
+        self,
+        backend: ExternalStoreBackend,
+        *,
+        secret_name: str,
+        task_id: str,
+        audience: str,
+        ttl_seconds: int,
+        run_id: str,
+        grant_id: str,
+    ) -> tuple[str, str, float | None]:
+        """Resolve, revocation-check, then mint against the operator's store.
+
+        Returns ``(credential value, store identity, store expiry or None)``.
+        The value is held in the broker registry for the token's lifetime and
+        goes nowhere else; only the store identity reaches the chain.
+
+        Raises:
+            SecretsBrokerError: When the store cannot serve the reference, or
+                when it reports the upstream secret revoked. An upstream
+                revocation is recorded as a chain-anchored refusal before the
+                error propagates, so "the operator revoked it upstream" and
+                "we refused to mint" are the same record.
+        """
+        try:
+            descriptor = backend.describe(secret_name)
+            revoked = descriptor.revoked or backend.report_revocation(secret_name, upstream_id=descriptor.upstream_id)
+        except ExternalStoreError as exc:
+            raise SecretsBrokerError(f"external store failed for {secret_name!r}: {exc}") from exc
+        store_id = descriptor.store_id or backend.store_name
+        if revoked:
+            self._record_grant_refusal(
+                run_id=run_id,
+                task_id=task_id,
+                secret_name=secret_name,
+                grant_id=grant_id,
+                reason="upstream_revoked",
+            )
+            raise SecretsBrokerError(f"upstream secret {secret_name!r} is revoked in store {store_id!r}")
+        try:
+            credential = backend.issue(secret_name, audience=audience, ttl_seconds=ttl_seconds)
+        except ExternalStoreError as exc:
+            raise SecretsBrokerError(f"external store refused to mint {secret_name!r}: {exc}") from exc
+        expiry = credential.expires_at if credential.expires_at > 0 else None
+        return credential.value, store_id, expiry
+
     def _record_grant_exchange(
         self,
         *,
@@ -1013,6 +1240,7 @@ class SecretsBroker:
         task_id: str,
         secret_name: str,
         audience: str,
+        store: str = "",
     ) -> None:
         if self._grant_ledger is None:
             return
@@ -1024,6 +1252,7 @@ class SecretsBroker:
                 task_id=task_id,
                 secret_name=secret_name,
                 audience=audience,
+                store=store,
             )
         except Exception as exc:  # pragma: no cover - defensive
             logger.warning("grant exchange record failed: %s", type(exc).__name__)
@@ -1089,6 +1318,7 @@ class SecretsBroker:
 
 
 _BACKEND_REGISTRY: dict[BackendName, Callable[..., SecretsBackend]] = {
+    "external": ExternalStoreBackend,
     "vault": VaultBackend,
     "aws_secretsmanager": AwsSecretsManagerBackend,
     "gcp_secret_manager": GcpSecretManagerBackend,

--- a/src/bernstein/plugins/hookspecs.py
+++ b/src/bernstein/plugins/hookspecs.py
@@ -631,6 +631,39 @@ class BernsteinSpec:
         """
 
     @hookspec
+    def provide_secret_store(self) -> Any:
+        """Provide one or more external secret-store registrations.
+
+        An external secret store is the operator's own store -- their Vault,
+        their cloud secret manager, their credential broker -- used as a
+        backend behind
+        :class:`bernstein.core.security.external_secret_store.ExternalSecretStore`.
+        The store resolves a named secret, mints a short-lived credential, and
+        reports a revocation; the credential value never enters the audit
+        chain, only the grant, the store identity, the audience and the expiry.
+
+        Stores ship as plugins so a vendor SDK import stays out of
+        ``bernstein.core``. Plugins implementing this hook return one of:
+
+        * ``None`` -- opt out for this call.
+        * A single
+          :class:`bernstein.core.security.secret_store_registry.SecretStoreRegistration`.
+        * A ``(name, factory)`` tuple where ``factory`` constructs the store
+          when called with keyword arguments.
+        * A list containing any mix of the above.
+
+        The registered name is the store half of a secret reference, so a
+        store registered as ``"acme"`` serves ``secret_name="acme:db/password"``.
+        Duplicate names are skipped with a warning; the first wins.
+
+        Construction is deferred until the broker resolves the store by name,
+        so factories may do non-trivial work (TLS handshake, auth login).
+
+        Returns:
+            A registration, list of registrations, or ``None``.
+        """
+
+    @hookspec
     def on_metric_record(
         self,
         metric_type: str,

--- a/tests/unit/security/test_core_vendor_sdk_imports.py
+++ b/tests/unit/security/test_core_vendor_sdk_imports.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import pytest
+
 CORE = Path(__file__).resolve().parents[3] / "src" / "bernstein" / "core"
 
 #: Distribution roots that ship a vendor SDK. Matching is on the top-level
@@ -59,13 +61,14 @@ ALLOWED_VENDOR_IMPORTS: frozenset[tuple[str, str]] = frozenset(
 )
 
 
-def _vendor_imports() -> set[tuple[str, str]]:
-    """Return every vendor SDK import site under ``bernstein/core``."""
+def _vendor_imports(root: Path = CORE, *, relative_to: Path | None = None) -> set[tuple[str, str]]:
+    """Return every vendor SDK import site under ``root``."""
+    base = relative_to if relative_to is not None else CORE.parents[1]
     found: set[tuple[str, str]] = set()
-    for path in sorted(CORE.rglob("*.py")):
+    for path in sorted(root.rglob("*.py")):
         if GENERATED_DIRS & set(path.parts):
             continue
-        rel = path.relative_to(CORE.parents[1]).as_posix()
+        rel = path.relative_to(base).as_posix()
         tree = ast.parse(path.read_text(encoding="utf-8"))
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
@@ -96,8 +99,26 @@ class TestCoreVendorSdkImports:
         stale = sorted(ALLOWED_VENDOR_IMPORTS - _vendor_imports())
         assert not stale, f"ALLOWED_VENDOR_IMPORTS lists sites that no longer exist: {stale}. Remove them."
 
+    @pytest.mark.parametrize(
+        ("source", "expected"),
+        [
+            ("import boto3\n", "boto3"),
+            ("from google.cloud import secretmanager\n", "google.cloud"),
+            ("import hvac as vault_client\n", "hvac"),
+        ],
+    )
+    def test_detector_flags_a_synthetic_vendor_import(self, tmp_path, source: str, expected: str) -> None:
+        """20. The check is not vacuous: a planted SDK import is found."""
+        (tmp_path / "planted.py").write_text(source, encoding="utf-8")
+        assert _vendor_imports(tmp_path, relative_to=tmp_path) == {("planted.py", expected)}
+
+    def test_detector_ignores_a_relative_import_of_a_same_named_module(self, tmp_path) -> None:
+        """21. A relative import is core's own module, not a vendor SDK."""
+        (tmp_path / "planted.py").write_text("from .keyring import Backend\n", encoding="utf-8")
+        assert _vendor_imports(tmp_path, relative_to=tmp_path) == set()
+
     def test_the_new_external_store_surface_is_sdk_free(self) -> None:
-        """20. The contract this issue adds imports no vendor SDK itself."""
+        """22. The contract this issue adds imports no vendor SDK itself."""
         new_surface = {
             "bernstein/core/security/external_secret_store.py",
             "bernstein/core/security/secret_store_registry.py",

--- a/tests/unit/security/test_core_vendor_sdk_imports.py
+++ b/tests/unit/security/test_core_vendor_sdk_imports.py
@@ -1,0 +1,106 @@
+"""``bernstein.core`` may not gain a vendor SDK import (issue #4984).
+
+A secret store, an object store, or a queue that needs a vendor SDK belongs
+behind a contract that core calls, in an adapter or plugin that core does not
+import. The sites below predate the external-store contract and are the only
+ones allowed; the set is a ratchet that only ever shrinks as each site moves
+out of core. Adding a site fails this test, and so does removing one without
+shrinking the baseline, so the list cannot quietly drift out of date.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+CORE = Path(__file__).resolve().parents[3] / "src" / "bernstein" / "core"
+
+#: Distribution roots that ship a vendor SDK. Matching is on the top-level
+#: module name, so ``google.cloud`` and ``google.api_core`` both match.
+VENDOR_SDK_ROOTS: frozenset[str] = frozenset(
+    {
+        "akeyless",
+        "azure",
+        "boto3",
+        "botocore",
+        "conjur",
+        "cyberark",
+        "doppler",
+        "google",
+        "googleapiclient",
+        "hvac",
+        "infisical",
+        "keyring",
+        "onepassword",
+        "openbao",
+    }
+)
+
+#: Directories holding generated code, which is not hand-written core.
+GENERATED_DIRS: frozenset[str] = frozenset({"grpc_gen"})
+
+#: Frozen baseline: ``(module path relative to src/, imported module)``.
+#: This set only ever shrinks.
+ALLOWED_VENDOR_IMPORTS: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("bernstein/core/security/secrets.py", "boto3"),
+        ("bernstein/core/security/secrets_broker.py", "boto3"),
+        ("bernstein/core/security/secrets_broker.py", "google.cloud"),
+        ("bernstein/core/security/secrets_broker.py", "keyring"),
+        ("bernstein/core/security/vault/backend_keyring.py", "keyring"),
+        ("bernstein/core/security/vault_injector.py", "boto3"),
+        ("bernstein/core/storage/sinks/azure_blob.py", "azure.core"),
+        ("bernstein/core/storage/sinks/azure_blob.py", "azure.storage"),
+        ("bernstein/core/storage/sinks/gcs.py", "google.api_core"),
+        ("bernstein/core/storage/sinks/gcs.py", "google.cloud"),
+        ("bernstein/core/storage/sinks/s3.py", "boto3"),
+        ("bernstein/core/storage/sinks/s3.py", "botocore"),
+    }
+)
+
+
+def _vendor_imports() -> set[tuple[str, str]]:
+    """Return every vendor SDK import site under ``bernstein/core``."""
+    found: set[tuple[str, str]] = set()
+    for path in sorted(CORE.rglob("*.py")):
+        if GENERATED_DIRS & set(path.parts):
+            continue
+        rel = path.relative_to(CORE.parents[1]).as_posix()
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                names = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom) and not node.level:
+                names = [node.module or ""]
+            else:
+                continue
+            for name in names:
+                if name.split(".")[0] in VENDOR_SDK_ROOTS:
+                    found.add((rel, name))
+    return found
+
+
+class TestCoreVendorSdkImports:
+    def test_core_may_not_gain_a_vendor_sdk_import(self) -> None:
+        """18. A new vendor SDK import anywhere under core fails this check."""
+        added = sorted(_vendor_imports() - ALLOWED_VENDOR_IMPORTS)
+        assert not added, (
+            "bernstein.core gained a vendor SDK import: "
+            f"{added}. Put the SDK behind a contract core calls -- see "
+            "core/security/external_secret_store.py -- and register the "
+            "implementation as a plugin instead."
+        )
+
+    def test_baseline_shrinks_when_a_site_leaves_core(self) -> None:
+        """19. The allowlist has a ceiling: a stale entry fails too."""
+        stale = sorted(ALLOWED_VENDOR_IMPORTS - _vendor_imports())
+        assert not stale, f"ALLOWED_VENDOR_IMPORTS lists sites that no longer exist: {stale}. Remove them."
+
+    def test_the_new_external_store_surface_is_sdk_free(self) -> None:
+        """20. The contract this issue adds imports no vendor SDK itself."""
+        new_surface = {
+            "bernstein/core/security/external_secret_store.py",
+            "bernstein/core/security/secret_store_registry.py",
+        }
+        offenders = sorted(site for site in _vendor_imports() if site[0] in new_surface)
+        assert not offenders, offenders

--- a/tests/unit/security/test_external_secret_store_backend.py
+++ b/tests/unit/security/test_external_secret_store_backend.py
@@ -137,7 +137,7 @@ class TestContractEndToEnd:
 
     def test_store_reported_expiry_caps_the_token_window(self, tmp_path) -> None:
         """2. A credential the store issues for less than the config TTL shortens the token."""
-        broker, ledger, store, now = _build(tmp_path)
+        broker, ledger, _store, now = _build(tmp_path)
         grant = _issue(ledger)
         token = broker.mint(
             secret_name=SECRET_NAME,
@@ -165,7 +165,7 @@ class TestContractEndToEnd:
 class TestNoSecretValueOnChain:
     def test_no_secret_value_appears_in_any_chain_event(self, tmp_path) -> None:
         """4. Load-bearing: scan every chain record for the credential value."""
-        broker, ledger, store, _ = _build(tmp_path)
+        broker, ledger, _store, _ = _build(tmp_path)
         grant = _issue(ledger)
         token = broker.mint(secret_name=SECRET_NAME, task_id="t-1", grant=grant)
         broker.revoke(token.token_id)

--- a/tests/unit/security/test_external_secret_store_backend.py
+++ b/tests/unit/security/test_external_secret_store_backend.py
@@ -1,0 +1,300 @@
+"""External secret stores as broker backends (issue #4984).
+
+The broker treats an external secret store as a backend behind one contract:
+resolve a named secret, mint a short-lived credential, report a revocation.
+The credential *value* never enters the grant chain -- what the chain records
+is the grant, the identity of the store that issued the credential, the
+audience, and the expiry. Grant enforcement is identical for an external
+backend and for the file backend, and a credential bound into the environment
+for one step is absent from the environment on both sides of that step.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from bernstein.core.identity import grants
+from bernstein.core.security.external_secret_store import (
+    ExternalCredential,
+    ExternalSecretStore,
+    ExternalStoreError,
+    SecretDescriptor,
+    SecretRef,
+)
+from bernstein.core.security.secrets_broker import (
+    BrokerConfig,
+    ExternalStoreBackend,
+    SecretsBroker,
+    SecretsBrokerError,
+    clear_redaction_registry,
+    get_redactable_values,
+)
+
+#: Distinctive so a chain scan can prove the value never lands on disk.
+UPSTREAM_VALUE = "UPSTREAM-SECRET-b7f3c1a9-do-not-record"
+SECRET_PATH = "prod/anthropic"
+SECRET_NAME = f"fake-vault:{SECRET_PATH}"
+
+
+class _FakeExternalStore(ExternalSecretStore):
+    """In-memory stand-in for an operator's own secret store."""
+
+    store_id = "fake-vault"
+
+    def __init__(self, clock) -> None:
+        self._clock = clock
+        self._entries = {SECRET_PATH: UPSTREAM_VALUE}
+        self._revoked: set[str] = set()
+        self.mint_calls = 0
+        self.revocation_calls = 0
+
+    # -- operator-side helpers ------------------------------------------
+    def revoke_upstream(self, path: str) -> None:
+        self._revoked.add(path)
+
+    # -- contract --------------------------------------------------------
+    def resolve(self, path: str) -> SecretDescriptor:
+        if path not in self._entries:
+            raise ExternalStoreError(f"fake-vault: no secret at {path!r}")
+        return SecretDescriptor(
+            store_id=self.store_id,
+            upstream_id=f"{path}#v1",
+            revoked=path in self._revoked,
+        )
+
+    def mint_credential(self, path: str, *, audience: str, ttl_seconds: int) -> ExternalCredential:
+        if path in self._revoked:
+            raise ExternalStoreError("fake-vault: upstream secret is revoked")
+        self.mint_calls += 1
+        return ExternalCredential(
+            value=f"{self._entries[path]}/lease-{self.mint_calls}",
+            expires_at=self._clock() + ttl_seconds,
+            upstream_id=f"{path}#v1",
+            audience=audience,
+        )
+
+    def report_revocation(self, path: str, *, upstream_id: str) -> bool:
+        self.revocation_calls += 1
+        return path in self._revoked
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    clear_redaction_registry()
+    yield
+    clear_redaction_registry()
+
+
+def _build(tmp_path, *, require_grant: bool = True):
+    now = [1_000.0]
+
+    def clock() -> float:
+        return now[0]
+
+    store = _FakeExternalStore(clock)
+    signer = grants.GrantSigner.generate(issuer="manager:test")
+    ledger = grants.GrantLedger(root=tmp_path, key=b"k" * 32, signer=signer)
+    backend = ExternalStoreBackend(store=store)
+    cfg = BrokerConfig(backend="external", ttl_seconds_default=900)
+    broker = SecretsBroker(
+        backend,
+        config=cfg,
+        clock=clock,
+        grant_ledger=ledger,
+        require_grant=require_grant,
+    )
+    return broker, ledger, store, now
+
+
+def _issue(ledger, *, expiry: int = 0):
+    return ledger.issue_grant(
+        run_id="run-1",
+        task_id="t-1",
+        secret_name=SECRET_NAME,
+        audience="api.anthropic.com",
+        expiry=expiry,
+    )
+
+
+class TestContractEndToEnd:
+    def test_external_backend_satisfies_broker_contract_end_to_end(self, tmp_path) -> None:
+        """1. Mint, resolve, and revoke work through an out-of-core store."""
+        broker, ledger, store, _ = _build(tmp_path)
+        grant = _issue(ledger)
+        token = broker.mint(secret_name=SECRET_NAME, task_id="t-1", grant=grant)
+
+        assert store.mint_calls == 1
+        assert token.audience == "api.anthropic.com"
+        # The agent sees the broker token, never the store's credential.
+        assert UPSTREAM_VALUE not in token.value
+        assert broker.resolve(token.value, audience="api.anthropic.com").startswith(UPSTREAM_VALUE)
+
+        assert broker.revoke(token.token_id) is True
+        with pytest.raises(SecretsBrokerError, match="revoked"):
+            broker.resolve(token.value)
+
+    def test_store_reported_expiry_caps_the_token_window(self, tmp_path) -> None:
+        """2. A credential the store issues for less than the config TTL shortens the token."""
+        broker, ledger, store, now = _build(tmp_path)
+        grant = _issue(ledger)
+        token = broker.mint(
+            secret_name=SECRET_NAME,
+            task_id="t-1",
+            ttl_seconds=60,
+            grant=grant,
+        )
+        assert token.expires_at == pytest.approx(now[0] + 60)
+        now[0] += 61
+        with pytest.raises(SecretsBrokerError, match="expired"):
+            broker.resolve(token.value)
+
+    def test_exchange_record_names_the_issuing_store(self, tmp_path) -> None:
+        """3. The chain says which store issued the credential."""
+        broker, ledger, _store, _ = _build(tmp_path)
+        grant = _issue(ledger)
+        broker.mint(secret_name=SECRET_NAME, task_id="t-1", grant=grant)
+        result = grants.verify_grant_chain(root=ledger.root, run_id="run-1", key=b"k" * 32)
+        assert result.valid
+        exchanged = [r for r in result.records if r.kind == grants.GRANT_EXCHANGED]
+        assert exchanged, "mint must append a grant_exchanged record"
+        assert "fake-vault" in exchanged[-1].reason
+
+
+class TestNoSecretValueOnChain:
+    def test_no_secret_value_appears_in_any_chain_event(self, tmp_path) -> None:
+        """4. Load-bearing: scan every chain record for the credential value."""
+        broker, ledger, store, _ = _build(tmp_path)
+        grant = _issue(ledger)
+        token = broker.mint(secret_name=SECRET_NAME, task_id="t-1", grant=grant)
+        broker.revoke(token.token_id)
+        # A refusal path too, so every record kind is present in the fixture.
+        with pytest.raises(SecretsBrokerError):
+            broker.mint(secret_name=SECRET_NAME, task_id="t-unknown", run_id="run-1")
+
+        raw = ledger.receipt_path("run-1").read_text(encoding="utf-8")
+        assert raw.strip(), "fixture chain must not be empty"
+        assert UPSTREAM_VALUE not in raw
+        assert token.value not in raw
+        # The backing-store path is a low-entropy name and is salted, not clear.
+        assert SECRET_PATH not in raw
+
+
+class TestGrantInvariantHoldsForExternalBackends:
+    def test_mint_without_verifying_grant_is_refused_for_external_backend(self, tmp_path) -> None:
+        """5. Same refusal as the file backend, and the store is never touched."""
+        broker, ledger, store, _ = _build(tmp_path)
+        with pytest.raises(SecretsBrokerError, match="grant"):
+            broker.mint(secret_name=SECRET_NAME, task_id="t-1", run_id="run-1")
+        assert store.mint_calls == 0
+        result = grants.verify_grant_chain(root=ledger.root, run_id="run-1", key=b"k" * 32)
+        assert result.valid
+        assert result.records[-1].kind == grants.GRANT_REFUSED
+
+    def test_mint_with_mismatched_grant_is_refused_for_external_backend(self, tmp_path) -> None:
+        """6. A grant for another secret does not authorize this one."""
+        broker, ledger, store, _ = _build(tmp_path)
+        other = ledger.issue_grant(
+            run_id="run-1",
+            task_id="t-1",
+            secret_name="fake-vault:prod/other",
+            audience="api.anthropic.com",
+        )
+        with pytest.raises(SecretsBrokerError, match="secret_mismatch"):
+            broker.mint(secret_name=SECRET_NAME, task_id="t-1", grant=other)
+        assert store.mint_calls == 0
+
+
+class TestUpstreamRevocation:
+    def test_revoked_upstream_secret_makes_subsequent_mints_fail(self, tmp_path) -> None:
+        """7. Revoking in the operator's own store stops the broker minting."""
+        broker, ledger, store, _ = _build(tmp_path)
+        grant = _issue(ledger)
+        broker.mint(secret_name=SECRET_NAME, task_id="t-1", grant=grant)
+
+        store.revoke_upstream(SECRET_PATH)
+
+        with pytest.raises(SecretsBrokerError, match="revoked"):
+            broker.mint(secret_name=SECRET_NAME, task_id="t-1", grant=grant)
+        assert store.mint_calls == 1
+        result = grants.verify_grant_chain(root=ledger.root, run_id="run-1", key=b"k" * 32)
+        assert result.valid
+        assert any("upstream_revoked" in r.reason for r in result.records if r.kind == grants.GRANT_REFUSED)
+
+
+class TestScopedEnvironmentBinding:
+    def test_bound_credential_is_absent_from_the_environment_outside_the_step(self, tmp_path) -> None:
+        """8. Dump the environment before and after; the value is absent both times."""
+        broker, ledger, _store, _ = _build(tmp_path)
+        grant = _issue(ledger)
+        env: dict[str, str] = {"PATH": "/usr/bin"}
+
+        before = dict(env)
+        with broker.bind_scoped(
+            secret_name=SECRET_NAME,
+            task_id="t-1",
+            env_var="ANTHROPIC_API_KEY",
+            grant=grant,
+            env=env,
+        ) as token:
+            inside = dict(env)
+        after = dict(env)
+
+        assert "ANTHROPIC_API_KEY" not in before
+        assert inside["ANTHROPIC_API_KEY"] == token.value
+        assert "ANTHROPIC_API_KEY" not in after
+        assert token.value not in " ".join(after.values())
+        # The token is revoked and its value is no longer redaction-registered.
+        assert token.value not in get_redactable_values()
+        with pytest.raises(SecretsBrokerError):
+            broker.resolve(token.value)
+
+    def test_bind_scoped_restores_a_pre_existing_variable(self, tmp_path) -> None:
+        """9. Binding does not clobber an operator-set variable of the same name."""
+        broker, ledger, _store, _ = _build(tmp_path)
+        grant = _issue(ledger)
+        env = {"ANTHROPIC_API_KEY": "operator-set"}
+        with broker.bind_scoped(
+            secret_name=SECRET_NAME,
+            task_id="t-1",
+            env_var="ANTHROPIC_API_KEY",
+            grant=grant,
+            env=env,
+        ):
+            assert env["ANTHROPIC_API_KEY"] != "operator-set"
+        assert env["ANTHROPIC_API_KEY"] == "operator-set"
+
+    def test_bind_scoped_defaults_to_the_process_environment(self, tmp_path) -> None:
+        """10. With no explicit mapping the binding targets os.environ and is undone."""
+        broker, ledger, _store, _ = _build(tmp_path)
+        grant = _issue(ledger)
+        var = "BERNSTEIN_TEST_BOUND_SECRET"
+        assert var not in os.environ
+        try:
+            with broker.bind_scoped(
+                secret_name=SECRET_NAME,
+                task_id="t-1",
+                env_var=var,
+                grant=grant,
+            ) as token:
+                assert os.environ[var] == token.value
+        finally:
+            os.environ.pop(var, None)
+        assert var not in os.environ
+
+
+class TestReferenceShape:
+    def test_reference_names_a_store_without_carrying_a_value(self) -> None:
+        """11. A spec names a secret by opaque reference: store plus store-native path."""
+        ref = SecretRef.parse(SECRET_NAME)
+        assert ref.store == "fake-vault"
+        assert ref.path == SECRET_PATH
+        assert str(ref) == SECRET_NAME
+        with pytest.raises(ExternalStoreError):
+            SecretRef.parse("no-store-separator")
+
+    def test_credential_repr_does_not_expose_the_value(self) -> None:
+        """12. A credential that reaches a log or traceback shows no value."""
+        cred = ExternalCredential(value=UPSTREAM_VALUE, expires_at=1.0, upstream_id="u")
+        assert UPSTREAM_VALUE not in repr(cred)

--- a/tests/unit/security/test_secret_store_registry.py
+++ b/tests/unit/security/test_secret_store_registry.py
@@ -1,0 +1,95 @@
+"""Secret-store backends are plugins, not core patches (issue #4984).
+
+Adding a store must not require a change to ``bernstein.core``: a store is
+registered through the same registry-plus-hook idiom the tracker adapters
+already use, and the broker resolves it by name from configuration.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.security import secret_store_registry as reg
+from bernstein.core.security.external_secret_store import (
+    ExternalCredential,
+    ExternalSecretStore,
+    SecretDescriptor,
+)
+from bernstein.core.security.secrets_broker import SecretsBrokerError, build_broker_from_config
+
+
+class _PluginStore(ExternalSecretStore):
+    store_id = "out-of-core"
+
+    def resolve(self, path: str) -> SecretDescriptor:
+        return SecretDescriptor(store_id=self.store_id, upstream_id=path)
+
+    def mint_credential(self, path: str, *, audience: str, ttl_seconds: int) -> ExternalCredential:
+        return ExternalCredential(value=f"cred-for-{path}", upstream_id=path, audience=audience)
+
+    def report_revocation(self, path: str, *, upstream_id: str) -> bool:
+        return False
+
+
+class _FakePlugin:
+    def provide_secret_store(self):
+        return ("out-of-core", _PluginStore)
+
+
+class _FakeInnerPm:
+    def __init__(self, plugins):
+        self._plugins = plugins
+
+    def get_plugin(self, name):
+        return self._plugins.get(name)
+
+
+class _FakePm:
+    def __init__(self, plugins):
+        self._registered_names = list(plugins)
+        self._pm = _FakeInnerPm(plugins)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    reg.reset_registry_for_tests()
+    yield
+    reg.reset_registry_for_tests()
+
+
+class TestRegistry:
+    def test_plugin_registered_store_is_discovered_without_a_core_change(self) -> None:
+        """13. A store contributed by a plugin becomes resolvable by name."""
+        added = reg.discover_plugin_secret_stores(_FakePm({"acme-plugin": _FakePlugin()}))
+        assert added == 1
+        registration = reg.get_registry().get("out-of-core")
+        assert registration.source == "plugin"
+        assert registration.provenance == "acme-plugin"
+        assert isinstance(registration.factory(), _PluginStore)
+
+    def test_duplicate_store_name_is_refused(self) -> None:
+        """14. Two stores cannot silently claim the same name."""
+        reg.register_secret_store("dup", _PluginStore)
+        with pytest.raises(reg.DuplicateSecretStoreError):
+            reg.register_secret_store("dup", _PluginStore)
+
+    def test_unknown_store_name_names_what_is_registered(self) -> None:
+        """15. A misconfigured store name fails closed with a usable message."""
+        with pytest.raises(KeyError, match="nope"):
+            reg.get_registry().get("nope")
+
+
+class TestBrokerConfigResolvesStoreByName:
+    def test_broker_config_selects_a_registered_store(self) -> None:
+        """16. ``backend: external`` plus a store name builds a working broker."""
+        reg.register_secret_store("out-of-core", _PluginStore)
+        broker = build_broker_from_config({"backend": "external", "backend_settings": {"store_name": "out-of-core"}})
+        assert broker.backend_name == "external"
+        token = broker.mint(secret_name="out-of-core:db/password", task_id="t-1")
+        assert broker.resolve(token.value) == "cred-for-db/password"
+
+    def test_unregistered_store_name_fails_at_mint(self) -> None:
+        """17. A store that was never registered refuses rather than minting."""
+        broker = build_broker_from_config({"backend": "external", "backend_settings": {"store_name": "absent"}})
+        with pytest.raises(SecretsBrokerError, match="absent"):
+            broker.mint(secret_name="absent:db/password", task_id="t-1")


### PR DESCRIPTION
## What

Adds one contract the secrets broker calls for a secret store it does not own, so an operator's existing store can back `bernstein secrets` without secrets being copied into ours.

New surface:

| File | Role |
|---|---|
| `src/bernstein/core/security/external_secret_store.py` | The contract: `resolve` / `mint_credential` / `report_revocation`, plus `SecretRef` (`<store>:<store-native path>`), `SecretDescriptor`, `ExternalCredential`. |
| `src/bernstein/core/security/secret_store_registry.py` | Name-to-factory registry, plugin-discovered or programmatic, mirroring `core/trackers/registry.py`. |
| `src/bernstein/core/security/secrets_broker.py` | `ExternalStoreBackend` registered as `backend: external`; the mint path resolves, revocation-checks, then mints. Adds `SecretsBroker.bind_scoped()`. |
| `src/bernstein/plugins/hookspecs.py` | `provide_secret_store` hookspec. |
| `src/bernstein/core/identity/grants.py` | `record_grant_exchange(..., store=...)`. |

**What this PR does not do**

- No concrete vendor store. None ships; each is its own slice on top of this contract.
- No secret rotation orchestration.
- No change to the file backend, to `core/security/secrets.py`, or to `vault_injector.py`.
- No schema change to the grant chain. The issuing store's identity is written into the existing signed `reason` field as `store:<id>`, so records written before external stores existed keep verifying against the same signed body.

## Why

`bernstein secrets` brokers short-lived tokens against a file-backed vault. An operator running compliance-sensitive workflows already runs a secret store, already audits it, and already has policy attached to it. Asking them to copy secrets into ours means governing two stores instead of one, which is worse than the problem it solves — and it puts their secret values inside our process and our audit surface for no gain.

The distinction this PR encodes: Bernstein is not a secret store that gained connectors. It is the authorization record that can say which task held which credential power over which window, whichever store issued the credential. So the value stays in the operator's store, and the chain records the grant, the store identity, the audience and the expiry.

## How

`backend: external` with `backend_settings.store_name` selects a registered store; any further settings are forwarded to its factory, and construction is deferred to first use so a misconfigured name fails at mint time with a message naming what *is* registered, rather than minting against some other store.

A spec names a secret by opaque reference. `SecretRef.parse` fails closed on a bare name: without a store half, a name would otherwise resolve against whichever store happened to be configured.

Every mint asks the store three things in order:

1. `resolve(path)` — non-secret facts only: store identity, store-native version or lease id, revoked flag, store-imposed expiry.
2. `report_revocation(path, upstream_id=...)` — revoking in the operator's own store is what stops us minting, so there is no second revocation list to keep in step. An upstream revocation is recorded as a chain-anchored refusal before the error propagates, so "they revoked it upstream" and "we refused to mint" are one record.
3. `mint_credential(path, audience=..., ttl_seconds=...)` — a store may return a shorter expiry than asked for and the broker caps the token to it, so a broker token never outlives the credential behind it.

Grant enforcement is untouched: the grant check runs before the backend is consulted at all, so a mint without a verifying grant refuses without the store ever being called.

`bind_scoped()` binds a minted token into a mapping (defaulting to `os.environ`) for one step, then removes it — or restores whatever the operator had set under that name — and revokes the token. Revocation now also clears the backing value out of the broker's in-process registry, so a bound credential cannot outlive the step that bound it.

Stores register from outside core, through the `provide_secret_store` hook or `register_secret_store()`, which is what keeps a vendor SDK import out of `bernstein.core`.

**The decision the issue left open** — how the issuing store reaches the chain. Options were a new signed field on `grant_exchanged` or reuse of the existing one. This PR reuses the existing `reason` field (`store:<id>`), because a new field changes the signed body and every grant record written before this change would have to be re-canonicalised to keep verifying. The store identity is non-secret and low-cardinality, so it fits the field it is put in, and `verify_grant_chain` needed no change.

## Tests

`tests/unit/security/test_external_secret_store_backend.py`

1. `test_external_backend_satisfies_broker_contract_end_to_end` — mint, resolve, revoke through an out-of-core store; the agent sees the broker token, never the store's credential.
2. `test_store_reported_expiry_caps_the_token_window` — a credential issued for less than the config TTL shortens the token.
3. `test_exchange_record_names_the_issuing_store` — the verified chain says which store issued the credential.
4. `test_no_secret_value_appears_in_any_chain_event` — **load-bearing.** Drives mint, revoke and a refusal so every record kind is present in the fixture chain, then scans the raw receipt file for the credential value, the token value, and the backing path. This is the property the whole design rests on: if it fails, the PR is wrong regardless of what else passes.
5. `test_mint_without_verifying_grant_is_refused_for_external_backend` — same refusal as the file backend, and the store is never touched.
6. `test_mint_with_mismatched_grant_is_refused_for_external_backend` — a grant for another secret does not authorize this one.
7. `test_revoked_upstream_secret_makes_subsequent_mints_fail` — revoking in the operator's store stops the broker, and the refusal is on the chain as `upstream_revoked`.
8. `test_bound_credential_is_absent_from_the_environment_outside_the_step` — dumps the mapping before and after the block; the bound value is absent both times, deregistered from redaction, and the token no longer resolves.
9. `test_bind_scoped_restores_a_pre_existing_variable` — binding does not clobber an operator-set variable of the same name.
10. `test_bind_scoped_defaults_to_the_process_environment` — with no explicit mapping the binding targets `os.environ` and is undone.
11. `test_reference_names_a_store_without_carrying_a_value` — reference parses to store plus store-native path; a bare name is refused.
12. `test_credential_repr_does_not_expose_the_value` — a credential reaching a log line or a traceback carries no value.

`tests/unit/security/test_secret_store_registry.py`

13. `test_plugin_registered_store_is_discovered_without_a_core_change` — a plugin-contributed store becomes resolvable by name, with its provenance recorded.
14. `test_duplicate_store_name_is_refused` — two stores cannot silently claim one name and repoint an operator's secrets.
15. `test_unknown_store_name_names_what_is_registered` — a misconfigured name fails closed with a usable message.
16. `test_broker_config_selects_a_registered_store` — `backend: external` plus a store name builds a working broker from config.
17. `test_unregistered_store_name_fails_at_mint` — an unregistered name refuses rather than minting.

`tests/unit/security/test_core_vendor_sdk_imports.py`

18. `test_core_may_not_gain_a_vendor_sdk_import` — a new vendor SDK import anywhere under `bernstein/core` fails the build.
19. `test_baseline_shrinks_when_a_site_leaves_core` — the allowlist has a ceiling too, so it cannot quietly drift out of date after a move.
20. `test_detector_flags_a_synthetic_vendor_import` — the check runs against a temporary tree holding a planted import, so it is shown to fire rather than passing by matching nothing.
21. `test_detector_ignores_a_relative_import_of_a_same_named_module` — a relative import of a local module of the same name is core's own code, not an SDK.
22. `test_the_new_external_store_surface_is_sdk_free` — the contract this PR adds imports no vendor SDK itself.

Tests 1–17 were confirmed to fail on the tree without this change: the modules they import do not exist, so collection errors out. Tests 18–22 are ratchet guards — 18, 19 and 22 pass on the unchanged tree by construction (that is what a ratchet is), and 20 and 21 are the failing-first evidence that the detector behind them is not vacuous.

Local runs, all green:

- `run_tests.py --parallel 2 -x` on the three new files (22 passed).
- `run_tests.py --parallel 2` on `tests/unit/security/test_secrets_broker.py`, `test_secrets_broker_grants.py`, `test_broker_grant_config.py`, `tests/unit/identity/test_grants.py`, `tests/unit/core/security/test_key_custody_boundary.py`, `tests/unit/cli/test_audit_verify_grants.py`, `tests/unit/cli/test_secrets_grants_cli.py`, `tests/unit/test_security_controls_are_wired.py`, `tests/unit/trackers/test_registry.py` (113 passed).
- `run_tests.py --parallel 2` on `tests/unit/test_unreleased_notes_rotation.py` and `tests/unit/scripts/test_rotate_release_notes.py` for the release-note fragment (39 passed).

`--affected origin/main` selects 1533 files here, well past the reviewable local ceiling, so I ran the tests of the modules touched plus the tests of their importers, listed above. CI runs the full suite.

## Checklist

- [x] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` — pyright strict has a pre-existing backlog on this tree (`secrets_broker.py` reports 35 errors before this change). The two new modules follow the typing shape of `core/trackers/registry.py`, which they mirror and which reports the same 11 diagnostics on `main`; nothing here is newly excluded.
- [x] `uv run python scripts/run_tests.py -x` passes for the files listed above
- [x] New code has type hints

### Documentation duty

- [ ] User-visible README section updated — N/A (README untouched by design)
- [x] `docs/operations/secrets.md` updated — new "Broker-side stores" section and three code pointers
- [ ] `docs/api/` schema regenerated — N/A (no HTTP surface changed)
- [x] `uv run bernstein agents-md sync` run — produced no changes
- [x] Tests cover the documented behaviour

Release-note fragment: `docs/release-notes/fragments/4984-external-secret-stores.md`.

Closes #4984
