### PR TITLE
feat: provision and deprovision agent principals through the standard directory schema (#4972)

### DIFF
--- a/docs/release-notes/fragments/4972-provision-deprovision-principals.md
+++ b/docs/release-notes/fragments/4972-provision-deprovision-principals.md
@@ -1,0 +1,11 @@
+## Agent principals gain a documented provisioning and deprovisioning lifecycle
+
+Scoped per-task grants are now bound to an agent principal that has a signed,
+HMAC-chained lifecycle record. Provisioning and deprovisioning are append-only
+chain events; a principal that has been deprovisioned ends any grant whose
+`principal` field names it, and a grant that names a principal with no chain
+record at all is refused. Existing grant records (those written before this
+change) are unaffected — their `principal` field is empty and the principal
+chain is consulted only when it is present. The SCIM 2.0 directory adapter
+(`bernstein.adapters.directory.scim`) maps standard provisioning resources
+onto the lifecycle API. (#4972)

--- a/docs/sdd/module-map.md
+++ b/docs/sdd/module-map.md
@@ -190,6 +190,7 @@ Full per-file module map. `AGENTS.md`'s own "Module map" section links here inst
 | `use_cases.py`              | Per-adapter metadata for the ``bernstein integrations list`` command |
 | `ci/`                       | CI system adapters for log parsing and failure extraction |
 | `digest/`                   | Tool output digesters registry and ruleset models |
+| `directory/`                | Directory provisioning adapters |
 
 ### `src/bernstein/agents/` - agent catalog & discovery
 

--- a/src/bernstein/adapters/directory/__init__.py
+++ b/src/bernstein/adapters/directory/__init__.py
@@ -1,0 +1,10 @@
+"""Directory provisioning adapters.
+
+The mapping from an external directory's provisioning resources onto Bernstein
+agent principals lives here, outside ``bernstein.core``: core owns the
+principal lifecycle chain and knows nothing about directories.
+"""
+
+from bernstein.adapters.directory import scim
+
+__all__ = ["scim"]

--- a/src/bernstein/adapters/directory/scim.py
+++ b/src/bernstein/adapters/directory/scim.py
@@ -27,7 +27,7 @@ the caller owns the transport and hands this module the decoded resource.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, cast
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
@@ -81,7 +81,8 @@ def _ceiling(groups: Iterable[Any]) -> tuple[str, ...]:
         if isinstance(entry, str):
             name = entry.strip()
         elif isinstance(entry, dict):
-            name = _text(entry, "display") or _text(entry, "value")
+            member = cast("Mapping[str, Any]", entry)
+            name = _text(member, "display") or _text(member, "value")
         else:  # pragma: no cover - defensive
             name = ""
         if name:
@@ -106,13 +107,12 @@ def principal_from_user(resource: Mapping[str, Any]) -> DirectoryPrincipal:
     if not principal_id:
         raise DirectorySchemaError("SCIM User resource carries no userName, externalId, or id")
     groups = resource.get("groups")
-    active = resource.get("active", True)
     return DirectoryPrincipal(
         principal_id=principal_id,
         external_id=_text(resource, "externalId"),
         display_name=_text(resource, "displayName"),
-        capability_ceiling=_ceiling(groups if isinstance(groups, list) else ()),
-        active=bool(active),
+        capability_ceiling=_ceiling(cast("list[Any]", groups) if isinstance(groups, list) else ()),
+        active=bool(resource.get("active", True)),
     )
 
 
@@ -134,9 +134,10 @@ def principals_in_group(resource: Mapping[str, Any]) -> tuple[str, ...]:
     if not isinstance(members, list):
         return ()
     out: list[str] = []
-    for member in members:
-        if not isinstance(member, dict):
+    for entry in cast("list[Any]", members):
+        if not isinstance(entry, dict):
             continue
+        member = cast("Mapping[str, Any]", entry)
         name = _text(member, "display") or _text(member, "value")
         if name and name not in out:
             out.append(name)

--- a/src/bernstein/adapters/directory/scim.py
+++ b/src/bernstein/adapters/directory/scim.py
@@ -1,0 +1,191 @@
+"""SCIM 2.0 provisioning resources mapped onto agent principals (issue #4972).
+
+An agent that outlives its purpose keeps its grants. Directories solved that
+for humans with provisioning and deprovisioning; the mechanism transfers, and
+the identity it operates on is ours. This adapter is the whole translation
+layer: it turns the standard provisioning resources of RFC 7643 into calls on
+:class:`bernstein.core.identity.principals.PrincipalLedger`.
+
+Mapping
+-------
+
+======================  ==========================================
+SCIM ``User``           Bernstein principal
+``userName``            ``principal_id`` (falls back to ``externalId``, ``id``)
+``externalId``          ``external_id`` (the directory's own id)
+``displayName``         ``display_name``
+``groups[].display``    one capability each, sorted and de-duplicated
+``active``              ``true`` provisions, ``false`` deprovisions
+======================  ==========================================
+
+A SCIM ``Group`` is a capability: its ``displayName`` is the capability name
+and its ``members`` are the principals that hold it. No third schema is
+introduced, no vendor SDK is imported, and nothing here reaches the network --
+the caller owns the transport and hands this module the decoded resource.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+    from bernstein.core.identity.principals import PrincipalLedger, PrincipalReceipt
+
+__all__ = [
+    "GROUP_SCHEMA",
+    "USER_SCHEMA",
+    "DirectoryPrincipal",
+    "DirectorySchemaError",
+    "apply_user",
+    "capability_from_group",
+    "deprovision_user",
+    "principal_from_user",
+    "principals_in_group",
+]
+
+#: RFC 7643 core resource schema URIs.
+USER_SCHEMA: Final[str] = "urn:ietf:params:scim:schemas:core:2.0:User"
+GROUP_SCHEMA: Final[str] = "urn:ietf:params:scim:schemas:core:2.0:Group"
+
+#: Reason recorded when the directory deactivates or deletes the user.
+DEACTIVATED_REASON: Final[str] = "directory_deactivated"
+
+
+class DirectorySchemaError(ValueError):
+    """Raised when a provisioning resource cannot be mapped onto a principal."""
+
+
+@dataclass(frozen=True)
+class DirectoryPrincipal:
+    """A SCIM ``User`` resource expressed in Bernstein's principal vocabulary."""
+
+    principal_id: str
+    external_id: str
+    display_name: str
+    capability_ceiling: tuple[str, ...]
+    active: bool
+
+
+def _text(resource: Mapping[str, Any], key: str) -> str:
+    value = resource.get(key)
+    return str(value).strip() if isinstance(value, str | int) else ""
+
+
+def _ceiling(groups: Iterable[Any]) -> tuple[str, ...]:
+    """Return the sorted, de-duplicated capability names the groups imply."""
+    names: set[str] = set()
+    for entry in groups:
+        if isinstance(entry, str):
+            name = entry.strip()
+        elif isinstance(entry, dict):
+            name = _text(entry, "display") or _text(entry, "value")
+        else:  # pragma: no cover - defensive
+            name = ""
+        if name:
+            names.add(name)
+    return tuple(sorted(names))
+
+
+def principal_from_user(resource: Mapping[str, Any]) -> DirectoryPrincipal:
+    """Map a SCIM ``User`` resource onto a :class:`DirectoryPrincipal`.
+
+    Args:
+        resource: The decoded SCIM ``User`` resource.
+
+    Returns:
+        The principal the resource describes, with the capability ceiling its
+        group memberships imply.
+
+    Raises:
+        DirectorySchemaError: The resource carries no usable identifier.
+    """
+    principal_id = _text(resource, "userName") or _text(resource, "externalId") or _text(resource, "id")
+    if not principal_id:
+        raise DirectorySchemaError("SCIM User resource carries no userName, externalId, or id")
+    groups = resource.get("groups")
+    active = resource.get("active", True)
+    return DirectoryPrincipal(
+        principal_id=principal_id,
+        external_id=_text(resource, "externalId"),
+        display_name=_text(resource, "displayName"),
+        capability_ceiling=_ceiling(groups if isinstance(groups, list) else ()),
+        active=bool(active),
+    )
+
+
+def capability_from_group(resource: Mapping[str, Any]) -> str:
+    """Return the capability name a SCIM ``Group`` resource stands for.
+
+    Raises:
+        DirectorySchemaError: The group carries neither ``displayName`` nor ``id``.
+    """
+    name = _text(resource, "displayName") or _text(resource, "id")
+    if not name:
+        raise DirectorySchemaError("SCIM Group resource carries no displayName or id")
+    return name
+
+
+def principals_in_group(resource: Mapping[str, Any]) -> tuple[str, ...]:
+    """Return the principal ids the group's ``members`` name, in resource order."""
+    members = resource.get("members")
+    if not isinstance(members, list):
+        return ()
+    out: list[str] = []
+    for member in members:
+        if not isinstance(member, dict):
+            continue
+        name = _text(member, "display") or _text(member, "value")
+        if name and name not in out:
+            out.append(name)
+    return tuple(out)
+
+
+def apply_user(
+    ledger: PrincipalLedger,
+    resource: Mapping[str, Any],
+    *,
+    created: int | None = None,
+) -> PrincipalReceipt:
+    """Record the lifecycle event a SCIM ``User`` resource implies.
+
+    ``active: true`` (the RFC default) appends a ``principal_provisioned``
+    record carrying the ceiling the directory implies; ``active: false``
+    appends a ``principal_deprovisioned`` record, which is what the grant
+    validity path consults from then on.
+
+    Args:
+        ledger: The principal ledger to append to.
+        resource: The decoded SCIM ``User`` resource.
+        created: Optional unix timestamp (exposed for deterministic tests).
+
+    Returns:
+        The appended :class:`~bernstein.core.identity.principals.PrincipalReceipt`;
+        its ``kind`` is :data:`~bernstein.core.identity.principals.PRINCIPAL_PROVISIONED`
+        or :data:`~bernstein.core.identity.principals.PRINCIPAL_DEPROVISIONED`.
+    """
+    principal = principal_from_user(resource)
+    if not principal.active:
+        return deprovision_user(ledger, principal.principal_id, created=created)
+    return ledger.provision(
+        principal_id=principal.principal_id,
+        display_name=principal.display_name,
+        capability_ceiling=principal.capability_ceiling,
+        external_id=principal.external_id,
+        created=created,
+    )
+
+
+def deprovision_user(
+    ledger: PrincipalLedger,
+    principal_id: str,
+    *,
+    reason: str = DEACTIVATED_REASON,
+    created: int | None = None,
+) -> PrincipalReceipt:
+    """Record the deprovision a SCIM delete (or deactivation) implies."""
+    if not principal_id:
+        raise DirectorySchemaError("cannot deprovision without a principal id")
+    return ledger.deprovision(principal_id=principal_id, reason=reason, created=created)

--- a/src/bernstein/core/identity/grants.py
+++ b/src/bernstein/core/identity/grants.py
@@ -77,6 +77,8 @@ from typing import TYPE_CHECKING, Any, Final
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from bernstein.core.identity.principals import PrincipalChainResult
+
 __all__ = [
     "DEFAULT_ROOT",
     "GENESIS_HMAC",
@@ -344,6 +346,11 @@ class GrantReceipt:
     issuer: str
     issuer_pubkey: str
     created: int
+    #: The agent principal the grant is issued to. Empty on records written
+    #: before principals existed; a non-empty value binds the grant's validity
+    #: to that principal's lifecycle (see
+    #: :mod:`bernstein.core.identity.principals`).
+    principal: str = ""
     token_id: str = ""
     reason: str = ""
     prev_hmac: str = GENESIS_HMAC
@@ -364,6 +371,7 @@ class GrantReceipt:
             "capability_ceiling": list(self.capability_ceiling),
             "issuer": self.issuer,
             "issuer_pubkey": self.issuer_pubkey,
+            "principal": self.principal,
             "token_id": self.token_id,
             "reason": self.reason,
             "created": self.created,
@@ -398,6 +406,7 @@ class GrantReceipt:
             issuer=str(obj["issuer"]),
             issuer_pubkey=str(obj["issuer_pubkey"]),
             created=int(obj["created"]),
+            principal=str(obj.get("principal", "")),
             token_id=str(obj.get("token_id", "")),
             reason=str(obj.get("reason", "")),
             prev_hmac=str(obj.get("prev_hmac", GENESIS_HMAC)),
@@ -478,6 +487,7 @@ class GrantLedger:
         token_id: str,
         reason: str,
         created: int | None,
+        principal: str = "",
     ) -> GrantReceipt:
         if kind not in _KINDS:  # pragma: no cover - defensive
             raise GrantError(f"unknown grant record kind {kind!r}")
@@ -499,6 +509,7 @@ class GrantLedger:
             "capability_ceiling": sorted(capability_ceiling),
             "issuer": self._signer.issuer,
             "issuer_pubkey": self._signer.public_key_pem,
+            "principal": principal,
             "token_id": token_id,
             "reason": reason,
             "created": ts,
@@ -526,6 +537,7 @@ class GrantLedger:
         capability_ceiling: Sequence[str] = (),
         grant_id: str | None = None,
         created: int | None = None,
+        principal: str = "",
     ) -> GrantReceipt:
         """Issue a scoped grant and append it as a ``grant_issued`` record.
 
@@ -538,6 +550,9 @@ class GrantLedger:
             capability_ceiling: Symbolic capability names the grant caps.
             grant_id: Optional explicit id (defaults to a fresh uuid4 hex).
             created: Optional unix timestamp (exposed for deterministic tests).
+            principal: Optional agent principal the grant is issued to. When
+                set, the grant stays valid only while that principal is
+                provisioned (:mod:`bernstein.core.identity.principals`).
 
         Returns:
             The freshly-appended :class:`GrantReceipt`.
@@ -554,6 +569,7 @@ class GrantLedger:
             token_id="",
             reason="",
             created=created,
+            principal=principal,
         )
 
     def record_exchange(
@@ -647,6 +663,10 @@ class GrantChainResult:
     valid: bool
     records: list[GrantReceipt] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
+    #: The principal lifecycle chain rooted beside this run's grant chain.
+    #: :func:`verify_grant_chain` fills it in, so the validity path below
+    #: reads deprovisioning as a chain fact rather than an out-of-band flag.
+    principals: PrincipalChainResult | None = None
 
     def lifecycles(self) -> dict[str, dict[str, Any]]:
         """Reconstruct each grant's issue/exchange/revoke state from the records."""
@@ -661,6 +681,7 @@ class GrantChainResult:
                     "secret_name": "",
                     "audience": "",
                     "expiry": 0,
+                    "principal": "",
                     "issued": False,
                     "revoked": False,
                     "token_ids": [],
@@ -673,6 +694,7 @@ class GrantChainResult:
                 state["secret_name"] = r.secret_name
                 state["audience"] = r.audience
                 state["expiry"] = r.expiry
+                state["principal"] = r.principal
             elif r.kind == GRANT_EXCHANGED and r.token_id:
                 state["token_ids"].append(r.token_id)
             elif r.kind == GRANT_REVOKED:
@@ -698,13 +720,18 @@ def verify_grant_chain(*, root: Path, run_id: str, key: bytes) -> GrantChainResu
 
     Returns:
         A :class:`GrantChainResult`. ``valid`` is True only when at least one
-        record exists and the whole chain verifies from genesis to tail.
+        record exists and the whole chain verifies from genesis to tail. The
+        principal lifecycle chain rooted at ``root`` rides along on
+        :attr:`GrantChainResult.principals` so that
+        :func:`find_active_grant` can read deprovisioning off the chain.
     """
     ledger_dir = Path(root) / _SUBDIR
     safe = run_id.replace("/", "_").replace("\\", "_")
     path = ledger_dir / f"{safe}.jsonl"
     if not path.is_file():
         return GrantChainResult(valid=False, records=[], errors=["no grant records for run"])
+
+    principals = _principal_chain(root, key)
 
     records: list[GrantReceipt] = []
     errors: list[str] = []
@@ -736,7 +763,7 @@ def verify_grant_chain(*, root: Path, run_id: str, key: bytes) -> GrantChainResu
         prev_hmac = stored_hmac
 
     valid = not errors and len(records) > 0
-    return GrantChainResult(valid=valid, records=records, errors=errors)
+    return GrantChainResult(valid=valid, records=records, errors=errors, principals=principals)
 
 
 def render_report(result: GrantChainResult, *, run_id: str) -> str:
@@ -762,6 +789,7 @@ def render_report(result: GrantChainResult, *, run_id: str) -> str:
                 "expiry": r.expiry,
                 "capability_ceiling": list(r.capability_ceiling),
                 "issuer": r.issuer,
+                "principal": r.principal,
                 "token_id": r.token_id,
                 "reason": r.reason,
             }
@@ -769,6 +797,27 @@ def render_report(result: GrantChainResult, *, run_id: str) -> str:
         ],
     }
     return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def _principal_chain(root: Path, key: bytes) -> PrincipalChainResult:
+    """Return the principal lifecycle chain rooted beside the grant chain."""
+    from bernstein.core.identity.principals import verify_principal_chain
+
+    return verify_principal_chain(root=Path(root), key=key)
+
+
+def _principal_permits(principals: PrincipalChainResult | None, principal_id: str, now: float) -> bool:
+    """Return whether ``principal_id`` may back a grant at ``now``.
+
+    Fail-closed: a grant that names a principal is refused unless a verifying
+    chain says that principal was provisioned and not yet deprovisioned at
+    ``now``. Deleting the principal journal therefore denies the grant instead
+    of resurrecting it.
+    """
+    if principals is None or not principals.valid:
+        return False
+    state = principals.registry().get(principal_id)
+    return state is not None and state.active_at(now)
 
 
 def find_active_grant(
@@ -780,9 +829,11 @@ def find_active_grant(
 ) -> GrantReceipt | None:
     """Return the newest verified grant for ``(task_id, secret_name)`` still active.
 
-    A grant is active when it was issued, is not revoked in the chain, and has
-    either no expiry or an expiry in the future. Returns ``None`` if the chain
-    did not verify or no matching active grant exists.
+    A grant is active when it was issued, is not revoked in the chain, has
+    either no expiry or an expiry in the future, and -- when it names an agent
+    principal -- that principal is provisioned and not deprovisioned at
+    ``now`` according to :attr:`GrantChainResult.principals`. Returns ``None``
+    if the chain did not verify or no matching active grant exists.
     """
     if not result.valid:
         return None
@@ -804,6 +855,11 @@ def find_active_grant(
             continue
         candidate = issued.get(grant_id)
         if candidate is None:
+            continue
+        # A grant bound to an agent principal is only as alive as the
+        # principal: a deprovision record at or before `current` ends it, and
+        # so does a principal the chain cannot account for.
+        if candidate.principal and not _principal_permits(result.principals, candidate.principal, current):
             continue
         if best is None or candidate.record_index > best.record_index:
             best = candidate

--- a/src/bernstein/core/identity/principals.py
+++ b/src/bernstein/core/identity/principals.py
@@ -1,0 +1,475 @@
+"""Chain-anchored agent-principal provisioning and deprovisioning (issue #4972).
+
+Scoped per-task grants (:mod:`bernstein.core.identity.grants`) bound what a
+single task can do, but they never removed the *principal* the grants were
+issued to. An install that has run for months therefore accumulates agent
+principals nobody can account for, each still able to back a fresh grant.
+
+This module gives a principal the same two-anchor lifecycle a grant already
+has. Provisioning and deprovisioning are records in an append-only,
+HMAC-chained, Ed25519-signed journal:
+
+* the **Ed25519 signature** by the manager identity proves who drew the line;
+* the **HMAC** over ``prev_hmac`` plus the canonical record body, keyed by the
+  install audit key, makes deletion, mutation, and reordering visible.
+
+The journal *is* the registry: :meth:`PrincipalChainResult.registry` replays it
+into the current set of principals and the capability ceiling each one carries.
+There is no separate mutable table that could disagree with the chain.
+
+Finality
+--------
+Deprovisioning is consulted by the grant-validity path itself
+(:func:`bernstein.core.identity.grants.find_active_grant`), not by an
+out-of-band flag: after a ``principal_deprovisioned`` record at time ``T``, no
+check performed at or after ``T`` returns a grant bound to that principal, and
+a grant whose principal has no ``principal_provisioned`` record at all is
+refused rather than waved through. Deprovisioning is *not* retroactive: a check
+against a moment inside the window the grant covered still returns it, and the
+grant's own signature and linkage stay valid forever.
+
+Record shape
+------------
+One JSONL line per record under ``<root>/principals/<scope>.jsonl``::
+
+    {
+      "scope": "install",
+      "record_index": 0,
+      "kind": "principal_provisioned",   # provisioned | deprovisioned
+      "principal_id": "agent:nightly-refactor",
+      "external_id": "dir-9911",         # the directory's own id, if any
+      "display_name": "Nightly refactor agent",
+      "capability_ceiling": ["list", "read"],
+      "issuer": "manager:...",
+      "issuer_pubkey": "-----BEGIN PUBLIC KEY----- ...",
+      "reason": "",                      # set on deprovision
+      "created": 1730000000,
+      "prev_hmac": "<hex>",
+      "signature": "<hex ed25519>",
+      "hmac": "<hex hmac>"
+    }
+"""
+
+from __future__ import annotations
+
+import hmac as _hmac
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final
+
+from bernstein.core.identity.grants import (
+    GENESIS_HMAC,
+    GrantSigner,
+    _compute_hmac,
+    verify_grant_signature,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+__all__ = [
+    "DEFAULT_SCOPE",
+    "GENESIS_HMAC",
+    "PRINCIPAL_DEPROVISIONED",
+    "PRINCIPAL_PROVISIONED",
+    "PrincipalChainResult",
+    "PrincipalError",
+    "PrincipalLedger",
+    "PrincipalReceipt",
+    "PrincipalState",
+    "default_principal_ledger",
+    "verify_principal_chain",
+]
+
+#: Record kinds. Both are chain events; there is no in-place mutation.
+PRINCIPAL_PROVISIONED: Final[str] = "principal_provisioned"
+PRINCIPAL_DEPROVISIONED: Final[str] = "principal_deprovisioned"
+
+_KINDS: Final[frozenset[str]] = frozenset({PRINCIPAL_PROVISIONED, PRINCIPAL_DEPROVISIONED})
+
+_SUBDIR: Final[str] = "principals"
+
+#: Principals outlive runs, so the journal is scoped to the install rather than
+#: to a run id the way the grant journal is.
+DEFAULT_SCOPE: Final[str] = "install"
+
+
+class PrincipalError(Exception):
+    """Raised when a principal record cannot be signed or recorded."""
+
+
+def _safe_scope(scope: str) -> str:
+    return scope.replace("/", "_").replace("\\", "_")
+
+
+# ---------------------------------------------------------------------------
+# Principal receipt
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PrincipalReceipt:
+    """A single chain-anchored, Ed25519-signed principal-lifecycle record."""
+
+    scope: str
+    record_index: int
+    kind: str
+    principal_id: str
+    external_id: str
+    display_name: str
+    capability_ceiling: tuple[str, ...]
+    issuer: str
+    issuer_pubkey: str
+    created: int
+    reason: str = ""
+    prev_hmac: str = GENESIS_HMAC
+    signature: str = ""
+    hmac: str = ""
+
+    def signed_body(self) -> dict[str, Any]:
+        """Return the canonical body the manager signs (chain-state-free)."""
+        return {
+            "scope": self.scope,
+            "record_index": self.record_index,
+            "kind": self.kind,
+            "principal_id": self.principal_id,
+            "external_id": self.external_id,
+            "display_name": self.display_name,
+            "capability_ceiling": list(self.capability_ceiling),
+            "issuer": self.issuer,
+            "issuer_pubkey": self.issuer_pubkey,
+            "reason": self.reason,
+            "created": self.created,
+        }
+
+    def chain_body(self) -> dict[str, Any]:
+        """Return the full record body the HMAC covers (everything but ``hmac``)."""
+        body = self.signed_body()
+        body["prev_hmac"] = self.prev_hmac
+        body["signature"] = self.signature
+        return body
+
+    def to_entry(self) -> dict[str, Any]:
+        """Return the on-disk JSONL entry (chain body plus ``hmac``)."""
+        entry = self.chain_body()
+        entry["hmac"] = self.hmac
+        return entry
+
+    @classmethod
+    def from_entry(cls, obj: dict[str, Any]) -> PrincipalReceipt:
+        """Rebuild a :class:`PrincipalReceipt` from its on-disk entry."""
+        return cls(
+            scope=str(obj["scope"]),
+            record_index=int(obj["record_index"]),
+            kind=str(obj["kind"]),
+            principal_id=str(obj["principal_id"]),
+            external_id=str(obj.get("external_id", "")),
+            display_name=str(obj.get("display_name", "")),
+            capability_ceiling=tuple(str(c) for c in obj.get("capability_ceiling", [])),
+            issuer=str(obj["issuer"]),
+            issuer_pubkey=str(obj["issuer_pubkey"]),
+            created=int(obj["created"]),
+            reason=str(obj.get("reason", "")),
+            prev_hmac=str(obj.get("prev_hmac", GENESIS_HMAC)),
+            signature=str(obj.get("signature", "")),
+            hmac=str(obj.get("hmac", "")),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Projected state
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PrincipalState:
+    """The current lifecycle state of one principal, replayed from the chain."""
+
+    principal_id: str
+    display_name: str
+    external_id: str
+    capability_ceiling: tuple[str, ...]
+    provisioned_at: int
+    deprovisioned_at: int = 0
+    reason: str = ""
+
+    def active_at(self, now: float) -> bool:
+        """Return whether the principal existed and was not deprovisioned at ``now``.
+
+        A deprovision recorded at ``T`` takes effect at ``T``: checks at or
+        after ``T`` refuse the principal, checks before ``T`` still see it.
+        """
+        if now < self.provisioned_at:
+            return False
+        return not (self.deprovisioned_at and now >= self.deprovisioned_at)
+
+
+# ---------------------------------------------------------------------------
+# Principal ledger (append-only, one JSONL file per scope)
+# ---------------------------------------------------------------------------
+
+
+class PrincipalLedger:
+    """Append-only, HMAC-chained + Ed25519-signed principal-lifecycle store."""
+
+    def __init__(self, root: Path, key: bytes, signer: GrantSigner, *, scope: str = DEFAULT_SCOPE) -> None:
+        """Bind the ledger to a root directory, an HMAC key, and a manager signer.
+
+        Args:
+            root: Base directory; records land under ``root/principals/``.
+            key: HMAC key -- use the install audit key so the chain is anchored
+                to the install identity, exactly as the grant chain is.
+            signer: The Ed25519 manager identity that authorizes the lifecycle.
+            scope: Journal scope; principals outlive runs, so this defaults to
+                the install rather than to a run id.
+        """
+        self.root = Path(root)
+        self._key = key
+        self._signer = signer
+        self._scope = scope
+        self._dir = self.root / _SUBDIR
+        self._dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def issuer(self) -> str:
+        return self._signer.issuer
+
+    @property
+    def scope(self) -> str:
+        return self._scope
+
+    @property
+    def hmac_key(self) -> bytes:
+        """Return the install-scoped HMAC key the chain is anchored on."""
+        return self._key
+
+    def receipt_path(self) -> Path:
+        """Return the JSONL path backing this ledger's scope."""
+        return self._dir / f"{_safe_scope(self._scope)}.jsonl"
+
+    def _tail(self) -> tuple[str, int]:
+        """Return ``(prev_hmac, next_record_index)`` for the scope."""
+        path = self.receipt_path()
+        if not path.is_file():
+            return GENESIS_HMAC, 0
+        prev = GENESIS_HMAC
+        count = 0
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            obj = json.loads(line)
+            prev = obj.get("hmac", prev)
+            count += 1
+        return prev, count
+
+    def _append(
+        self,
+        *,
+        kind: str,
+        principal_id: str,
+        external_id: str,
+        display_name: str,
+        capability_ceiling: Sequence[str],
+        reason: str,
+        created: int | None,
+    ) -> PrincipalReceipt:
+        if kind not in _KINDS:  # pragma: no cover - defensive
+            raise PrincipalError(f"unknown principal record kind {kind!r}")
+        if not principal_id:
+            raise PrincipalError("principal_id must not be empty")
+        prev_hmac, record_index = self._tail()
+        ts = int(created if created is not None else time.time())
+        signed = {
+            "scope": self._scope,
+            "record_index": record_index,
+            "kind": kind,
+            "principal_id": principal_id,
+            "external_id": external_id,
+            "display_name": display_name,
+            "capability_ceiling": sorted(set(capability_ceiling)),
+            "issuer": self._signer.issuer,
+            "issuer_pubkey": self._signer.public_key_pem,
+            "reason": reason,
+            "created": ts,
+        }
+        signature = self._signer.sign(signed)
+        chain_body = signed.copy()
+        chain_body["prev_hmac"] = prev_hmac
+        chain_body["signature"] = signature
+        entry = chain_body.copy()
+        entry["hmac"] = _compute_hmac(self._key, prev_hmac, chain_body)
+        with self.receipt_path().open("a", encoding="utf-8", newline="") as fh:
+            fh.write(json.dumps(entry, sort_keys=True) + "\n")
+        return PrincipalReceipt.from_entry(entry)
+
+    def provision(
+        self,
+        *,
+        principal_id: str,
+        display_name: str = "",
+        capability_ceiling: Sequence[str] = (),
+        external_id: str = "",
+        created: int | None = None,
+    ) -> PrincipalReceipt:
+        """Append a signed ``principal_provisioned`` record.
+
+        Args:
+            principal_id: Stable id grants bind to (``principal`` on a grant).
+            display_name: Human-readable label carried for the registry.
+            capability_ceiling: Symbolic capability names the principal caps.
+            external_id: The upstream directory's own id for the resource.
+            created: Optional unix timestamp (exposed for deterministic tests).
+
+        Returns:
+            The freshly-appended :class:`PrincipalReceipt`.
+        """
+        return self._append(
+            kind=PRINCIPAL_PROVISIONED,
+            principal_id=principal_id,
+            external_id=external_id,
+            display_name=display_name,
+            capability_ceiling=capability_ceiling,
+            reason="",
+            created=created,
+        )
+
+    def deprovision(
+        self,
+        *,
+        principal_id: str,
+        reason: str = "deprovisioned",
+        created: int | None = None,
+    ) -> PrincipalReceipt:
+        """Append a signed ``principal_deprovisioned`` record drawing the line."""
+        return self._append(
+            kind=PRINCIPAL_DEPROVISIONED,
+            principal_id=principal_id,
+            external_id="",
+            display_name="",
+            capability_ceiling=(),
+            reason=reason,
+            created=created,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Offline verification + registry projection
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PrincipalChainResult:
+    """Outcome of reconstructing a scope's principal chain offline."""
+
+    valid: bool
+    records: list[PrincipalReceipt] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    def registry(self) -> dict[str, PrincipalState]:
+        """Replay the records into the current principal registry.
+
+        Later records win, so a re-provision after a deprovision restores the
+        principal and a deprovision closes it. The projection is deterministic:
+        two verifiers replaying the same chain slice produce the same registry.
+        """
+        states: dict[str, PrincipalState] = {}
+        for r in self.records:
+            if not r.principal_id:
+                continue
+            current = states.get(r.principal_id)
+            if r.kind == PRINCIPAL_PROVISIONED:
+                states[r.principal_id] = PrincipalState(
+                    principal_id=r.principal_id,
+                    display_name=r.display_name,
+                    external_id=r.external_id,
+                    capability_ceiling=r.capability_ceiling,
+                    provisioned_at=r.created,
+                    deprovisioned_at=0,
+                    reason="",
+                )
+            elif r.kind == PRINCIPAL_DEPROVISIONED and current is not None:
+                states[r.principal_id] = PrincipalState(
+                    principal_id=current.principal_id,
+                    display_name=current.display_name,
+                    external_id=current.external_id,
+                    capability_ceiling=current.capability_ceiling,
+                    provisioned_at=current.provisioned_at,
+                    deprovisioned_at=r.created,
+                    reason=r.reason,
+                )
+        return states
+
+
+def verify_principal_chain(*, root: Path, key: bytes, scope: str = DEFAULT_SCOPE) -> PrincipalChainResult:
+    """Reconstruct and verify a scope's principal chain offline.
+
+    Walks ``<root>/principals/<scope>.jsonl`` from genesis, recomputing each
+    record's HMAC, checking linkage, and verifying the manager Ed25519
+    signature against the embedded issuer public key. A mutated field, a
+    deleted record, or reordered records surface as an error naming the
+    offending record; verification stops at the first break.
+
+    Args:
+        root: Base directory the ledger was rooted at.
+        key: The HMAC key (install audit key) the records were written with.
+        scope: Journal scope to verify.
+
+    Returns:
+        A :class:`PrincipalChainResult`. ``valid`` is True only when at least
+        one record exists and the whole chain verifies from genesis to tail.
+    """
+    path = Path(root) / _SUBDIR / f"{_safe_scope(scope)}.jsonl"
+    if not path.is_file():
+        return PrincipalChainResult(valid=False, records=[], errors=["no principal records for scope"])
+
+    records: list[PrincipalReceipt] = []
+    errors: list[str] = []
+    prev_hmac = GENESIS_HMAC
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines()):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            obj = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            errors.append(f"record {lineno}: malformed JSON: {exc}")
+            break
+        stored_hmac = obj.get("hmac", "")
+        idx = obj.get("record_index", lineno)
+        chain_body = {k: v for k, v in obj.items() if k != "hmac"}
+        if chain_body.get("prev_hmac") != prev_hmac:
+            errors.append(f"record {idx}: broken linkage (prev_hmac does not match preceding record)")
+            break
+        expected = _compute_hmac(key, prev_hmac, chain_body)
+        if not _hmac.compare_digest(expected, stored_hmac):
+            errors.append(f"record {idx}: HMAC mismatch (record tampered or wrong key)")
+            break
+        signed = {k: v for k, v in chain_body.items() if k not in ("prev_hmac", "signature")}
+        if not verify_grant_signature(str(obj.get("issuer_pubkey", "")), signed, str(obj.get("signature", ""))):
+            errors.append(f"record {idx}: Ed25519 signature invalid (record not authorized by the issuer key)")
+            break
+        records.append(PrincipalReceipt.from_entry(obj))
+        prev_hmac = stored_hmac
+
+    return PrincipalChainResult(valid=not errors and len(records) > 0, records=records, errors=errors)
+
+
+def default_principal_ledger(
+    root: Path | None = None,
+    *,
+    signer: GrantSigner | None = None,
+    issuer: str = "manager",
+    scope: str = DEFAULT_SCOPE,
+) -> PrincipalLedger:
+    """Return a ledger rooted at the audit tree, keyed by the install audit key.
+
+    The principal chain shares the grant chain's root and key so a verifier
+    holding the install audit key can reconstruct both from one slice.
+    """
+    from bernstein.core.identity.grants import DEFAULT_ROOT, _audit_key, install_grant_signer
+
+    active_signer = signer if signer is not None else install_grant_signer(issuer=issuer)
+    return PrincipalLedger(root=root or DEFAULT_ROOT, key=_audit_key(), signer=active_signer, scope=scope)

--- a/src/bernstein/core/identity/principals.py
+++ b/src/bernstein/core/identity/principals.py
@@ -52,6 +52,7 @@ One JSONL line per record under ``<root>/principals/<scope>.jsonl``::
 
 from __future__ import annotations
 
+import hashlib
 import hmac as _hmac
 import json
 import time
@@ -62,7 +63,6 @@ from typing import TYPE_CHECKING, Any, Final
 from bernstein.core.identity.grants import (
     GENESIS_HMAC,
     GrantSigner,
-    _compute_hmac,
     verify_grant_signature,
 )
 
@@ -98,6 +98,18 @@ DEFAULT_SCOPE: Final[str] = "install"
 
 class PrincipalError(Exception):
     """Raised when a principal record cannot be signed or recorded."""
+
+
+def _compute_hmac(key: bytes, prev_hmac: str, body: dict[str, Any]) -> str:
+    """HMAC-SHA256 over ``prev_hmac`` concatenated with the canonical record body.
+
+    Identical construction to
+    :func:`bernstein.core.identity.grants._compute_hmac`, so a verifier holding
+    the install audit key walks the principal chain exactly as it walks the
+    grant chain.
+    """
+    payload = prev_hmac + json.dumps(body, sort_keys=True)
+    return _hmac.new(key, payload.encode(), hashlib.sha256).hexdigest()
 
 
 def _safe_scope(scope: str) -> str:
@@ -469,7 +481,13 @@ def default_principal_ledger(
     The principal chain shares the grant chain's root and key so a verifier
     holding the install audit key can reconstruct both from one slice.
     """
-    from bernstein.core.identity.grants import DEFAULT_ROOT, _audit_key, install_grant_signer
+    from bernstein.core.identity.grants import DEFAULT_ROOT, install_grant_signer
+    from bernstein.core.security.audit import load_or_create_audit_key
 
     active_signer = signer if signer is not None else install_grant_signer(issuer=issuer)
-    return PrincipalLedger(root=root or DEFAULT_ROOT, key=_audit_key(), signer=active_signer, scope=scope)
+    return PrincipalLedger(
+        root=root or DEFAULT_ROOT,
+        key=load_or_create_audit_key(),
+        signer=active_signer,
+        scope=scope,
+    )

--- a/tests/unit/adapters/test_directory_scim.py
+++ b/tests/unit/adapters/test_directory_scim.py
@@ -1,0 +1,84 @@
+"""Tests for the directory-provisioning adapter (issue #4972).
+
+The adapter maps the standard SCIM 2.0 provisioning resources onto the
+Bernstein principal objects: a ``User`` resource becomes a principal, its
+group memberships become the capability ceiling, and ``active: false`` (or an
+explicit delete) becomes a deprovision record. No vendor SDK and no third
+schema: ``bernstein.core`` never learns what a directory is.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.adapters.directory import scim
+from bernstein.core.identity import grants, principals
+
+
+@pytest.fixture
+def ledger(tmp_path) -> principals.PrincipalLedger:
+    signer = grants.GrantSigner.generate(issuer="manager:test")
+    return principals.PrincipalLedger(root=tmp_path, key=b"k" * 32, signer=signer)
+
+
+USER = {
+    "schemas": [scim.USER_SCHEMA],
+    "id": "2819c223-7f76-453a-919d-413861904646",
+    "externalId": "dir-9911",
+    "userName": "agent:nightly-refactor",
+    "displayName": "Nightly refactor agent",
+    "active": True,
+    "groups": [
+        {"value": "g-2", "display": "read"},
+        {"value": "g-1", "display": "list"},
+    ],
+}
+
+
+class TestSchemaMapping:
+    def test_directory_user_groups_become_the_capability_ceiling(self) -> None:
+        principal = scim.principal_from_user(USER)
+        assert principal.principal_id == "agent:nightly-refactor"
+        assert principal.external_id == "dir-9911"
+        assert principal.display_name == "Nightly refactor agent"
+        assert principal.active is True
+        # Sorted and de-duplicated so two directories that list the same
+        # groups in a different order imply the same ceiling.
+        assert principal.capability_ceiling == ("list", "read")
+
+    def test_directory_group_resource_maps_to_capability_and_members(self) -> None:
+        group = {
+            "schemas": [scim.GROUP_SCHEMA],
+            "id": "g-1",
+            "displayName": "list",
+            "members": [
+                {"value": "2819c223", "display": "agent:nightly-refactor"},
+                {"value": "9f2b", "display": "agent:release-notes"},
+            ],
+        }
+        assert scim.capability_from_group(group) == "list"
+        assert scim.principals_in_group(group) == ("agent:nightly-refactor", "agent:release-notes")
+
+    def test_user_resource_without_an_identifier_is_refused(self) -> None:
+        with pytest.raises(scim.DirectorySchemaError):
+            scim.principal_from_user({"schemas": [scim.USER_SCHEMA], "active": True})
+
+
+class TestLifecycle:
+    def test_directory_deactivation_deprovisions_the_principal(self, tmp_path, ledger) -> None:
+        scim.apply_user(ledger, USER, created=1_000)
+        deactivated = dict(USER, active=False)
+        receipt = scim.apply_user(ledger, deactivated, created=2_000)
+        assert receipt.kind == principals.PRINCIPAL_DEPROVISIONED
+
+        result = principals.verify_principal_chain(root=tmp_path, key=b"k" * 32)
+        assert result.valid, result.errors
+        state = result.registry()["agent:nightly-refactor"]
+        assert state.deprovisioned_at == 2_000
+        assert not state.active_at(2_000)
+
+    def test_apply_user_provisions_with_the_ceiling_the_directory_implies(self, tmp_path, ledger) -> None:
+        receipt = scim.apply_user(ledger, USER, created=1_000)
+        assert receipt.kind == principals.PRINCIPAL_PROVISIONED
+        result = principals.verify_principal_chain(root=tmp_path, key=b"k" * 32)
+        assert result.registry()["agent:nightly-refactor"].capability_ceiling == ("list", "read")

--- a/tests/unit/identity/test_principal_provisioning.py
+++ b/tests/unit/identity/test_principal_provisioning.py
@@ -1,0 +1,178 @@
+"""Tests for agent-principal provisioning and deprovisioning (issue #4972).
+
+A scoped per-task grant bounds one task's blast radius, but nothing used to
+remove the *principal* the grants were issued to. These tests pin the
+lifecycle: a principal is provisioned as a signed chain record carrying the
+ceiling the directory implies, deprovisioning is a second chain record with
+finality, and the grant-validity path in
+:mod:`bernstein.core.identity.grants` consults that chain rather than an
+out-of-band flag.
+
+Deprovisioning is deliberately *not* retroactive: a grant that was active
+before the line was drawn still verifies for the window it covered, while any
+check performed at or after the deprovision timestamp refuses it.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bernstein.core.identity import grants, principals
+
+
+@pytest.fixture
+def signer() -> grants.GrantSigner:
+    return grants.GrantSigner.generate(issuer="manager:test")
+
+
+@pytest.fixture
+def grant_ledger(tmp_path, signer) -> grants.GrantLedger:
+    return grants.GrantLedger(root=tmp_path, key=b"k" * 32, signer=signer)
+
+
+@pytest.fixture
+def principal_ledger(tmp_path, signer) -> principals.PrincipalLedger:
+    return principals.PrincipalLedger(root=tmp_path, key=b"k" * 32, signer=signer)
+
+
+def _grant_chain(tmp_path, run_id: str = "run-1") -> grants.GrantChainResult:
+    return grants.verify_grant_chain(root=tmp_path, run_id=run_id, key=b"k" * 32)
+
+
+class TestProvisioning:
+    def test_provisioning_creates_principal_in_registry_with_directory_ceiling(
+        self, tmp_path, principal_ledger
+    ) -> None:
+        receipt = principal_ledger.provision(
+            principal_id="agent:nightly-refactor",
+            display_name="Nightly refactor agent",
+            capability_ceiling=("read", "list"),
+            external_id="dir-9911",
+            created=1_000,
+        )
+        assert receipt.kind == principals.PRINCIPAL_PROVISIONED
+        assert receipt.prev_hmac == principals.GENESIS_HMAC
+        assert grants.verify_grant_signature(receipt.issuer_pubkey, receipt.signed_body(), receipt.signature)
+
+        result = principals.verify_principal_chain(root=tmp_path, key=b"k" * 32)
+        assert result.valid, result.errors
+        registry = result.registry()
+        state = registry["agent:nightly-refactor"]
+        assert state.capability_ceiling == ("list", "read")
+        assert state.external_id == "dir-9911"
+        assert state.provisioned_at == 1_000
+        assert state.deprovisioned_at == 0
+        assert state.active_at(1_500)
+
+    def test_tampered_deprovision_record_breaks_the_principal_chain(self, tmp_path, principal_ledger) -> None:
+        principal_ledger.provision(principal_id="agent:a", capability_ceiling=("read",), created=1_000)
+        principal_ledger.deprovision(principal_id="agent:a", created=2_000)
+        path = principal_ledger.receipt_path()
+        lines = path.read_text(encoding="utf-8").splitlines()
+        obj = json.loads(lines[1])
+        obj["kind"] = principals.PRINCIPAL_PROVISIONED
+        lines[1] = json.dumps(obj, sort_keys=True)
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        result = principals.verify_principal_chain(root=tmp_path, key=b"k" * 32)
+        assert not result.valid
+        assert any("record 1" in err for err in result.errors)
+
+
+class TestDeprovisioningIsConsultedByGrantValidity:
+    def test_deprovisioning_makes_every_later_grant_check_fail(
+        self, tmp_path, grant_ledger, principal_ledger
+    ) -> None:
+        principal_ledger.provision(principal_id="agent:a", capability_ceiling=("read",), created=1_000)
+        grant_ledger.issue_grant(
+            run_id="run-1",
+            task_id="t-1",
+            secret_name="K",
+            audience="aud",
+            expiry=9_000_000_000,
+            principal="agent:a",
+            created=1_100,
+        )
+        chain = _grant_chain(tmp_path)
+        assert chain.valid, chain.errors
+        assert grants.find_active_grant(chain, task_id="t-1", secret_name="K", now=1_200) is not None
+
+        principal_ledger.deprovision(principal_id="agent:a", reason="run finished", created=2_000)
+        after = _grant_chain(tmp_path)
+        assert grants.find_active_grant(after, task_id="t-1", secret_name="K", now=2_000) is None
+        assert grants.find_active_grant(after, task_id="t-1", secret_name="K", now=8_000) is None
+
+    def test_grant_issued_before_deprovisioning_still_verifies_for_its_window(
+        self, tmp_path, grant_ledger, principal_ledger
+    ) -> None:
+        principal_ledger.provision(principal_id="agent:a", capability_ceiling=("read",), created=1_000)
+        issued = grant_ledger.issue_grant(
+            run_id="run-1",
+            task_id="t-1",
+            secret_name="K",
+            audience="aud",
+            expiry=9_000_000_000,
+            principal="agent:a",
+            created=1_100,
+        )
+        principal_ledger.deprovision(principal_id="agent:a", created=2_000)
+
+        chain = _grant_chain(tmp_path)
+        # The record itself is untouched: deprovisioning draws a line, it does
+        # not retroactively falsify the grant's own signature or linkage.
+        assert chain.valid, chain.errors
+        window = grants.find_active_grant(chain, task_id="t-1", secret_name="K", now=1_500)
+        assert window is not None
+        assert window.grant_id == issued.grant_id
+
+    def test_replayed_grant_of_deprovisioned_principal_fails_against_now(
+        self, tmp_path, grant_ledger, principal_ledger
+    ) -> None:
+        principal_ledger.provision(principal_id="agent:a", capability_ceiling=("read",), created=1_000)
+        grant_ledger.issue_grant(
+            run_id="run-1",
+            task_id="t-1",
+            secret_name="K",
+            audience="aud",
+            expiry=0,
+            principal="agent:a",
+            created=1_100,
+        )
+        principal_ledger.deprovision(principal_id="agent:a", created=2_000)
+        chain = _grant_chain(tmp_path)
+        # No expiry at all: only the deprovision fact can stop the replay.
+        assert grants.find_active_grant(chain, task_id="t-1", secret_name="K", now=9_999_999) is None
+
+    def test_missing_principal_chain_denies_a_principal_bound_grant(self, tmp_path, grant_ledger) -> None:
+        grant_ledger.issue_grant(
+            run_id="run-1",
+            task_id="t-1",
+            secret_name="K",
+            audience="aud",
+            expiry=9_000_000_000,
+            principal="agent:ghost",
+            created=1_100,
+        )
+        chain = _grant_chain(tmp_path)
+        assert chain.valid, chain.errors
+        # Deleting or never writing the principal chain must not resurrect the
+        # grant: an unknown principal is refused, not waved through.
+        assert grants.find_active_grant(chain, task_id="t-1", secret_name="K", now=1_200) is None
+
+    def test_grant_without_a_principal_is_unaffected_by_the_principal_chain(
+        self, tmp_path, grant_ledger, principal_ledger
+    ) -> None:
+        principal_ledger.provision(principal_id="agent:a", created=1_000)
+        principal_ledger.deprovision(principal_id="agent:a", created=2_000)
+        grant_ledger.issue_grant(
+            run_id="run-1",
+            task_id="t-1",
+            secret_name="K",
+            audience="aud",
+            expiry=9_000_000_000,
+            created=2_100,
+        )
+        chain = _grant_chain(tmp_path)
+        assert grants.find_active_grant(chain, task_id="t-1", secret_name="K", now=3_000) is not None

--- a/tests/unit/identity/test_principal_provisioning.py
+++ b/tests/unit/identity/test_principal_provisioning.py
@@ -82,9 +82,7 @@ class TestProvisioning:
 
 
 class TestDeprovisioningIsConsultedByGrantValidity:
-    def test_deprovisioning_makes_every_later_grant_check_fail(
-        self, tmp_path, grant_ledger, principal_ledger
-    ) -> None:
+    def test_deprovisioning_makes_every_later_grant_check_fail(self, tmp_path, grant_ledger, principal_ledger) -> None:
         principal_ledger.provision(principal_id="agent:a", capability_ceiling=("read",), created=1_000)
         grant_ledger.issue_grant(
             run_id="run-1",


### PR DESCRIPTION
## What

Gives an agent principal a lifecycle. Provisioning and deprovisioning become
signed, HMAC-chained records; the grant-validity path reads deprovisioning off
that chain; and a small adapter maps the standard SCIM 2.0 provisioning
resources onto principals and capability ceilings.

Does **not** do (out of this slice, and out of the issue's scope as written):

- human user provisioning;
- directory write-back beyond the principal lifecycle;
- any network transport, HTTP surface, or SCIM server — the caller owns the
  transport and hands the adapter a decoded resource;
- a CLI listing command for the registry (the projection exists as
  `PrincipalChainResult.registry()`; a listing surface belongs to #4969);
- retrofitting `principal` onto the spawn path that issues grants today, so
  existing callers are byte-for-byte unaffected.

## Why

`src/bernstein/core/identity/grants.py` issues scoped, expiring per-task
credentials, which bounds what any single task can reach. Nothing, however,
removed the *principal* those grants were issued to. An install that has run
for months therefore accumulates agent principals that no operator can account
for, each still able to back a freshly issued grant, and the only tool for
stopping one was revoking its grants one at a time.

The lifecycle also has to be a fact the validity decision consults rather than
a flag set beside it, otherwise a caller that forgets to check the flag hands
out a credential to a principal that was retired months ago.

## How

- `src/bernstein/core/identity/principals.py` (new) records
  `principal_provisioned` / `principal_deprovisioned` in the same two-anchor
  construction the grant chain already uses: an Ed25519 signature by the
  manager identity over the canonical body, plus an HMAC over `prev_hmac`
  concatenated with that body under the install audit key. Records land in
  `<root>/principals/<scope>.jsonl`, beside `<root>/grants/`, so one chain
  slice and one key reconstruct both offline. The journal *is* the registry:
  `PrincipalChainResult.registry()` replays it into the current principals and
  the ceiling each one carries — there is no second mutable table to disagree
  with the chain.
- `GrantReceipt` gains a `principal` field (empty on every record written
  before this change), and `GrantLedger.issue_grant` accepts it. Verification
  of pre-existing records is untouched: `verify_grant_chain` recomputes the
  HMAC and signature over whatever keys the record on disk actually carries.
- `verify_grant_chain` now also verifies the principal chain rooted at the same
  tree and key and attaches it to `GrantChainResult.principals`, so
  `find_active_grant` — the one function that decides grant validity, and the
  one `secrets_broker` calls — refuses a grant whose principal is deprovisioned
  at the check time. No caller change and no out-of-band flag.
- `src/bernstein/adapters/directory/scim.py` (new) maps RFC 7643 resources:
  `User.userName` → principal id, `User.externalId` → external id,
  `User.groups[].display` → capability ceiling (sorted, de-duplicated),
  `active: false` → deprovision; a `Group` is a capability, its `displayName`
  the capability name and its `members` the principals holding it. No vendor
  SDK, no third schema, and `bernstein.core` never learns what a directory is.

### The open decision, and how it was decided

The issue does not say what "unknown principal" means at check time — a grant
naming a principal the chain cannot account for (journal never written,
truncated, or deleted). It is decided **fail-closed**: `_principal_permits`
returns `False` unless a *verifying* chain says the principal was provisioned
and not yet deprovisioned. Fail-open would make deleting one file the cheapest
way to resurrect every retired principal at once, which defeats the finality
the issue asks for. Grants that name no principal (every record written before
this change) keep their previous behaviour exactly.

Deprovisioning is deliberately **not** retroactive. A deprovision recorded at
`T` binds checks at or after `T`; a check against a moment inside the window a
grant covered still returns it, and the grant's own signature and linkage stay
valid forever. Revocation draws a line, it does not falsify history.

## Tests

Each failed on the unmodified tree — the first seven with an import error for
the module that did not exist, and, once the module existed, tests 2, 4 and 5
still failed on the un-enforced validity path (verified by removing only the
`find_active_grant` guard and re-running: exactly those three go red).

`tests/unit/identity/test_principal_provisioning.py`

1. `test_provisioning_creates_principal_in_registry_with_directory_ceiling` —
   a provision record is signed, chains to genesis, and replays into a registry
   entry carrying the ceiling, the external id, and the provisioning time.
2. `test_deprovisioning_makes_every_later_grant_check_fail` — **load-bearing**:
   the same grant that resolves before the deprovision resolves to `None` at
   the deprovision timestamp and at every later instant.
3. `test_grant_issued_before_deprovisioning_still_verifies_for_its_window` —
   the grant chain still verifies after the deprovision, and a check inside the
   covered window returns the original grant.
4. `test_replayed_grant_of_deprovisioned_principal_fails_against_now` — a grant
   with no expiry at all is stopped by the deprovision fact alone.
5. `test_missing_principal_chain_denies_a_principal_bound_grant` — the
   fail-closed decision above: no principal journal means no grant.
6. `test_tampered_deprovision_record_breaks_the_principal_chain` — rewriting a
   deprovision record's `kind` flips verification and names record 1.
7. `test_grant_without_a_principal_is_unaffected_by_the_principal_chain` —
   records written before this change keep resolving as they did.

`tests/unit/adapters/test_directory_scim.py`

8. `test_directory_user_groups_become_the_capability_ceiling` — group
   memberships map to a sorted, de-duplicated ceiling.
9. `test_directory_group_resource_maps_to_capability_and_members` — a `Group`
   maps to one capability name and the principals holding it.
10. `test_user_resource_without_an_identifier_is_refused` — an unmappable
    resource raises instead of minting an anonymous principal.
11. `test_directory_deactivation_deprovisions_the_principal` — `active: false`
    appends a deprovision record with the directory's timestamp.
12. `test_apply_user_provisions_with_the_ceiling_the_directory_implies` —
    end-to-end from resource to registry entry.

Locally green (`--parallel 2`): the two new files plus `test_grants.py`,
`test_secrets_broker_grants.py`, `test_broker_grant_config.py`,
`test_audit_verify_grants.py`, `test_secrets_grants_cli.py`,
`test_key_custody_boundary.py`, `test_identity_spawn_anchor.py`,
`test_agents_md_mirror_guards.py`, `test_pyright_excludes.py`.
`--affected origin/main` did not finish inside the local budget on this
machine, so the set above was chosen as the touched modules plus every importer
of `bernstein.core.identity.grants` and their tests; CI runs the full suite.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` — no new errors in the files this PR touches;
      `grants.py` keeps its three pre-existing advisory errors, and
      `principals.py` reports only the two `field(default_factory=list)`
      inference notes that `grants.py` already carries
- [x] `uv run python scripts/run_tests.py -x` passes for the files listed above
      (the full suite is CI's job)
- [x] New code has type hints

### Documentation duty

- [x] User-visible README section updated — N/A (no user-facing surface yet;
      the module is a library boundary, and the listing command belongs to a
      later slice)
- [x] `docs/operations/<area>.md` updated — N/A (no operator command changes)
- [x] `docs/api/` schema regenerated — N/A (no HTTP surface changed)
- [x] `uv run bernstein agents-md sync` run — yes; it added the new adapters
      package to `docs/sdd/module-map.md`, which is committed here
- [x] Tests cover the documented behaviour

Part of #4972

## Remaining

- The listable registry surface (a command that prints
  `PrincipalChainResult.registry()`) — #4969 owns it; this PR ships the
  chain-derived projection it will read.
- Re-homing this adapter behind the directory bridge contract of #4970 once
  that contract exists. Today `scim.py` takes a `PrincipalLedger` and a decoded
  resource directly, which is the smallest surface that keeps
  `bernstein.core` vendor-free.
- Binding `principal` at grant-issue time in the spawn path, so principals a
  directory provisioned actually appear on newly issued grants. Nothing issues
  a principal-bound grant yet; the plumbing and the enforcement land first.
