### PR TITLE
docs: supersede ADR-006 and guard the decision record (#5026)

### DIFF
--- a/docs/decisions/002-withdrawn.md
+++ b/docs/decisions/002-withdrawn.md
@@ -1,0 +1,21 @@
+# ADR-002: Withdrawn
+
+**Status**: Withdrawn
+**Date**: 2026-05-10
+**Context**: `docs/decisions/`
+
+---
+
+ADR-002 was removed from the published documentation set on 2026-05-10
+(commit `de76216`). It is not being rewritten, and the number is not
+being reused.
+
+This file exists so the gap has an answer. A number missing from a
+decision record is a question every future reader has to ask once, and
+the directory gives them nowhere to ask it: an absent file cannot say
+whether the record was withdrawn, never written, or lost.
+
+Numbers here are addresses. Anything that ever cited ADR-002 keeps
+pointing at this file rather than at a record about something else, so
+the rule is that a withdrawn number keeps a record stating so and is
+never reassigned.

--- a/docs/decisions/006-no-embedded-llm.md
+++ b/docs/decisions/006-no-embedded-llm.md
@@ -1,8 +1,14 @@
 # ADR-006: No Embedded LLM in the Orchestrator
 
-**Status**: Accepted  
+**Status**: Superseded by ADR-011  
 **Date**: 2026-03-22  
 **Context**: Bernstein multi-agent orchestration system
+
+> Superseded on 2026-09-02 by
+> [ADR-011](011-model-drafts-human-signs.md), which keeps the decision
+> below intact and adds the case it does not cover: a model that drafts an
+> artefact a human must sign. The coordination boundary this record sets is
+> unchanged. The body is left as written.
 
 ---
 

--- a/docs/decisions/011-model-drafts-human-signs.md
+++ b/docs/decisions/011-model-drafts-human-signs.md
@@ -1,0 +1,164 @@
+# ADR-011: A Model May Draft What a Human Signs
+
+**Status**: Accepted
+**Date**: 2026-09-02
+**Supersedes**: [ADR-006](006-no-embedded-llm.md)
+**Context**: `src/bernstein/core/govern/` (`findings.py`, `proposal.py`),
+issues #4973, #4981, #4982, #5020
+
+---
+
+## Problem
+
+ADR-006 described the system as having two places a model can be. Coordination
+— scheduling, task assignment, lifecycle, retry — is deterministic Python and
+spends zero tokens. Everything else a model does happens at "the explicit leaf
+nodes of the system": decomposing a goal into tasks, reviewing a finished diff,
+verifying a completed change.
+
+`govern discover --assist` (#5020) is in neither place. It hands a findings
+document — built entirely from chain-recorded observations — to a model the
+operator nominates, and gets back a draft governance playbook. The scheduler
+never sees it. No task is executing while it runs. Its output governs future
+runs rather than performing one.
+
+A contributor reading ADR-006 before writing that command has two bad options.
+They can decide it is out of bounds and not write it, which costs a feature the
+record never actually forbade. Or they can call it a leaf node, which quietly
+stretches "leaf" to mean "wherever a model turned out to be fine" — and a
+boundary that stretches on contact is not a boundary.
+
+The claim itself is also load-bearing outside the repository. We state publicly
+that no model sits in the coordination loop. That statement is still exactly
+true and needs to stay checkable, which it cannot be while the record it rests
+on does not describe what ships.
+
+---
+
+## Decision
+
+There are three categories, not two.
+
+1. **Coordination.** Deterministic Python. No model, no tokens. Unchanged from
+   ADR-006.
+2. **Leaf execution.** A model performs a task inside a run — decomposition,
+   review, cross-model verification. Unchanged from ADR-006.
+3. **Drafting.** A model produces an artefact that has no effect until a human
+   signs it.
+
+The rule a contributor can apply without asking:
+
+> **A model may draft an artefact a human must sign. It may never decide what
+> runs next, which agent gets it, whether it is retried, or when it ends.**
+
+"Must sign" is a property of the artefact, not a convention. A drafted artefact
+is recorded as a proposal, and the command that would act on it refuses while it
+is unsigned: `DraftProposal.is_signed()` in
+`src/bernstein/core/govern/proposal.py` is what `govern apply` (#4982) checks,
+and an unsigned draft is a refusal, not a warning.
+
+Three things are recorded with the draft, so it can be read later as evidence
+rather than as a suggestion: which model produced it, the digest of the prompt
+it was given, and the digest of the findings document it read. The findings
+document is content-addressed and on the chain, so "what did it actually see"
+is answerable six weeks later without re-running anything (#5020).
+
+---
+
+## Why the coordination claim survives
+
+The drafting call is not on the tick loop and no run's task graph depends on it.
+A run consumes a playbook that a human already signed; replaying that run
+replays against the same playbook by hash. Two operators with the same signed
+playbook get the same task graph, which is the property ADR-006 existed to
+protect and the one that would break if a model sat between "a task finished"
+and "what runs next".
+
+What a drafting model changes is what a human was shown before they decided.
+That is worth recording, which is why it is, and it is not the same thing as
+changing what the scheduler did.
+
+---
+
+## Rejected alternative: leave ADR-006 alone and call drafting a leaf node
+
+Cheapest option, and it is the one a contributor under time pressure will reach
+for. Rejected because a leaf node executes a task inside a run and its output is
+consumed by that run; a drafting command runs outside any run and its output
+governs later ones. Folding the second into the first leaves "leaf node" meaning
+nothing in particular, and the next contributor stretches it one step further —
+this time toward something that does touch scheduling.
+
+## Rejected alternative: edit ADR-006 in place
+
+`index.md` states the reason this directory works: a record is written when the
+decision is made and then left alone, because one edited to match today's code
+stops being evidence of anything. ADR-006 was not wrong about what it decided.
+It is incomplete about a case that did not exist when it was written. Editing it
+would erase the fact that the two-category model was ever the position, which is
+the part a reader needs in order to trust the third category was argued for
+rather than assumed.
+
+Ten accepted records and zero supersessions across a moving architecture is a
+record being appended to. This is the first supersession, and the mechanism it
+establishes — status changes to `Superseded by ADR-NNN`, body untouched — is
+how the next one goes.
+
+## Rejected alternative: forbid model drafting outright
+
+Defensible on the surface: the narrowest rule is the easiest to police.
+
+Rejected because it does not remove the model, it removes our record of it. The
+reason an environment has no governance playbook is almost always that nobody
+can enumerate the environment (#5020). An operator facing that will ask a model
+anyway, in a chat window, with no digest of what it read and no signature on
+what came out. Forbidding the supported path trades an attributable draft for an
+unattributable one and calls the result stricter.
+
+The fallback stays first-class rather than degraded: with no connector
+configured, the command still emits the findings document and no draft.
+
+---
+
+## Consequences
+
+### Benefits
+
+**A legitimate feature has an answer.** #4981 and #5020 stop depending on how a
+reviewer reads "leaf node".
+
+**The public claim gets narrower and true.** "No model in the coordination loop"
+is a statement about scheduling, and it stays exactly true. It was never the
+same claim as "no model anywhere but leaf execution", and only the second one
+would have had to be withdrawn.
+
+**Supersession is now a thing this directory does.** The status flip on ADR-006
+is the worked example.
+
+### Costs
+
+**A third category is more surface to police.** Two categories could be checked
+by reading an import; three cannot. The check that replaces it is the signature
+requirement: a command that writes a governance artefact from model output must
+produce something `apply` refuses until a human signs it. A drafting path that
+skips that is not in category 3 — it is an unrecorded change to a security
+posture.
+
+**Category 3 will be argued about at its edge.** "The human signs it" is doing
+the work, so the pressure lands on what counts as signing. A signature is a
+human action on a specific content hash. A default-on setting that auto-accepts
+drafts is not one, whatever it is called.
+
+---
+
+## What is still forbidden
+
+Unchanged from ADR-006, and not softened by any of the above. No model decides:
+
+- which task runs next, or in what order;
+- which agent a task is assigned to;
+- whether a failed task is retried or abandoned;
+- when an agent's life ends.
+
+Those are deterministic Python, and a proposal to move any of them is answered
+by [Scope](../scope.md).

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -12,31 +12,64 @@ that is the part a record preserves and a commit message does not.
 | ADR | Decision | Status | Date |
 |---|---|---|---|
 | [001](001-agent-lifecycle.md) | Agent lifecycle model: agents that exhaust their queue exit rather than idle | Accepted | 2026-03-22 |
+| [002](002-withdrawn.md) | Withdrawn — the number is recorded, not reused | Withdrawn | 2026-05-10 |
 | [003](003-self-evolution.md) | Self-evolution feedback loop architecture | Approved | 2026-03-22 |
 | [004](004-file-based-state.md) | Persistent state is plain text under `.sdd/` — no embedded database | Accepted | 2026-03-22 |
 | [005](005-short-lived-agents.md) | Agents spawn with 1–3 tasks, execute, and exit | Accepted | 2026-03-22 |
-| [006](006-no-embedded-llm.md) | Scheduling and lifecycle are deterministic Python; zero tokens on coordination | Accepted | 2026-03-22 |
+| [006](006-no-embedded-llm.md) | Scheduling and lifecycle are deterministic Python; zero tokens on coordination | Superseded by [011](011-model-drafts-human-signs.md) | 2026-03-22 |
 | [007](007-pluggy-plugin-system.md) | Pluggy is the plugin surface, so extending does not mean forking | Accepted | 2026-03-22 |
 | [008](008-click-for-cli.md) | Click for the CLI | Accepted | 2026-03-22 |
 | [009](009-lineage-v1.md) | Lineage v1: per-artefact transparency log | Accepted | 2026-05-13 |
 | [010](010-audit-chain-default-cost.md) | What turning the HMAC audit chain on by default costs, and the path to it | Accepted | 2026-07-24 |
+| [011](011-model-drafts-human-signs.md) | A model may draft an artefact a human must sign; it never decides what runs | Accepted | 2026-09-02 |
 
-## When to write one
+## When a record is required
 
-Write a record when a decision closes off an alternative someone will
-reasonably propose again later. That is the test — not how large the
-change is. A small decision that will be re-litigated every quarter is
-worth a record; a large one nobody will question is not.
+A record is required when a decision closes off an alternative someone
+will reasonably propose again later. That is the test — not how large
+the change is. A small decision that will be re-litigated every quarter
+is worth a record; a large one nobody will question is not.
+
+Concretely, write one before the change merges when any of these is
+true:
+
+- it narrows or widens a boundary listed in [Scope](../scope.md);
+- it makes a claim the project states publicly, or makes an existing
+  one narrower;
+- it picks one of several defensible designs, and the losing one is
+  something a reviewer would otherwise ask for by default;
+- it changes what a stored artefact means to a reader six months later.
 
 Skip it when the choice is reversible at no cost, or when the code
 already states the reason plainly enough to survive the next reader.
+
+Six months of arguments in issue threads is not a record. A thread
+holds the argument; a record holds which way it went and what it cost.
+When the two diverge, the record is what binds.
+
+## Superseding, withdrawing, numbering
+
+A record is never rewritten to match what the code does now. When a
+decision changes, write a new record and set the old one's status to
+`Superseded by ADR-NNN`, leaving its body as written. Both stay
+readable, so a reader can see the position that was replaced and why.
+
+Numbers are addresses. A record that is withdrawn keeps its number and
+a file stating so; a number is never reused, and the sequence never has
+a gap that the directory itself cannot explain.
 
 ## Format
 
 Follow the existing files: number in sequence, `Status`, `Date`,
 `Context`, then the problem, the decision, and what it costs. State the
 alternatives that lost and why — a record with no rejected alternative
-is a description, not a decision.
+is a description, not a decision. Cite the issues the reasoning came
+from, so a reader can get to the argument behind the outcome.
+
+`tests/unit/test_decision_records.py` checks the parts of this that a
+machine can check: every record carries a status and an ISO date, the
+numbering has no unexplained gap, a superseded record names a successor
+that exists, and the table above matches the directory.
 
 The boundaries these records set are collected in
 [Scope](../scope.md), which is the page to link when a proposal runs

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -22,7 +22,13 @@ rather than a sampling artefact you can only shrug at. Anything that
 would put a model between "a task finished" and "what runs next" is out
 of scope, however good the model.
 
-Record: [ADR-006](decisions/006-no-embedded-llm.md).
+A model may draft an artefact a human must sign — a proposed governance
+playbook, for instance — because nothing it writes takes effect until
+someone signs a specific content hash. It may never decide what runs
+next, which agent gets it, whether it is retried, or when it ends.
+
+Record: [ADR-011](decisions/011-model-drafts-human-signs.md),
+superseding [ADR-006](decisions/006-no-embedded-llm.md).
 
 ## No database for run state
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -654,6 +654,7 @@ nav:
       - Decisions (ADRs):
           - Index: decisions/index.md
           - Agent lifecycle: decisions/001-agent-lifecycle.md
+          - ADR-002 (withdrawn): decisions/002-withdrawn.md
           - Self-evolution: decisions/003-self-evolution.md
           - File-based state: decisions/004-file-based-state.md
           - Short-lived agents: decisions/005-short-lived-agents.md
@@ -662,6 +663,7 @@ nav:
           - Click for CLI: decisions/008-click-for-cli.md
           - Lineage v1: decisions/009-lineage-v1.md
           - Audit-chain default cost: decisions/010-audit-chain-default-cost.md
+          - A model drafts, a human signs: decisions/011-model-drafts-human-signs.md
   - Contribute:
       - contributing/index.md
       - Code review process: CODE_REVIEW.md

--- a/tests/unit/test_decision_records.py
+++ b/tests/unit/test_decision_records.py
@@ -1,0 +1,149 @@
+"""Guard: the decision record under ``docs/decisions/`` stays readable.
+
+The directory is prose, so nothing fails when it drifts: a record can lose
+its ``Status``, a number can go missing, a superseded record can point at a
+successor that was never written, and the index can list a file that no
+longer exists. Each of those is invisible until a contributor reads the
+directory and cannot tell which record is binding.
+
+These checks pin the structure the directory already relies on, the same way
+``test_docs_url_hygiene`` pins the docs host in shipped source.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_DECISIONS = Path(__file__).resolve().parents[2] / "docs" / "decisions"
+_INDEX = _DECISIONS / "index.md"
+
+_RECORD_NAME = re.compile(r"^(\d{3})-[a-z0-9-]+\.md$")
+_STATUS = re.compile(r"^\*\*Status\*\*:\s*(?P<value>.+?)\s*$", re.MULTILINE)
+_DATE = re.compile(r"^\*\*Date\*\*:\s*(?P<value>.+?)\s*$", re.MULTILINE)
+_ISO_DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_SUPERSEDED_BY = re.compile(r"^Superseded by ADR-(\d{3})\b")
+_INDEX_LINK = re.compile(r"\]\((\d{3}-[a-z0-9-]+\.md)\)")
+_ISSUE_CITATION = re.compile(r"(?<![\w/])#(\d+)\b")
+_GITHUB_URL = re.compile(r"https://github\.com/([^/\s)\]`]+/[^/\s)\]`]+)")
+
+_REPOSITORY = "sipyourdrink-ltd/bernstein"
+
+
+def _records() -> dict[int, Path]:
+    """Every numbered decision record, keyed by its number."""
+    found: dict[int, Path] = {}
+    for path in sorted(_DECISIONS.glob("*.md")):
+        match = _RECORD_NAME.match(path.name)
+        if match is None:
+            continue
+        found[int(match.group(1))] = path
+    return found
+
+
+def _header_field(text: str, pattern: re.Pattern[str]) -> str | None:
+    match = pattern.search(text)
+    return None if match is None else match.group("value").strip()
+
+
+def test_every_decision_record_declares_status_and_date() -> None:
+    """A record without a status or a date cannot be acted on.
+
+    The reader's first question is "does this still hold, and since when".
+    """
+    missing: list[str] = []
+    for number, path in sorted(_records().items()):
+        text = path.read_text(encoding="utf-8")
+        status = _header_field(text, _STATUS)
+        date = _header_field(text, _DATE)
+        if not status:
+            missing.append(f"{path.name}: no '**Status**:' line")
+        if not date:
+            missing.append(f"{path.name}: no '**Date**:' line")
+        elif not _ISO_DATE.match(date):
+            missing.append(f"{path.name}: '**Date**: {date}' is not YYYY-MM-DD")
+        del number
+    assert missing == [], "decision records must carry a status and an ISO date:\n" + "\n".join(
+        missing
+    )
+
+
+def test_decision_record_numbering_has_no_unexplained_gap() -> None:
+    """Numbers run 001..N with nothing missing.
+
+    A number nobody can account for is a question every future reader has to
+    ask once. A record that was withdrawn keeps its number and says so.
+    """
+    numbers = sorted(_records())
+    assert numbers, f"no decision records found under {_DECISIONS}"
+    expected = list(range(1, numbers[-1] + 1))
+    gaps = sorted(set(expected) - set(numbers))
+    assert gaps == [], (
+        "decision-record numbering has gaps at "
+        + ", ".join(f"{n:03d}" for n in gaps)
+        + "; a number that is no longer in use keeps a record stating that, "
+        "and is never reused"
+    )
+
+
+def test_a_superseded_record_names_a_successor_that_exists() -> None:
+    """``Superseded`` is only useful when it says by what.
+
+    A record marked superseded with no successor is worse than one left
+    accepted: the reader knows it is stale and still has nowhere to go.
+    """
+    records = _records()
+    broken: list[str] = []
+    for number, path in sorted(records.items()):
+        status = _header_field(path.read_text(encoding="utf-8"), _STATUS) or ""
+        if not status.lower().startswith("superseded"):
+            continue
+        match = _SUPERSEDED_BY.match(status)
+        if match is None:
+            broken.append(f"{path.name}: '**Status**: {status}' does not name a successor")
+            continue
+        successor = int(match.group(1))
+        if successor not in records:
+            broken.append(f"{path.name}: names ADR-{successor:03d}, which does not exist")
+        elif successor == number:
+            broken.append(f"{path.name}: names itself as its successor")
+    assert broken == [], (
+        "a superseded record must read 'Superseded by ADR-NNN' and point at a "
+        "record that exists:\n" + "\n".join(broken)
+    )
+
+
+def test_index_row_exists_for_every_record_and_every_row_resolves() -> None:
+    """The index is the entry point, so it must match the directory.
+
+    A record the index omits is unfindable; a row pointing at a deleted file
+    is a dead link in the one place a reader starts.
+    """
+    index_text = _INDEX.read_text(encoding="utf-8")
+    linked = set(_INDEX_LINK.findall(index_text))
+    on_disk = {path.name for path in _records().values()}
+
+    unlisted = sorted(on_disk - linked)
+    dangling = sorted(linked - on_disk)
+    assert unlisted == [], f"{_INDEX.name} does not list: {', '.join(unlisted)}"
+    assert dangling == [], f"{_INDEX.name} links files that do not exist: {', '.join(dangling)}"
+
+
+def test_issue_citations_are_well_formed_and_point_at_this_repository() -> None:
+    """An ADR derived from a thread has to be traceable back to it.
+
+    A citation with a leading zero or a number of zero resolves to nothing,
+    and a GitHub link to another repository resolves to someone else's
+    numbering — both read as evidence and are not.
+    """
+    bad: list[str] = []
+    for path in sorted(_records().values()) + [_INDEX]:
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            for raw in _ISSUE_CITATION.findall(line):
+                if raw != str(int(raw)) or int(raw) == 0:
+                    bad.append(f"{path.name}:{lineno}: '#{raw}' is not an issue number")
+            for repo in _GITHUB_URL.findall(line):
+                if repo != _REPOSITORY:
+                    bad.append(f"{path.name}:{lineno}: links {repo}, not {_REPOSITORY}")
+    assert bad == [], "issue citations in decision records must resolve:\n" + "\n".join(bad)

--- a/tests/unit/test_decision_records.py
+++ b/tests/unit/test_decision_records.py
@@ -15,8 +15,10 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-_DECISIONS = Path(__file__).resolve().parents[2] / "docs" / "decisions"
+_ROOT = Path(__file__).resolve().parents[2]
+_DECISIONS = _ROOT / "docs" / "decisions"
 _INDEX = _DECISIONS / "index.md"
+_MKDOCS = _ROOT / "mkdocs.yml"
 
 _RECORD_NAME = re.compile(r"^(\d{3})-[a-z0-9-]+\.md$")
 _STATUS = re.compile(r"^\*\*Status\*\*:\s*(?P<value>.+?)\s*$", re.MULTILINE)
@@ -52,7 +54,7 @@ def test_every_decision_record_declares_status_and_date() -> None:
     The reader's first question is "does this still hold, and since when".
     """
     missing: list[str] = []
-    for number, path in sorted(_records().items()):
+    for path in sorted(_records().values()):
         text = path.read_text(encoding="utf-8")
         status = _header_field(text, _STATUS)
         date = _header_field(text, _DATE)
@@ -62,10 +64,7 @@ def test_every_decision_record_declares_status_and_date() -> None:
             missing.append(f"{path.name}: no '**Date**:' line")
         elif not _ISO_DATE.match(date):
             missing.append(f"{path.name}: '**Date**: {date}' is not YYYY-MM-DD")
-        del number
-    assert missing == [], "decision records must carry a status and an ISO date:\n" + "\n".join(
-        missing
-    )
+    assert missing == [], "decision records must carry a status and an ISO date:\n" + "\n".join(missing)
 
 
 def test_decision_record_numbering_has_no_unexplained_gap() -> None:
@@ -108,8 +107,7 @@ def test_a_superseded_record_names_a_successor_that_exists() -> None:
         elif successor == number:
             broken.append(f"{path.name}: names itself as its successor")
     assert broken == [], (
-        "a superseded record must read 'Superseded by ADR-NNN' and point at a "
-        "record that exists:\n" + "\n".join(broken)
+        "a superseded record must read 'Superseded by ADR-NNN' and point at a record that exists:\n" + "\n".join(broken)
     )
 
 
@@ -129,6 +127,20 @@ def test_index_row_exists_for_every_record_and_every_row_resolves() -> None:
     assert dangling == [], f"{_INDEX.name} links files that do not exist: {', '.join(dangling)}"
 
 
+def test_every_record_is_reachable_from_the_published_navigation() -> None:
+    """A record nobody can reach on the docs site is not published.
+
+    The nav is hand-maintained, so a new record is easy to write and easy to
+    leave off — and the omission looks identical to the record not existing.
+    """
+    nav = _MKDOCS.read_text(encoding="utf-8")
+    unlisted = sorted(path.name for path in _records().values() if f"decisions/{path.name}" not in nav)
+    assert unlisted == [], (
+        f"{_MKDOCS.name} nav does not list: {', '.join(unlisted)}; "
+        "a decision record that is not in the nav does not ship on the docs site"
+    )
+
+
 def test_issue_citations_are_well_formed_and_point_at_this_repository() -> None:
     """An ADR derived from a thread has to be traceable back to it.
 
@@ -137,7 +149,7 @@ def test_issue_citations_are_well_formed_and_point_at_this_repository() -> None:
     numbering — both read as evidence and are not.
     """
     bad: list[str] = []
-    for path in sorted(_records().values()) + [_INDEX]:
+    for path in [*sorted(_records().values()), _INDEX]:
         text = path.read_text(encoding="utf-8")
         for lineno, line in enumerate(text.splitlines(), start=1):
             for raw in _ISSUE_CITATION.findall(line):


### PR DESCRIPTION
## What

Supersedes ADR-006 with ADR-011, which names the case ADR-006 does not cover: a model that drafts an artefact a human must sign.

Also, in the same directory: ADR-002 gets a record explaining its number, `index.md` states when a record is required and how supersession, withdrawal and numbering work, `docs/scope.md` points at the record that is now binding, the docs nav lists both new files, and `tests/unit/test_decision_records.py` pins the structure.

Not in this PR: the six transcription ADRs for the decisions that currently live only in issue threads. Those are listed under Remaining.

## Why

ADR-006 is `Status: Accepted` and describes two places a model can be — deterministic coordination, and leaf execution inside a run. `govern discover --assist` is in neither. It hands a chain-recorded findings document to a model the operator nominates and gets back a draft playbook that `govern apply` refuses while it is unsigned (`DraftProposal.is_signed()` in `src/bernstein/core/govern/proposal.py`). The scheduler never sees it, no task is executing while it runs, and its output governs future runs rather than performing one.

A contributor reading ADR-006 before writing that command has two bad options: decide it is out of bounds and not write it, or call it a leaf node — which stretches "leaf" to mean "wherever a model turned out to be fine". A boundary that stretches on contact stops being one, and this particular boundary is also a claim the project states publicly.

The directory has a second problem behind that one. It has ten records, all `Accepted`, no supersessions, and a number missing at 002 with nothing accounting for it. Nothing fails when a record loses its status or the index links a file that no longer exists, so nothing has.

## How

- **ADR-011** states the rule in one sentence a contributor can apply: a model may draft an artefact a human must sign, and may never decide what runs next, which agent gets it, whether it is retried, or when it ends. It records three rejected alternatives — calling drafting a leaf node, editing ADR-006 in place, and forbidding model drafting outright — and lists what stays forbidden.
- **ADR-006** keeps its body verbatim and gets `Status: Superseded by ADR-011` plus a pointer at the top. `index.md` already says a record edited to match today's code stops being evidence of anything, so supersession was the mechanism the directory already argued for; this is its first use.
- **ADR-002** was removed from the published docs in May (`de76216`). It gets a record saying so, so the gap has an answer and the number is never reassigned.
- **`index.md`** gains a "when a record is required" threshold — four concrete triggers, not a size rule — and a section on superseding, withdrawing and numbering.
- **`docs/scope.md`** is the page a proposal gets answered from, so its "No model in the coordination loop" boundary now carries the drafting sentence and points at ADR-011.

One open decision, made here: **supersede rather than amend.** Amending ADR-006 would erase the fact that the two-category model was ever the position, which is the part a reader needs to trust that the third category was argued for rather than assumed. It also gives acceptance item 5 (a `Superseded` status used at least once) a real worked example instead of a synthetic one.

## Tests

`tests/unit/test_decision_records.py`, all six committed before the documentation change:

1. `test_every_decision_record_declares_status_and_date` — a record carries a status and an ISO date, or a reader cannot tell whether it still holds.
2. `test_decision_record_numbering_has_no_unexplained_gap` — **load-bearing.** Numbers run 001..N. Red on the unmodified tree: `decision-record numbering has gaps at 002`. Green once ADR-002 has a record.
3. `test_a_superseded_record_names_a_successor_that_exists` — `Superseded by ADR-NNN` must name a record that exists and is not itself. Verified by temporarily setting ADR-006 to `Superseded by ADR-042`, which fails the test.
4. `test_index_row_exists_for_every_record_and_every_row_resolves` — the index lists every record and links no deleted file.
5. `test_every_record_is_reachable_from_the_published_navigation` — a record missing from the mkdocs nav does not ship on the docs site. Verified by reverting `mkdocs.yml`, which fails the test.
6. `test_issue_citations_are_well_formed_and_point_at_this_repository` — an `#N` citation resolves, and a GitHub link in a record points at this repository rather than someone else's numbering.

Tests 1, 4 and 6 pin invariants that hold today and had no guard; 2, 3 and 5 were each shown red before the corresponding change.

Run locally:

```
uv run python scripts/run_tests.py --parallel 2 -x \
  tests/unit/test_decision_records.py \
  tests/unit/test_check_docs_requirements_pins.py \
  tests/unit/test_check_docs_requirements_staleness.py \
  tests/unit/test_docs_url_hygiene.py \
  tests/unit/test_docs_capability_reachability.py \
  tests/unit/test_docs_prose_cli_drift.py
```

6 files passed. `--affected origin/main` did not finish inside the local time budget, so the selection above is the tests that read `docs/`, `docs/scope.md` or `mkdocs.yml`; CI runs the full suite. `tests/unit/test_tui_render_freshness.py::test_the_committed_render_matches_what_the_dashboard_draws` fails on this machine with `ScreenStackError: No screens on stack`; it fails identically with `mkdocs.yml` restored from `origin/main`, so it is not from this change.

## Checklist

- [x] `uv run ruff check src/` — clean
- [x] `uv run ruff format --check src/` — clean
- [x] `uv run pyright` on the added test file — 0 errors
- [x] `uv run python scripts/run_tests.py --parallel 2 -x <files above>` — green
- [x] Type hints on all added functions
- [x] Documentation updated — this PR is the documentation change; `docs/scope.md` and the mkdocs nav updated with it
- [x] `AGENTS.md` — N/A, no public surface changed, so `bernstein agents-md sync` produces no diff
- [x] `README.md` and translations — N/A, untouched
- [x] Release notes — N/A, no shipped behaviour changed

Part of #5026

## Remaining

- Six ADRs transcribing decisions that currently live only in issue threads: the governance boundary (#4962, #4990), the ingest contract for unscheduled activity (#4962, #4963, #5024), the agent identity plane (#4969, #4970, #5022), artifact contracts as a completion basis, TRACE conformance level and what is not claimed (#4987), and receipt coverage semantics (#4968, #4977).
- Checking a cited issue number against the live tracker. Test 6 checks that a citation is well-formed and points at this repository; existence needs a network call, which does not belong in a hermetic unit test. It is worth deciding alongside the six transcriptions, since those are what introduce the citations.
