### PR TITLE
feat: re-decide grant preconditions at tool-call dispatch (#5022)

### DIFF
--- a/src/bernstein/core/identity/grants.py
+++ b/src/bernstein/core/identity/grants.py
@@ -173,6 +173,10 @@ def record_hmac(key: bytes, prev_hmac: str, body: dict[str, Any]) -> str:
     return _hmac.new(key, payload.encode(), hashlib.sha256).hexdigest()
 
 
+#: Pre-rename name, kept importable for external callers written against it.
+_compute_hmac = record_hmac
+
+
 #: Salted-reference format written to new records. ``sha256:`` (unsalted) is
 #: the legacy format older releases wrote; it is still matched on read so
 #: pre-existing chains stay usable, but it is never written anymore.

--- a/src/bernstein/core/identity/grants.py
+++ b/src/bernstein/core/identity/grants.py
@@ -94,6 +94,7 @@ __all__ = [
     "find_active_grant",
     "hash_secret_name",
     "install_grant_signer",
+    "record_hmac",
     "render_report",
     "secret_name_matches",
     "verify_grant_chain",
@@ -155,13 +156,18 @@ def _canonical(body: dict[str, Any]) -> str:
     return json.dumps(body, sort_keys=True, separators=(",", ":"))
 
 
-def _compute_hmac(key: bytes, prev_hmac: str, body: dict[str, Any]) -> str:
+def record_hmac(key: bytes, prev_hmac: str, body: dict[str, Any]) -> str:
     """HMAC-SHA256 over ``prev_hmac`` concatenated with the canonical record body.
 
     Identical construction to
     :func:`bernstein.core.identity.delegation._compute_hmac` and
     :func:`bernstein.core.security.audit._compute_hmac`, so the grant chain
     shares tamper-evidence semantics with the delegation and audit chains.
+
+    Public because a reader that authenticates the chain incrementally (see
+    :mod:`bernstein.core.security.grant_precondition`) must recompute the
+    *same* digest as the writer; a second copy of the construction elsewhere
+    could drift from this one and silently accept a re-chained record.
     """
     payload = prev_hmac + json.dumps(body, sort_keys=True)
     return _hmac.new(key, payload.encode(), hashlib.sha256).hexdigest()
@@ -507,7 +513,7 @@ class GrantLedger:
         chain_body = signed.copy()
         chain_body["prev_hmac"] = prev_hmac
         chain_body["signature"] = signature
-        computed = _compute_hmac(self._key, prev_hmac, chain_body)
+        computed = record_hmac(self._key, prev_hmac, chain_body)
         entry = chain_body.copy()
         entry["hmac"] = computed
         path = self.receipt_path(run_id)
@@ -724,7 +730,7 @@ def verify_grant_chain(*, root: Path, run_id: str, key: bytes) -> GrantChainResu
         if chain_body.get("prev_hmac") != prev_hmac:
             errors.append(f"record {idx}: broken linkage (prev_hmac does not match preceding record)")
             break
-        expected = _compute_hmac(key, prev_hmac, chain_body)
+        expected = record_hmac(key, prev_hmac, chain_body)
         if not _hmac.compare_digest(expected, stored_hmac):
             errors.append(f"record {idx}: HMAC mismatch (record tampered or wrong key)")
             break

--- a/src/bernstein/core/security/grant_precondition.py
+++ b/src/bernstein/core/security/grant_precondition.py
@@ -1,0 +1,410 @@
+"""Re-decide a grant's preconditions at dispatch, against current chain state.
+
+A grant is decided once, at issue, and then carried. Every fact it rested on
+can change before it is spent: the grant is revoked, its capability ceiling is
+narrowed, its expiry elapses. The signature over the issued record stays valid
+through all of that, so a check that only verifies the signature keeps passing
+-- correct cryptography, wrong authorisation. The window is not theoretical: a
+long-running fan-out issues grants at the start and spends them over the
+following hours.
+
+This module re-decides at the point of use and, when it refuses, says *which
+fact changed and where*. A refusal carries a chain position, not a boolean:
+"grant ``g`` issued at chain position 0 was superseded by ``grant_revoked`` at
+chain position 3". That statement is checkable offline, later, by someone who
+was not there -- the same JSONL slice and the install audit key reconstruct it.
+The reverse query becomes answerable too: given a grant, everything it
+authorised, and the exact record after which it should not have.
+
+Cost
+----
+The re-decision runs on every dispatch, so it must not walk the chain per call.
+:class:`GrantPreconditionIndex` keeps a byte offset into the run's append-only
+JSONL and a running ``prev_hmac``, exactly like
+:class:`bernstein.core.security.audit.ChainScanCursor` does for the audit
+chain. Per dispatch the index reads the bytes appended since the last call --
+normally none -- and then answers from a dict lookup and a frozenset membership
+test. Authenticating a record (one HMAC, one Ed25519 verification) happens once
+per record, never once per call.
+
+Semantics
+---------
+* **Revocation is monotone.** Once a ``grant_revoked`` record is seen, a later
+  ``grant_issued`` record for the same ``grant_id`` cannot resurrect it.
+* **Re-issue narrows, it never widens.** The effective ceiling is the
+  *intersection* of the ceilings across every ``grant_issued`` record for the
+  ``grant_id``, in chain order; the position where it last shrank is the
+  superseding position a refusal names. A re-issue carrying a wider ceiling
+  therefore restores nothing, which matches the attenuation rule the delegation
+  capability tokens already enforce.
+* **An empty ceiling authorises nothing.** A ceiling is a maximum, so an empty
+  one caps every capability out. The gate is opt-in, so this fails closed
+  without changing how any existing grant is issued.
+* **A chain break refuses everything.** A record that does not link, does not
+  re-HMAC, or does not verify against its embedded issuer key poisons the
+  index; every later decision refuses and names the offending record.
+"""
+
+from __future__ import annotations
+
+import hmac as _hmac
+import json
+import time
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any, Protocol
+
+from bernstein.core.identity.grants import (
+    GENESIS_HMAC,
+    GRANT_ISSUED,
+    GRANT_REVOKED,
+    GrantLedger,
+    record_hmac,
+    verify_grant_signature,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+__all__ = [
+    "DispatchGrantGate",
+    "GrantDecision",
+    "GrantPreconditionIndex",
+    "GrantPreconditions",
+    "GrantRefusedError",
+    "RedecisionOutcome",
+    "ToolCallDescription",
+    "tool_call_capability",
+]
+
+
+class RedecisionOutcome(StrEnum):
+    """What the chain says about a grant's preconditions at the point of use."""
+
+    #: Nothing on the chain changed the grant since it was issued.
+    VALID = "valid"
+    #: The grant still authorises, but over a narrower set than at issue.
+    NARROWED = "narrowed"
+    #: The grant authorises nothing any more -- revoked, expired, or unknown.
+    REVOKED = "revoked"
+
+
+@dataclass(frozen=True, slots=True)
+class GrantDecision:
+    """One re-decision, with the chain position that explains it.
+
+    ``reason`` is the whole point of the record: it names the position the
+    grant was issued at and, when something superseded it, the kind and
+    position of the superseding record. ``permitted`` is the dispatch verdict;
+    ``outcome`` is what happened to the grant, which is not the same question
+    (a still-valid grant refuses a call outside its ceiling).
+    """
+
+    outcome: RedecisionOutcome
+    permitted: bool
+    grant_id: str
+    capability: str
+    reason: str
+    issued_index: int = -1
+    superseded_index: int = -1
+    superseding_kind: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class GrantPreconditions:
+    """The current state of one grant's preconditions, folded from the chain."""
+
+    grant_id: str
+    issued_index: int
+    task_id: str
+    expiry: int
+    capabilities: frozenset[str]
+    narrowed_index: int = -1
+    revoked_index: int = -1
+    revoked_kind: str = ""
+
+
+class GrantRefusedError(RuntimeError):
+    """Raised when a re-decision refuses an about-to-run call.
+
+    Carries the :class:`GrantDecision` so a caller that catches it can report
+    the superseding chain position rather than only the fact of refusal.
+    """
+
+    def __init__(self, decision: GrantDecision) -> None:
+        super().__init__(decision.reason)
+        self.decision = decision
+
+
+class ToolCallDescription(Protocol):
+    """The part of an about-to-dispatch tool call a capability is derived from."""
+
+    @property
+    def server_name(self) -> str: ...
+
+    @property
+    def tool_name(self) -> str: ...
+
+
+def tool_call_capability(intent: ToolCallDescription) -> str:
+    """Return the capability name a tool call needs -- its tool name.
+
+    A grant's ``capability_ceiling`` holds symbolic capability names, and the
+    tool name is the symbol an operator writes when scoping a grant to a tool.
+    A deployment whose ceiling is expressed differently supplies its own
+    resolver through :attr:`DispatchGrantGate.capability_of`.
+    """
+    return intent.tool_name
+
+
+def _empty_precondition_map() -> dict[str, GrantPreconditions]:
+    """Return the per-grant map an index starts from."""
+    return {}
+
+
+@dataclass(slots=True)
+class GrantPreconditionIndex:
+    """Incrementally authenticated projection of one run's grant chain.
+
+    The index owns a byte offset and a running ``prev_hmac``, so a refresh
+    authenticates only the records appended since the previous one. Records
+    that fail linkage, HMAC, or signature poison the index permanently: the
+    offset is not advanced past them and every later decision refuses.
+    """
+
+    path: Path
+    key: bytes
+    _offset: int = 0
+    _prev_hmac: str = GENESIS_HMAC
+    _grants: dict[str, GrantPreconditions] = field(default_factory=_empty_precondition_map)
+    _break: str = ""
+
+    @classmethod
+    def for_run(cls, ledger: GrantLedger, run_id: str) -> GrantPreconditionIndex:
+        """Return an index over ``run_id``'s records in ``ledger``'s tree."""
+        return cls(path=ledger.receipt_path(run_id), key=ledger.hmac_key)
+
+    def refresh(self) -> None:
+        """Authenticate and fold the records appended since the last refresh."""
+        if self._break:
+            return
+        try:
+            with self.path.open("rb") as fh:
+                fh.seek(self._offset)
+                blob = fh.read()
+        except FileNotFoundError:
+            return
+        # A record is durable only once its terminating newline is on disk, so
+        # a trailing partial line is left for the next refresh rather than
+        # parsed and rejected as malformed.
+        cut = blob.rfind(b"\n")
+        if cut < 0:
+            return
+        for raw in blob[: cut + 1].splitlines(keepends=True):
+            text = raw.strip()
+            if text and not self._consume(text):
+                return
+            self._offset += len(raw)
+
+    def _consume(self, raw: bytes) -> bool:
+        """Authenticate one record and fold it in; False marks the chain broken."""
+        try:
+            entry: dict[str, Any] = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            self._break = f"grant chain broke at byte offset {self._offset}: malformed JSON: {exc}"
+            return False
+        index = int(entry.get("record_index", -1))
+        chain_body = {k: v for k, v in entry.items() if k != "hmac"}
+        if chain_body.get("prev_hmac") != self._prev_hmac:
+            self._break = f"grant chain broke at record {index}: prev_hmac does not match the preceding record"
+            return False
+        if not _hmac.compare_digest(record_hmac(self.key, self._prev_hmac, chain_body), str(entry.get("hmac", ""))):
+            self._break = f"grant chain broke at record {index}: HMAC mismatch (record tampered or wrong key)"
+            return False
+        signed = {k: v for k, v in chain_body.items() if k not in ("prev_hmac", "signature")}
+        if not verify_grant_signature(str(entry.get("issuer_pubkey", "")), signed, str(entry.get("signature", ""))):
+            self._break = f"grant chain broke at record {index}: Ed25519 signature invalid"
+            return False
+        self._fold(entry, index)
+        self._prev_hmac = str(entry.get("hmac", ""))
+        return True
+
+    def _fold(self, entry: dict[str, Any], index: int) -> None:
+        """Apply one authenticated record to the per-grant precondition state."""
+        grant_id = str(entry.get("grant_id", ""))
+        if not grant_id:
+            return
+        kind = str(entry.get("kind", ""))
+        current = self._grants.get(grant_id)
+        if kind == GRANT_ISSUED:
+            self._grants[grant_id] = self._fold_issued(entry, index, current)
+        elif kind == GRANT_REVOKED and current is not None and current.revoked_index < 0:
+            self._grants[grant_id] = GrantPreconditions(
+                grant_id=current.grant_id,
+                issued_index=current.issued_index,
+                task_id=current.task_id,
+                expiry=current.expiry,
+                capabilities=current.capabilities,
+                narrowed_index=current.narrowed_index,
+                revoked_index=index,
+                revoked_kind=GRANT_REVOKED,
+            )
+
+    @staticmethod
+    def _fold_issued(
+        entry: dict[str, Any],
+        index: int,
+        current: GrantPreconditions | None,
+    ) -> GrantPreconditions:
+        """Fold a ``grant_issued`` record, narrowing but never widening."""
+        ceiling = frozenset(str(c) for c in entry.get("capability_ceiling", ()))
+        expiry = int(entry.get("expiry", 0))
+        if current is None:
+            return GrantPreconditions(
+                grant_id=str(entry.get("grant_id", "")),
+                issued_index=index,
+                task_id=str(entry.get("task_id", "")),
+                expiry=expiry,
+                capabilities=ceiling,
+            )
+        narrowed = current.capabilities & ceiling
+        # ``expiry == 0`` means "no explicit expiry", which is the widest
+        # value, so a re-issue can only bring the effective expiry forward.
+        candidates = [e for e in (current.expiry, expiry) if e]
+        return GrantPreconditions(
+            grant_id=current.grant_id,
+            issued_index=current.issued_index,
+            task_id=current.task_id,
+            expiry=min(candidates) if candidates else 0,
+            capabilities=narrowed,
+            narrowed_index=index if narrowed != current.capabilities else current.narrowed_index,
+            revoked_index=current.revoked_index,
+            revoked_kind=current.revoked_kind,
+        )
+
+    def decide(self, grant_id: str, capability: str, *, now: float | None = None) -> GrantDecision:
+        """Re-decide ``grant_id`` for ``capability`` against current chain state."""
+        self.refresh()
+        if self._break:
+            return GrantDecision(
+                outcome=RedecisionOutcome.REVOKED,
+                permitted=False,
+                grant_id=grant_id,
+                capability=capability,
+                reason=self._break,
+            )
+        pre = self._grants.get(grant_id)
+        if pre is None:
+            return GrantDecision(
+                outcome=RedecisionOutcome.REVOKED,
+                permitted=False,
+                grant_id=grant_id,
+                capability=capability,
+                reason=f"no grant_issued record for grant {grant_id} on this chain",
+            )
+        if pre.revoked_index >= 0:
+            return GrantDecision(
+                outcome=RedecisionOutcome.REVOKED,
+                permitted=False,
+                grant_id=grant_id,
+                capability=capability,
+                reason=(
+                    f"grant {grant_id} issued at chain position {pre.issued_index} "
+                    f"was superseded by {pre.revoked_kind} at chain position {pre.revoked_index}"
+                ),
+                issued_index=pre.issued_index,
+                superseded_index=pre.revoked_index,
+                superseding_kind=pre.revoked_kind,
+            )
+        current = time.time() if now is None else now
+        if pre.expiry and current >= pre.expiry:
+            return GrantDecision(
+                outcome=RedecisionOutcome.REVOKED,
+                permitted=False,
+                grant_id=grant_id,
+                capability=capability,
+                reason=(f"grant {grant_id} issued at chain position {pre.issued_index} expired at {pre.expiry}"),
+                issued_index=pre.issued_index,
+            )
+        return self._decide_capability(pre, capability)
+
+    @staticmethod
+    def _decide_capability(pre: GrantPreconditions, capability: str) -> GrantDecision:
+        """Decide a live grant against the capability the call needs."""
+        narrowed = pre.narrowed_index >= 0
+        outcome = RedecisionOutcome.NARROWED if narrowed else RedecisionOutcome.VALID
+        superseded = pre.narrowed_index if narrowed else -1
+        superseding = GRANT_ISSUED if narrowed else ""
+        if capability in pre.capabilities:
+            reason = (
+                f"grant {pre.grant_id} issued at chain position {pre.issued_index} still authorises "
+                f"capability {capability!r}"
+            )
+            if narrowed:
+                reason += f" after being narrowed at chain position {pre.narrowed_index}"
+            return GrantDecision(
+                outcome=outcome,
+                permitted=True,
+                grant_id=pre.grant_id,
+                capability=capability,
+                reason=reason,
+                issued_index=pre.issued_index,
+                superseded_index=superseded,
+                superseding_kind=superseding,
+            )
+        if narrowed:
+            reason = (
+                f"capability {capability!r} authorised by grant {pre.grant_id} at chain position "
+                f"{pre.issued_index} was superseded by {GRANT_ISSUED} at chain position {pre.narrowed_index}"
+            )
+        else:
+            reason = (
+                f"grant {pre.grant_id} issued at chain position {pre.issued_index} never authorised "
+                f"capability {capability!r}"
+            )
+        return GrantDecision(
+            outcome=outcome,
+            permitted=False,
+            grant_id=pre.grant_id,
+            capability=capability,
+            reason=reason,
+            issued_index=pre.issued_index,
+            superseded_index=superseded,
+            superseding_kind=superseding,
+        )
+
+
+@dataclass(slots=True)
+class DispatchGrantGate:
+    """Re-decide the grant behind one run's tool calls, and chain the refusals.
+
+    A refusal is appended to the same grant chain as a ``grant_refused``
+    record, so the sequence ``grant_issued -> grant_revoked -> grant_refused``
+    is ordered evidence rather than a log line: a verifier reading the chain
+    later sees when the authority lapsed and which call was refused after it.
+    A permitted call writes nothing, so re-deciding on every dispatch does not
+    flood the chain.
+    """
+
+    index: GrantPreconditionIndex
+    grant_id: str
+    run_id: str
+    task_id: str = ""
+    ledger: GrantLedger | None = None
+    capability_of: Callable[[ToolCallDescription], str] = tool_call_capability
+
+    def re_decide(self, intent: ToolCallDescription) -> GrantDecision:
+        """Return the decision for ``intent``, raising when it is refused."""
+        decision = self.index.decide(self.grant_id, self.capability_of(intent))
+        if decision.permitted:
+            return decision
+        if self.ledger is not None:
+            self.ledger.record_refusal(
+                run_id=self.run_id,
+                task_id=self.task_id,
+                secret_name="",
+                reason=decision.reason,
+                grant_id=self.grant_id,
+            )
+        raise GrantRefusedError(decision)

--- a/src/bernstein/core/security/toolcall_interlock.py
+++ b/src/bernstein/core/security/toolcall_interlock.py
@@ -9,6 +9,15 @@ mode attempts the same preparation but deliberately keeps failures non-fatal.
 The provider protocol is intentionally about evidence, not key management or
 policy.  Bernstein's native signer can implement it, as can an operator adapter,
 without making either implementation a dependency of the dispatch boundary.
+
+The boundary is also where a grant is *spent*, so it is where a grant's
+preconditions are re-decided against current chain state.  A grant decided at
+issue and carried for hours can be revoked or narrowed before the call it
+authorises goes out, and the issued signature stays valid throughout.  An
+optional grant gate (see :mod:`bernstein.core.security.grant_precondition`)
+therefore runs before evidence preparation and refuses with the chain position
+of the record that superseded the grant.  Its refusal is an authorisation
+verdict, not an evidence failure, so observed mode does not downgrade it.
 """
 
 from __future__ import annotations
@@ -21,6 +30,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any, Protocol, cast
 
+from bernstein.core.security.grant_precondition import GrantDecision, GrantRefusedError
 from bernstein.core.security.sanitize import sanitize_log
 from bernstein.core.security.toolcall_identity import ToolCallIdentityError, verify_identity_envelope
 
@@ -122,6 +132,14 @@ class ToolCallEvidenceProvider(Protocol):
         ...
 
 
+class GrantRedecider(Protocol):
+    """Re-decide the grant behind one about-to-dispatch call."""
+
+    def re_decide(self, intent: ToolCallIntent) -> GrantDecision:
+        """Return the decision, raising ``GrantRefusedError`` when refused."""
+        ...
+
+
 class ToolCallInterlockError(RuntimeError):
     """Raised when enforced dispatch cannot establish durable evidence."""
 
@@ -146,6 +164,7 @@ class ToolCallAttestationInterlock:
     provider: ToolCallEvidenceProvider
     scope_id: str
     mode: AttestationMode = AttestationMode.ENFORCED
+    grant_gate: GrantRedecider | None = None
 
     async def before_dispatch(self, intent: ToolCallIntent) -> VerifiedDispatchEvidence | None:
         """Prepare evidence before a connector is invoked.
@@ -153,16 +172,28 @@ class ToolCallAttestationInterlock:
         Enforced mode fails closed.  Observed mode logs preparation failures and
         returns ``None`` so the connector remains reachable, which is precisely
         why a verifier must report that run as observed rather than complete.
+
+        A configured grant gate is consulted before any evidence is prepared,
+        because a call whose authority has lapsed must not be attested as
+        authorised.  Its refusal names the chain position that superseded the
+        grant and propagates in both modes.
         """
         try:
             if not self.scope_id.strip() or intent.scope_id != self.scope_id:
                 raise ToolCallInterlockError("tool-call intent is not bound to the configured evidence scope")
+            if self.grant_gate is not None:
+                self.grant_gate.re_decide(intent)
             evidence = await self.provider.prepare_dispatch(intent)
             if not evidence.attestation_ref.strip() or not evidence.dispatch_ref.strip():
                 raise ToolCallInterlockError("attestation provider returned an incomplete evidence handle")
             if evidence.intent_digest != intent.digest():
                 raise ToolCallInterlockError("attestation provider returned evidence for a different tool-call intent")
             return evidence
+        except GrantRefusedError:
+            # An authorisation verdict, not an evidence failure: observed mode
+            # exists so instrumentation gaps stay non-fatal, and downgrading a
+            # lapsed grant to a warning would make the gate advisory.
+            raise
         except Exception as exc:
             if self.mode is AttestationMode.OBSERVED:
                 logger.warning(
@@ -482,6 +513,7 @@ __all__ = [
     "AttestationMode",
     "AttestationModeProjection",
     "AttestationVerdict",
+    "GrantRedecider",
     "ToolCallAttestationInterlock",
     "ToolCallEvidenceProvider",
     "ToolCallIntent",

--- a/tests/unit/security/test_grant_precondition_redecision.py
+++ b/tests/unit/security/test_grant_precondition_redecision.py
@@ -1,0 +1,305 @@
+"""A grant valid at issue must be re-decided at dispatch (issue #5022).
+
+The issued record's Ed25519 signature stays valid after the grant is revoked or
+narrowed, so a boundary that only verifies the signature keeps authorising
+calls whose authority has lapsed. These tests pin the re-decision at the
+dispatch boundary, the chain position a refusal must name, and the ordering the
+refusal takes on the grant chain.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.identity import grants
+from bernstein.core.security.grant_precondition import (
+    DispatchGrantGate,
+    GrantPreconditionIndex,
+    GrantRefusedError,
+    RedecisionOutcome,
+)
+from bernstein.core.security.toolcall_interlock import (
+    AttestationMode,
+    ToolCallAttestationInterlock,
+    ToolCallIntent,
+    VerifiedDispatchEvidence,
+)
+
+RUN_ID = "run-5022"
+SCOPE_ID = "scope:run-5022:agent-1"
+
+
+class _RecordingProvider:
+    """Evidence provider that always succeeds, so refusals are unambiguous."""
+
+    def __init__(self) -> None:
+        self.intents: list[ToolCallIntent] = []
+
+    async def prepare_dispatch(self, intent: ToolCallIntent) -> VerifiedDispatchEvidence:
+        self.intents.append(intent)
+        return VerifiedDispatchEvidence(
+            attestation_ref=f"attestation:{intent.span_id}",
+            dispatch_ref=f"dispatch:{intent.span_id}",
+            intent_digest=intent.digest(),
+        )
+
+
+@pytest.fixture
+def ledger(tmp_path: Path) -> grants.GrantLedger:
+    return grants.GrantLedger(
+        root=tmp_path,
+        key=b"k" * 32,
+        signer=grants.GrantSigner.generate(issuer="manager:test"),
+    )
+
+
+def _intent(tool_name: str) -> ToolCallIntent:
+    return ToolCallIntent.from_request(
+        scope_id=SCOPE_ID,
+        server_name="filesystem",
+        method="tools/call",
+        tool_name=tool_name,
+        request_id=1,
+        span_id=f"span-{tool_name}",
+        arguments={"path": "/tmp/x"},
+    )
+
+
+def _issue(ledger: grants.GrantLedger, *, ceiling: tuple[str, ...], expiry: int = 0) -> grants.GrantReceipt:
+    return ledger.issue_grant(
+        run_id=RUN_ID,
+        task_id="t-1",
+        secret_name="ANTHROPIC_API_KEY",
+        audience="api.anthropic.com",
+        expiry=expiry,
+        capability_ceiling=ceiling,
+    )
+
+
+def _gate(ledger: grants.GrantLedger, grant_id: str) -> DispatchGrantGate:
+    return DispatchGrantGate(
+        index=GrantPreconditionIndex.for_run(ledger, RUN_ID),
+        grant_id=grant_id,
+        run_id=RUN_ID,
+        task_id="t-1",
+        ledger=ledger,
+    )
+
+
+def _interlock(
+    gate: DispatchGrantGate,
+    *,
+    mode: AttestationMode = AttestationMode.ENFORCED,
+) -> ToolCallAttestationInterlock:
+    return ToolCallAttestationInterlock(
+        provider=_RecordingProvider(),
+        scope_id=SCOPE_ID,
+        mode=mode,
+        grant_gate=gate,
+    )
+
+
+def _records(ledger: grants.GrantLedger) -> list[dict[str, Any]]:
+    path = ledger.receipt_path(RUN_ID)
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+@pytest.mark.asyncio
+async def test_revoked_grant_is_refused_at_dispatch_not_at_issue(ledger: grants.GrantLedger) -> None:
+    """The same interlock permits, then refuses, once the chain records revocation."""
+    grant = _issue(ledger, ceiling=("read_file",))
+    interlock = _interlock(_gate(ledger, grant.grant_id))
+    intent = _intent("read_file")
+
+    assert await interlock.before_dispatch(intent) is not None
+
+    ledger.revoke_grant(run_id=RUN_ID, grant_id=grant.grant_id, reason="group membership withdrawn")
+
+    with pytest.raises(GrantRefusedError) as excinfo:
+        await interlock.before_dispatch(intent)
+    assert excinfo.value.decision.outcome is RedecisionOutcome.REVOKED
+
+
+@pytest.mark.asyncio
+async def test_refusal_names_the_superseding_event(ledger: grants.GrantLedger) -> None:
+    """The refusal states which record superseded the grant, and at what position."""
+    grant = _issue(ledger, ceiling=("read_file",))
+    interlock = _interlock(_gate(ledger, grant.grant_id))
+    ledger.revoke_grant(run_id=RUN_ID, grant_id=grant.grant_id, reason="playbook withdrew the group")
+
+    with pytest.raises(GrantRefusedError) as excinfo:
+        await interlock.before_dispatch(_intent("read_file"))
+
+    decision = excinfo.value.decision
+    assert decision.issued_index == 0
+    assert decision.superseded_index == 1
+    assert decision.superseding_kind == grants.GRANT_REVOKED
+    assert "issued at chain position 0" in decision.reason
+    assert "superseded by grant_revoked at chain position 1" in decision.reason
+
+
+@pytest.mark.asyncio
+async def test_narrowed_capability_permits_the_narrower_call_and_refuses_the_wider_one(
+    ledger: grants.GrantLedger,
+) -> None:
+    """Re-issuing the grant with a smaller ceiling narrows it from that position on."""
+    grant = _issue(ledger, ceiling=("read_file", "write_file"))
+    interlock = _interlock(_gate(ledger, grant.grant_id))
+    assert await interlock.before_dispatch(_intent("write_file")) is not None
+
+    ledger.issue_grant(
+        run_id=RUN_ID,
+        task_id="t-1",
+        secret_name="ANTHROPIC_API_KEY",
+        audience="api.anthropic.com",
+        capability_ceiling=("read_file",),
+        grant_id=grant.grant_id,
+    )
+
+    assert await interlock.before_dispatch(_intent("read_file")) is not None
+    with pytest.raises(GrantRefusedError) as excinfo:
+        await interlock.before_dispatch(_intent("write_file"))
+
+    decision = excinfo.value.decision
+    assert decision.outcome is RedecisionOutcome.NARROWED
+    assert decision.superseded_index == 1
+    assert "'write_file'" in decision.reason
+    assert "superseded by grant_issued at chain position 1" in decision.reason
+
+
+@pytest.mark.asyncio
+async def test_unchanged_preconditions_do_not_produce_an_event(ledger: grants.GrantLedger) -> None:
+    """Re-deciding an unchanged grant appends nothing, however many calls run."""
+    grant = _issue(ledger, ceiling=("read_file",))
+    interlock = _interlock(_gate(ledger, grant.grant_id))
+    before = _records(ledger)
+
+    for _ in range(5):
+        assert await interlock.before_dispatch(_intent("read_file")) is not None
+
+    assert _records(ledger) == before
+
+
+def test_re_decision_reads_only_the_chain() -> None:
+    """The re-decision path imports no network, subprocess, or model module."""
+    module_root = Path(grants.__file__).parents[3] / "bernstein" / "core" / "security"
+    redecision = module_root / "grant_precondition.py"
+    interlock = module_root / "toolcall_interlock.py"
+
+    forbidden = {
+        "aiohttp",
+        "httpx",
+        "requests",
+        "socket",
+        "ssl",
+        "subprocess",
+        "urllib",
+        "urllib3",
+        "websockets",
+    }
+    for path in (redecision, interlock):
+        assert _imported_roots(path).isdisjoint(forbidden), path.name
+        assert not any(root.startswith("bernstein.core.llm") for root in _imported_modules(path)), path.name
+
+    # The re-decision module itself is held to an allowlist, so a later edit
+    # cannot reach a live service through a module that is merely not on the
+    # denylist above.
+    assert _imported_roots(redecision) == {
+        "__future__",
+        "bernstein",
+        "collections",
+        "dataclasses",
+        "enum",
+        "hmac",
+        "json",
+        "pathlib",
+        "time",
+        "typing",
+    }
+    assert {m for m in _imported_modules(redecision) if m.startswith("bernstein")} == {"bernstein.core.identity.grants"}
+
+
+def _imported_modules(path: Path) -> set[str]:
+    """Return every module name imported anywhere in ``path``, nested included."""
+    names: set[str] = set()
+    for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and not node.level:
+            names.add(node.module)
+    return names
+
+
+def _imported_roots(path: Path) -> set[str]:
+    return {name.split(".")[0] for name in _imported_modules(path)}
+
+
+@pytest.mark.asyncio
+async def test_grant_valid_at_issue_and_invalid_at_use_is_ordered_correctly_on_the_chain(
+    ledger: grants.GrantLedger,
+) -> None:
+    """Issue, revocation, and the refusal it caused verify in that chain order."""
+    grant = _issue(ledger, ceiling=("read_file",))
+    interlock = _interlock(_gate(ledger, grant.grant_id))
+    assert await interlock.before_dispatch(_intent("read_file")) is not None
+    ledger.revoke_grant(run_id=RUN_ID, grant_id=grant.grant_id, reason="budget envelope exhausted")
+    with pytest.raises(GrantRefusedError):
+        await interlock.before_dispatch(_intent("read_file"))
+
+    result = grants.verify_grant_chain(root=ledger.root, run_id=RUN_ID, key=ledger.hmac_key)
+    assert result.valid, result.errors
+    assert [r.kind for r in result.records] == [
+        grants.GRANT_ISSUED,
+        grants.GRANT_REVOKED,
+        grants.GRANT_REFUSED,
+    ]
+    refusal = result.records[2]
+    assert refusal.record_index > result.records[1].record_index
+    assert refusal.grant_id == grant.grant_id
+    assert "chain position 1" in refusal.reason
+
+
+@pytest.mark.asyncio
+async def test_observed_mode_does_not_downgrade_a_grant_refusal(ledger: grants.GrantLedger) -> None:
+    """Observed mode softens missing evidence, never a lapsed authority."""
+    grant = _issue(ledger, ceiling=("read_file",))
+    interlock = _interlock(_gate(ledger, grant.grant_id), mode=AttestationMode.OBSERVED)
+    ledger.revoke_grant(run_id=RUN_ID, grant_id=grant.grant_id, reason="certification lapsed")
+
+    with pytest.raises(GrantRefusedError):
+        await interlock.before_dispatch(_intent("read_file"))
+
+
+@pytest.mark.asyncio
+async def test_tampered_grant_record_refuses_every_dispatch(ledger: grants.GrantLedger) -> None:
+    """A chain that no longer authenticates refuses instead of falling open."""
+    grant = _issue(ledger, ceiling=("read_file",))
+    interlock = _interlock(_gate(ledger, grant.grant_id))
+    path = ledger.receipt_path(RUN_ID)
+    entry = _records(ledger)[0]
+    entry["capability_ceiling"] = ["read_file", "write_file"]
+    path.write_text(json.dumps(entry, sort_keys=True) + "\n", encoding="utf-8")
+
+    with pytest.raises(GrantRefusedError) as excinfo:
+        await interlock.before_dispatch(_intent("read_file"))
+    assert "record 0" in excinfo.value.decision.reason
+    assert grant.grant_id == excinfo.value.decision.grant_id
+
+
+@pytest.mark.asyncio
+async def test_expired_grant_is_refused_even_though_its_signature_verifies(
+    ledger: grants.GrantLedger,
+) -> None:
+    """An elapsed expiry withdraws authority the issued signature still covers."""
+    grant = _issue(ledger, ceiling=("read_file",), expiry=1_000_000_000)
+    gate = _gate(ledger, grant.grant_id)
+    assert gate.index.decide(grant.grant_id, "read_file", now=999_999_999.0).permitted
+
+    with pytest.raises(GrantRefusedError) as excinfo:
+        await _interlock(gate).before_dispatch(_intent("read_file"))
+    assert "expired at 1000000000" in excinfo.value.decision.reason

--- a/tests/unit/security/test_grant_precondition_redecision.py
+++ b/tests/unit/security/test_grant_precondition_redecision.py
@@ -22,6 +22,7 @@ from bernstein.core.security.grant_precondition import (
     GrantPreconditionIndex,
     GrantRefusedError,
     RedecisionOutcome,
+    tool_call_capability,
 )
 from bernstein.core.security.toolcall_interlock import (
     AttestationMode,
@@ -107,6 +108,19 @@ def _interlock(
 def _records(ledger: grants.GrantLedger) -> list[dict[str, Any]]:
     path = ledger.receipt_path(RUN_ID)
     return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def test_tool_call_capability_is_the_default_capability_resolver(ledger: grants.GrantLedger) -> None:
+    """Every _gate() above wires capability_of only implicitly, through this default.
+
+    A grant's capability_ceiling holds tool names, so the default projection from an
+    about-to-dispatch intent to a capability is just the intent's own tool_name.
+    """
+    gate = _gate(ledger, "unused-grant-id")
+    assert gate.capability_of is tool_call_capability
+
+    intent = _intent("read_file")
+    assert tool_call_capability(intent) == intent.tool_name
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Re-decides a grant's preconditions at the tool-call dispatch boundary instead of trusting the decision taken at issue, and makes a refusal carry the chain position of the record that superseded the grant.

Adds `src/bernstein/core/security/grant_precondition.py`:

- `GrantPreconditionIndex` — an incrementally authenticated projection of one run's grant chain.
- `DispatchGrantGate` — re-decides one run's grant per call and appends the refusal to the chain.
- `GrantDecision` / `RedecisionOutcome` — the verdict, the outcome (`valid` / `narrowed` / `revoked`), and the reason that names the positions.

`ToolCallAttestationInterlock` gains one optional field, `grant_gate`, consulted before evidence preparation.

**Not in this PR:** signing-key rotation and revocation (#4211), per-tool-call admission policy (#2957), org-level allow/deny declarations (#4907). No new grant record kind, no schema change, no change to how grants are issued or exchanged, no change to the secrets broker.

## Why

A grant is decided once, at issue, and then carried. Every fact it rested on can change before it is spent: it is revoked, its capability ceiling is narrowed, its expiry elapses. None of that touches the Ed25519 signature over the issued record, so a boundary that verifies only the signature keeps authorising calls whose authority has already lapsed — correct cryptography, wrong authorisation. The window is real in this repository's own shape: a fan-out issues grants at the start of a run and spends them over the following hours, and `find_active_grant` in `core/identity/grants.py` is only consulted when a token is minted, never again at the point the authority is actually used.

The refusal is the other half. A boundary that re-checks authorisation can only report that a call was denied. What an operator reconstructing an incident needs is *when the authority lapsed and what ran between then and the refusal* — so the refusal states "grant `g` issued at chain position 0 was superseded by `grant_revoked` at chain position 1", and that statement re-derives from the same JSONL slice and install audit key, offline, by someone who was not there.

## How

`GrantPreconditionIndex` folds a run's `grants/<run_id>.jsonl` into per-grant preconditions: effective capability ceiling, effective expiry, revocation position. It keeps a byte offset and a running `prev_hmac`, so a refresh authenticates only the records appended since the previous one — the same resume shape `ChainScanCursor` already uses for the audit chain. Each new record is checked for linkage, re-HMAC'd with the writer's own construction, and verified against its embedded issuer key; a record that fails any of those poisons the index permanently and every later decision refuses, naming the offending record.

`DispatchGrantGate.re_decide` looks the grant up, and on refusal appends a `grant_refused` record before raising. A permitted call appends nothing.

**Cost per dispatch,** as the issue asks: one `stat`/short read of the tail (normally zero new bytes), one dict lookup, one frozenset membership test, one integer comparison. Authenticating a record — one HMAC and one Ed25519 verification — happens once per record, never once per call. The chain is never re-walked. A refusal additionally writes one record, which is the exception path.

The interlock consults the gate before `provider.prepare_dispatch`, so a call whose authority has lapsed is never attested as authorised.

Three decisions the issue left open, and why:

1. **Narrowing is a re-issue of the same `grant_id` with a smaller `capability_ceiling`.** No new record kind and no migration; the effective ceiling is the intersection of the ceilings across every `grant_issued` record for that id, in chain order, and the position where it last shrank is what a refusal names. A re-issue carrying a *wider* ceiling therefore restores nothing — the same attenuation rule `capability_tokens.py` already enforces on delegation hops. Revocation is monotone for the same reason.
2. **An empty ceiling authorises nothing.** A ceiling is a maximum, so an empty maximum caps everything out. The gate is opt-in, so no existing grant changes behaviour.
3. **A grant refusal is not downgraded in observed mode.** Observed mode exists so an instrumentation gap stays non-fatal; a lapsed authority is an authorisation verdict, not missing evidence, and downgrading it to a log line would make the gate advisory.

The capability a call needs defaults to its tool name, which is the symbol an operator writes when scoping a grant to a tool; a deployment whose ceiling is spelled differently supplies its own resolver through `capability_of`.

Wiring: `ToolCallAttestationInterlock` is constructed by its integrator, not inside `src/`, so `grant_gate` is an optional constructor field in the same shape as `provider` and `mode`. Nothing changes for an interlock built without one.

## Tests

`tests/unit/security/test_grant_precondition_redecision.py`. Every test below failed before the change: on the unmodified tree the module does not exist (collection error), and with the module present but the interlock's `re_decide` step removed, 1, 2, 3, 6, 7, 8 and 9 fail because a revoked, narrowed, expired or unauthenticatable grant still reaches the connector.

1. `test_revoked_grant_is_refused_at_dispatch_not_at_issue` — **load-bearing.** The same interlock instance permits the call, the chain then records a revocation, and the next identical call is refused. This is the defect: nothing about the issued record changed between the two calls.
2. `test_refusal_names_the_superseding_event` — the decision carries `issued_index`, `superseded_index` and the superseding kind, and the reason states both positions.
3. `test_narrowed_capability_permits_the_narrower_call_and_refuses_the_wider_one` — after a narrowing re-issue, the surviving capability dispatches and the removed one is refused at the narrowing position.
4. `test_unchanged_preconditions_do_not_produce_an_event` — five permitted dispatches leave the chain byte-identical. This one guards against flooding rather than reproducing the defect, so it also passes without the interlock step.
5. `test_re_decision_reads_only_the_chain` — a static assertion over the re-decision path: an allowlist over every module `grant_precondition.py` imports anywhere (nested imports included), plus a denylist over the interlock. No network, no subprocess, no model module can enter without failing this test.
6. `test_grant_valid_at_issue_and_invalid_at_use_is_ordered_correctly_on_the_chain` — after a refusal the chain verifies end to end and reads `grant_issued -> grant_revoked -> grant_refused`, with the refusal strictly after the revocation and its reason naming that position.
7. `test_observed_mode_does_not_downgrade_a_grant_refusal` — decision 3 above, pinned.
8. `test_tampered_grant_record_refuses_every_dispatch` — a mutated ceiling breaks the HMAC, and the index fails closed naming the record instead of falling open on a widened grant.
9. `test_expired_grant_is_refused_even_though_its_signature_verifies` — the index permits before the expiry and refuses after it, with the same signed record throughout.

Local runs (`XDG_*` and the confidence DB pointed at a scratch tree):

- `run_tests.py --parallel 2 -x tests/unit/security/test_grant_precondition_redecision.py tests/unit/security/test_toolcall_interlock.py tests/unit/identity/test_grants.py` — 35 passed.
- The importers of both touched modules: `test_key_custody_boundary`, `test_secrets_broker_grants`, `test_secrets_grants_cli`, `test_audit_verify_grants`, `test_toolcall_interlock_benchmark`, `test_lineage_toolcall_gate`, `test_run_attestation_receipt`, `test_native_toolcall_evidence`, `test_toolcall_identity`, `test_mcp_gateway`, `test_mcp_gateway_x402`, `test_pyright_excludes` — 100 passed.

`--affected origin/main` did not finish inside the local time budget on this shared machine, so the importer set above was run explicitly instead; CI runs the full suite.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes (0 errors on both touched security modules; `grants.py` carries three pre-existing errors unchanged by this PR)
- [x] `uv run python scripts/run_tests.py -x` passes for the files listed above
- [x] New code has type hints

### Documentation duty

- [ ] User-visible README section updated — N/A (internal boundary, no user-facing surface)
- [ ] `docs/operations/<area>.md` updated — N/A (no operator-facing command or config added)
- [ ] `docs/api/` schema regenerated — N/A (no HTTP surface changed)
- [x] `uv run bernstein agents-md sync` run — produced no changes
- [x] Tests cover the documented behaviour

Closes #5022
