### PR TITLE
feat(govern): the check contract, stable ids, and the three-state verdict (#5072)

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -27,6 +27,8 @@ source_modules =
 forbidden_modules =
     bernstein.cli
     bernstein.tui
+ignore_imports =
+    bernstein.core.checks.adapters -> bernstein.cli.commands.status_cmd
 
 
 # ---------------------------------------------------------------------------

--- a/.importlinter
+++ b/.importlinter
@@ -28,7 +28,6 @@ forbidden_modules =
     bernstein.cli
     bernstein.tui
 ignore_imports =
-    bernstein.core.checks.adapters -> bernstein.cli.commands.status_cmd
 
 
 # ---------------------------------------------------------------------------

--- a/.importlinter
+++ b/.importlinter
@@ -27,7 +27,6 @@ source_modules =
 forbidden_modules =
     bernstein.cli
     bernstein.tui
-ignore_imports =
 
 
 # ---------------------------------------------------------------------------

--- a/docs/release-notes/fragments/5072-govern-audit-check-contract.md
+++ b/docs/release-notes/fragments/5072-govern-audit-check-contract.md
@@ -1,0 +1,3 @@
+Define the govern audit check contract, stable namespaced IDs, the three-state
+verdict (`pass`, `fail`, `not_measurable`), evidence pairs with canonical JSON
+hashing, and an isolated check registry with initial doctor and compliance adapters (#5072).

--- a/docs/sdd/module-map.md
+++ b/docs/sdd/module-map.md
@@ -24,6 +24,7 @@ Full per-file module map. `AGENTS.md`'s own "Module map" section links here inst
 | `autofix/`                  | Bernstein autofix daemon - auto-repair CI failures on Bernstein PRs |
 | `autoheal/`                 | Auto-heal v2 subpackage |
 | `chat/`                     | Chat-control bridges for driving Bernstein agents from messaging apps |
+| `checks/`                   | Audit check contract, registry, and producer adapters (#5072) |
 | `communication/`            | communication sub-package |
 | `compliance/`               | Compliance subpackage |
 | `config/`                   | Config: seed parsing, config management, settings, feature gates |

--- a/src/bernstein/cli/commands/status_cmd.py
+++ b/src/bernstein/cli/commands/status_cmd.py
@@ -1103,28 +1103,12 @@ def _doctor_check_schedule_supervisor(checks: list[dict[str, Any]], workdir: Pat
 
 def _doctor_check_compliance(checks: list[dict[str, Any]], workdir: Path) -> None:
     """Check compliance mode prerequisites."""
-    from bernstein.core.compliance import load_compliance_config
+    from bernstein.core.compliance import compliance_prerequisite_summary
 
-    compliance_cfg = load_compliance_config(workdir / ".sdd")
-    compliance_env = os.environ.get("BERNSTEIN_COMPLIANCE")
-    if compliance_env:
-        from bernstein.core.compliance import ComplianceConfig, CompliancePreset
-
-        compliance_cfg = ComplianceConfig.from_preset(CompliancePreset(compliance_env.lower()))
-
-    if compliance_cfg is not None:
-        preset_label = compliance_cfg.preset.value if compliance_cfg.preset else "custom"
-        prereq_warnings = compliance_cfg.check_prerequisites()
-        if prereq_warnings:
-            _add_check(
-                checks,
-                f"Compliance ({preset_label})",
-                False,
-                f"{len(prereq_warnings)} issue(s): {prereq_warnings[0]}",
-                "; ".join(prereq_warnings),
-            )
-        else:
-            _add_check(checks, f"Compliance ({preset_label})", True, "all prerequisites met")
+    summary = compliance_prerequisite_summary(workdir)
+    if summary is not None:
+        name, ok, detail, fix = summary
+        _add_check(checks, name, ok, detail, fix)
 
 
 def _doctor_print_fix_summary(auto_fix: bool, fixed: list[str], manual_needed: list[str]) -> None:

--- a/src/bernstein/core/checks/__init__.py
+++ b/src/bernstein/core/checks/__init__.py
@@ -1,0 +1,39 @@
+"""Audit check contract, registry, and producer adapters (#5072)."""
+
+from __future__ import annotations
+
+from bernstein.core.checks.adapters import (
+    ComplianceEncryptionAtRestAdapter,
+    DoctorComplianceAdapter,
+)
+from bernstein.core.checks.contract import (
+    Check,
+    Evidence,
+    Finding,
+    Verdict,
+)
+from bernstein.core.checks.registry import (
+    CheckRegistry,
+    clear,
+    get_check,
+    iter_checks,
+    register,
+    run_all,
+    unregister,
+)
+
+__all__ = [
+    "Check",
+    "CheckRegistry",
+    "ComplianceEncryptionAtRestAdapter",
+    "DoctorComplianceAdapter",
+    "Evidence",
+    "Finding",
+    "Verdict",
+    "clear",
+    "get_check",
+    "iter_checks",
+    "register",
+    "run_all",
+    "unregister",
+]

--- a/src/bernstein/core/checks/adapters.py
+++ b/src/bernstein/core/checks/adapters.py
@@ -1,0 +1,104 @@
+"""Adapters wrapping existing diagnostic and compliance checks into the Check contract (#5072).
+
+Adapts:
+1. ``_doctor_check_compliance`` from :mod:`bernstein.cli.commands.status_cmd`.
+2. ``check_encryption_at_rest`` from :mod:`bernstein.core.security.compliance_library`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from bernstein.core.checks.contract import Evidence, Finding, Verdict
+
+
+class DoctorComplianceAdapter:
+    """Adapter wrapping ``_doctor_check_compliance`` into the Check contract."""
+
+    @property
+    def check_id(self) -> str:
+        return "doctor:compliance"
+
+    @property
+    def title(self) -> str:
+        return "Doctor Compliance Prerequisites"
+
+    @property
+    def description(self) -> str:
+        return "Verify compliance mode configuration and prerequisite health."
+
+    def run(self, workdir: Path | None = None) -> Finding:
+        from bernstein.cli.commands.status_cmd import _doctor_check_compliance
+
+        path = workdir or Path(".")
+        collected: list[dict[str, Any]] = []
+        _doctor_check_compliance(collected, path)
+
+        if not collected:
+            return Finding(
+                check_id=self.check_id,
+                verdict=Verdict.NOT_MEASURABLE,
+                what_would_make_it_measurable="No compliance configuration (.sdd or BERNSTEIN_COMPLIANCE) found",
+                reason="missing_compliance_config",
+                message="Compliance prerequisites not configured for this workspace.",
+            )
+
+        entry = collected[0]
+        ok = bool(entry.get("ok", False))
+        payload = {
+            "name": str(entry.get("name", "")),
+            "ok": ok,
+            "detail": str(entry.get("detail", "")),
+            "fix": str(entry.get("fix", "")),
+        }
+        evidence = Evidence.from_payload(
+            locator=f"doctor:compliance:{path}",
+            payload=payload,
+        )
+        return Finding(
+            check_id=self.check_id,
+            verdict=Verdict.PASS if ok else Verdict.FAIL,
+            evidence=(evidence,),
+            message=str(entry.get("detail", "")),
+            remediation=str(entry.get("fix", "")),
+        )
+
+
+class ComplianceEncryptionAtRestAdapter:
+    """Adapter wrapping ``check_encryption_at_rest`` from the compliance library."""
+
+    @property
+    def check_id(self) -> str:
+        return "compliance:soc2:encryption_at_rest"
+
+    @property
+    def title(self) -> str:
+        return "Compliance SOC2 Encryption At Rest"
+
+    @property
+    def description(self) -> str:
+        return "Verify that state_encryption or compliance.encrypt_state_at_rest is configured."
+
+    def run(self, workdir: Path | None = None) -> Finding:
+        from bernstein.core.security.compliance_library import check_encryption_at_rest
+
+        path = workdir or Path(".")
+        result = check_encryption_at_rest(path)
+
+        payload = {
+            "passed": bool(result.passed),
+            "evidence": str(result.evidence),
+            "remediation": str(result.remediation),
+        }
+        evidence = Evidence.from_payload(
+            locator=f"compliance:encryption_at_rest:{path}",
+            payload=payload,
+        )
+        return Finding(
+            check_id=self.check_id,
+            verdict=Verdict.PASS if result.passed else Verdict.FAIL,
+            evidence=(evidence,),
+            message=str(result.evidence),
+            remediation=str(result.remediation),
+        )

--- a/src/bernstein/core/checks/adapters.py
+++ b/src/bernstein/core/checks/adapters.py
@@ -1,7 +1,8 @@
 """Adapters wrapping existing diagnostic and compliance checks into the Check contract (#5072).
 
 Adapts:
-1. ``_doctor_check_compliance`` from :mod:`bernstein.cli.commands.status_cmd`.
+1. ``compliance_prerequisite_summary`` from :mod:`bernstein.core.compliance`, the
+   same producer the ``bernstein doctor`` compliance row renders.
 2. ``check_encryption_at_rest`` from :mod:`bernstein.core.security.compliance_library`.
 """
 
@@ -14,7 +15,7 @@ from bernstein.core.checks.contract import Evidence, Finding, Verdict
 
 
 class DoctorComplianceAdapter:
-    """Adapter wrapping ``_doctor_check_compliance`` into the Check contract."""
+    """Adapter wrapping the doctor compliance prerequisite check into the Check contract."""
 
     @property
     def check_id(self) -> str:
@@ -29,13 +30,12 @@ class DoctorComplianceAdapter:
         return "Verify compliance mode configuration and prerequisite health."
 
     def run(self, workdir: Path | None = None) -> Finding:
-        from bernstein.cli.commands.status_cmd import _doctor_check_compliance
+        from bernstein.core.compliance import compliance_prerequisite_summary
 
         path = workdir or Path(".")
-        collected: list[dict[str, Any]] = []
-        _doctor_check_compliance(collected, path)
+        summary = compliance_prerequisite_summary(path)
 
-        if not collected:
+        if summary is None:
             return Finding(
                 check_id=self.check_id,
                 verdict=Verdict.NOT_MEASURABLE,
@@ -44,14 +44,8 @@ class DoctorComplianceAdapter:
                 message="Compliance prerequisites not configured for this workspace.",
             )
 
-        entry = collected[0]
-        ok = bool(entry.get("ok", False))
-        payload = {
-            "name": str(entry.get("name", "")),
-            "ok": ok,
-            "detail": str(entry.get("detail", "")),
-            "fix": str(entry.get("fix", "")),
-        }
+        name, ok, detail, fix = summary
+        payload: dict[str, Any] = {"name": name, "ok": ok, "detail": detail, "fix": fix}
         evidence = Evidence.from_payload(
             locator=f"doctor:compliance:{path}",
             payload=payload,
@@ -60,8 +54,8 @@ class DoctorComplianceAdapter:
             check_id=self.check_id,
             verdict=Verdict.PASS if ok else Verdict.FAIL,
             evidence=(evidence,),
-            message=str(entry.get("detail", "")),
-            remediation=str(entry.get("fix", "")),
+            message=detail,
+            remediation=fix,
         )
 
     def __call__(self, workdir: Path | None = None) -> Finding:

--- a/src/bernstein/core/checks/adapters.py
+++ b/src/bernstein/core/checks/adapters.py
@@ -64,6 +64,9 @@ class DoctorComplianceAdapter:
             remediation=str(entry.get("fix", "")),
         )
 
+    def __call__(self, workdir: Path | None = None) -> Finding:
+        return self.run(workdir)
+
 
 class ComplianceEncryptionAtRestAdapter:
     """Adapter wrapping ``check_encryption_at_rest`` from the compliance library."""
@@ -102,3 +105,6 @@ class ComplianceEncryptionAtRestAdapter:
             message=str(result.evidence),
             remediation=str(result.remediation),
         )
+
+    def __call__(self, workdir: Path | None = None) -> Finding:
+        return self.run(workdir)

--- a/src/bernstein/core/checks/contract.py
+++ b/src/bernstein/core/checks/contract.py
@@ -1,0 +1,164 @@
+"""Core contract and data models for govern audit checks (#5072).
+
+Defines the check protocol, three-state verdict enum, immutable evidence
+pairs with canonical JSON hashing, and finding dataclass.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from bernstein.core.evidence.bundle import _canonical_bytes
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Verdict
+# ---------------------------------------------------------------------------
+
+
+class Verdict(StrEnum):
+    """The three-state verdict for an audit check finding."""
+
+    PASS = "pass"
+    FAIL = "fail"
+    NOT_MEASURABLE = "not_measurable"
+
+
+# ---------------------------------------------------------------------------
+# Evidence
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Evidence:
+    """An immutable (locator, sha256) evidence pair.
+
+    Attributes:
+        locator: URI, path, or identifier locating the source of evidence.
+        sha256: SHA-256 digest of the canonical evidence payload.
+    """
+
+    locator: str
+    sha256: str
+
+    def __post_init__(self) -> None:
+        if not self.locator or not self.locator.strip():
+            raise ValueError("Evidence locator must be a non-empty string")
+        if not self.sha256 or not self.sha256.strip():
+            raise ValueError("Evidence sha256 must be a non-empty string")
+
+    @classmethod
+    def from_payload(cls, locator: str, payload: dict[str, Any]) -> Evidence:
+        """Create evidence by computing the canonical JSON SHA-256 digest."""
+        raw = _canonical_bytes(payload)
+        digest = hashlib.sha256(raw).hexdigest()
+        return cls(locator=locator, sha256=f"sha256:{digest}")
+
+    @classmethod
+    def from_bytes(cls, locator: str, raw: bytes) -> Evidence:
+        """Create evidence by computing the SHA-256 digest of raw bytes."""
+        digest = hashlib.sha256(raw).hexdigest()
+        return cls(locator=locator, sha256=f"sha256:{digest}")
+
+
+# ---------------------------------------------------------------------------
+# Finding
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Finding:
+    """An immutable outcome of executing a check.
+
+    Attributes:
+        check_id: Stable namespaced identifier (e.g. ``doctor:compliance``).
+        verdict: One of :class:`Verdict` (``pass``, ``fail``, ``not_measurable``).
+        evidence: Tuple of :class:`Evidence` pairs supporting measured findings.
+        what_would_make_it_measurable: Prerequisite explanation when verdict is
+            ``not_measurable``.
+        reason: Optional human-readable reason or exception class name.
+        message: Optional diagnostic summary of the result.
+        remediation: Optional remediation guidance if the check failed.
+    """
+
+    check_id: str
+    verdict: Verdict
+    evidence: tuple[Evidence, ...] = ()
+    what_would_make_it_measurable: str | None = None
+    reason: str | None = None
+    message: str = ""
+    remediation: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.check_id or not self.check_id.strip():
+            raise ValueError("check_id must be a non-empty string")
+
+        if isinstance(self.verdict, str):
+            object.__setattr__(self, "verdict", Verdict(self.verdict))
+
+        if not isinstance(self.evidence, tuple):
+            if isinstance(self.evidence, Sequence):
+                object.__setattr__(self, "evidence", tuple(self.evidence))
+            else:
+                raise TypeError("evidence must be a tuple or sequence of Evidence")
+
+        for item in self.evidence:
+            if not isinstance(item, Evidence):
+                raise TypeError(f"evidence item must be an Evidence instance, got {type(item).__name__}")
+
+        # Keep reason and what_would_make_it_measurable in sync
+        if self.what_would_make_it_measurable and not self.reason:
+            object.__setattr__(self, "reason", self.what_would_make_it_measurable)
+        elif self.reason and not self.what_would_make_it_measurable:
+            object.__setattr__(self, "what_would_make_it_measurable", self.reason)
+
+        if self.verdict in (Verdict.PASS, Verdict.FAIL):
+            if not self.evidence:
+                raise ValueError(
+                    f"Measured finding with verdict '{self.verdict.value}' requires at least one evidence item"
+                )
+        elif self.verdict == Verdict.NOT_MEASURABLE and (
+            not self.what_would_make_it_measurable or not self.what_would_make_it_measurable.strip()
+        ):
+            raise ValueError("not_measurable finding requires 'what_would_make_it_measurable'")
+
+    @property
+    def id(self) -> str:
+        """Alias for :attr:`check_id`."""
+        return self.check_id
+
+
+# ---------------------------------------------------------------------------
+# Check Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class Check(Protocol):
+    """Protocol for an audit check producer."""
+
+    @property
+    def check_id(self) -> str:
+        """Stable namespaced identifier for the check (e.g. ``doctor:compliance``)."""
+        ...
+
+    @property
+    def title(self) -> str:
+        """Short human-readable title."""
+        ...
+
+    @property
+    def description(self) -> str:
+        """Description of what this check verifies."""
+        ...
+
+    def run(self, workdir: Path | None = None) -> Finding:
+        """Run the check against the given workspace and return a Finding."""
+        ...

--- a/src/bernstein/core/checks/contract.py
+++ b/src/bernstein/core/checks/contract.py
@@ -24,11 +24,13 @@ if TYPE_CHECKING:
 
 
 class Verdict(StrEnum):
-    """The three-state verdict for an audit check finding."""
+    """The verdict vocabulary for an audit check finding."""
 
     PASS = "pass"
     FAIL = "fail"
     NOT_MEASURABLE = "not_measurable"
+    MEASURED = "measured"
+    DECLARED = "declared"
 
 
 # ---------------------------------------------------------------------------
@@ -85,7 +87,10 @@ class Finding:
             ``not_measurable``.
         reason: Optional human-readable reason or exception class name.
         message: Optional diagnostic summary of the result.
+        summary: Alias for :attr:`message`.
         remediation: Optional remediation guidance if the check failed.
+        area: Check area / category (e.g. ``doctor``, ``compliance``).
+        passed: Boolean pass/fail indicator for measured findings.
     """
 
     check_id: str
@@ -94,7 +99,10 @@ class Finding:
     what_would_make_it_measurable: str | None = None
     reason: str | None = None
     message: str = ""
+    summary: str = ""
     remediation: str = ""
+    area: str = ""
+    passed: bool | None = None
 
     def __post_init__(self) -> None:
         if not self.check_id or not self.check_id.strip():
@@ -113,13 +121,29 @@ class Finding:
             if not isinstance(item, Evidence):
                 raise TypeError(f"evidence item must be an Evidence instance, got {type(item).__name__}")
 
+        # Derive area from namespaced ID if not explicitly given
+        if not self.area and ":" in self.check_id:
+            object.__setattr__(self, "area", self.check_id.split(":", 1)[0])
+
+        # Synchronize summary and message
+        if self.summary and not self.message:
+            object.__setattr__(self, "message", self.summary)
+        elif self.message and not self.summary:
+            object.__setattr__(self, "summary", self.message)
+
+        # Synchronize passed boolean with verdict
+        if self.verdict == Verdict.PASS and self.passed is None:
+            object.__setattr__(self, "passed", True)
+        elif self.verdict == Verdict.FAIL and self.passed is None:
+            object.__setattr__(self, "passed", False)
+
         # Keep reason and what_would_make_it_measurable in sync
         if self.what_would_make_it_measurable and not self.reason:
             object.__setattr__(self, "reason", self.what_would_make_it_measurable)
         elif self.reason and not self.what_would_make_it_measurable:
             object.__setattr__(self, "what_would_make_it_measurable", self.reason)
 
-        if self.verdict in (Verdict.PASS, Verdict.FAIL):
+        if self.verdict in (Verdict.PASS, Verdict.FAIL, Verdict.MEASURED):
             if not self.evidence:
                 raise ValueError(
                     f"Measured finding with verdict '{self.verdict.value}' requires at least one evidence item"
@@ -161,4 +185,8 @@ class Check(Protocol):
 
     def run(self, workdir: Path | None = None) -> Finding:
         """Run the check against the given workspace and return a Finding."""
+        ...
+
+    def __call__(self, workdir: Path | None = None) -> Finding:
+        """Callable invocation returning a Finding."""
         ...

--- a/src/bernstein/core/checks/registry.py
+++ b/src/bernstein/core/checks/registry.py
@@ -33,7 +33,7 @@ class CheckRegistry:
             TypeError: If ``check`` does not conform to the :class:`Check` protocol.
             ValueError: If ``check.check_id`` is invalid, not namespaced, or already registered.
         """
-        if not isinstance(check, Check):
+        if not hasattr(check, "check_id") or not (hasattr(check, "run") or callable(check)):
             raise TypeError(f"Expected Check instance, got {type(check).__name__}")
 
         check_id = check.check_id

--- a/src/bernstein/core/checks/registry.py
+++ b/src/bernstein/core/checks/registry.py
@@ -1,0 +1,132 @@
+"""Registry for govern audit checks (#5072).
+
+Maintains an explicit, ordered registry of checks and coordinates their
+execution with exception isolation so a throwing check is reported as a
+``not_measurable`` finding carrying the exception class without aborting
+the rest of the check suite.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from bernstein.core.checks.contract import Check, Finding, Verdict
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class CheckRegistry:
+    """Registry managing registered audit checks."""
+
+    def __init__(self) -> None:
+        self._checks: dict[str, Check] = {}
+
+    def register(self, check: Check) -> None:
+        """Register a check.
+
+        Raises:
+            TypeError: If ``check`` does not conform to the :class:`Check` protocol.
+            ValueError: If ``check.check_id`` is invalid, not namespaced, or already registered.
+        """
+        if not isinstance(check, Check):
+            raise TypeError(f"Expected Check instance, got {type(check).__name__}")
+
+        check_id = check.check_id
+        if not check_id or not isinstance(check_id, str) or not check_id.strip():
+            raise ValueError("check_id must be a non-empty string")
+
+        if ":" not in check_id or check_id.startswith(":") or check_id.endswith(":"):
+            raise ValueError(
+                f"check_id '{check_id}' must be namespaced with a colon delimiter (e.g. 'namespace:check_name')"
+            )
+
+        if check_id in self._checks:
+            raise ValueError(f"Check with id '{check_id}' is already registered")
+
+        self._checks[check_id] = check
+
+    def unregister(self, check_id: str) -> None:
+        """Unregister a check by its ID."""
+        self._checks.pop(check_id, None)
+
+    def clear(self) -> None:
+        """Clear all registered checks."""
+        self._checks.clear()
+
+    def get_check(self, check_id: str) -> Check | None:
+        """Retrieve a registered check by ID."""
+        return self._checks.get(check_id)
+
+    def iter_checks(self) -> Iterator[Check]:
+        """Iterate over registered checks in registration order."""
+        yield from self._checks.values()
+
+    def run_all(self, workdir: Path | None = None) -> list[Finding]:
+        """Execute all registered checks against *workdir*.
+
+        Catches exceptions raised by individual checks, recording them as
+        ``not_measurable`` findings with the exception class name as reason,
+        and proceeds to execute all remaining checks.
+        """
+        findings: list[Finding] = []
+        for check in self._checks.values():
+            try:
+                finding = check.run(workdir)
+            except Exception as exc:
+                logger.warning(
+                    "Check '%s' raised %s: %s; reporting as not_measurable",
+                    check.check_id,
+                    exc.__class__.__name__,
+                    exc,
+                )
+                finding = Finding(
+                    check_id=check.check_id,
+                    verdict=Verdict.NOT_MEASURABLE,
+                    what_would_make_it_measurable=f"{exc.__class__.__name__}: {exc}",
+                    reason=exc.__class__.__name__,
+                    message=f"Check execution failed with {exc.__class__.__name__}: {exc}",
+                )
+            findings.append(finding)
+        return findings
+
+
+# ---------------------------------------------------------------------------
+# Global default registry and module-level conveniences
+# ---------------------------------------------------------------------------
+
+_DEFAULT_REGISTRY = CheckRegistry()
+
+
+def register(check: Check) -> None:
+    """Register a check in the default registry."""
+    _DEFAULT_REGISTRY.register(check)
+
+
+def unregister(check_id: str) -> None:
+    """Unregister a check from the default registry."""
+    _DEFAULT_REGISTRY.unregister(check_id)
+
+
+def clear() -> None:
+    """Clear the default registry."""
+    _DEFAULT_REGISTRY.clear()
+
+
+def get_check(check_id: str) -> Check | None:
+    """Retrieve a check from the default registry."""
+    return _DEFAULT_REGISTRY.get_check(check_id)
+
+
+def iter_checks() -> Iterator[Check]:
+    """Iterate over checks in the default registry."""
+    return _DEFAULT_REGISTRY.iter_checks()
+
+
+def run_all(workdir: Path | None = None) -> list[Finding]:
+    """Execute all checks in the default registry."""
+    return _DEFAULT_REGISTRY.run_all(workdir)

--- a/src/bernstein/core/compliance/__init__.py
+++ b/src/bernstein/core/compliance/__init__.py
@@ -47,12 +47,14 @@ from bernstein.core.security.compliance import (
     CompliancePreset,
     SBOMEntry,
     ai_label_for_file,
+    compliance_prerequisite_summary,
     export_evidence_bundle,
     export_soc2_package,
     generate_sbom,
     load_compliance_config,
     parse_period,
     persist_compliance_config,
+    resolve_compliance_config,
 )
 
 __all__ = [
@@ -76,6 +78,7 @@ __all__ = [
     "ai_label_for_file",
     "bom_content_hash",
     "build_pack",
+    "compliance_prerequisite_summary",
     "encode_bom",
     "export_evidence_bundle",
     "export_soc2_package",
@@ -86,5 +89,6 @@ __all__ = [
     "persist_compliance_config",
     "render_csv",
     "render_pdf",
+    "resolve_compliance_config",
     "verify_bom",
 ]

--- a/src/bernstein/core/security/compliance.py
+++ b/src/bernstein/core/security/compliance.py
@@ -25,6 +25,7 @@ import dataclasses
 import hashlib
 import json
 import logging
+import os
 import re
 import time
 from dataclasses import dataclass
@@ -1045,3 +1046,53 @@ def load_compliance_config(sdd_dir: Path) -> ComplianceConfig | None:
     except (ValueError, KeyError):
         logger.warning("Failed to load compliance config from %s", path)
         return None
+
+
+def resolve_compliance_config(workdir: Path) -> ComplianceConfig | None:
+    """Resolve the effective compliance config for a workspace.
+
+    Reads ``<workdir>/.sdd/config/compliance.json`` and lets the
+    ``BERNSTEIN_COMPLIANCE`` environment variable override it with a named
+    preset.
+
+    Args:
+        workdir: Workspace root containing the ``.sdd`` directory.
+
+    Returns:
+        The effective ComplianceConfig, or None when compliance is not
+        configured for this workspace.
+
+    Raises:
+        ValueError: If ``BERNSTEIN_COMPLIANCE`` names an unknown preset.
+    """
+    config = load_compliance_config(workdir / ".sdd")
+    preset_env = os.environ.get("BERNSTEIN_COMPLIANCE")
+    if preset_env:
+        config = ComplianceConfig.from_preset(CompliancePreset(preset_env.lower()))
+    return config
+
+
+def compliance_prerequisite_summary(workdir: Path) -> tuple[str, bool, str, str] | None:
+    """Summarise unmet compliance prerequisites for a workspace.
+
+    Args:
+        workdir: Workspace root containing the ``.sdd`` directory.
+
+    Returns:
+        A ``(name, ok, detail, fix)`` tuple describing the active preset and
+        any unmet prerequisites, or None when compliance is not configured.
+    """
+    config = resolve_compliance_config(workdir)
+    if config is None:
+        return None
+
+    preset_label = config.preset.value if config.preset else "custom"
+    warnings = config.check_prerequisites()
+    if warnings:
+        return (
+            f"Compliance ({preset_label})",
+            False,
+            f"{len(warnings)} issue(s): {warnings[0]}",
+            "; ".join(warnings),
+        )
+    return (f"Compliance ({preset_label})", True, "all prerequisites met", "")

--- a/tests/unit/checks/__init__.py
+++ b/tests/unit/checks/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for govern audit check contract and registry."""

--- a/tests/unit/checks/test_contract.py
+++ b/tests/unit/checks/test_contract.py
@@ -280,28 +280,42 @@ def test_two_wrapped_producers_yield_valid_findings(tmp_path: Path, monkeypatch:
 # ---------------------------------------------------------------------------
 
 
-def test_doctor_adapter_agrees_with_doctor_row(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize(
+    ("config", "expected_ok"),
+    [
+        # Every named preset satisfies its own prerequisites.
+        ('{"preset": "standard"}', True),
+        # Evidence bundle export without WAL or audit logging does not.
+        ('{"evidence_bundle": true}', False),
+    ],
+)
+def test_doctor_adapter_agrees_with_doctor_row(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config: str, expected_ok: bool
+) -> None:
     """The adapter and the ``bernstein doctor`` row report the same compliance result.
 
     Both read the same core producer, so a change to one cannot silently drift
-    from the other. ``standard`` leaves prerequisites unmet, which exercises the
-    failing branch where the detail and fix strings actually carry text.
+    from the other. The unmet-prerequisite case is covered as well as the met
+    one, so the assertion on ``remediation`` compares real text rather than two
+    empty strings.
     """
     from bernstein.cli.commands.status_cmd import _doctor_check_compliance
 
     monkeypatch.delenv("BERNSTEIN_COMPLIANCE", raising=False)
     sdd_config = tmp_path / ".sdd" / "config"
     sdd_config.mkdir(parents=True, exist_ok=True)
-    (sdd_config / "compliance.json").write_text('{"preset": "standard"}', encoding="utf-8")
+    (sdd_config / "compliance.json").write_text(config, encoding="utf-8")
 
     rows: list[dict[str, object]] = []
     _doctor_check_compliance(rows, tmp_path)
     assert len(rows) == 1
     row = rows[0]
+    assert row["ok"] is expected_ok
+    assert bool(row["fix"]) is not expected_ok
 
     finding = DoctorComplianceAdapter().run(tmp_path)
 
-    assert finding.verdict == (Verdict.PASS if row["ok"] else Verdict.FAIL)
+    assert finding.verdict == (Verdict.PASS if expected_ok else Verdict.FAIL)
     assert finding.message == row["detail"]
     assert finding.remediation == row["fix"]
 

--- a/tests/unit/checks/test_contract.py
+++ b/tests/unit/checks/test_contract.py
@@ -1,0 +1,269 @@
+"""Contract and registry tests for govern audit checks (#5072).
+
+Tests verify:
+1. Measured findings without evidence are rejected.
+2. not_measurable findings require what_would_make_it_measurable.
+3. Raising checks are isolated, reported as not_measurable with the exception
+   class name, and do not drop or abort subsequent checks.
+4. Check IDs are unique and strictly namespaced.
+5. Wrapped producers (doctor adapter and compliance library adapter) yield
+   valid findings with canonically hashed evidence.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.checks.adapters import (
+    ComplianceEncryptionAtRestAdapter,
+    DoctorComplianceAdapter,
+)
+from bernstein.core.checks.contract import Evidence, Finding, Verdict
+from bernstein.core.checks.registry import CheckRegistry
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class _DummyCheck:
+    """Dummy check implementation for testing."""
+
+    def __init__(self, check_id: str, outcome: Finding | Exception) -> None:
+        self._check_id = check_id
+        self._outcome = outcome
+
+    @property
+    def check_id(self) -> str:
+        return self._check_id
+
+    @property
+    def title(self) -> str:
+        return f"Dummy check {self._check_id}"
+
+    @property
+    def description(self) -> str:
+        return "A test check for contract verification"
+
+    def run(self, workdir: Path | None = None) -> Finding:
+        if isinstance(self._outcome, Exception):
+            raise self._outcome
+        return self._outcome
+
+
+# ---------------------------------------------------------------------------
+# 1. Measured finding without evidence is rejected
+# ---------------------------------------------------------------------------
+
+
+def test_measured_finding_without_evidence_is_rejected() -> None:
+    """A measured finding (PASS or FAIL) must carry at least one evidence item."""
+    # PASS without evidence must raise
+    with pytest.raises(ValueError, match="requires at least one evidence item"):
+        Finding(
+            check_id="test:check_pass",
+            verdict=Verdict.PASS,
+            evidence=(),
+        )
+
+    # FAIL without evidence must raise
+    with pytest.raises(ValueError, match="requires at least one evidence item"):
+        Finding(
+            check_id="test:check_fail",
+            verdict=Verdict.FAIL,
+            evidence=(),
+        )
+
+    # Providing evidence allows creation
+    ev = Evidence(locator="test:file", sha256="sha256:abcd1234abcd1234")
+    f_pass = Finding(
+        check_id="test:check_pass",
+        verdict=Verdict.PASS,
+        evidence=(ev,),
+    )
+    assert f_pass.verdict == Verdict.PASS
+    assert len(f_pass.evidence) == 1
+
+    f_fail = Finding(
+        check_id="test:check_fail",
+        verdict=Verdict.FAIL,
+        evidence=(ev,),
+        remediation="Fix the config",
+    )
+    assert f_fail.verdict == Verdict.FAIL
+
+
+# ---------------------------------------------------------------------------
+# 2. not_measurable requires what_would_make_it_measurable
+# ---------------------------------------------------------------------------
+
+
+def test_not_measurable_requires_what_would_make_it_measurable() -> None:
+    """A not_measurable finding must explain what prerequisite is missing."""
+    # None raises ValueError
+    with pytest.raises(ValueError, match="requires 'what_would_make_it_measurable'"):
+        Finding(
+            check_id="test:unmeasurable",
+            verdict=Verdict.NOT_MEASURABLE,
+            what_would_make_it_measurable=None,
+        )
+
+    # Empty string raises ValueError
+    with pytest.raises(ValueError, match="requires 'what_would_make_it_measurable'"):
+        Finding(
+            check_id="test:unmeasurable",
+            verdict=Verdict.NOT_MEASURABLE,
+            what_would_make_it_measurable="   ",
+        )
+
+    # Non-empty explanation succeeds
+    finding = Finding(
+        check_id="test:unmeasurable",
+        verdict=Verdict.NOT_MEASURABLE,
+        what_would_make_it_measurable="Set BERNSTEIN_COMPLIANCE=soc2 to enable this check",
+    )
+    assert finding.verdict == Verdict.NOT_MEASURABLE
+    assert finding.what_would_make_it_measurable == "Set BERNSTEIN_COMPLIANCE=soc2 to enable this check"
+    assert finding.reason == "Set BERNSTEIN_COMPLIANCE=soc2 to enable this check"
+
+
+# ---------------------------------------------------------------------------
+# 3. Raising check is reported not dropped
+# ---------------------------------------------------------------------------
+
+
+def test_raising_check_is_reported_not_dropped(tmp_path: Path) -> None:
+    """A throwing check is reported as not_measurable carrying the exception class."""
+    registry = CheckRegistry()
+
+    ev = Evidence(locator="test:mock", sha256="sha256:1111222233334444")
+    healthy_finding = Finding(
+        check_id="test:healthy",
+        verdict=Verdict.PASS,
+        evidence=(ev,),
+        message="Healthy check passed",
+    )
+
+    throwing_check = _DummyCheck(
+        check_id="test:thrower",
+        outcome=ConnectionResetError("Socket reset by peer"),
+    )
+    healthy_check = _DummyCheck(
+        check_id="test:healthy",
+        outcome=healthy_finding,
+    )
+
+    registry.register(throwing_check)
+    registry.register(healthy_check)
+
+    findings = registry.run_all(tmp_path)
+
+    # Both checks produced findings (none dropped)
+    assert len(findings) == 2
+
+    # The throwing check produced exactly one not_measurable finding
+    throw_finding = findings[0]
+    assert throw_finding.check_id == "test:thrower"
+    assert throw_finding.verdict == Verdict.NOT_MEASURABLE
+    assert throw_finding.reason == "ConnectionResetError"
+    assert "ConnectionResetError" in (throw_finding.what_would_make_it_measurable or "")
+
+    # The second check ran successfully
+    healthy_result = findings[1]
+    assert healthy_result.check_id == "test:healthy"
+    assert healthy_result.verdict == Verdict.PASS
+    assert healthy_result.message == "Healthy check passed"
+
+
+# ---------------------------------------------------------------------------
+# 4. Check IDs are unique and namespaced
+# ---------------------------------------------------------------------------
+
+
+def test_ids_are_unique_and_namespaced() -> None:
+    """Check IDs must be non-empty, namespaced with colon, and uniquely registered."""
+    registry = CheckRegistry()
+
+    ev = Evidence(locator="test:loc", sha256="sha256:aabbccdd")
+    finding = Finding(check_id="ns:valid", verdict=Verdict.PASS, evidence=(ev,))
+
+    # Reject un-namespaced IDs
+    with pytest.raises(ValueError, match="must be namespaced"):
+        registry.register(_DummyCheck("plain_id_without_namespace", finding))
+
+    with pytest.raises(ValueError, match="must be namespaced"):
+        registry.register(_DummyCheck(":leading_colon", finding))
+
+    with pytest.raises(ValueError, match="must be namespaced"):
+        registry.register(_DummyCheck("trailing_colon:", finding))
+
+    # Registering valid namespaced ID succeeds
+    check1 = _DummyCheck("security:rbac_check", finding)
+    registry.register(check1)
+    assert registry.get_check("security:rbac_check") is check1
+
+    # Registering duplicate ID raises ValueError
+    check1_duplicate = _DummyCheck("security:rbac_check", finding)
+    with pytest.raises(ValueError, match="already registered"):
+        registry.register(check1_duplicate)
+
+    # Registering another distinct namespaced ID succeeds
+    check2 = _DummyCheck("doctor:auth_status", finding)
+    registry.register(check2)
+
+    registered_ids = [c.check_id for c in registry.iter_checks()]
+    assert registered_ids == ["security:rbac_check", "doctor:auth_status"]
+
+
+# ---------------------------------------------------------------------------
+# 5. Two wrapped producers yield valid findings
+# ---------------------------------------------------------------------------
+
+
+def test_two_wrapped_producers_yield_valid_findings(tmp_path: Path) -> None:
+    """The two producer adapters yield valid Findings with canonical hashed evidence."""
+    # 1. Doctor adapter: DoctorComplianceAdapter
+    doctor_adapter = DoctorComplianceAdapter()
+    assert doctor_adapter.check_id == "doctor:compliance"
+    assert ":" in doctor_adapter.check_id
+
+    # Running in empty workspace -> not_measurable
+    doc_finding_unconfigured = doctor_adapter.run(tmp_path)
+    assert doc_finding_unconfigured.check_id == "doctor:compliance"
+    assert doc_finding_unconfigured.verdict == Verdict.NOT_MEASURABLE
+    assert doc_finding_unconfigured.what_would_make_it_measurable is not None
+
+    # Running with compliance config file in .sdd -> PASS or FAIL with valid Evidence
+    sdd_config = tmp_path / ".sdd" / "config"
+    sdd_config.mkdir(parents=True, exist_ok=True)
+    (sdd_config / "compliance.json").write_text('{"preset": "standard"}', encoding="utf-8")
+
+    doc_finding_configured = doctor_adapter.run(tmp_path)
+    assert doc_finding_configured.check_id == "doctor:compliance"
+    assert doc_finding_configured.verdict in (Verdict.PASS, Verdict.FAIL)
+    assert len(doc_finding_configured.evidence) >= 1
+    assert doc_finding_configured.evidence[0].sha256.startswith("sha256:")
+    assert len(doc_finding_configured.evidence[0].sha256) == 71  # "sha256:" + 64 hex chars
+
+    # 2. Compliance library adapter: ComplianceEncryptionAtRestAdapter
+    comp_adapter = ComplianceEncryptionAtRestAdapter()
+    assert comp_adapter.check_id == "compliance:soc2:encryption_at_rest"
+    assert ":" in comp_adapter.check_id
+
+    # Running against empty directory -> FAIL with evidence
+    comp_finding_fail = comp_adapter.run(tmp_path)
+    assert comp_finding_fail.check_id == "compliance:soc2:encryption_at_rest"
+    assert comp_finding_fail.verdict == Verdict.FAIL
+    assert len(comp_finding_fail.evidence) == 1
+    assert comp_finding_fail.evidence[0].sha256.startswith("sha256:")
+    assert len(comp_finding_fail.evidence[0].sha256) == 71
+
+    # Running against directory with state_encryption configured -> PASS with evidence
+    (tmp_path / "bernstein.yaml").write_text("state_encryption: true\n", encoding="utf-8")
+    comp_finding_pass = comp_adapter.run(tmp_path)
+    assert comp_finding_pass.check_id == "compliance:soc2:encryption_at_rest"
+    assert comp_finding_pass.verdict == Verdict.PASS
+    assert len(comp_finding_pass.evidence) == 1
+    assert comp_finding_pass.evidence[0].sha256.startswith("sha256:")

--- a/tests/unit/checks/test_contract.py
+++ b/tests/unit/checks/test_contract.py
@@ -225,8 +225,11 @@ def test_ids_are_unique_and_namespaced() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_two_wrapped_producers_yield_valid_findings(tmp_path: Path) -> None:
+def test_two_wrapped_producers_yield_valid_findings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """The two producer adapters yield valid Findings with canonical hashed evidence."""
+    # An ambient preset would configure compliance for every workspace.
+    monkeypatch.delenv("BERNSTEIN_COMPLIANCE", raising=False)
+
     # 1. Doctor adapter: DoctorComplianceAdapter
     doctor_adapter = DoctorComplianceAdapter()
     assert doctor_adapter.check_id == "doctor:compliance"
@@ -270,3 +273,56 @@ def test_two_wrapped_producers_yield_valid_findings(tmp_path: Path) -> None:
     assert comp_finding_pass.verdict == Verdict.PASS
     assert len(comp_finding_pass.evidence) == 1
     assert comp_finding_pass.evidence[0].sha256.startswith("sha256:")
+
+
+# ---------------------------------------------------------------------------
+# 6. The doctor adapter and the doctor row share one producer
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_adapter_agrees_with_doctor_row(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The adapter and the ``bernstein doctor`` row report the same compliance result.
+
+    Both read the same core producer, so a change to one cannot silently drift
+    from the other. ``standard`` leaves prerequisites unmet, which exercises the
+    failing branch where the detail and fix strings actually carry text.
+    """
+    from bernstein.cli.commands.status_cmd import _doctor_check_compliance
+
+    monkeypatch.delenv("BERNSTEIN_COMPLIANCE", raising=False)
+    sdd_config = tmp_path / ".sdd" / "config"
+    sdd_config.mkdir(parents=True, exist_ok=True)
+    (sdd_config / "compliance.json").write_text('{"preset": "standard"}', encoding="utf-8")
+
+    rows: list[dict[str, object]] = []
+    _doctor_check_compliance(rows, tmp_path)
+    assert len(rows) == 1
+    row = rows[0]
+
+    finding = DoctorComplianceAdapter().run(tmp_path)
+
+    assert finding.verdict == (Verdict.PASS if row["ok"] else Verdict.FAIL)
+    assert finding.message == row["detail"]
+    assert finding.remediation == row["fix"]
+
+    # The evidence digest is taken over the same row the doctor renders.
+    expected = Evidence.from_payload(
+        locator=f"doctor:compliance:{tmp_path}",
+        payload={"name": row["name"], "ok": row["ok"], "detail": row["detail"], "fix": row["fix"]},
+    )
+    assert finding.evidence == (expected,)
+
+
+def test_doctor_adapter_reports_no_config_as_not_measurable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unconfigured workspace yields no doctor row and a not_measurable finding."""
+    from bernstein.cli.commands.status_cmd import _doctor_check_compliance
+
+    monkeypatch.delenv("BERNSTEIN_COMPLIANCE", raising=False)
+
+    rows: list[dict[str, object]] = []
+    _doctor_check_compliance(rows, tmp_path)
+    assert rows == []
+
+    finding = DoctorComplianceAdapter().run(tmp_path)
+    assert finding.verdict == Verdict.NOT_MEASURABLE
+    assert finding.evidence == ()

--- a/tests/unit/checks/test_contract.py
+++ b/tests/unit/checks/test_contract.py
@@ -52,6 +52,9 @@ class _DummyCheck:
             raise self._outcome
         return self._outcome
 
+    def __call__(self, workdir: Path | None = None) -> Finding:
+        return self.run(workdir)
+
 
 # ---------------------------------------------------------------------------
 # 1. Measured finding without evidence is rejected


### PR DESCRIPTION
## Overview

Part of #5072 (Parent: #5071).

Slice 1 of `govern audit`: defines the check contract, stable namespaced IDs, the three-state verdict (`pass`/`measured`, `fail`, `not_measurable`), evidence pairs with canonical hashing, an isolated check registry, and two producer adapters.

## Decision: Registry Population Strategy

**Selected Strategy**: **Explicit import list**.
- **Trade-off & Rationale**: We opted for an explicit registry rather than package scanning. This guarantees deterministic execution ordering across environments, eliminates import-time filesystem scanning overhead / side-effects, and provides a single, readable location to audit all registered checks.

## Key Changes

1. **Check Contract (`src/bernstein/core/checks/contract.py`)**:
   - `Verdict`: StrEnum covering verdict states (`pass`, `fail`, `not_measurable`, `measured`, `declared`).
   - `Evidence`: Frozen dataclass with `locator` and `sha256`. Computes canonical JSON SHA-256 digests using `_canonical_bytes` imported directly from `src/bernstein/core/evidence/bundle.py` (no duplicate helper created).
   - `Finding`: Frozen dataclass with fields `id`/`check_id`, `area`, `verdict`, `evidence`, `summary`/`message`, `remediation`, `passed`, and `what_would_make_it_measurable`:
     - Measured findings (`pass` / `fail` / `measured`) reject missing or empty evidence.
     - `not_measurable` findings require non-empty `what_would_make_it_measurable`.
     - Automatically derives `area` from namespaced `check_id` prefix.
   - `Check`: Runtime-checkable protocol and callable returning `Finding`.

2. **Registry (`src/bernstein/core/checks/registry.py`)**:
   - `CheckRegistry`: Manages registered checks with strictly namespaced IDs (`namespace:check_name`) and uniqueness enforcement.
   - `run_all()`: Executes all checks with exception isolation. If a check raises an exception, it is recorded as a `not_measurable` finding carrying the exception class name in `reason` and `what_would_make_it_measurable`, and remaining checks continue executing.

3. **Producer Adapters (`src/bernstein/core/checks/adapters.py`)**:
   - `DoctorComplianceAdapter` (`doctor:compliance`): reads `compliance_prerequisite_summary` from `bernstein.core.compliance` — the same producer the `bernstein doctor` compliance row renders.
   - `ComplianceEncryptionAtRestAdapter` (`compliance:soc2:encryption_at_rest`): Adapts `check_encryption_at_rest` from `src/bernstein/core/security/compliance_library.py`.

4. **Shared compliance producer (`src/bernstein/core/security/compliance.py`)**:
   - The doctor's compliance prerequisite logic was already core-resident — load `.sdd/config/compliance.json`, let `BERNSTEIN_COMPLIANCE` override it with a named preset, then report `ComplianceConfig.check_prerequisites()`. It now lives in `compliance_prerequisite_summary()` beside the config loader, and both `bernstein doctor` and the check adapter read it.
   - This keeps `bernstein.core` free of any import into `bernstein.cli`: an earlier revision of this branch reached into `bernstein.cli.commands.status_cmd` and needed an `ignore_imports` entry in `.importlinter` to pass the "Core must not import CLI" contract. That entry is gone and all three architecture contracts hold with no exemptions.
   - Neither surface changes behaviour: the doctor renders the same row and the adapter hashes the same payload as before.

5. **Tests (`tests/unit/checks/test_contract.py`)**:
   - `test_measured_finding_without_evidence_is_rejected`
   - `test_not_measurable_requires_what_would_make_it_measurable`
   - `test_raising_check_is_reported_not_dropped`
   - `test_ids_are_unique_and_namespaced`
   - `test_two_wrapped_producers_yield_valid_findings`
   - `test_doctor_adapter_agrees_with_doctor_row` — pins that the adapter's verdict, message, remediation and evidence digest match the row `bernstein doctor` renders, so the two cannot drift apart.
   - `test_doctor_adapter_reports_no_config_as_not_measurable`

6. **Documentation & Release Notes**:
   - Updated `docs/sdd/module-map.md` via `bernstein agents-md sync`.
   - Added release notes fragment `docs/release-notes/fragments/5072-govern-audit-check-contract.md`.

## Remaining for #5072

Not covered by this slice:

- The `govern audit` CLI surface: `--list` printing ids and areas, `--only AREA`, and `--skip ID`. The registry exposes `iter_checks()` for it, but no command is wired yet.
- The id-stability guard: a test pinning that no id is reused and none is removed without a tombstone. `test_ids_are_unique_and_namespaced` pins uniqueness at registration time, which is a weaker property — it says nothing across releases.
- The default registry ships empty. Nothing registers `DoctorComplianceAdapter` or `ComplianceEncryptionAtRestAdapter` into it, so `run_all()` on the module-level registry returns `[]` until the CLI slice populates it. The explicit-import-list decision above describes where that population will live, not code that exists on this branch.
- `Verdict` carries two members beyond the three advertised states. `measured` is validated alongside `pass`/`fail` and requires evidence; `declared` has no validation rule, no producer and no test, so a `declared` finding is currently accepted carrying neither evidence nor a `what_would_make_it_measurable`. Nothing emits it today.

## Verification

```bash
uv run pytest tests/unit/checks tests/unit/test_compliance.py tests/unit/test_hipaa.py \
  tests/unit/test_doctor.py tests/unit/test_doctor_cmd.py tests/unit/test_cli_status.py \
  tests/unit/compliance tests/unit/doctor -q
uv run lint-imports
uv run ruff check src/bernstein/core/checks src/bernstein/core/security/compliance.py \
  src/bernstein/cli/commands/status_cmd.py tests/unit/checks
uv run mypy src/bernstein/core/checks src/bernstein/core/security/compliance.py tests/unit/checks
```
All passed.

