### PR TITLE
chore(ci): ratchet coverage baseline up to 84.49%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,8 +1,8 @@
 {
   "diff_coverage_floor_percent": 89,
-  "head_sha": "f3a65b8c3ce345e149f250e39aa6bcf4a6d530d9",
-  "line_rate": 0.8422,
-  "run_id": "32972568476",
-  "total_coverage_percent": 84.22,
-  "updated_at": "2026-08-31T15:12:02+00:00"
+  "head_sha": "e0c98b3750ad34db49612f3e6909afea42f686c6",
+  "line_rate": 0.8449,
+  "run_id": "33774776359",
+  "total_coverage_percent": 84.49,
+  "updated_at": "2026-09-03T16:35:42+00:00"
 }


### PR DESCRIPTION
Total line coverage rose on `main`, so the monotonic ratchet
bumped the committed high-water mark in `.coverage-baseline.json`
to **84.49%**.

Measured on `e0c98b3750ad34db49612f3e6909afea42f686c6` from the
`coverage-report` artifact of CI run
[33774776359](https://github.com/sipyourdrink-ltd/bernstein/actions/runs/33774776359).
Those, and the raw Cobertura `line-rate` the percentage was
rounded from, are recorded in the baseline, so the number in the
diff can be re-derived from the file itself:

```bash
uv run python scripts/coverage_ratchet.py verify \
    --baseline .coverage-baseline.json --require-provenance
```

From here, any later push whose total coverage falls below this
mark is flagged by the LEVEL 2 ratchet. The gate stays advisory
until promoted; see `docs/operations/coverage-ratchet.md`.

Generated by `.github/workflows/coverage-ratchet.yml`.