### PR TITLE
govern: validate playbook fields and make its digest order-independent (#4979)

### DIFF
--- a/docs/release-notes/fragments/4979-playbook-validation.md
+++ b/docs/release-notes/fragments/4979-playbook-validation.md
@@ -1,0 +1,3 @@
+## Playbook validation and order-independent digest
+
+Playbook parsing now rejects unknown fields and invalid clause kinds, raising `PlaybookValidationError` instead of silently ignoring them. The `principal_class` field on clauses and `principal_classes` on playbooks allow scoping ceilings to declared agent roles. `Playbook.content_hash()` now produces identical digests for playbooks that declare the same posture in a different clause order. Closes #4979.

--- a/src/bernstein/core/govern/__init__.py
+++ b/src/bernstein/core/govern/__init__.py
@@ -9,7 +9,11 @@ from typing import Any
 from bernstein.core.govern.findings import Finding, FindingsDocument
 from bernstein.core.govern.inventory_models import Inventory, Surface
 from bernstein.core.govern.plan_models import GovernPlan, PlanEntry, PlanEntryKind
-from bernstein.core.govern.playbook_models import Playbook, PlaybookClause
+from bernstein.core.govern.playbook_models import (
+    Playbook,
+    PlaybookClause,
+    PlaybookValidationError,
+)
 from bernstein.core.govern.proposal import DraftProposal, ProposalStatus
 
 
@@ -195,6 +199,7 @@ __all__ = [
     "PlanEntryKind",
     "Playbook",
     "PlaybookClause",
+    "PlaybookValidationError",
     "ProposalStatus",
     "Surface",
     "compute_plan",

--- a/src/bernstein/core/govern/playbook_models.py
+++ b/src/bernstein/core/govern/playbook_models.py
@@ -3,14 +3,46 @@
 The playbook represents declared posture: a set of clauses describing what
 is permitted, required, or forbidden in the environment. It is the "desired
 state" against which the inventory is diffed to produce a GovernPlan.
+
+The playbook is data, not a script: parsing it either produces a fully-typed
+object or raises. A field the schema does not know about is rejected, never
+silently dropped, and a clause naming a principal class the playbook did not
+declare is rejected too -- a ceiling nothing can satisfy or violate is not a
+looser posture, it is a typo. Two playbooks that declare the same rules in a
+different order are the same declared posture, so :meth:`Playbook.content_hash`
+canonicalizes clause order before hashing: the digest names the *content*,
+not the author's typing order.
 """
 
 from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
+
+#: The three kinds a clause may declare. Anything else is a typo, not a
+#: looser schema -- rejected at construction, not carried through as an
+#: opaque string.
+_KNOWN_KINDS = frozenset({"forbidden", "required", "permitted"})
+
+#: Keys a clause dict may carry. Declared once so ``from_dict`` can tell a
+#: key the schema does not know about from one it merely left unset.
+_CLAUSE_KEYS = frozenset({"surface", "clause", "kind", "declared_value", "declared_ceiling", "principal_class"})
+
+#: Keys a playbook dict may carry, for the same reason.
+_PLAYBOOK_KEYS = frozenset({"clauses", "principal_classes"})
+
+
+class PlaybookValidationError(ValueError):
+    """Raised when a playbook or clause fails validation.
+
+    Covers three distinct failures, all reported as this one error so a
+    caller can catch "this playbook is not usable" without enumerating
+    variants: an unrecognized field, a clause ``kind`` outside the declared
+    set, and a clause whose ``principal_class`` was never declared on the
+    enclosing playbook.
+    """
 
 
 @dataclass(frozen=True, slots=True)
@@ -28,6 +60,12 @@ class PlaybookClause:
             allowed value. None for ``forbidden`` clauses without values.
         declared_ceiling: For ``permitted`` clauses: the maximum allowed
             value. None if not applicable.
+        principal_class: The class of principal (e.g. ``worker``,
+            ``manager``) this clause's ceiling applies to. None for clauses
+            that are not scoped to a principal class. When set, it must name
+            a class the enclosing :class:`Playbook` declares in
+            ``principal_classes`` -- validated in :meth:`Playbook.__post_init__`
+            because a bare clause has no view of its siblings.
     """
 
     surface: str
@@ -35,6 +73,13 @@ class PlaybookClause:
     kind: str  # "forbidden" | "required" | "permitted"
     declared_value: str | None = None
     declared_ceiling: str | None = None
+    principal_class: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.kind not in _KNOWN_KINDS:
+            raise PlaybookValidationError(
+                f"unknown clause kind {self.kind!r} for surface {self.surface!r}: must be one of {sorted(_KNOWN_KINDS)}"
+            )
 
     def to_dict(self) -> dict[str, Any]:
         """Return the canonical serialization."""
@@ -47,17 +92,31 @@ class PlaybookClause:
             result["declared_value"] = self.declared_value
         if self.declared_ceiling is not None:
             result["declared_ceiling"] = self.declared_ceiling
+        if self.principal_class is not None:
+            result["principal_class"] = self.principal_class
         return result
 
     @classmethod
     def from_dict(cls, raw: dict[str, Any]) -> PlaybookClause:
-        """Rebuild a clause from a serialized dict."""
+        """Rebuild a clause from a serialized dict.
+
+        Raises:
+            PlaybookValidationError: *raw* carries a key this schema does not
+                know, or ``kind`` is outside the declared set.
+        """
+        unknown = set(raw) - _CLAUSE_KEYS
+        if unknown:
+            raise PlaybookValidationError(
+                f"unknown clause field(s) {sorted(unknown)} for surface "
+                f"{raw.get('surface')!r}: known fields are {sorted(_CLAUSE_KEYS)}"
+            )
         return cls(
             surface=str(raw["surface"]),
             clause=str(raw["clause"]),
             kind=str(raw["kind"]),
             declared_value=raw.get("declared_value"),
             declared_ceiling=raw.get("declared_ceiling"),
+            principal_class=raw.get("principal_class"),
         )
 
 
@@ -66,36 +125,76 @@ class Playbook:
     """A declared posture specification.
 
     The playbook is a tuple of clauses, each declaring a posture rule for a
-    specific surface. Tuple ensures immutability and deterministic ordering
-    for content hashing.
+    specific surface, plus the set of principal classes a clause may scope
+    a ceiling to. Tuple ensures immutability; hashing canonicalizes order
+    (see the module docstring) rather than relying on it.
 
     Attributes:
         clauses: Tuple of declared posture clauses.
+        principal_classes: The principal classes this playbook declares.
+            A clause naming a ``principal_class`` outside this set fails to
+            construct -- see :meth:`__post_init__`.
     """
 
     clauses: tuple[PlaybookClause, ...]
+    principal_classes: tuple[str, ...] = field(default=())
+
+    def __post_init__(self) -> None:
+        declared = frozenset(self.principal_classes)
+        for c in self.clauses:
+            if c.principal_class is not None and c.principal_class not in declared:
+                raise PlaybookValidationError(
+                    f"clause for surface {c.surface!r} references undeclared "
+                    f"principal class {c.principal_class!r}: declared classes "
+                    f"are {sorted(declared)}"
+                )
 
     def to_dict(self) -> dict[str, Any]:
         """Return the canonical serialization."""
-        return {
-            "clauses": [c.to_dict() for c in self.clauses],
-        }
+        result: dict[str, Any] = {"clauses": [c.to_dict() for c in self.clauses]}
+        if self.principal_classes:
+            result["principal_classes"] = list(self.principal_classes)
+        return result
 
     @classmethod
     def from_dict(cls, raw: dict[str, Any]) -> Playbook:
-        """Rebuild a playbook from a serialized dict."""
+        """Rebuild a playbook from a serialized dict.
+
+        Raises:
+            PlaybookValidationError: *raw* (or a nested clause) carries a key
+                this schema does not know, a clause ``kind`` is outside the
+                declared set, or a clause references an undeclared principal
+                class.
+        """
+        unknown = set(raw) - _PLAYBOOK_KEYS
+        if unknown:
+            raise PlaybookValidationError(
+                f"unknown playbook field(s) {sorted(unknown)}: known fields are {sorted(_PLAYBOOK_KEYS)}"
+            )
         clauses = tuple(PlaybookClause.from_dict(c) for c in raw.get("clauses", []))
-        return cls(clauses=clauses)
+        principal_classes = tuple(str(p) for p in raw.get("principal_classes", ()))
+        return cls(clauses=clauses, principal_classes=principal_classes)
 
     def content_hash(self) -> str:
         """Compute a stable content hash of the playbook.
 
-        Uses canonical JSON (sorted keys, minimal separators, UTF-8) so
-        identical playbooks produce identical hashes regardless of Python
-        dict ordering.
+        Uses canonical JSON (sorted keys, minimal separators, UTF-8) over a
+        *canonicalized* structure -- clauses sorted by their own canonical
+        JSON and principal classes sorted -- so two playbooks that declare
+        the same posture in a different order (a different author, a
+        different tool, a reformatted file) produce the same digest. Only a
+        genuine difference in declared clauses or principal classes changes
+        it.
         """
+        canonical_clauses = sorted(
+            (c.to_dict() for c in self.clauses),
+            key=lambda c: json.dumps(c, ensure_ascii=False, sort_keys=True),
+        )
         canonical = json.dumps(
-            self.to_dict(),
+            {
+                "clauses": canonical_clauses,
+                "principal_classes": sorted(self.principal_classes),
+            },
             ensure_ascii=False,
             separators=(",", ":"),
             sort_keys=True,
@@ -114,4 +213,5 @@ class Playbook:
 __all__ = [
     "Playbook",
     "PlaybookClause",
+    "PlaybookValidationError",
 ]

--- a/tests/unit/core/govern/test_models.py
+++ b/tests/unit/core/govern/test_models.py
@@ -7,7 +7,11 @@ import pytest
 from bernstein.core.govern import compute_plan
 from bernstein.core.govern.inventory_models import Inventory, Surface
 from bernstein.core.govern.plan_models import PlanEntryKind
-from bernstein.core.govern.playbook_models import Playbook, PlaybookClause
+from bernstein.core.govern.playbook_models import (
+    Playbook,
+    PlaybookClause,
+    PlaybookValidationError,
+)
 
 
 class TestSurface:
@@ -274,7 +278,13 @@ class TestPlaybook:
         pb2 = Playbook(clauses=clauses)
         assert pb1.content_hash() == pb2.content_hash()
 
-    def test_playbook_content_hash_different_order(self) -> None:
+    def test_semantically_identical_playbooks_hash_equal_regardless_of_clause_order(
+        self,
+    ) -> None:
+        # A playbook is a *set* of declared posture rules: two operators who
+        # write the same rules in a different order have declared the same
+        # posture, and a receipt naming "the playbook in force" must not
+        # depend on which order an author happened to type the clauses in.
         clauses1 = (
             PlaybookClause("s1", "c1", "forbidden"),
             PlaybookClause("s2", "c2", "required", declared_value="v2"),
@@ -285,8 +295,7 @@ class TestPlaybook:
         )
         pb1 = Playbook(clauses=clauses1)
         pb2 = Playbook(clauses=clauses2)
-        # Hash differs because clauses preserve their tuple order
-        assert pb1.content_hash() != pb2.content_hash()
+        assert pb1.content_hash() == pb2.content_hash()
 
     def test_playbook_content_hash_different_content(self) -> None:
         clauses1 = (PlaybookClause("s1", "c1", "forbidden"),)
@@ -322,6 +331,67 @@ class TestPlaybook:
         pb = Playbook(clauses=(PlaybookClause("s1", "c1", "forbidden"),))
         with pytest.raises(AttributeError):
             pb.clauses = ()  # type: ignore[attr-defined]
+
+
+class TestPlaybookValidation:
+    """Tests for #4979: a playbook is data, not a script -- an unknown key or
+    an undeclared reference is a validation error, never a silently-ignored
+    field."""
+
+    def test_unknown_clause_field_is_rejected_not_ignored(self) -> None:
+        d = {
+            "surface": "s1",
+            "clause": "c1",
+            "kind": "forbidden",
+            "notes": "left over from an older schema",
+        }
+        with pytest.raises(PlaybookValidationError):
+            PlaybookClause.from_dict(d)
+
+    def test_unknown_playbook_field_is_rejected_not_ignored(self) -> None:
+        d = {
+            "clauses": [{"surface": "s1", "clause": "c1", "kind": "forbidden"}],
+            "owner": "someone typed the wrong top-level key",
+        }
+        with pytest.raises(PlaybookValidationError):
+            Playbook.from_dict(d)
+
+    def test_clause_kind_outside_declared_set_is_rejected(self) -> None:
+        d = {"surface": "s1", "clause": "c1", "kind": "recommended"}
+        with pytest.raises(PlaybookValidationError):
+            PlaybookClause.from_dict(d)
+
+    def test_clause_referencing_undeclared_principal_class_fails_validation(
+        self,
+    ) -> None:
+        clause = PlaybookClause(
+            surface="tool:shell",
+            clause="worker agents may not invoke shell",
+            kind="forbidden",
+            principal_class="worker",
+        )
+        with pytest.raises(PlaybookValidationError):
+            # "manager" is declared, but the clause names "worker", which is
+            # not -- a ceiling that references a principal class nobody
+            # declared can never be satisfied or violated, so it must fail
+            # to construct rather than parse into an inert no-op.
+            Playbook(clauses=(clause,), principal_classes=("manager",))
+
+    def test_clause_referencing_declared_principal_class_is_accepted(self) -> None:
+        clause = PlaybookClause(
+            surface="tool:shell",
+            clause="worker agents may not invoke shell",
+            kind="forbidden",
+            principal_class="worker",
+        )
+        pb = Playbook(clauses=(clause,), principal_classes=("worker", "manager"))
+        assert pb.clauses[0].principal_class == "worker"
+
+    def test_content_hash_changes_when_principal_classes_differ(self) -> None:
+        clause = PlaybookClause("s1", "c1", "forbidden")
+        pb1 = Playbook(clauses=(clause,), principal_classes=("worker",))
+        pb2 = Playbook(clauses=(clause,), principal_classes=("manager",))
+        assert pb1.content_hash() != pb2.content_hash()
 
 
 class TestRoundTrip:


### PR DESCRIPTION
## What

Playbook parsing and hashing in `src/bernstein/core/govern/playbook_models.py`
now match the properties a declared posture file is supposed to have:

- `PlaybookClause.from_dict` / `Playbook.from_dict` reject any field the
  schema does not declare, and reject a clause `kind` outside
  `forbidden`/`required`/`permitted`, instead of silently ignoring or
  passing it through.
- `Playbook.content_hash()` canonicalizes clause order (and principal-class
  order) before hashing, so two playbooks that declare the same posture in
  a different order produce the same digest.
- `Playbook` gains a declared `principal_classes` set. A clause whose
  `principal_class` is not in that set fails to construct, so a ceiling
  scoped to an undeclared class cannot silently become a no-op.

This does **not**:
- Add endpoint-allowlist, evidence-framework, or coverage as distinct
  schema fields -- those are already representable through the existing
  generic `surface` + `clause` shape (e.g. `surface="endpoint:api.example.com"`),
  and the issue's own proof list only names principal-class scoping as a
  concept the current schema cannot express.
- Diff a playbook against an inventory (`#4980`) or apply one (`#4982`) --
  both explicitly out of scope per the issue.
- Touch `compute_plan` in `src/bernstein/core/govern/__init__.py`, which
  consumes playbooks as plain dicts with a different top-level shape
  (`forbidden`/`required`/`permitted` lists) and does not go through
  `Playbook`/`PlaybookClause` at all.

## Why

The playbook models were added as a dependency of the posture-diff work,
sized to what that diff needed. Two gaps remained that a declarative
config format cannot have: an unrecognized field was accepted and dropped
rather than rejected, and the content digest depended on clause order --
so a file reformatted by a different tool, or written by a different
author in a different order, hashed differently even though it declared
the same posture. A digest meant to identify "the policy in force" has to
be stable under that kind of syntactic noise, and a parser meant to
produce a fully-typed object has to fail loudly on a field it does not
recognize rather than let a typo travel silently into what looks like a
successfully-parsed policy.

## How

- Added `_KNOWN_KINDS`, `_CLAUSE_KEYS`, `_PLAYBOOK_KEYS` constants and a
  `PlaybookValidationError` raised from `PlaybookClause.__post_init__`
  (bad `kind`), `PlaybookClause.from_dict` / `Playbook.from_dict` (unknown
  field), and `Playbook.__post_init__` (clause references an undeclared
  `principal_class`).
- `Playbook.content_hash()` now sorts each clause's own canonical JSON
  before hashing the whole structure, and sorts `principal_classes`,
  instead of hashing `to_dict()`'s insertion-order list directly.
- Added `principal_class: str | None` to `PlaybookClause` and
  `principal_classes: tuple[str, ...]` to `Playbook`, both included in
  `to_dict()` / `content_hash()`.

## Tests

All in `tests/unit/core/govern/test_models.py`:

1. `test_semantically_identical_playbooks_hash_equal_regardless_of_clause_order`
   -- **load-bearing**. This replaces a previously-passing test that
   asserted the opposite (`!=`) on the grounds that "clauses preserve
   their tuple order" -- that was the exact defect. Failed before the
   change (asserted `==` against order-dependent hashing); passes after.
2. `test_unknown_clause_field_is_rejected_not_ignored` -- failed before
   (no validation existed, `PlaybookValidationError` did not exist so the
   whole file failed to collect); passes after.
3. `test_unknown_playbook_field_is_rejected_not_ignored` -- same shape, at
   the playbook level.
4. `test_clause_kind_outside_declared_set_is_rejected` -- a clause with
   `kind="recommended"` parsed silently before; now rejected.
5. `test_clause_referencing_undeclared_principal_class_fails_validation` --
   new concept, did not exist before this change.
6. `test_clause_referencing_declared_principal_class_is_accepted` --
   positive counterpart to (5), guards against an over-eager check that
   rejects every principal-class reference.
7. `test_content_hash_changes_when_principal_classes_differ` -- guards
   against an over-eager canonicalization that makes the digest
   insensitive to a real content difference.

Confirmed all seven fail on the unmodified tree (import error for 2-7
since `PlaybookValidationError` did not exist; assertion failure for 1)
before implementing, and all 49 tests in the file pass after (43
pre-existing + 6 new; test 1 replaces a pre-existing test rather than
adding one).

Also ran, as every other importer of `bernstein.core.govern` /
`playbook_models` found by grep, to confirm no regression outside the
changed file: `tests/unit/core/govern/test_identity_join.py`,
`tests/unit/core/govern/test_audit_watch.py`,
`tests/unit/test_govern_proposal.py`, `tests/unit/test_govern_findings.py`
-- all green. These consume playbooks as plain dicts and do not exercise
the changed code paths, which is why they were unaffected.

`--affected origin/main` was not run: the changed files are deep, widely
imported modules and the two changed source files plus every direct
importer were run explicitly above instead. CI runs the full suite.

## Checklist

- [x] `uv run ruff check src/` (scoped to changed files) -- clean
- [x] `uv run ruff format --check src/` (scoped to changed files) -- clean
- [x] `pyright src/` (scoped to changed files) -- 0 errors, 0 warnings
- [x] `uv run python scripts/run_tests.py -x` (scoped to changed + importing files) -- all green
- [x] Type hints on all new/changed signatures
- [x] `uv run bernstein agents-md sync` -- ran, produced no diff (module-level
  docs already described this module correctly)
- N/A README.md / translations -- not touched
- N/A schema/data migration -- no persisted playbook files exist yet to migrate

## Remaining

- Diffing a playbook against an inventory (`#4980`) -- already shipped
  separately, does not consume `Playbook`/`PlaybookClause`.
- Applying a playbook and recording its digest in a receipt when it is
  "in force" (`#4982`) -- `Playbook.content_hash()` is stable and
  receipt-ready (`sha256:` prefix, matching the convention used
  elsewhere in the codebase), but there is no "in force" state yet for a
  receipt to attach to; that arrives with apply.
- Any interactive/assisted authoring of a playbook -- explicitly excluded
  by the issue.

Part of #4979
