### PR TITLE
ci: weekly project pulse page

### DIFF
--- a/.github/workflows/project-pulse.yml
+++ b/.github/workflows/project-pulse.yml
@@ -1,0 +1,147 @@
+name: Project pulse
+
+# Publish a weekly, public snapshot of this repository's health into ONE
+# rolling issue, so a prospective contributor can answer "if I open a PR
+# here, will it be reviewed?" without reading the tracker.
+#
+# What it publishes (and does not):
+#   * Ten aggregates, every one of them derivable from the public GitHub API
+#     or this repository's own tree. The exact list is the allow-list comment
+#     block at the top of scripts/project_pulse.py; nothing outside it is
+#     collected or rendered.
+#   * Counts, never people. No individual logins, no e-mail addresses, no
+#     per-person ranking, no commit-hour histograms. Contributions are
+#     bucketed into outside / maintainer / automation and reported as counts,
+#     with a unit test asserting the rendered page names no account.
+#   * The aggregation and rendering live in scripts/project_pulse.py
+#     (unit-tested, deterministic) so a re-run produces a byte-identical body
+#     and the weekly upsert does not thrash the issue.
+#
+# Fails closed: `collect` exits non-zero and writes no file if any API call
+# fails, so a broken query can never publish zeros that read as a quiet week.
+# The publish step only runs on a successful collection.
+#
+# Rolling, not proliferating: exactly one issue titled "Project pulse
+# (weekly)" is created on the first run and edited in place afterwards. It is
+# labelled `docs` and deliberately not pinned.
+#
+# The rendered page is also uploaded as a workflow artifact. Nothing is
+# committed to the repository: the page is generated output, and a workflow
+# that pushes to main to publish a report is a merge-queue hazard for no gain.
+
+on:
+  schedule:
+    # Monday 09:19 UTC -- after the weekend rollover, off the crowded 03:00 -
+    # 08:00 band the nightly and weekly jobs already occupy.
+    - cron: "19 9 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: project-pulse
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  pulse:
+    name: Collect and publish the project pulse
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout (for the collector and the in-repo metrics)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      # The adapter count reads the live registry and the translation count
+      # shells out to `bernstein readme-l10n verify`, so the collector needs
+      # the project environment rather than a bare interpreter. Both sources
+      # are offline; only the GitHub queries touch the network.
+      - uses: ./.github/actions/bootstrap
+
+      - name: Collect (fails closed on any API error)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          uv run python scripts/project_pulse.py collect \
+            --repo "${REPO}" \
+            --out pulse.json \
+            --repo-root .
+
+      - name: Render the page
+        run: |
+          set -euo pipefail
+          uv run python scripts/project_pulse.py render pulse.json > project-pulse.md
+          # A renderer that produced an empty page would otherwise blank the
+          # issue body in place, which reads as "the project died" rather than
+          # "the render broke".
+          test -s project-pulse.md
+
+      - name: Upsert the rolling pulse issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TITLE: Project pulse (weekly)
+        run: |
+          set -euo pipefail
+
+          # Strict title match on an exact-title search: a substring match
+          # could adopt an unrelated issue and overwrite someone's report.
+          EXISTING=$(gh issue list --repo "${REPO}" --state open \
+            --search "in:title \"${TITLE}\"" \
+            --limit 100 \
+            --json number,title \
+            --jq ".[] | select(.title == env.TITLE) | .number" \
+            | head -1)
+
+          if [ -n "${EXISTING}" ]; then
+            echo "Updating existing pulse issue #${EXISTING}"
+            gh issue edit "${EXISTING}" --repo "${REPO}" --body-file project-pulse.md
+            PULSE_NUMBER="${EXISTING}"
+          else
+            echo "Creating the pulse issue"
+            # Probe the label rather than retrying a failed create: a blind
+            # `create --label docs || create` retries on any failure -- a
+            # transport error that already created the issue included -- and
+            # can open a duplicate.
+            LABELS=$(gh label list --repo "${REPO}" --limit 200 --json name --jq '.[].name')
+            if grep -qxF "docs" <<<"${LABELS}"; then
+              PULSE_URL=$(gh issue create --repo "${REPO}" \
+                --title "${TITLE}" \
+                --body-file project-pulse.md \
+                --label "docs")
+            else
+              PULSE_URL=$(gh issue create --repo "${REPO}" \
+                --title "${TITLE}" \
+                --body-file project-pulse.md)
+            fi
+            PULSE_NUMBER=$(basename "${PULSE_URL}")
+          fi
+
+          {
+            echo "### Project pulse"
+            echo ""
+            echo "- Pulse issue: #${PULSE_NUMBER}"
+            echo ""
+            cat project-pulse.md
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload the rendered page and its inputs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: project-pulse
+          path: |
+            project-pulse.md
+            pulse.json
+          if-no-files-found: error
+          retention-days: 90

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -58,6 +58,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/pr-labels.yml | PR labels | pull_request_target | {"cancel-in-progress": "true", "group": "pr-labels-${{ github.event.pull_request.number }}"} | 1 |
 | .github/workflows/pr-observability-summary.yml | PR observability summary | pull_request, workflow_dispatch | {"cancel-in-progress": "true", "group": "pr-observability-${{ github.event.pull_request.number \|\| github.event.inputs.pr_number }}"} | 1 |
 | .github/workflows/pr-policy.yml | PR policy | pull_request | {"cancel-in-progress": "${{ github.event_name == 'pull_request' }}", "group": "pr-policy-${{ github.event.pull_request.number }}"} | 1 |
+| .github/workflows/project-pulse.yml | Project pulse | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "project-pulse"} | 1 |
 | .github/workflows/publish-docker.yml | Publish Docker Image | release, workflow_dispatch | {"cancel-in-progress": "false", "group": "publish-docker-${{ github.ref }}"} | 1 |
 | .github/workflows/publish-extension.yml | Publish VS Code Extension | push, workflow_dispatch | {"cancel-in-progress": "false", "group": "publish-extension-${{ github.ref }}"} | 1 |
 | .github/workflows/publish-homebrew.yml | Publish Homebrew Formula | release, workflow_dispatch | {"cancel-in-progress": "false", "group": "publish-homebrew-${{ github.ref }}"} | 1 |
@@ -132,6 +133,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/pr-labels.yml | label |
 | .github/workflows/pr-observability-summary.yml | summary: Sticky observability comment |
 | .github/workflows/pr-policy.yml | pr-policy: PR policy |
+| .github/workflows/project-pulse.yml | pulse: Collect and publish the project pulse |
 | .github/workflows/publish-docker.yml | publish: Build and push image to GHCR |
 | .github/workflows/publish-extension.yml | publish |
 | .github/workflows/publish-homebrew.yml | update-formula: Update Homebrew formula |
@@ -206,6 +208,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/pr-labels.yml | workflow: {"contents": "read"}<br>label: {"contents": "read", "issues": "write", "pull-requests": "write"} | GITHUB_TOKEN |
 | .github/workflows/pr-observability-summary.yml | workflow: {"contents": "read"}<br>summary: {"checks": "read", "contents": "read", "pull-requests": "write", "security-events": "read"} | GITHUB_TOKEN |
 | .github/workflows/pr-policy.yml | workflow: {"contents": "read"}<br>pr-policy: {"actions": "read", "contents": "write", "issues": "read", "pull-requests": "read"} | BERNSTEIN_AUTOSYNC_TOKEN |
+| .github/workflows/project-pulse.yml | pulse: {"contents": "read", "issues": "write"} | - |
 | .github/workflows/publish-docker.yml | publish: {"attestations": "write", "contents": "read", "id-token": "write", "packages": "write"} | GITHUB_TOKEN |
 | .github/workflows/publish-extension.yml | workflow: {"contents": "read"}<br>publish: {"contents": "read"} | OPEN_VSX_TOKEN, VS_MARKETPLACE_TOKEN |
 | .github/workflows/publish-homebrew.yml | workflow: {"contents": "read"}<br>update-formula: {"contents": "read"} | HOMEBREW_TAP_TOKEN |
@@ -254,6 +257,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/mutation-fixed.yml | mutate: upload mutation-${{ matrix.module }} |
 | .github/workflows/nightly-deep-tests.yml | bandit-medium-and-high: upload nightly-bandit-results<br>mutmut-full: upload nightly-mutmut-results |
 | .github/workflows/pentest.yml | pentest: upload pentest-results-${{ github.run_number }} |
+| .github/workflows/project-pulse.yml | pulse: upload project-pulse |
 | .github/workflows/publish.yml | build: upload dist<br>github-release: download dist<br>publish: download dist |
 | .github/workflows/sbom.yml | sbom: upload sbom |
 | .github/workflows/scorecard.yml | analysis: upload scorecard-results<br>upload: download scorecard-results |

--- a/docs/project-pulse.md
+++ b/docs/project-pulse.md
@@ -1,0 +1,40 @@
+# Project pulse
+
+A weekly public snapshot of this repository's health, written to answer the question a
+prospective contributor has before opening a pull request: will it be looked at? The headline
+is the median time from PR opened to merged over the last 30 days, then a link to grabbable issues.
+
+[`.github/workflows/project-pulse.yml`](https://github.com/sipyourdrink-ltd/bernstein/blob/main/.github/workflows/project-pulse.yml)
+publishes it every Monday at 09:19 UTC into one rolling issue titled `Project pulse (weekly)`,
+labelled `docs` -- created on the first run, edited in place afterwards.
+Find it with [`is:issue "Project pulse (weekly)"`](https://github.com/sipyourdrink-ltd/bernstein/issues?q=is%3Aissue+%22Project+pulse+%28weekly%29%22), or as a workflow artifact on any run.
+
+## What it reports
+
+| # | Metric | Definition |
+| --- | --- | --- |
+| 1 | Median PR merge lag | Median hours from opened to merged, merged PRs of the last 30 days |
+| 2 | Merged within 24 h | Share of those PRs whose merge lag was 24 hours or less |
+| 3 | Merged PRs by author class | Counts per class: outside contributor, maintainer account, automation account |
+| 4 | Distinct outside authors | How many distinct non-bot, non-maintainer accounts had a PR merged in 90 days |
+| 5 | Median issue close lag | Median hours from opened to closed, issues closed in the last 30 days |
+| 6 | Work you can pick up | Open `up-for-grabs` and `good first issue` counts, and how many are unassigned |
+| 7 | Commit volume | Commits landed on `main` in the last 7 days, and days since the last one |
+| 8 | Adapters | Registry size, from the same source `bernstein integrations list` enumerates |
+| 9 | Latest release | Tag name and publication date of the most recent release |
+| 10 | Translated READMEs | How many of the 23 translations are in sync, per `bernstein readme-l10n verify` |
+
+That table is the whole allow-list, restated as a comment block at the top of
+`scripts/project_pulse.py`. Every field is an already-public aggregate. Individual
+logins, e-mail addresses, per-person rankings, commit-hour histograms and review-comment
+attribution are out of scope and must not be added.
+
+## Regenerate locally
+
+`collect` needs `GH_TOKEN` with public read access and fails closed: a failed query
+aborts the run and writes nothing. `render` is pure -- identical input, identical bytes.
+
+```bash
+uv run python scripts/project_pulse.py collect --repo sipyourdrink-ltd/bernstein --out pulse.json
+uv run python scripts/project_pulse.py render pulse.json
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -664,6 +664,7 @@ nav:
           - Audit-chain default cost: decisions/010-audit-chain-default-cost.md
   - Contribute:
       - contributing/index.md
+      - Project pulse: project-pulse.md
       - Code review process: CODE_REVIEW.md
       - Testing & CI hardening: contributing/testing.md
       - Lifecycle hooks contract: contributing/hooks.md

--- a/scripts/project_pulse.py
+++ b/scripts/project_pulse.py
@@ -1,0 +1,557 @@
+#!/usr/bin/env python3
+"""Publish a weekly, deterministic snapshot of this repository's public health.
+
+Consumed by ``.github/workflows/project-pulse.yml``. Two stages, deliberately
+split so the numbers and the page are separable concerns:
+
+* ``collect`` queries the public GitHub REST API plus two in-repo sources and
+  writes ``pulse.json``. It fails closed: any HTTP error, unexpected payload,
+  or unreadable local source aborts with a non-zero exit and leaves no output
+  file behind, so a partial page can never be published as a complete one.
+* ``render`` is a pure function of that JSON. Identical input yields a
+  byte-identical page (sorted keys, fixed number formatting, ISO dates, and no
+  clock reads other than the collected ``generated_at`` date), so the weekly
+  idempotent upsert does not thrash the issue body.
+
+The page answers one question a prospective contributor has before opening a
+pull request: will it be looked at? The headline is the median time from PR
+opened to merged over the last 30 days, followed by a link to the issues that
+are free to pick up.
+
+Stdlib only for the HTTP path; the two in-repo metrics import the same
+sources the README count guards already use, so the page cannot drift from
+the code it describes.
+
+"""
+
+# ---------------------------------------------------------------------------
+# PUBLISHED FIELD ALLOW-LIST
+#
+# Everything the rendered page may contain. Aggregates only. Adding a field
+# here is a deliberate decision, not an implementation detail: anything not on
+# this list must not be collected and must not be rendered.
+#
+#   1.  pr_merge_lag_hours_median      median PR opened -> merged, 30 days
+#   2.  pr_merged_within_24h_pct       share of those merged inside 24 hours
+#   3.  merged_prs_by_author_class     counts per class: outside / maintainer
+#                                      / automation. Counts only, never names
+#                                      beyond the two documented account
+#                                      labels, never a per-person ranking.
+#   4.  distinct_outside_authors_90d   cardinality only, no logins
+#   5.  issue_close_lag_hours_median   median issue opened -> closed, 30 days
+#   6.  grabbable                      open up-for-grabs / good first issue
+#                                      counts and how many are unassigned
+#   7.  commits_main_7d,               commit volume on the default branch
+#       days_since_last_commit
+#   8.  adapters                       registry size, read from the registry
+#   9.  latest_release                 tag name and publication date
+#  10.  readme_translations            translated READMEs in sync vs stale
+#
+# Explicitly out of scope, and not to be added: individual logins, e-mail
+# addresses, per-person leaderboards, commit-hour or timezone histograms,
+# review-comment attribution, anything sourced outside the public API and this
+# repository's own tree.
+# ---------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+import time
+import tomllib
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+API_ROOT = "https://api.github.com"
+USER_AGENT = "bernstein-project-pulse"
+
+PR_WINDOW_DAYS = 30
+ISSUE_WINDOW_DAYS = 30
+OUTSIDE_AUTHOR_WINDOW_DAYS = 90
+COMMIT_WINDOW_DAYS = 7
+
+#: Slice width for search queries. The Search API returns at most 1000 results
+#: per query; on a busy week this repository merges enough pull requests that a
+#: single 30-day query would silently truncate. Slicing the window into weeks
+#: keeps every query far below the cap, and a slice that still exceeds it is a
+#: hard error rather than a quietly short median.
+SLICE_DAYS = 7
+SEARCH_PAGE_SIZE = 100
+SEARCH_RESULT_CAP = 1000
+
+#: Spacing between Search API calls. The authenticated search limit is 30
+#: requests per minute; a full collection issues roughly 25.
+SEARCH_INTERVAL_SECONDS = 2.5
+
+#: The maintainer account. Its merged pull requests are counted separately
+#: from outside contributions so the outside number is not flattered by them.
+MAINTAINER_LOGIN = "chernistry"
+
+#: This repository's automation app. Any account GitHub reports as a Bot is
+#: also counted here, so a second automation account cannot silently land in
+#: the "outside contributor" bucket and inflate it.
+AUTOMATION_LOGIN = "bernstein-orchestrator[bot]"
+
+CLASS_OUTSIDE = "outside"
+CLASS_MAINTAINER = "maintainer"
+CLASS_AUTOMATION = "automation"
+
+
+class PulseError(RuntimeError):
+    """Collection failed. Nothing is written and the process exits non-zero."""
+
+
+# ---------------------------------------------------------------------------
+# HTTP layer (mocked wholesale in the unit tests)
+# ---------------------------------------------------------------------------
+
+
+class GitHubClient:
+    """Minimal read-only GitHub API client over ``urllib``.
+
+    Every failure mode -- transport error, non-2xx status, undecodable body --
+    raises :class:`PulseError`. There is no ``|| true`` path: a page built from
+    a failed query would report a healthy-looking zero.
+    """
+
+    def __init__(self, token: str, *, interval_seconds: float = SEARCH_INTERVAL_SECONDS) -> None:
+        self._token = token
+        self._interval = interval_seconds
+        self._last_call = 0.0
+
+    def _throttle(self) -> None:
+        elapsed = time.monotonic() - self._last_call
+        if self._last_call and elapsed < self._interval:
+            time.sleep(self._interval - elapsed)
+        self._last_call = time.monotonic()
+
+    def get(self, path: str, params: dict[str, str] | None = None) -> tuple[Any, dict[str, str]]:
+        """GET *path*, returning ``(decoded_body, response_headers)``."""
+        self._throttle()
+        url = f"{API_ROOT}/{path.lstrip('/')}"
+        if params:
+            url = f"{url}?{urllib.parse.urlencode(params)}"
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Authorization": f"Bearer {self._token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": USER_AGENT,
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                raw = response.read()
+                headers = {k.lower(): v for k, v in response.headers.items()}
+        except urllib.error.HTTPError as exc:
+            raise PulseError(f"GitHub API {exc.code} for {url}") from exc
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            raise PulseError(f"GitHub API request failed for {url}: {exc}") from exc
+        try:
+            return json.loads(raw.decode("utf-8")), headers
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise PulseError(f"GitHub API returned an undecodable body for {url}") from exc
+
+
+def _search(client: GitHubClient, query: str, *, page: int = 1) -> dict[str, Any]:
+    body, _ = client.get(
+        "search/issues",
+        {"q": query, "per_page": str(SEARCH_PAGE_SIZE), "page": str(page), "advanced_search": "true"},
+    )
+    if not isinstance(body, dict) or "total_count" not in body or "items" not in body:
+        raise PulseError(f"unexpected search payload for query: {query}")
+    return body
+
+
+def _search_total(client: GitHubClient, query: str) -> int:
+    return int(_search(client, query)["total_count"])
+
+
+def _search_items(client: GitHubClient, query: str) -> list[dict[str, Any]]:
+    """Return every item matching *query*, refusing to truncate silently."""
+    first = _search(client, query)
+    total = int(first["total_count"])
+    if total > SEARCH_RESULT_CAP:
+        raise PulseError(f"query exceeds the {SEARCH_RESULT_CAP}-result API cap ({total}): {query}")
+    items: list[dict[str, Any]] = list(first["items"])
+    page = 2
+    while len(items) < total:
+        batch = _search(client, query, page=page)["items"]
+        if not batch:
+            raise PulseError(f"search pagination stalled at {len(items)}/{total} for query: {query}")
+        items.extend(batch)
+        page += 1
+    return items[:total]
+
+
+# ---------------------------------------------------------------------------
+# Time helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_ts(value: str) -> datetime:
+    return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+
+
+def _slices(now: datetime, days: int) -> list[tuple[str, str]]:
+    """Split ``[now - days, now]`` into inclusive ``YYYY-MM-DD`` date ranges.
+
+    Deterministic given *now*: the slice boundaries are derived from the date
+    only, so a collection run at any hour of the same day produces the same
+    queries.
+    """
+    end = now.date()
+    start = end - timedelta(days=days)
+    out: list[tuple[str, str]] = []
+    cursor = start
+    while cursor <= end:
+        stop = min(cursor + timedelta(days=SLICE_DAYS - 1), end)
+        out.append((cursor.isoformat(), stop.isoformat()))
+        cursor = stop + timedelta(days=1)
+    return out
+
+
+def _median_hours(deltas: list[float]) -> float | None:
+    return round(statistics.median(deltas), 1) if deltas else None
+
+
+# ---------------------------------------------------------------------------
+# Collection
+# ---------------------------------------------------------------------------
+
+
+def _author_class(user: dict[str, Any]) -> str:
+    login = str(user.get("login") or "")
+    if user.get("type") == "Bot" or login.endswith("[bot]") or login == AUTOMATION_LOGIN:
+        return CLASS_AUTOMATION
+    if login == MAINTAINER_LOGIN:
+        return CLASS_MAINTAINER
+    return CLASS_OUTSIDE
+
+
+def _collect_pull_requests(client: GitHubClient, repo: str, now: datetime) -> dict[str, Any]:
+    """Merge lag, 24-hour share, and author-class counts over the PR window."""
+    lags: list[float] = []
+    within_24h = 0
+    by_class = {CLASS_AUTOMATION: 0, CLASS_MAINTAINER: 0, CLASS_OUTSIDE: 0}
+    for start, stop in _slices(now, PR_WINDOW_DAYS):
+        query = f"repo:{repo} is:pr is:merged merged:{start}..{stop}"
+        for item in _search_items(client, query):
+            pull = item.get("pull_request") or {}
+            merged_at = pull.get("merged_at")
+            created_at = item.get("created_at")
+            if not merged_at or not created_at:
+                raise PulseError(f"merged pull request without timestamps in slice {start}..{stop}")
+            hours = (_parse_ts(merged_at) - _parse_ts(created_at)).total_seconds() / 3600.0
+            lags.append(hours)
+            if hours <= 24.0:
+                within_24h += 1
+            by_class[_author_class(item.get("user") or {})] += 1
+    merged = len(lags)
+    return {
+        "merged_prs_by_author_class": by_class,
+        "pr_merge_lag_hours_median": _median_hours(lags),
+        "pr_merged_count": merged,
+        "pr_merged_within_24h_pct": round(100.0 * within_24h / merged, 1) if merged else None,
+    }
+
+
+def _collect_outside_authors(client: GitHubClient, repo: str, now: datetime) -> int:
+    """Cardinality of distinct non-bot, non-maintainer merged-PR authors."""
+    logins: set[str] = set()
+    for start, stop in _slices(now, OUTSIDE_AUTHOR_WINDOW_DAYS):
+        query = f"repo:{repo} is:pr is:merged merged:{start}..{stop}"
+        for item in _search_items(client, query):
+            user = item.get("user") or {}
+            if _author_class(user) == CLASS_OUTSIDE:
+                logins.add(str(user.get("login") or ""))
+    return len(logins)
+
+
+def _collect_issues(client: GitHubClient, repo: str, now: datetime) -> dict[str, Any]:
+    lags: list[float] = []
+    for start, stop in _slices(now, ISSUE_WINDOW_DAYS):
+        query = f"repo:{repo} is:issue is:closed closed:{start}..{stop}"
+        for item in _search_items(client, query):
+            closed_at, created_at = item.get("closed_at"), item.get("created_at")
+            if not closed_at or not created_at:
+                raise PulseError(f"closed issue without timestamps in slice {start}..{stop}")
+            lags.append((_parse_ts(closed_at) - _parse_ts(created_at)).total_seconds() / 3600.0)
+    return {
+        "issue_close_lag_hours_median": _median_hours(lags),
+        "issues_closed_count": len(lags),
+    }
+
+
+def _collect_grabbable(client: GitHubClient, repo: str) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for key, label in (("up_for_grabs", "up-for-grabs"), ("good_first_issue", "good first issue")):
+        base = f'repo:{repo} is:issue is:open label:"{label}"'
+        out[f"{key}_open"] = _search_total(client, base)
+        out[f"{key}_unassigned"] = _search_total(client, f"{base} no:assignee")
+    return out
+
+
+def _last_page_count(client: GitHubClient, path: str, params: dict[str, str]) -> int:
+    """Exact item count via the ``rel="last"`` link on a ``per_page=1`` query.
+
+    One request instead of paging thousands of commits. When no ``last`` link
+    is present the result set fits on the single requested page.
+    """
+    body, headers = client.get(path, {**params, "per_page": "1"})
+    if not isinstance(body, list):
+        raise PulseError(f"expected a list payload from {path}")
+    link = headers.get("link", "")
+    for part in link.split(","):
+        if 'rel="last"' in part:
+            url = part.split(";")[0].strip().strip("<>")
+            last = urllib.parse.parse_qs(urllib.parse.urlparse(url).query).get("page", ["1"])[0]
+            return int(last)
+    return len(body)
+
+
+def _collect_commits(client: GitHubClient, repo: str, now: datetime) -> dict[str, Any]:
+    since = (now - timedelta(days=COMMIT_WINDOW_DAYS)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    count = _last_page_count(client, f"repos/{repo}/commits", {"sha": "main", "since": since})
+    head, _ = client.get(f"repos/{repo}/commits", {"sha": "main", "per_page": "1"})
+    if not isinstance(head, list) or not head:
+        raise PulseError("default branch returned no commits")
+    committed = head[0].get("commit", {}).get("committer", {}).get("date")
+    if not committed:
+        raise PulseError("head commit carries no committer date")
+    return {
+        "commits_main_7d": count,
+        "days_since_last_commit": max((now - _parse_ts(committed)).days, 0),
+    }
+
+
+def _collect_release(client: GitHubClient, repo: str) -> dict[str, str]:
+    body, _ = client.get(f"repos/{repo}/releases/latest")
+    if not isinstance(body, dict) or not body.get("tag_name") or not body.get("published_at"):
+        raise PulseError("latest release payload is missing a tag or publication date")
+    return {"date": str(body["published_at"])[:10], "tag": str(body["tag_name"])}
+
+
+def _collect_adapters(repo_root: Path) -> dict[str, int]:
+    """Adapter counts from the registry, via the sources the README guards use.
+
+    ``_enumerate_rows`` backs ``bernstein integrations list``, and
+    ``selectable_adapter_names`` backs every ``--cli`` choice. Reading them
+    here means the page cannot claim a number the code does not back.
+    """
+    src = str((repo_root / "src").resolve())
+    if src not in sys.path:
+        sys.path.insert(0, src)
+    try:
+        from bernstein.adapters.registry import selectable_adapter_names
+        from bernstein.cli.commands.integrations_cmd import _enumerate_rows
+    except ImportError as exc:
+        raise PulseError(f"adapter registry is not importable from {src}: {exc}") from exc
+    return {"registered": len(_enumerate_rows()), "selectable": len(selectable_adapter_names())}
+
+
+def _configured_languages(repo_root: Path) -> list[str]:
+    data = tomllib.loads((repo_root / "pyproject.toml").read_text(encoding="utf-8"))
+    langs = data.get("tool", {}).get("bernstein", {}).get("readme-l10n", {}).get("languages", [])
+    if not isinstance(langs, list):
+        raise PulseError("[tool.bernstein.readme-l10n] languages is malformed")
+    return [str(lang) for lang in langs]
+
+
+def _collect_translations(repo_root: Path) -> dict[str, int]:
+    """Translated-README freshness, read off ``readme-l10n verify``.
+
+    That command is offline (it compares committed section hashes), so it runs
+    on a CI runner without network access to anything but the checkout. Exit 0
+    means every translation is in sync, exit 1 means at least one drifted; any
+    other exit is a broken tool, not a finding, and fails the collection.
+    """
+    total = len(_configured_languages(repo_root))
+    executable = shutil.which("bernstein")
+    command = [executable] if executable else [sys.executable, "-m", "bernstein"]
+    command += ["readme-l10n", "verify", "--workdir", str(repo_root)]
+    try:
+        proc = subprocess.run(command, capture_output=True, text=True, timeout=600, check=False)
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise PulseError(f"readme-l10n verify could not be run: {exc}") from exc
+    if proc.returncode not in (0, 1):
+        raise PulseError(f"readme-l10n verify exited {proc.returncode}: {proc.stderr.strip()[:300]}")
+    in_sync = sum(1 for line in proc.stdout.splitlines() if line.startswith("OK       docs/i18n/README."))
+    if proc.returncode == 0:
+        in_sync = total
+    return {"in_sync": in_sync, "stale": max(total - in_sync, 0), "total": total}
+
+
+def collect(client: GitHubClient, repo: str, repo_root: Path, now: datetime) -> dict[str, Any]:
+    """Gather every allow-listed field, or raise :class:`PulseError`."""
+    data: dict[str, Any] = {
+        "adapters": _collect_adapters(repo_root),
+        "generated_at": now.date().isoformat(),
+        "grabbable": _collect_grabbable(client, repo),
+        "latest_release": _collect_release(client, repo),
+        "readme_translations": _collect_translations(repo_root),
+        "repo": repo,
+        "windows": {
+            "commit_days": COMMIT_WINDOW_DAYS,
+            "issue_days": ISSUE_WINDOW_DAYS,
+            "outside_author_days": OUTSIDE_AUTHOR_WINDOW_DAYS,
+            "pr_days": PR_WINDOW_DAYS,
+        },
+    }
+    data.update(_collect_pull_requests(client, repo, now))
+    data.update(_collect_issues(client, repo, now))
+    data.update(_collect_commits(client, repo, now))
+    data["distinct_outside_authors"] = _collect_outside_authors(client, repo, now)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Rendering (pure)
+# ---------------------------------------------------------------------------
+
+
+def _hours(value: float | None) -> str:
+    """Format an hour count as a stable, human-readable duration."""
+    if value is None:
+        return "n/a"
+    if value < 1.0:
+        return f"{round(value * 60):d} min"
+    if value < 48.0:
+        return f"{value:.1f} h"
+    return f"{value / 24.0:.1f} d"
+
+
+def _pct(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.1f}%"
+
+
+def render(data: dict[str, Any]) -> str:
+    """Render *data* as Markdown. Pure: same input, byte-identical output."""
+    repo = str(data["repo"])
+    generated = str(data["generated_at"])
+    windows = data["windows"]
+    classes = data["merged_prs_by_author_class"]
+    grab = data["grabbable"]
+    adapters = data["adapters"]
+    release = data["latest_release"]
+    l10n = data["readme_translations"]
+    base = f"https://github.com/{repo}"
+    grabbable_query = f"{base}/issues?q=is%3Aissue+is%3Aopen+label%3Aup-for-grabs+no%3Aassignee"
+
+    lines: list[str] = [
+        "# Project pulse",
+        "",
+        f"Median time from pull request opened to merged over the last {windows['pr_days']} days: "
+        f"**{_hours(data['pr_merge_lag_hours_median'])}**.",
+        "",
+        f"[Issues that are free to pick up]({grabbable_query}) "
+        f"({grab['up_for_grabs_unassigned']} unassigned of {grab['up_for_grabs_open']} labelled up-for-grabs).",
+        "",
+        "## Review and merge",
+        "",
+        "| Metric | Value |",
+        "| --- | --- |",
+        f"| Median PR merge lag ({windows['pr_days']} d) | {_hours(data['pr_merge_lag_hours_median'])} |",
+        f"| Merged within 24 h ({windows['pr_days']} d) | {_pct(data['pr_merged_within_24h_pct'])} |",
+        f"| Merged PRs ({windows['pr_days']} d) | {data['pr_merged_count']} |",
+        f"| Median issue open to close ({windows['issue_days']} d) | {_hours(data['issue_close_lag_hours_median'])} |",
+        f"| Issues closed ({windows['issue_days']} d) | {data['issues_closed_count']} |",
+        "",
+        "## Who merges what",
+        "",
+        "Counts only, by account class. Outside contributions are everything that is neither the",
+        "maintainer account nor an automation account, so the outside number is never flattered.",
+        "",
+        "| Author class | Merged PRs |",
+        "| --- | --- |",
+        f"| Outside contributors | {classes[CLASS_OUTSIDE]} |",
+        f"| Maintainer | {classes[CLASS_MAINTAINER]} |",
+        f"| Automation | {classes[CLASS_AUTOMATION]} |",
+        "",
+        f"Distinct outside authors with a merged PR in the last {windows['outside_author_days']} days: "
+        f"**{data['distinct_outside_authors']}**.",
+        "",
+        "## Work you can pick up",
+        "",
+        "| Label | Open | Unassigned |",
+        "| --- | --- | --- |",
+        f"| up-for-grabs | {grab['up_for_grabs_open']} | {grab['up_for_grabs_unassigned']} |",
+        f"| good first issue | {grab['good_first_issue_open']} | {grab['good_first_issue_unassigned']} |",
+        "",
+        "## Project state",
+        "",
+        "| Metric | Value |",
+        "| --- | --- |",
+        f"| Commits to main ({windows['commit_days']} d) | {data['commits_main_7d']} |",
+        f"| Days since last commit | {data['days_since_last_commit']} |",
+        f"| Adapters in the registry | {adapters['registered']} wired in, {adapters['selectable']} selectable |",
+        f"| Latest release | {release['tag']} ({release['date']}) |",
+        f"| Translated READMEs | {l10n['in_sync']} in sync, {l10n['stale']} stale, of {l10n['total']} |",
+        "",
+        "---",
+        "",
+        f"Generated {generated} from the public GitHub API and this repository's own tree.",
+        "Aggregates only: no individual logins, no per-person ranking, no data that is not already public.",
+        "Regenerate with `scripts/project_pulse.py`; the field allow-list is documented at the top of that",
+        f"file and in [docs/project-pulse.md]({base}/blob/main/docs/project-pulse.md).",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _token() -> str:
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
+    if not token:
+        raise PulseError("GH_TOKEN or GITHUB_TOKEN must be set")
+    return token
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="stage", required=True)
+
+    collect_parser = sub.add_parser("collect", help="query the public API and write pulse.json")
+    collect_parser.add_argument("--repo", required=True, help="OWNER/NAME")
+    collect_parser.add_argument("--out", required=True, type=Path, help="path to write pulse.json")
+    collect_parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="repository checkout used for the adapter and translation counts",
+    )
+
+    render_parser = sub.add_parser("render", help="render a collected pulse.json to Markdown on stdout")
+    render_parser.add_argument("input", type=Path, help="path to a pulse.json produced by `collect`")
+
+    args = parser.parse_args(argv)
+    try:
+        if args.stage == "collect":
+            data = collect(GitHubClient(_token()), args.repo, args.repo_root.resolve(), datetime.now(tz=UTC))
+            # Written only after every field is in hand, so an aborted run
+            # leaves no half-collected file for `render` to publish.
+            args.out.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            print(f"collected {len(data)} fields for {args.repo} -> {args.out}", file=sys.stderr)
+        else:
+            sys.stdout.write(render(json.loads(args.input.read_text(encoding="utf-8"))))
+    except PulseError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/fixtures/ci/project_pulse.json
+++ b/tests/fixtures/ci/project_pulse.json
@@ -1,0 +1,42 @@
+{
+  "adapters": {
+    "registered": 54,
+    "selectable": 52
+  },
+  "commits_main_7d": 340,
+  "days_since_last_commit": 0,
+  "distinct_outside_authors": 7,
+  "generated_at": "2026-09-02",
+  "grabbable": {
+    "good_first_issue_open": 6,
+    "good_first_issue_unassigned": 5,
+    "up_for_grabs_open": 25,
+    "up_for_grabs_unassigned": 23
+  },
+  "issue_close_lag_hours_median": 6.5,
+  "issues_closed_count": 614,
+  "latest_release": {
+    "date": "2026-08-31",
+    "tag": "v3.19.0"
+  },
+  "merged_prs_by_author_class": {
+    "automation": 61,
+    "maintainer": 920,
+    "outside": 11
+  },
+  "pr_merge_lag_hours_median": 3.4,
+  "pr_merged_count": 992,
+  "pr_merged_within_24h_pct": 88.2,
+  "readme_translations": {
+    "in_sync": 23,
+    "stale": 0,
+    "total": 23
+  },
+  "repo": "sipyourdrink-ltd/bernstein",
+  "windows": {
+    "commit_days": 7,
+    "issue_days": 30,
+    "outside_author_days": 90,
+    "pr_days": 30
+  }
+}

--- a/tests/unit/test_project_pulse.py
+++ b/tests/unit/test_project_pulse.py
@@ -1,0 +1,281 @@
+"""Unit tests for ``scripts/project_pulse.py``.
+
+Three properties carry the weight here, because the page is published
+unattended every week into an issue everyone can read:
+
+* ``render`` is a pure function -- identical input, byte-identical output.
+  The weekly job upserts one issue body, so a renderer that reorders a dict
+  or formats a float differently would rewrite the body on every run and
+  bury real movement in the noise.
+* ``collect`` fails closed. A page built from a partly-failed collection
+  would publish zeros that read as "quiet week" instead of "the query
+  broke", so any API failure must abort with a non-zero exit and leave no
+  output file behind.
+* The rendered page carries aggregates only: no individual logins beyond the
+  two documented account labels, and no e-mail addresses.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import itertools
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SPEC = importlib.util.spec_from_file_location("project_pulse", _REPO_ROOT / "scripts" / "project_pulse.py")
+assert _SPEC is not None and _SPEC.loader is not None
+_MOD = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MOD)
+
+FIXTURE = _REPO_ROOT / "tests" / "fixtures" / "ci" / "project_pulse.json"
+
+#: The only account labels the page is allowed to name. Everything else is a
+#: count. Keep in step with the allow-list at the top of the script.
+DOCUMENTED_ACCOUNTS = frozenset({"chernistry", "bernstein-orchestrator"})
+
+_LOGIN_RE = re.compile(r"@([A-Za-z0-9](?:[A-Za-z0-9-]{0,38}))")
+_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+
+
+def _fixture() -> dict[str, Any]:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_render_is_byte_identical_across_calls() -> None:
+    """Two renders of the same input produce the same bytes."""
+    first = _MOD.render(_fixture())
+    second = _MOD.render(_fixture())
+    assert first.encode("utf-8") == second.encode("utf-8")
+
+
+def test_render_ignores_key_insertion_order() -> None:
+    """A re-ordered JSON object renders identically.
+
+    ``collect`` writes with ``sort_keys=True``, but a hand-edited or
+    re-serialised ``pulse.json`` must not change the page either.
+    """
+    data = _fixture()
+    shuffled = dict(reversed(list(data.items())))
+    assert _MOD.render(shuffled) == _MOD.render(data)
+
+
+def test_render_carries_no_timestamp_beyond_the_collected_date() -> None:
+    """No clock read leaks into the page; only ``generated_at`` dates it."""
+    page = _MOD.render(_fixture())
+    assert "2026-09-02" in page
+    assert not re.search(r"\d{2}:\d{2}:\d{2}", page), "a wall-clock time would change the body on every run"
+
+
+def test_headline_states_the_median_merge_lag_and_links_grabbable_issues() -> None:
+    """The page answers 'will my PR be reviewed?' before anything else."""
+    page = _MOD.render(_fixture())
+    headline = page.split("\n\n")[1]
+    assert "Median time from pull request opened to merged" in headline
+    assert "is%3Aissue+is%3Aopen+label%3Aup-for-grabs+no%3Aassignee" in page
+
+
+def test_absent_medians_render_as_not_available_rather_than_zero() -> None:
+    """An empty window must not read as an instant review turnaround."""
+    data = _fixture()
+    data["pr_merge_lag_hours_median"] = None
+    data["pr_merged_within_24h_pct"] = None
+    data["issue_close_lag_hours_median"] = None
+    page = _MOD.render(data)
+    assert "n/a" in page
+    assert "0.0 h" not in page
+
+
+# ---------------------------------------------------------------------------
+# Privacy: aggregates only
+# ---------------------------------------------------------------------------
+
+
+def test_rendered_page_names_no_undocumented_account() -> None:
+    """No ``@login`` other than the two documented account labels."""
+    page = _MOD.render(_fixture())
+    found = {match.lower() for match in _LOGIN_RE.findall(page)}
+    assert found <= DOCUMENTED_ACCOUNTS, f"page names undocumented account(s): {sorted(found - DOCUMENTED_ACCOUNTS)}"
+
+
+def test_rendered_page_carries_no_email_address() -> None:
+    page = _MOD.render(_fixture())
+    assert not _EMAIL_RE.findall(page)
+
+
+def test_collected_fields_stay_inside_the_allow_list() -> None:
+    """The fixture -- and therefore ``collect``'s shape -- adds no field.
+
+    A new top-level key means someone widened what gets published without
+    widening the allow-list comment the page's privacy claim rests on.
+    """
+    expected = {
+        "adapters",
+        "commits_main_7d",
+        "days_since_last_commit",
+        "distinct_outside_authors",
+        "generated_at",
+        "grabbable",
+        "issue_close_lag_hours_median",
+        "issues_closed_count",
+        "latest_release",
+        "merged_prs_by_author_class",
+        "pr_merge_lag_hours_median",
+        "pr_merged_count",
+        "pr_merged_within_24h_pct",
+        "readme_translations",
+        "repo",
+        "windows",
+    }
+    assert set(_fixture()) == expected
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed collection
+# ---------------------------------------------------------------------------
+
+
+class _FailingClient:
+    """HTTP layer that fails on the *n*-th call, mimicking a flaky API."""
+
+    def __init__(self, fail_after: int = 0) -> None:
+        self.calls = 0
+        self._fail_after = fail_after
+
+    def get(self, path: str, params: dict[str, str] | None = None) -> tuple[Any, dict[str, str]]:
+        self.calls += 1
+        if self.calls > self._fail_after:
+            raise _MOD.PulseError(f"GitHub API 503 for {path}")
+        return {"total_count": 0, "items": []}, {}
+
+
+def test_collect_raises_on_the_first_api_failure(tmp_path: Path) -> None:
+    with pytest.raises(_MOD.PulseError):
+        _MOD.collect(_FailingClient(), "owner/name", _REPO_ROOT, _MOD.datetime.now(tz=_MOD.UTC))
+    assert not list(tmp_path.iterdir())
+
+
+def test_collect_stage_exits_non_zero_and_writes_nothing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CLI surface, not just the function: no partial page on failure."""
+    out = tmp_path / "pulse.json"
+    monkeypatch.setenv("GH_TOKEN", "test-token")
+    monkeypatch.setattr(_MOD, "GitHubClient", lambda *_a, **_kw: _FailingClient())
+    rc = _MOD.main(["collect", "--repo", "owner/name", "--out", str(out), "--repo-root", str(_REPO_ROOT)])
+    assert rc == 2
+    assert not out.exists(), "a failed collection must not leave a half-written pulse.json"
+
+
+def test_collect_requires_a_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    out = tmp_path / "pulse.json"
+    assert _MOD.main(["collect", "--repo", "owner/name", "--out", str(out)]) == 2
+    assert not out.exists()
+
+
+def test_search_refuses_to_truncate_at_the_api_result_cap() -> None:
+    """A window wider than the API can enumerate is an error, not a short list.
+
+    Silently returning the first 1000 of 1500 merged PRs would report a
+    median computed on an arbitrary subset.
+    """
+
+    class _OverCapClient:
+        def get(self, path: str, params: dict[str, str] | None = None) -> tuple[Any, dict[str, str]]:
+            return {"total_count": _MOD.SEARCH_RESULT_CAP + 1, "items": []}, {}
+
+    with pytest.raises(_MOD.PulseError, match="result API cap"):
+        _MOD._search_items(_OverCapClient(), "repo:owner/name is:pr is:merged")
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("user", "expected"),
+    [
+        ({"login": "bernstein-orchestrator[bot]", "type": "Bot"}, "automation"),
+        ({"login": "dependabot[bot]", "type": "Bot"}, "automation"),
+        ({"login": "chernistry", "type": "User"}, "maintainer"),
+        ({"login": "a-first-time-contributor", "type": "User"}, "outside"),
+    ],
+)
+def test_author_class(user: dict[str, str], expected: str) -> None:
+    """Any bot lands in automation, so 'outside' is never inflated by one."""
+    assert _MOD._author_class(user) == expected
+
+
+def test_slices_cover_the_window_without_gaps_or_overlap() -> None:
+    """Sliced search windows must tile the period exactly once."""
+    now = _MOD.datetime(2026, 9, 2, 11, 30, tzinfo=_MOD.UTC)
+    slices = _MOD._slices(now, 30)
+    assert slices[0][0] == "2026-08-03"
+    assert slices[-1][1] == "2026-09-02"
+    for (_, prev_end), (next_start, _) in itertools.pairwise(slices):
+        expected = _MOD.datetime.strptime(prev_end, "%Y-%m-%d") + _MOD.timedelta(days=1)
+        assert next_start == expected.date().isoformat()
+
+
+def test_slices_do_not_depend_on_the_hour_of_the_run() -> None:
+    morning = _MOD._slices(_MOD.datetime(2026, 9, 2, 3, 0, tzinfo=_MOD.UTC), 30)
+    evening = _MOD._slices(_MOD.datetime(2026, 9, 2, 23, 0, tzinfo=_MOD.UTC), 30)
+    assert morning == evening
+
+
+# ---------------------------------------------------------------------------
+# Workflow shape
+# ---------------------------------------------------------------------------
+
+WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "project-pulse.yml"
+
+
+def _workflow() -> dict[str, Any]:
+    yaml = pytest.importorskip("yaml")
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(doc, dict), "project-pulse.yml is not a mapping"
+    return doc
+
+
+def test_workflow_runs_weekly_and_on_demand() -> None:
+    triggers = _workflow().get(True, _workflow().get("on"))
+    assert isinstance(triggers, dict)
+    assert "workflow_dispatch" in triggers
+    cron = str(triggers["schedule"][0]["cron"])
+    assert cron.split()[-1] != "*", f"cron {cron!r} fires daily, not weekly"
+
+
+def test_workflow_asks_for_no_more_than_it_needs() -> None:
+    """Default-deny at the top, read + issues:write on the one job."""
+    doc = _workflow()
+    assert doc["permissions"] == {}
+    assert doc["jobs"]["pulse"]["permissions"] == {"contents": "read", "issues": "write"}
+
+
+def test_workflow_uses_only_the_built_in_token() -> None:
+    """No new secret: the page is built from public data."""
+    assert "secrets." not in WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_workflow_does_not_commit_the_generated_page() -> None:
+    """Generated output is upserted into an issue and uploaded, never pushed."""
+    body = WORKFLOW.read_text(encoding="utf-8")
+    assert "git push" not in body
+    assert "git commit" not in body
+    assert "upload-artifact" in body
+
+
+def test_documented_page_exists_and_is_in_the_nav() -> None:
+    doc_path = _REPO_ROOT / "docs" / "project-pulse.md"
+    assert doc_path.is_file()
+    assert "project-pulse.md" in (_REPO_ROOT / "mkdocs.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
Contributors cannot see this project's review latency before they open a pull request, so the decision to contribute is made blind.

Adds `scripts/project_pulse.py`, which publishes ten public aggregates weekly into one rolling issue: median PR merge lag, 24-hour share, merged PRs by author class, distinct outside authors, issue close lag, grabbable-issue counts, commit volume, adapter registry size, latest release, translated-README freshness.

`collect` fails closed - any API error exits non-zero and writes no file, so a broken query cannot publish zeros that read as a quiet week. `render` is a pure function of `pulse.json`, byte-identical for identical input, so the weekly upsert does not thrash the issue body.

Aggregates only: no individual logins, no e-mail addresses, no per-person ranking. The published field allow-list is a comment block at the top of the script, with unit tests asserting the rendered page names no account and carries no address.

Publication follows the existing weekly-digest mechanism: `GITHUB_TOKEN` only, no new secret, idempotent issue upsert plus a workflow artifact, nothing committed to `main`.
