### PR TITLE
ci: fail when a security or identity control has no production caller (#5053)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -576,6 +576,14 @@ jobs:
         # src/bernstein/core/routes/**.py without a `bot-ack:` or
         # `intentional-broad-except` marker within 3 lines.
         run: uv run python scripts/check_routes_broad_except.py
+      - name: Unreached security controls (#5053)
+        # Fails if a public symbol under src/bernstein/core/security/ or
+        # src/bernstein/core/identity/ has no caller in the shipped package.
+        # A control whose only importers are its own tests, an `__init__`
+        # re-export, or the lazy module map in core/__init__.py looks live to
+        # every other tool while never running. Known cases live in
+        # unreachable_controls_allowlist.txt, one written reason each.
+        run: uv run python scripts/check_unreachable_controls.py
 
   spelling:
     name: Spelling (typos)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,6 +215,35 @@ Run locally before committing:
 uv run python scripts/check_routes_broad_except.py
 ```
 
+### Production reachability (security and identity controls)
+
+`src/bernstein/core/security/**.py` and `src/bernstein/core/identity/**.py`
+are policed by a CI lint (`scripts/check_unreachable_controls.py`) that fails
+the build when a public symbol has no caller inside the shipped package. A
+control whose only importers are its own tests, an `__init__` re-export, or
+the lazy module map in `src/bernstein/core/__init__.py` passes every other
+check while never running.
+
+Only `Name` loads and attribute accesses count as callers. Imports and string
+literals do not, which is what makes a re-export and the lazy module map
+invisible to the check. Reachability is a fixpoint, so a symbol called only by
+another unreached symbol is still unreached.
+
+Known cases live in `unreachable_controls_allowlist.txt`, one line per symbol
+with a mandatory written reason. Removing an entry is the goal: an entry whose
+symbol becomes reachable fails the gate, so the list cannot rot.
+
+Run locally before committing:
+
+```bash
+uv run python scripts/check_unreachable_controls.py
+# after adding or deleting a symbol, refresh the entry list (reasons survive):
+uv run python scripts/check_unreachable_controls.py --update
+```
+
+Replace every `REASON REQUIRED` marker `--update` writes before committing --
+the gate rejects it.
+
 See [AGENTS.md](AGENTS.md) for the full doctrine, including change classification, conflict protocol, and zero-tolerance failures.
 
 ## CLI Structure

--- a/scripts/check_unreachable_controls.py
+++ b/scripts/check_unreachable_controls.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python
+"""Gate for issue #5053: a security control that ships with no production caller.
+
+``vulture`` asks whether a symbol is dead. This asks a different question:
+is the symbol *reached from the shipped package*? A control whose only
+importers are its own tests, an ``__init__`` re-export, or the lazy module
+map in ``src/bernstein/core/__init__.py`` reads as live to every existing
+tool - its tests pass, its name greps - while never running in production.
+
+What counts as a reference
+--------------------------
+Only ``Name`` loads and attribute accesses inside ``src/bernstein/`` count.
+Deliberately *not* references:
+
+* ``import`` / ``from ... import`` statements - a re-export is an import, so
+  ``__init__`` re-exports contribute nothing on their own;
+* string literals - which is why ``__all__`` entries and the lazy module map
+  in ``core/__init__.py`` (a ``dict[str, str]`` of module paths) do not keep
+  a symbol alive;
+* anything under ``tests/`` - the reference scan never leaves the package.
+
+Reachability is a fixpoint, not a single pass. A reference only counts when
+it is made from module-level code, from a symbol that is itself reachable,
+or from outside the scanned packages. So a symbol called only by another
+unreachable symbol stays unreachable, and allowlisting a symbol does *not*
+make what it calls reachable.
+
+Approximation, in the safe direction
+------------------------------------
+Matching is by name, not by resolved binding, and a type annotation counts
+as a reference. Both make the check *under*-report: a symbol is reported
+only when its bare name appears nowhere in the package outside imports and
+strings. It never fails the build on a symbol that is actually called.
+
+The allowlist
+-------------
+``unreachable_controls_allowlist.txt`` carries one entry per known-unreached
+symbol, each with a written reason. A reason is mandatory: an entry with an
+empty reason, or one still carrying the ``REASON REQUIRED`` marker that
+``--update`` writes for a new finding, fails the gate. An entry whose symbol
+is now reachable (or gone) also fails, so the list cannot rot.
+
+Run locally::
+
+    uv run python scripts/check_unreachable_controls.py
+    uv run python scripts/check_unreachable_controls.py --update
+
+Exit codes:
+  0 = every unreachable public symbol is allowlisted with a reason.
+  1 = an unlisted finding, or a malformed / reasonless / stale allowlist entry.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_SCAN_ROOTS = (
+    Path("src/bernstein/core/security"),
+    Path("src/bernstein/core/identity"),
+)
+DEFAULT_REFERENCE_ROOT = Path("src/bernstein")
+DEFAULT_ALLOWLIST = Path("unreachable_controls_allowlist.txt")
+
+#: Marker ``--update`` writes for a newly discovered symbol. The gate refuses
+#: it, so a new finding cannot be silenced without someone writing a reason.
+REASON_REQUIRED = "REASON REQUIRED"
+
+_HEADER = """\
+# Allowlist for scripts/check_unreachable_controls.py (issue #5053).
+#
+# Each line names a public symbol under src/bernstein/core/security/ or
+# src/bernstein/core/identity/ that no production code path reaches, and
+# states why. The reason after '#' is mandatory - an entry without one, or
+# one still carrying the 'REASON REQUIRED' marker, fails the gate.
+#
+# Format:
+#   <path>::<function>            # <reason>
+#   <path>::<Class>.<method>      # <reason>
+#
+# Regenerate the entry list (reasons for existing entries are preserved):
+#   uv run python scripts/check_unreachable_controls.py --update
+#
+# Removing an entry is the goal: wire the symbol into a live code path, or
+# delete it. An entry whose symbol became reachable fails the gate too, so a
+# stale line cannot sit here unnoticed.
+"""
+
+
+@dataclass(frozen=True, order=True)
+class SymbolId:
+    """Identity of a tracked definition: file, top-level name, optional member."""
+
+    path: str
+    owner: str
+    member: str | None = None
+
+    @property
+    def local_name(self) -> str:
+        """The name a caller would have to write to reach this definition."""
+        return self.member if self.member is not None else self.owner
+
+    @property
+    def is_public(self) -> bool:
+        """True when neither the owner nor the member is underscore-prefixed."""
+        if self.owner.startswith("_"):
+            return False
+        return self.member is None or not self.member.startswith("_")
+
+    @property
+    def key(self) -> str:
+        """Stable ``path::name`` form used in the allowlist file."""
+        qualified = self.owner if self.member is None else f"{self.owner}.{self.member}"
+        return f"{self.path}::{qualified}"
+
+
+@dataclass(frozen=True)
+class Finding:
+    """An unreachable public symbol, with the source location to report."""
+
+    symbol: SymbolId
+    lineno: int
+
+
+_DEF_NODES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+
+
+def _iter_python_files(root: Path) -> list[Path]:
+    return sorted(p for p in root.rglob("*.py") if p.is_file())
+
+
+def _parse(path: Path) -> ast.Module | None:
+    try:
+        return ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError) as exc:
+        print(f"warning: could not parse {path}: {exc}", file=sys.stderr)
+        return None
+
+
+def collect_symbols(scan_roots: list[Path], repo_root: Path) -> tuple[dict[SymbolId, int], set[str]]:
+    """Return ``(symbol -> lineno, scanned relative paths)`` for the scan roots.
+
+    Private definitions are tracked too. They are never reported, but they must
+    participate in the fixpoint: a dead private helper must not keep the public
+    symbols it calls alive.
+
+    ``__init__.py`` is skipped - a re-export defines nothing of its own.
+    """
+    symbols: dict[SymbolId, int] = {}
+    scanned: set[str] = set()
+    for root in scan_roots:
+        for path in _iter_python_files(root):
+            if path.name == "__init__.py":
+                continue
+            tree = _parse(path)
+            if tree is None:
+                continue
+            rel = path.relative_to(repo_root).as_posix()
+            scanned.add(rel)
+            for node in tree.body:
+                if not isinstance(node, _DEF_NODES):
+                    continue
+                symbols[SymbolId(rel, node.name)] = node.lineno
+                if not isinstance(node, ast.ClassDef):
+                    continue
+                for member in node.body:
+                    if isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                        symbols[SymbolId(rel, node.name, member.name)] = member.lineno
+    return symbols, scanned
+
+
+def _record(refs: set[str], node: ast.AST) -> None:
+    if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+        refs.add(node.id)
+    elif isinstance(node, ast.Attribute):
+        refs.add(node.attr)
+
+
+def collect_references(
+    reference_root: Path,
+    repo_root: Path,
+    symbols: dict[SymbolId, int],
+    scanned: set[str],
+) -> tuple[set[str], dict[SymbolId, set[str]]]:
+    """Split every name reference in the package by the definition that owns it.
+
+    Returns ``(root_refs, owned_refs)``. ``root_refs`` are references made from
+    module-level code or from a file outside the scanned packages: those are
+    unconditionally live. ``owned_refs`` maps a tracked definition to the names
+    its body mentions, and only counts once that definition is reachable.
+    """
+    root_refs: set[str] = set()
+    owned_refs: dict[SymbolId, set[str]] = defaultdict(set)
+
+    def walk(
+        node: ast.AST,
+        owner: SymbolId | None,
+        *,
+        rel: str,
+        tracked: bool,
+        at_module_level: bool,
+    ) -> None:
+        for child in ast.iter_child_nodes(node):
+            child_owner = owner
+            if tracked and isinstance(child, _DEF_NODES):
+                if at_module_level and SymbolId(rel, child.name) in symbols:
+                    child_owner = SymbolId(rel, child.name)
+                elif owner is not None and owner.member is None and SymbolId(rel, owner.owner, child.name) in symbols:
+                    child_owner = SymbolId(rel, owner.owner, child.name)
+            _record(root_refs if owner is None else owned_refs[owner], child)
+            walk(child, child_owner, rel=rel, tracked=tracked, at_module_level=False)
+
+    for path in _iter_python_files(reference_root):
+        tree = _parse(path)
+        if tree is None:
+            continue
+        rel = path.relative_to(repo_root).as_posix()
+        walk(tree, None, rel=rel, tracked=rel in scanned, at_module_level=True)
+
+    return root_refs, owned_refs
+
+
+def reachable_symbols(
+    symbols: dict[SymbolId, int],
+    root_refs: set[str],
+    owned_refs: dict[SymbolId, set[str]],
+) -> set[SymbolId]:
+    """Grow the live-name set until it stops changing, and return what it reached."""
+    live = set(root_refs)
+    reached: set[SymbolId] = set()
+    changed = True
+    while changed:
+        changed = False
+        for symbol in symbols:
+            if symbol in reached or symbol.local_name not in live:
+                continue
+            reached.add(symbol)
+            live |= owned_refs.get(symbol, set())
+            changed = True
+    return reached
+
+
+def find_unreachable(symbols: dict[SymbolId, int], reached: set[SymbolId]) -> list[Finding]:
+    """Report unreached public symbols, one line per independent finding.
+
+    A method of an unreachable class is dropped: the class already carries the
+    finding, and listing every method under it would bury the signal.
+    """
+    findings: list[Finding] = []
+    for symbol, lineno in symbols.items():
+        if symbol in reached or not symbol.is_public:
+            continue
+        if symbol.member is not None and SymbolId(symbol.path, symbol.owner) not in reached:
+            continue
+        findings.append(Finding(symbol, lineno))
+    return sorted(findings, key=lambda f: (f.symbol.path, f.symbol.owner, f.symbol.member or ""))
+
+
+def parse_allowlist(path: Path) -> tuple[dict[str, str], list[str]]:
+    """Return ``(key -> reason, errors)`` for the allowlist at *path*."""
+    reasons: dict[str, str] = {}
+    errors: list[str] = []
+    if not path.exists():
+        return reasons, errors
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        entry, sep, reason = line.partition("#")
+        key = entry.strip()
+        reason = reason.strip()
+        if "::" not in key:
+            errors.append(f"{path}:{lineno}: malformed entry (expected '<path>::<symbol>'): {line}")
+            continue
+        if key in reasons:
+            errors.append(f"{path}:{lineno}: duplicate entry for {key}")
+            continue
+        if not sep or not reason or reason == REASON_REQUIRED:
+            errors.append(f"{path}:{lineno}: {key} has no reason; state why it has no caller")
+            continue
+        reasons[key] = reason
+    return reasons, errors
+
+
+def render_allowlist(findings: list[Finding], existing: dict[str, str]) -> str:
+    """Render the allowlist file, keeping the reason already written for an entry."""
+    width = max((len(f.symbol.key) for f in findings), default=0)
+    lines = [_HEADER]
+    for finding in findings:
+        key = finding.symbol.key
+        reason = existing.get(key, REASON_REQUIRED)
+        lines.append(f"{key.ljust(width)}  # {reason}")
+    return "\n".join(lines) + "\n"
+
+
+def scan(repo_root: Path, scan_roots: list[Path], reference_root: Path) -> list[Finding]:
+    """Run the whole analysis against *repo_root* and return the findings."""
+    symbols, scanned = collect_symbols(scan_roots, repo_root)
+    root_refs, owned_refs = collect_references(reference_root, repo_root, symbols, scanned)
+    return find_unreachable(symbols, reachable_symbols(symbols, root_refs, owned_refs))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Fail on a public symbol no production code reaches.")
+    parser.add_argument("--repo-root", type=Path, default=Path("."), help="Repository root (default: cwd).")
+    parser.add_argument(
+        "--scan-roots",
+        nargs="*",
+        type=Path,
+        default=None,
+        help="Packages to scan, relative to --repo-root (default: core/security, core/identity).",
+    )
+    parser.add_argument(
+        "--reference-root",
+        type=Path,
+        default=None,
+        help="Package searched for callers, relative to --repo-root (default: src/bernstein).",
+    )
+    parser.add_argument(
+        "--allowlist",
+        type=Path,
+        default=None,
+        help="Allowlist file, relative to --repo-root (default: unreachable_controls_allowlist.txt).",
+    )
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="Rewrite the allowlist from the current tree, preserving written reasons.",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo_root.resolve()
+    scan_roots = [repo_root / p for p in (args.scan_roots or list(DEFAULT_SCAN_ROOTS))]
+    reference_root = repo_root / (args.reference_root or DEFAULT_REFERENCE_ROOT)
+    allowlist_path = repo_root / (args.allowlist or DEFAULT_ALLOWLIST)
+
+    missing = [p for p in [*scan_roots, reference_root] if not p.is_dir()]
+    if missing:
+        for path in missing:
+            print(f"check_unreachable_controls: no such directory: {path}", file=sys.stderr)
+        return 1
+
+    findings = scan(repo_root, scan_roots, reference_root)
+    reasons, errors = parse_allowlist(allowlist_path)
+
+    if args.update:
+        allowlist_path.write_text(render_allowlist(findings, reasons), encoding="utf-8")
+        print(f"check_unreachable_controls: wrote {len(findings)} entries to {allowlist_path}")
+        return 0
+
+    found_keys = {f.symbol.key for f in findings}
+    unlisted = [f for f in findings if f.symbol.key not in reasons]
+    stale = sorted(key for key in reasons if key not in found_keys)
+
+    if not unlisted and not stale and not errors:
+        print(f"check_unreachable_controls: OK ({len(findings)} known-unreached symbols, all with a reason)")
+        return 0
+
+    if unlisted:
+        print(
+            "check_unreachable_controls: public symbols with no production caller and no allowlist entry:",
+            file=sys.stderr,
+        )
+        for finding in unlisted:
+            print(f"  {finding.symbol.path}:{finding.lineno}: {finding.symbol.key}", file=sys.stderr)
+    if stale:
+        print(
+            "\ncheck_unreachable_controls: allowlist entries that are now reachable or gone:",
+            file=sys.stderr,
+        )
+        for key in stale:
+            print(f"  {key}", file=sys.stderr)
+    for error in errors:
+        print(f"check_unreachable_controls: {error}", file=sys.stderr)
+
+    print(
+        "\nEither wire the symbol into a live code path (preferred), delete it, or\n"
+        f"add it to {DEFAULT_ALLOWLIST} with a written reason. Regenerate the entry\n"
+        "list with:\n"
+        "  uv run python scripts/check_unreachable_controls.py --update\n"
+        "and replace every 'REASON REQUIRED' marker before committing.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_check_unreachable_controls.py
+++ b/tests/unit/scripts/test_check_unreachable_controls.py
@@ -1,0 +1,405 @@
+"""Guard: a public security/identity symbol must be reached from production.
+
+``scripts/check_unreachable_controls.py`` fails when a public symbol under
+``src/bernstein/core/security/`` or ``src/bernstein/core/identity/`` has no
+caller outside tests, ``__init__`` re-exports, and the lazy module map in
+``src/bernstein/core/__init__.py`` (issue #5053).
+
+Every test here builds a miniature package tree on disk and runs the real
+``main()`` over it, so the failure path executes rather than being asserted
+about. The last test runs the gate over this repository, which is what binds
+the committed allowlist to the tree.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_unreachable_controls.py"
+
+
+@pytest.fixture(scope="module")
+def check_module() -> ModuleType:
+    """Load ``scripts/check_unreachable_controls.py`` as an importable module."""
+    spec = importlib.util.spec_from_file_location("check_unreachable_controls_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(body).lstrip(), encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def tree(tmp_path: Path) -> Path:
+    """A minimal ``src/bernstein`` tree with the two scanned packages present."""
+    for package in ("core/security", "core/identity"):
+        _write(tmp_path / "src/bernstein" / package / "__init__.py", '"""package."""\n')
+    _write(tmp_path / "src/bernstein/core/__init__.py", '"""core."""\n')
+    return tmp_path
+
+
+def _run(check_module: ModuleType, tree: Path, *extra: str) -> int:
+    return check_module.main(["--repo-root", str(tree), *extra])
+
+
+def test_uncalled_public_function_fails_the_gate(
+    check_module: ModuleType, tree: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A throwaway uncalled public control fails; deleting it makes the gate pass.
+
+    This is the acceptance test named in issue #5053: the gate has to change
+    verdict on the presence of one uncalled function and nothing else.
+    """
+    module = tree / "src/bernstein/core/security/throwaway_control.py"
+    _write(
+        module,
+        '''
+        """Throwaway."""
+
+
+        def enforce_throwaway_control() -> bool:
+            return True
+        ''',
+    )
+
+    assert _run(check_module, tree) == 1
+    assert "enforce_throwaway_control" in capsys.readouterr().err
+
+    module.unlink()
+    assert _run(check_module, tree) == 0
+
+
+def test_symbol_called_from_a_production_module_passes(check_module: ModuleType, tree: Path) -> None:
+    """A control a shipped module actually calls is not a finding."""
+    _write(
+        tree / "src/bernstein/core/security/live_control.py",
+        '''
+        """Live."""
+
+
+        def enforce_live_control() -> bool:
+            return True
+        ''',
+    )
+    _write(
+        tree / "src/bernstein/core/orchestration/runner.py",
+        '''
+        """Runner."""
+
+        from bernstein.core.security.live_control import enforce_live_control
+
+
+        def run() -> bool:
+            return enforce_live_control()
+        ''',
+    )
+
+    assert _run(check_module, tree) == 0
+
+
+def test_symbol_called_only_from_tests_is_reported(
+    check_module: ModuleType, tree: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A passing unit test is not a production caller."""
+    _write(
+        tree / "src/bernstein/core/security/tested_control.py",
+        '''
+        """Tested."""
+
+
+        def enforce_tested_control() -> bool:
+            return True
+        ''',
+    )
+    _write(
+        tree / "tests/unit/test_tested_control.py",
+        '''
+        """Test."""
+
+        from bernstein.core.security.tested_control import enforce_tested_control
+
+
+        def test_it() -> None:
+            assert enforce_tested_control()
+        ''',
+    )
+
+    assert _run(check_module, tree) == 1
+    assert "enforce_tested_control" in capsys.readouterr().err
+
+
+def test_symbol_reexported_by_init_only_is_reported(
+    check_module: ModuleType, tree: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An ``__init__`` re-export is an import and an ``__all__`` string, not a call."""
+    _write(
+        tree / "src/bernstein/core/identity/reexported_control.py",
+        '''
+        """Re-exported."""
+
+        __all__ = ["verify_reexported_control"]
+
+
+        def verify_reexported_control() -> bool:
+            return True
+        ''',
+    )
+    _write(
+        tree / "src/bernstein/core/identity/__init__.py",
+        '''
+        """Package."""
+
+        from bernstein.core.identity.reexported_control import verify_reexported_control
+
+        __all__ = ["verify_reexported_control"]
+        ''',
+    )
+
+    assert _run(check_module, tree) == 1
+    assert "verify_reexported_control" in capsys.readouterr().err
+
+
+def test_symbol_named_only_in_the_lazy_module_map_is_reported(
+    check_module: ModuleType, tree: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The lazy ``core/__init__.py`` map holds strings, so it reaches nothing."""
+    _write(
+        tree / "src/bernstein/core/security/mapped_control.py",
+        '''
+        """Mapped."""
+
+
+        def enforce_mapped_control() -> bool:
+            return True
+        ''',
+    )
+    _write(
+        tree / "src/bernstein/core/__init__.py",
+        '''
+        """Core."""
+
+        _REDIRECT_MAP = {
+            "mapped_control": "bernstein.core.security.mapped_control",
+            "enforce_mapped_control": "bernstein.core.security.mapped_control",
+        }
+        ''',
+    )
+
+    assert _run(check_module, tree) == 1
+    assert "enforce_mapped_control" in capsys.readouterr().err
+
+
+def test_symbol_called_only_from_an_unreachable_symbol_is_reported(
+    check_module: ModuleType, tree: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Reachability is a fixpoint: a caller that is itself dead reaches nothing."""
+    _write(
+        tree / "src/bernstein/core/security/chained_control.py",
+        '''
+        """Chained."""
+
+
+        def enforce_inner_control() -> bool:
+            return True
+
+
+        def enforce_outer_control() -> bool:
+            return enforce_inner_control()
+        ''',
+    )
+
+    assert _run(check_module, tree) == 1
+    reported = capsys.readouterr().err
+    assert "enforce_outer_control" in reported
+    assert "enforce_inner_control" in reported
+
+
+def test_allowlisted_symbol_does_not_make_its_callee_reachable(
+    check_module: ModuleType, tree: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Allowlisting silences one symbol; it does not revive what that symbol calls."""
+    _write(
+        tree / "src/bernstein/core/security/chained_control.py",
+        '''
+        """Chained."""
+
+
+        def enforce_inner_control() -> bool:
+            return True
+
+
+        def enforce_outer_control() -> bool:
+            return enforce_inner_control()
+        ''',
+    )
+    _write(
+        tree / "unreachable_controls_allowlist.txt",
+        """
+        src/bernstein/core/security/chained_control.py::enforce_outer_control  # planned wiring
+        """,
+    )
+
+    assert _run(check_module, tree) == 1
+    reported = capsys.readouterr().err
+    assert "enforce_inner_control" in reported
+    assert "enforce_outer_control" not in reported
+
+
+def test_uncalled_method_of_a_reachable_class_is_reported(
+    check_module: ModuleType, tree: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A live class can still carry a control method nothing ever calls."""
+    _write(
+        tree / "src/bernstein/core/security/graph_control.py",
+        '''
+        """Graph."""
+
+
+        class DecisionGraphStub:
+            def evaluate_decision_graph(self) -> bool:
+                return True
+        ''',
+    )
+    _write(
+        tree / "src/bernstein/core/orchestration/runner.py",
+        '''
+        """Runner."""
+
+        from bernstein.core.security.graph_control import DecisionGraphStub
+
+
+        def run() -> DecisionGraphStub:
+            return DecisionGraphStub()
+        ''',
+    )
+
+    assert _run(check_module, tree) == 1
+    reported = capsys.readouterr().err
+    assert "DecisionGraphStub.evaluate_decision_graph" in reported
+
+
+def test_allowlisted_symbol_passes_the_gate(check_module: ModuleType, tree: Path) -> None:
+    """An entry with a written reason silences its finding."""
+    _write(
+        tree / "src/bernstein/core/security/listed_control.py",
+        '''
+        """Listed."""
+
+
+        def enforce_listed_control() -> bool:
+            return True
+        ''',
+    )
+    _write(
+        tree / "unreachable_controls_allowlist.txt",
+        """
+        # header comment
+        src/bernstein/core/security/listed_control.py::enforce_listed_control  # offline verifier, no runtime path
+        """,
+    )
+
+    assert _run(check_module, tree) == 0
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        "src/bernstein/core/security/listed_control.py::enforce_listed_control",
+        "src/bernstein/core/security/listed_control.py::enforce_listed_control  #",
+        "src/bernstein/core/security/listed_control.py::enforce_listed_control  # REASON REQUIRED",
+    ],
+    ids=["no-comment", "empty-comment", "update-marker"],
+)
+def test_allowlist_entry_without_a_reason_fails(
+    check_module: ModuleType, tree: Path, capsys: pytest.CaptureFixture[str], entry: str
+) -> None:
+    """A reason is the deliverable: an entry without one is not a valid entry."""
+    _write(
+        tree / "src/bernstein/core/security/listed_control.py",
+        '''
+        """Listed."""
+
+
+        def enforce_listed_control() -> bool:
+            return True
+        ''',
+    )
+    (tree / "unreachable_controls_allowlist.txt").write_text(entry + "\n", encoding="utf-8")
+
+    assert _run(check_module, tree) == 1
+    assert "has no reason" in capsys.readouterr().err
+
+
+def test_allowlist_entry_for_a_reachable_symbol_is_reported_as_stale(
+    check_module: ModuleType, tree: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Wiring a symbol up must retire its entry, so the list cannot rot."""
+    _write(
+        tree / "src/bernstein/core/security/live_control.py",
+        '''
+        """Live."""
+
+
+        def enforce_live_control() -> bool:
+            return True
+        ''',
+    )
+    _write(
+        tree / "src/bernstein/core/orchestration/runner.py",
+        '''
+        """Runner."""
+
+        from bernstein.core.security.live_control import enforce_live_control
+
+
+        def run() -> bool:
+            return enforce_live_control()
+        ''',
+    )
+    _write(
+        tree / "unreachable_controls_allowlist.txt",
+        """
+        src/bernstein/core/security/live_control.py::enforce_live_control  # planned wiring
+        """,
+    )
+
+    assert _run(check_module, tree) == 1
+    assert "now reachable or gone" in capsys.readouterr().err
+
+
+def test_update_writes_a_reason_marker_the_gate_rejects(check_module: ModuleType, tree: Path) -> None:
+    """``--update`` records the finding but refuses to grant it a reason."""
+    _write(
+        tree / "src/bernstein/core/security/new_control.py",
+        '''
+        """New."""
+
+
+        def enforce_new_control() -> bool:
+            return True
+        ''',
+    )
+
+    assert _run(check_module, tree, "--update") == 0
+    written = (tree / "unreachable_controls_allowlist.txt").read_text(encoding="utf-8")
+    assert "enforce_new_control" in written
+    assert check_module.REASON_REQUIRED in written
+    assert _run(check_module, tree) == 1
+
+
+def test_repository_tree_matches_the_committed_allowlist(check_module: ModuleType) -> None:
+    """The shipped allowlist covers this tree exactly - no unlisted, no stale."""
+    assert check_module.main(["--repo-root", str(REPO_ROOT)]) == 0

--- a/unreachable_controls_allowlist.txt
+++ b/unreachable_controls_allowlist.txt
@@ -1,0 +1,419 @@
+# Allowlist for scripts/check_unreachable_controls.py (issue #5053).
+#
+# Each line names a public symbol under src/bernstein/core/security/ or
+# src/bernstein/core/identity/ that no production code path reaches, and
+# states why. The reason after '#' is mandatory - an entry without one, or
+# one still carrying the 'REASON REQUIRED' marker, fails the gate.
+#
+# Format:
+#   <path>::<function>            # <reason>
+#   <path>::<Class>.<method>      # <reason>
+#
+# Regenerate the entry list (reasons for existing entries are preserved):
+#   uv run python scripts/check_unreachable_controls.py --update
+#
+# Removing an entry is the goal: wire the symbol into a live code path, or
+# delete it. An entry whose symbol became reachable fails the gate too, so a
+# stale line cannot sit here unnoticed.
+
+src/bernstein/core/identity/delegation.py::DelegationLedger.record_hop                         # backing method for record_delegation_hop, which itself has no caller
+src/bernstein/core/identity/delegation.py::record_delegation_hop                               # delegation-hop ledger writer; nothing calls it and no test covers it - wiring the hop recorder is its own slice
+src/bernstein/core/identity/delegation_scope.py::DelegationScope.is_narrowing_of               # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/identity/grants.py::GrantLedger.issue_grant                                 # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/identity/grants.py::GrantReceipt.to_entry                                   # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/identity/grants.py::GrantSigner.with_issuer                                 # exported in the module's __all__ as public surface; no in-tree caller
+src/bernstein/core/identity/spiffe/binding.py::BindingError                                    # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/identity/spiffe/binding.py::bind_svid_to_card                               # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/identity/spiffe/grant_identity.py::spiffe_grant_issuer                      # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/identity/spiffe/grant_identity.py::spiffe_grant_issuer_with_reference       # exported in the module's __all__ as public surface; no in-tree caller
+src/bernstein/core/identity/spiffe/mtls.py::svid_tls_config                                    # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/identity/spiffe/mtls.py::tls_config_from_svid_files                         # exported in the module's __all__ as public surface; no in-tree caller
+src/bernstein/core/identity/spiffe/mtls.py::write_svid_to_files                                # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/identity/spiffe/spiffe_id.py::SpiffeId                                      # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/identity/spiffe/spiffe_id.py::parse_spiffe_id                               # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/identity/spiffe/svid.py::X509Svid                                           # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/identity/spiffe/svid.py::svid_reference_from_x509                           # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/identity/spiffe/workload_api.py::WorkloadApiError                           # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/identity/spiffe/workload_api.py::fetch_x509_svid                            # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/agent_card_signer.py::sign_agent_card                              # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/agent_identity.py::check_capability                                # capability check for identity cards nothing issues yet; unblocks once issue_identity_card is wired
+src/bernstein/core/security/agent_identity.py::issue_identity_card                             # identity-card issuance is exercised by tests only; no runtime path mints a card yet
+src/bernstein/core/security/agent_identity.py::load_identity_card                              # exercised by tests only; no production caller
+src/bernstein/core/security/agent_identity.py::save_identity_card                              # exercised by tests only; no production caller
+src/bernstein/core/security/article12_bundle.py::ChainBreakError                               # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/article12_bundle.py::RunBundleResult                               # exported in the module's __all__ as public surface; no in-tree caller
+src/bernstein/core/security/article12_bundle.py::assemble_from_run                             # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/article12_bundle.py::emit_run_audit_event                          # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/article12_bundle.py::validate_retention                            # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/article12_bundle.py::verify_bundle                                 # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit.py::AuditLog.force_full_verify                               # exercised by tests only; no production caller
+src/bernstein/core/security/audit.py::AuditLog.last_tile_read_count                            # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/audit.py::AuditLog.verify_incremental                              # exercised by tests only; no production caller
+src/bernstein/core/security/audit.py::IncrementalVerifyReport                                  # exercised by tests only; no production caller
+src/bernstein/core/security/audit_chain.py::CapabilityAuthorizationDetails                     # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::CapabilityDeltaDetails                             # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::MemoryWriteDetails                                 # exported in the module's __all__ as public surface; no in-tree caller
+src/bernstein/core/security/audit_chain.py::ThreadApprovalDetails                              # exported in the module's __all__ as public surface; no in-tree caller
+src/bernstein/core/security/audit_chain.py::reconstruct_claim_holders                          # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::reconstruct_mcp_call_order                         # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_a2a_message_receipt                         # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_adapter_floor_update_receipt                # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_cache_dedup_claim                           # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_cache_hit                                   # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_cache_miss                                  # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_capability_authorization                    # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_capability_delta                            # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_delegation_minted                           # exported in the module's __all__ as public surface; no in-tree caller
+src/bernstein/core/security/audit_chain.py::record_escalation_ladder_budget_stop               # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_escalation_ladder_exhaustion                # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_escalation_ladder_hop                       # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_escalation_ladder_refusal                   # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_expectation_expired                         # exported in the module's __all__ as public surface; no in-tree caller
+src/bernstein/core/security/audit_chain.py::record_intent_capsule                              # exported in the module's __all__ as public surface; no in-tree caller
+src/bernstein/core/security/audit_chain.py::record_intent_drift                                # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_mcp_task_handle                             # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_memory_write                                # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_pool_claim_receipt                          # exported in the module's __all__ as public surface; no in-tree caller
+src/bernstein/core/security/audit_chain.py::record_pool_override_refused                       # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_pool_retired                                # exported in the module's __all__ as public surface; no in-tree caller
+src/bernstein/core/security/audit_chain.py::record_pool_worker_enrolled                        # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_provenance_quarantine                       # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_render_failure                              # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_schedule_collision                          # exported in the module's __all__ as public surface; no in-tree caller
+src/bernstein/core/security/audit_chain.py::record_skill_usage                                 # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_spiffe_svid_binding                         # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_taint_decision                              # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_thread_approval                             # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_tournament_selection                        # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_webhook_node_receipt                        # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::record_webhook_payload_anchor                      # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_chain.py::release_ledger_boundary                            # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/audit_dsse.py::EnvelopeSignatureError                              # exercised by tests only; no production caller
+src/bernstein/core/security/audit_dsse.py::EnvelopeTypeMismatchError                           # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/audit_dsse.py::wrap_bundle                                         # exercised by tests only; no production caller
+src/bernstein/core/security/audit_export.py::BaseSIEMExporter                                  # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/audit_export.py::CloudWatchExporter                                # exercised by tests only; no production caller
+src/bernstein/core/security/audit_export.py::ElasticsearchExporter                             # exercised by tests only; no production caller
+src/bernstein/core/security/audit_export.py::FileExporter                                      # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/audit_export.py::SplunkHECExporter                                 # exercised by tests only; no production caller
+src/bernstein/core/security/audit_export.py::SyslogExporter                                    # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/audit_export.py::WebhookExporter                                   # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/auth.py::AuthService.validate_legacy_token                         # exercised by tests only; no production caller
+src/bernstein/core/security/auth.py::AuthSession.max_acknowledgement_lag                       # exercised by tests only; no production caller
+src/bernstein/core/security/auth.py::AuthStore.cleanup_expired_devices                         # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/auth.py::AuthStore.cleanup_expired_sessions                        # exercised by tests only; no production caller
+src/bernstein/core/security/auth.py::AuthStore.find_user_by_email                              # exercised by tests only; no production caller
+src/bernstein/core/security/auth.py::AuthStore.revoke_user_sessions                            # exercised by tests only; no production caller
+src/bernstein/core/security/auth.py::GroupRoleMappingEntry                                     # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/auth_rate_limiter.py::RateLimitDecision                            # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/auth_rate_limiter.py::RequestRateLimitMiddleware.sse_connections   # exercised by tests only; no production caller
+src/bernstein/core/security/auth_rate_limiter.py::check_auth_rate_limit                        # exercised by tests only; no production caller
+src/bernstein/core/security/auto_approve.py::reload_extra_allow_patterns_from_env              # exercised by tests only; no production caller
+src/bernstein/core/security/auto_approve.py::set_extra_allow_patterns                          # exercised by tests only; no production caller
+src/bernstein/core/security/blocking_hooks.py::BlockingHookRunner.registered_events            # exercised by tests only; no production caller
+src/bernstein/core/security/blocking_hooks.py::make_blocking_payload                           # exercised by tests only; no production caller
+src/bernstein/core/security/blocking_hooks.py::validate_blocking_event                         # exercised by tests only; no production caller
+src/bernstein/core/security/capability_delta.py::compute_grant_delta                           # exercised by tests only; no production caller
+src/bernstein/core/security/capability_matrix.py::record_spawn_capabilities                    # exercised by tests only; no production caller
+src/bernstein/core/security/capability_tokens.py::AttenuationError                             # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/capability_tokens.py::Caveats.is_narrowing_of                      # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/capability_tokens.py::TokenVerificationError                       # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/capability_tokens.py::attenuate                                    # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/capability_tokens.py::caveats_for_scope                            # exported in the module's __all__ as public surface; no in-tree caller
+src/bernstein/core/security/capability_tokens.py::mint_root                                    # root of the capability-token chain; the delegation CLI verifies chains but nothing mints one, so no production path reaches it
+src/bernstein/core/security/capability_tokens.py::scope_permissions                            # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/capability_tokens.py::sign_token                                   # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/capability_tokens.py::to_actor_claims                              # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/change_receipt.py::ChangeAttempt                                   # exercised by tests only; no production caller
+src/bernstein/core/security/change_receipt.py::ChangeReceipt                                   # exercised by tests only; no production caller
+src/bernstein/core/security/change_receipt.py::ChangeReceiptError                              # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/claude_permission_profiles.py::PermissionProfile.to_settings_json  # exercised by tests only; no production caller
+src/bernstein/core/security/claude_permission_profiles.py::PermissionProfileManager            # exercised by tests only; no production caller
+src/bernstein/core/security/claude_tool_result_injection.py::ToolResultInjector.has_failures   # exercised by tests only; no production caller
+src/bernstein/core/security/command_allowlist.py::AllowlistVerdict                             # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/command_allowlist.py::ScopeAllowlistConfig                         # exercised by tests only; no production caller
+src/bernstein/core/security/command_allowlist.py::check_command                                # exercised by tests only; no production caller
+src/bernstein/core/security/command_policy.py::CommandPoliciesConfig                           # exercised by tests only; no production caller
+src/bernstein/core/security/command_policy.py::CommandVerdict                                  # exercised by tests only; no production caller
+src/bernstein/core/security/command_policy.py::check_command                                   # exercised by tests only; no production caller
+src/bernstein/core/security/command_policy.py::load_command_policies                           # exercised by tests only; no production caller
+src/bernstein/core/security/command_policy.py::record_command_verdict                          # exercised by tests only; no production caller
+src/bernstein/core/security/commit_signing.py::CommitProvenance                                # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/commit_signing.py::SignedCommitResult                              # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/commit_signing.py::SigningConfig                                   # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/commit_signing.py::build_provenance_trailers                       # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/commit_signing.py::is_agent_commit                                 # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/commit_signing.py::read_commit_provenance                          # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/commit_signing.py::sign_and_commit                                 # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/commit_signing.py::verify_commit_signature                         # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/compliance.py::SBOMEntry                                           # exercised by tests only; no production caller
+src/bernstein/core/security/compliance.py::ai_label_for_file                                   # exercised by tests only; no production caller
+src/bernstein/core/security/compliance.py::export_evidence_bundle                              # exercised by tests only; no production caller
+src/bernstein/core/security/compliance.py::generate_sbom                                       # exercised by tests only; no production caller
+src/bernstein/core/security/compliance_library.py::ComplianceReport                            # exercised by tests only; no production caller
+src/bernstein/core/security/compliance_library.py::get_all_rules                               # exercised by tests only; no production caller
+src/bernstein/core/security/compliance_library.py::get_framework_rules                         # exercised by tests only; no production caller
+src/bernstein/core/security/compliance_library.py::get_registered_check_names                  # exercised by tests only; no production caller
+src/bernstein/core/security/compliance_library.py::get_rule_by_id                              # exercised by tests only; no production caller
+src/bernstein/core/security/compliance_library.py::render_compliance_report                    # exercised by tests only; no production caller
+src/bernstein/core/security/compliance_library.py::run_compliance_check                        # exercised by tests only; no production caller
+src/bernstein/core/security/compliance_report.py::CompliancePackage                            # exercised by tests only; no production caller
+src/bernstein/core/security/compliance_report.py::build_compliance_package                     # exercised by tests only; no production caller
+src/bernstein/core/security/compliance_report.py::compute_merkle_root                          # exercised by tests only; no production caller
+src/bernstein/core/security/compliance_report.py::format_compliance_report                     # exercised by tests only; no production caller
+src/bernstein/core/security/compliance_report.py::map_events_to_controls                       # exercised by tests only; no production caller
+src/bernstein/core/security/data_residency.py::DataResidencyController                         # exercised by tests only; no production caller
+src/bernstein/core/security/data_residency.py::ResidencyCheckResult                            # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/data_residency.py::ResidencyViolation                              # exercised by tests only; no production caller
+src/bernstein/core/security/denial_tracker.py::DenialTracker.clear_session                     # exercised by tests only; no production caller
+src/bernstein/core/security/denial_tracker.py::DenialTracker.get_all_sessions                  # exercised by tests only; no production caller
+src/bernstein/core/security/denial_tracker.py::DenialTracker.get_denial_count                  # exercised by tests only; no production caller
+src/bernstein/core/security/denial_tracker.py::DenialTracker.get_record                        # exercised by tests only; no production caller
+src/bernstein/core/security/denial_tracker.py::DenialTracker.is_over_threshold                 # exercised by tests only; no production caller
+src/bernstein/core/security/deployment_profile.py::read_posture_attestation                    # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/dlp_scanner.py::DLPScanner.scan_diff                               # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/dlp_scanner.py::scan_diff_for_dlp                                  # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/dlp_scanner.py::scan_text_for_dlp                                  # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/dlp_scanner_v2.py::render_dlp_report                               # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/dlp_scanner_v2.py::scan_agent_output                               # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/dlp_scanner_v2.py::scan_file                                       # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/dp_telemetry.py::DPTelemetryExporter                               # exercised by tests only; no production caller
+src/bernstein/core/security/dp_telemetry.py::PrivacyBudgetTracker.epsilon_remaining            # exercised by tests only; no production caller
+src/bernstein/core/security/dp_telemetry.py::PrivacyBudgetTracker.epsilon_spent                # exercised by tests only; no production caller
+src/bernstein/core/security/dp_telemetry.py::PrivacyBudgetTracker.queries_remaining            # exercised by tests only; no production caller
+src/bernstein/core/security/dual_approval.py::ApprovalChannel                                  # exercised by tests only; no production caller
+src/bernstein/core/security/dual_approval.py::ApprovalRequest                                  # exercised by tests only; no production caller
+src/bernstein/core/security/dual_approval.py::ApprovalResponse                                 # exercised by tests only; no production caller
+src/bernstein/core/security/dual_approval.py::ApprovalStatus                                   # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/dual_approval.py::create_approval_request                          # exercised by tests only; no production caller
+src/bernstein/core/security/dual_approval.py::evaluate_approval                                # exercised by tests only; no production caller
+src/bernstein/core/security/dual_approval.py::format_approval_prompt                           # exercised by tests only; no production caller
+src/bernstein/core/security/dual_approval.py::is_destructive                                   # exercised by tests only; no production caller
+src/bernstein/core/security/engagement_mandate.py::EngagementMandate                           # exercised by tests only; no production caller
+src/bernstein/core/security/engagement_mandate.py::MandateAction                               # exercised by tests only; no production caller
+src/bernstein/core/security/engagement_mandate.py::MandateReceipt                              # exercised by tests only; no production caller
+src/bernstein/core/security/engagement_mandate.py::check_mandate                               # exercised by tests only; no production caller
+src/bernstein/core/security/environment_digest.py::DigestMismatchError                         # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/environment_digest.py::compare_digests                             # exercised by tests only; no production caller
+src/bernstein/core/security/environment_digest.py::compute_environment_digest                  # exercised by tests only; no production caller
+src/bernstein/core/security/eu_ai_act.py::assess_risk                                          # exercised by tests only; no production caller
+src/bernstein/core/security/external_policy_hook.py::CedarHook                                 # exercised by tests only; no production caller
+src/bernstein/core/security/external_policy_hook.py::OPAHook                                   # exercised by tests only; no production caller
+src/bernstein/core/security/external_policy_hook.py::PolicyHookRegistry                        # exercised by tests only; no production caller
+src/bernstein/core/security/governance.py::BudgetRefused                                       # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/governance.py::check_budget_decision                               # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/guardrail_pipeline.py::CostGuardrail.check_input                   # exercised by tests only; no production caller
+src/bernstein/core/security/guardrail_pipeline.py::Guardrail.check_input                       # exercised by tests only; no production caller
+src/bernstein/core/security/guardrail_pipeline.py::GuardrailPipeline.check_input               # exercised by tests only; no production caller
+src/bernstein/core/security/guardrail_pipeline.py::PromptInjectionGuardrail.check_input        # exercised by tests only; no production caller
+src/bernstein/core/security/guardrail_pipeline.py::ScopeGuardrail.check_input                  # exercised by tests only; no production caller
+src/bernstein/core/security/guardrail_pipeline.py::SecretLeakGuardrail.check_input             # exercised by tests only; no production caller
+src/bernstein/core/security/hipaa.py::HIPAAComplianceReport                                    # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/hipaa.py::HIPAAMode                                                # exercised by tests only; no production caller
+src/bernstein/core/security/hipaa.py::PHIDetector                                              # exercised by tests only; no production caller
+src/bernstein/core/security/hipaa.py::decrypt_file_aes256gcm                                   # exercised by tests only; no production caller
+src/bernstein/core/security/hipaa.py::encrypt_file_aes256gcm                                   # exercised by tests only; no production caller
+src/bernstein/core/security/hipaa.py::generate_hipaa_report                                    # exercised by tests only; no production caller
+src/bernstein/core/security/hipaa.py::is_phi_file                                              # exercised by tests only; no production caller
+src/bernstein/core/security/hipaa.py::load_or_create_hipaa_encryption_key                      # exercised by tests only; no production caller
+src/bernstein/core/security/hipaa.py::save_hipaa_report                                        # exercised by tests only; no production caller
+src/bernstein/core/security/identity_spawn_anchor.py::IdentitySpawnAnchor                      # spawn anchor is written by tests only, so run_attestation_receipt's 'exactly one anchor' branch cannot fire on real data - wiring is its own slice
+src/bernstein/core/security/input_refusal.py::RefusalVerifyResult                              # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/input_refusal.py::read_refusal_receipt                             # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/input_refusal.py::verify_refusal_against_chain                     # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/intent_capsule.py::approve_and_capsule                             # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/intent_capsule.py::assemble_intent_drift_escalation                # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/intent_capsule.py::assert_no_llm_imports                           # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/intent_capsule.py::bind_capsule_into_journal                       # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/intent_capsule.py::classify_journal_event                          # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/intent_capsule.py::compile_capsule                                 # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/intent_capsule.py::iter_module_import_names                        # exported in the module's __all__ as public surface; no in-tree caller
+src/bernstein/core/security/intent_capsule.py::record_intent_drift                             # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/intent_capsule.py::write_capsule                                   # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/ip_allowlist.py::check_ip_allowed                                  # exercised by tests only; no production caller
+src/bernstein/core/security/jwt_tokens.py::TokenRefreshScheduler                               # exercised by tests only; no production caller
+src/bernstein/core/security/key_rotation.py::KeyRotationManager.detect_leak                    # exercised by tests only; no production caller
+src/bernstein/core/security/key_rotation.py::KeyRotationManager.get_active_keys                # exercised by tests only; no production caller
+src/bernstein/core/security/key_rotation.py::KeyRotationManager.get_all_keys                   # exercised by tests only; no production caller
+src/bernstein/core/security/key_rotation.py::KeyRotationManager.handle_leak                    # exercised by tests only; no production caller
+src/bernstein/core/security/key_rotation.py::KeyRotationManager.register_key                   # exercised by tests only; no production caller
+src/bernstein/core/security/key_rotation.py::KeyRotationManager.revoke_key                     # exercised by tests only; no production caller
+src/bernstein/core/security/key_rotation.py::KeyRotationScheduler                              # exercised by tests only; no production caller
+src/bernstein/core/security/key_rotation_support.py::AgentKeyUpdater.get_agent_env             # exercised by tests only; no production caller
+src/bernstein/core/security/key_rotation_support.py::AgentKeyUpdater.unregister_agent          # exercised by tests only; no production caller
+src/bernstein/core/security/key_rotation_support.py::AgentKeyUpdater.update_agent              # exercised by tests only; no production caller
+src/bernstein/core/security/key_rotation_support.py::AgentKeyUpdater.update_all_agents         # exercised by tests only; no production caller
+src/bernstein/core/security/key_rotation_support.py::AgentKeyUpdater.update_log                # exercised by tests only; no production caller
+src/bernstein/core/security/key_rotation_support.py::ExpiryStatus                              # exercised by tests only; no production caller
+src/bernstein/core/security/key_rotation_support.py::KeyExpiryDetector.check_key               # exercised by tests only; no production caller
+src/bernstein/core/security/key_rotation_support.py::KeyExpiryDetector.check_keys              # exercised by tests only; no production caller
+src/bernstein/core/security/key_rotation_support.py::KeyExpiryDetector.get_expiring            # exercised by tests only; no production caller
+src/bernstein/core/security/key_rotation_support.py::KeyExpiryInfo                             # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/key_rotation_support.py::RotationOrchestrator                      # exercised by tests only; no production caller
+src/bernstein/core/security/license_manager.py::FeatureCheckResult                             # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/license_manager.py::LicenseManager                                 # exercised by tests only; no production caller
+src/bernstein/core/security/license_manager.py::LicenseValidationResult                        # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/license_manager.py::decode_license                                 # exercised by tests only; no production caller
+src/bernstein/core/security/license_manager.py::encode_license                                 # exercised by tests only; no production caller
+src/bernstein/core/security/license_manager.py::validate_license_signature                     # exercised by tests only; no production caller
+src/bernstein/core/security/native_toolcall_evidence.py::NativeToolCallEvidenceProvider        # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/network_isolation.py::NetworkIsolationValidator                    # exercised by tests only; no production caller
+src/bernstein/core/security/oauth_pkce.py::OAuthStateError                                     # exercised by tests only; no production caller
+src/bernstein/core/security/oauth_pkce.py::PKCEFlow                                            # exercised by tests only; no production caller
+src/bernstein/core/security/owasp_asi_detectors.py::OwaspAsiGuardrail.check_input              # exercised by tests only; no production caller
+src/bernstein/core/security/permission_delegation.py::DelegationToken.use                      # exercised by tests only; no production caller
+src/bernstein/core/security/permission_delegation.py::PermissionDelegator                      # exercised by tests only; no production caller
+src/bernstein/core/security/permission_delegation.py::enum_to_caveats                          # exercised by tests only; no production caller
+src/bernstein/core/security/permission_delegation.py::should_delegate                          # exercised by tests only; no production caller
+src/bernstein/core/security/permission_graph.py::ClassifierLayer                               # exercised by tests only; no production caller
+src/bernstein/core/security/permission_graph.py::DenyRulesLayer                                # exercised by tests only; no production caller
+src/bernstein/core/security/permission_graph.py::PermissionGraph                               # exercised by tests only; no production caller
+src/bernstein/core/security/permission_graph.py::PromptLayer                                   # exercised by tests only; no production caller
+src/bernstein/core/security/permission_matrix.py::log_resolution                               # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/permission_mode.py::default_for_no_match                           # exercised by tests only; no production caller
+src/bernstein/core/security/permission_policy.py::check_tool_call                              # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/permission_policy.py::list_builtin_profiles                        # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/permission_rules.py::load_permission_rules                         # exercised by tests only; no production caller
+src/bernstein/core/security/permissions.py::is_command_allowed                                 # exercised by tests only; no production caller
+src/bernstein/core/security/pii_output_gate.py::scan_diff                                      # exercised by tests only; no production caller
+src/bernstein/core/security/plan_approval.py::PlanStore.save_plan                              # exercised by tests only; no production caller
+src/bernstein/core/security/policy.py::PolicyEngine.add_policy                                 # exercised by tests only; no production caller
+src/bernstein/core/security/policy.py::PolicyEngine.disable_policy                             # exercised by tests only; no production caller
+src/bernstein/core/security/policy.py::PolicyEngine.enable_policy                              # exercised by tests only; no production caller
+src/bernstein/core/security/policy.py::PolicyEngine.list_policies                              # exercised by tests only; no production caller
+src/bernstein/core/security/policy.py::PolicyEngine.remove_policy                              # exercised by tests only; no production caller
+src/bernstein/core/security/policy.py::create_context                                          # exercised by tests only; no production caller
+src/bernstein/core/security/policy_engine.py::PolicyCheckResult                                # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/policy_engine.py::evaluate_lethal_trifecta                         # exercised by tests only; no production caller
+src/bernstein/core/security/policy_engine.py::run_policy_engine                                # exercised by tests only; no production caller
+src/bernstein/core/security/policy_limits.py::PolicyLimitsClient.get_snapshot                  # exercised by tests only; no production caller
+src/bernstein/core/security/policy_limits.py::PolicyLimitsClient.start_background_polling      # exercised by tests only; no production caller
+src/bernstein/core/security/policy_limits.py::PolicyLimitsClient.stop_background_polling       # exercised by tests only; no production caller
+src/bernstein/core/security/policy_limits.py::is_allowed_sync                                  # exercised by tests only; no production caller
+src/bernstein/core/security/policy_limits.py::managed_policy_limits                            # exercised by tests only; no production caller
+src/bernstein/core/security/policy_templates.py::OrgPolicyTemplate                             # exercised by tests only; no production caller
+src/bernstein/core/security/policy_templates.py::apply_org_policies                            # exercised by tests only; no production caller
+src/bernstein/core/security/policy_templates.py::load_org_policies                             # exercised by tests only; no production caller
+src/bernstein/core/security/post_tool_enforcement.py::redact_tool_output                       # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/post_tool_enforcement.py::run_post_tool_enforcement                # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/promptware_detector.py::PromptwareScore.is_warn                    # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/promptware_ingest.py::PromptwareIngestResult                       # exported in the module's __all__ as public surface; no in-tree caller
+src/bernstein/core/security/promptware_ingest.py::QuarantinedIngestResult                      # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/promptware_ingest.py::build_lifecycle_payload                      # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/promptware_ingest.py::get_default_detector                         # exported in the module's __all__ as public surface; no in-tree caller
+src/bernstein/core/security/promptware_ingest.py::quarantine_untrusted_payload                 # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/promptware_ingest.py::scan_tool_output                             # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/quarantined_parser.py::FieldSpec                                   # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/quarantined_parser.py::QuarantinedExtract                          # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/quarantined_parser.py::extract_structured                          # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/rbac.py::RBACEnforcer                                              # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/rbac.py::require_permission                                        # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/rbac.py::require_role                                              # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/resource_limits.py::ResourceLimits.has_any_limit                   # exercised by tests only; no production caller
+src/bernstein/core/security/resource_limits.py::ResourceUsage                                  # exercised by tests only; no production caller
+src/bernstein/core/security/resource_limits.py::check_usage                                    # exercised by tests only; no production caller
+src/bernstein/core/security/result_receipt_bundle.py::BundleError                              # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/result_receipt_bundle.py::parse_bundle                             # exercised by tests only; no production caller
+src/bernstein/core/security/rfc3161_verifier.py::hash_payload_for_tsa                          # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/role_adapter_policy.py::reset_policy                               # exercised by tests only; no production caller
+src/bernstein/core/security/role_adapter_policy.py::set_policy                                 # exercised by tests only; no production caller
+src/bernstein/core/security/rule_enforcer.py::get_rule_violation_stats                         # exercised by tests only; no production caller
+src/bernstein/core/security/run_closure.py::RunClosureProjection.complete_range                # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/run_closure.py::project_run_closure                                # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/sandbox_escape_detector.py::SandboxEscapeDetector                  # exercised by tests only; no production caller
+src/bernstein/core/security/sandbox_eval.py::SandboxManager.check_timeouts                     # exercised by tests only; no production caller
+src/bernstein/core/security/sandbox_eval.py::SandboxManager.cleanup_finished                   # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/sandbox_eval.py::SandboxManager.get_orchestrator_config            # exercised by tests only; no production caller
+src/bernstein/core/security/sandbox_eval.py::SandboxManager.mark_cloning                       # exercised by tests only; no production caller
+src/bernstein/core/security/sandbox_eval.py::SandboxManager.mark_started                       # exercised by tests only; no production caller
+src/bernstein/core/security/sandbox_eval.py::SandboxManager.record_cost                        # exercised by tests only; no production caller
+src/bernstein/core/security/sandbox_profiles.py::ProfileConflict                               # exercised by tests only; no production caller
+src/bernstein/core/security/sandbox_profiles.py::compose_profiles                              # exercised by tests only; no production caller
+src/bernstein/core/security/sandbox_profiles.py::list_builtin_profiles                         # exercised by tests only; no production caller
+src/bernstein/core/security/sandbox_profiles.py::render_profile_summary                        # exercised by tests only; no production caller
+src/bernstein/core/security/sandbox_profiles.py::validate_profile                              # exercised by tests only; no production caller
+src/bernstein/core/security/sbom.py::SBOMScanResult.has_critical                               # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/seccomp_profiles.py::build_custom_profile                          # exercised by tests only; no production caller
+src/bernstein/core/security/seccomp_profiles.py::build_profile                                 # exercised by tests only; no production caller
+src/bernstein/core/security/seccomp_profiles.py::profile_for_role                              # exercised by tests only; no production caller
+src/bernstein/core/security/seccomp_profiles.py::write_custom_profile                          # exercised by tests only; no production caller
+src/bernstein/core/security/seccomp_profiles.py::write_profile                                 # exercised by tests only; no production caller
+src/bernstein/core/security/seccomp_sandbox.py::generate_seccomp_json                          # exercised by tests only; no production caller
+src/bernstein/core/security/seccomp_sandbox.py::get_recommended_profile                        # exercised by tests only; no production caller
+src/bernstein/core/security/seccomp_sandbox.py::merge_profiles                                 # exercised by tests only; no production caller
+src/bernstein/core/security/seccomp_sandbox.py::render_profile_summary                         # exercised by tests only; no production caller
+src/bernstein/core/security/seccomp_sandbox.py::validate_profile                               # exercised by tests only; no production caller
+src/bernstein/core/security/secrets_broker.py::SecretsBroker.list_live                         # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/secrets_broker.py::SecretsBroker.mint_scoped                       # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/secrets_broker.py::SecretsBroker.revoke_task                       # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/secrets_broker.py::clear_redaction_registry                        # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/security_correlation.py::CorrelationMatch                          # exercised by tests only; no production caller
+src/bernstein/core/security/security_correlation.py::SecurityEvent                             # exercised by tests only; no production caller
+src/bernstein/core/security/security_correlation.py::correlate_events                          # exercised by tests only; no production caller
+src/bernstein/core/security/security_correlation.py::format_correlation_report                 # exercised by tests only; no production caller
+src/bernstein/core/security/security_correlation.py::load_security_events                      # exercised by tests only; no production caller
+src/bernstein/core/security/security_incident_response.py::ContainmentResult                   # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/security_incident_response.py::ContainmentStep                     # exercised by tests only; no production caller
+src/bernstein/core/security/security_incident_response.py::SecurityEventType                   # exercised by tests only; no production caller
+src/bernstein/core/security/security_incident_response.py::SecurityIncidentResponder           # exercised by tests only; no production caller
+src/bernstein/core/security/security_incident_response.py::is_task_blocked                     # exercised by tests only; no production caller
+src/bernstein/core/security/security_incident_response.py::list_active_security_incidents      # exercised by tests only; no production caller
+src/bernstein/core/security/security_incident_response.py::load_block_metadata                 # exercised by tests only; no production caller
+src/bernstein/core/security/security_posture.py::PostureReport                                 # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/security_posture.py::compute_posture                               # exercised by tests only; no production caller
+src/bernstein/core/security/security_posture.py::format_posture_report                         # exercised by tests only; no production caller
+src/bernstein/core/security/security_posture.py::score_audit_integrity                         # exercised by tests only; no production caller
+src/bernstein/core/security/security_posture.py::score_permissions                             # exercised by tests only; no production caller
+src/bernstein/core/security/security_posture.py::score_policy_compliance                       # exercised by tests only; no production caller
+src/bernstein/core/security/security_posture.py::score_sandbox                                 # exercised by tests only; no production caller
+src/bernstein/core/security/security_posture.py::score_secrets                                 # exercised by tests only; no production caller
+src/bernstein/core/security/sensitive_data.py::SensitiveData                                   # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/sensitive_data.py::is_sensitive                                    # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/sensitive_data.py::strip_sensitive_fields                          # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/sensitive_file_detector.py::ScanSummary                            # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/sensitive_file_detector.py::SensitiveFileDetector                  # exercised by tests only; no production caller
+src/bernstein/core/security/sigstore_attestation.py::list_attestations                         # exercised by tests only; no production caller
+src/bernstein/core/security/sigstore_attestation.py::load_attestation_record                   # exercised by tests only; no production caller
+src/bernstein/core/security/sigstore_attestation.py::verify_local_attestation                  # exercised by tests only; no production caller
+src/bernstein/core/security/soc2_report.py::MerkleAttestation                                  # exercised by tests only; no production caller
+src/bernstein/core/security/soc2_report.py::SOC2ComplianceReport                               # exercised by tests only; no production caller
+src/bernstein/core/security/soc2_report.py::generate_soc2_report                               # exercised by tests only; no production caller
+src/bernstein/core/security/soc2_report.py::save_soc2_report                                   # exercised by tests only; no production caller
+src/bernstein/core/security/socket_guard.py::collect_unmonitored_destinations                  # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/sso_oidc.py::OIDCProvider                                          # exercised by tests only; no production caller
+src/bernstein/core/security/sso_oidc.py::parse_discovery_document                              # exercised by tests only; no production caller
+src/bernstein/core/security/sso_oidc.py::parse_token_response                                  # exercised by tests only; no production caller
+src/bernstein/core/security/state_encryption.py::EncryptedFile.encrypted_path                  # exercised by tests only; no production caller
+src/bernstein/core/security/state_encryption.py::KeyManager                                    # exercised by tests only; no production caller
+src/bernstein/core/security/state_encryption.py::decrypt_file                                  # exercised by tests only; no production caller
+src/bernstein/core/security/state_encryption.py::encrypt_file                                  # exercised by tests only; no production caller
+src/bernstein/core/security/state_encryption.py::is_encrypted                                  # exercised by tests only; no production caller
+src/bernstein/core/security/surface_grant_delta.py::SurfaceGrantChange                         # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/surface_grant_delta.py::SurfaceGrantDelta                          # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/surface_grant_delta.py::compute_surface_grant_delta                # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/surface_grant_delta.py::is_permission_bearing_surface              # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/tenant_isolation.py::TenantIsolationContext.normalized_id          # exercised by tests only; no production caller
+src/bernstein/core/security/tenant_isolation.py::TenantIsolationManager.list_tenants           # exercised by tests only; no production caller
+src/bernstein/core/security/tenant_isolation.py::TenantIsolationManager.persist_state          # exercised by tests only; no production caller
+src/bernstein/core/security/tenant_isolation.py::TenantIsolationManager.register_quota         # exercised by tests only; no production caller
+src/bernstein/core/security/tenant_isolation_verify.py::IsolationReport                        # exercised by tests only; no production caller
+src/bernstein/core/security/tenant_isolation_verify.py::IsolationTest                          # exercised by tests only; no production caller
+src/bernstein/core/security/tenant_isolation_verify.py::TenantIsolationVerifier                # exercised by tests only; no production caller
+src/bernstein/core/security/tenant_isolation_verify.py::render_isolation_report                # exercised by tests only; no production caller
+src/bernstein/core/security/tenant_rate_limiter.py::DenialReason                               # exercised by tests only; no production caller
+src/bernstein/core/security/tenant_rate_limiter.py::QuotaDenial                                # no production caller and no test reference; baseline entry from the first scan
+src/bernstein/core/security/tenant_rate_limiter.py::QuotaKind                                  # exercised by tests only; no production caller
+src/bernstein/core/security/tenant_rate_limiter.py::TenantRateLimiter                          # exercised by tests only; no production caller
+src/bernstein/core/security/tenanting.py::tenant_metrics_dir                                   # exercised by tests only; no production caller
+src/bernstein/core/security/toolcall_identity.py::LineageToolCallIdentitySigner                # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/toolcall_identity.py::ToolCallIdentitySigner                       # exported in the module's __all__ as public surface; no in-tree caller
+src/bernstein/core/security/toolcall_interlock.py::AttestationModeProjection                   # exported in the module's __all__ as public surface; no in-tree caller
+src/bernstein/core/security/toolcall_interlock.py::project_attestation_mode                    # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/url_allowlist.py::StrictHTTPRedirectHandler.redirect_request       # exported in the module's __all__ and exercised by tests; no production caller
+src/bernstein/core/security/vault_injector.py::VaultInjector                                   # exercised by tests only; no production caller
+src/bernstein/core/security/vault_injector.py::inject_agent_credentials                        # exercised by tests only; no production caller
+src/bernstein/core/security/vault_injector.py::revoke_agent_credentials                        # exercised by tests only; no production caller
+src/bernstein/core/security/vuln_disclosure.py::DisclosureTimeline                             # exercised by tests only; no production caller
+src/bernstein/core/security/vuln_disclosure.py::RecognitionTier                                # exercised by tests only; no production caller
+src/bernstein/core/security/vuln_disclosure.py::VulnerabilityDisclosureManager                 # exercised by tests only; no production caller
+src/bernstein/core/security/vuln_disclosure.py::generate_security_txt                          # exercised by tests only; no production caller


### PR DESCRIPTION
## What

Adds a CI lint that fails when a public symbol under `src/bernstein/core/security/`
or `src/bernstein/core/identity/` has no caller inside the shipped package, plus
the reasoned allowlist the check produces from the current tree.

New: `scripts/check_unreachable_controls.py`, `unreachable_controls_allowlist.txt`
(401 entries, one written reason each), `tests/unit/scripts/test_check_unreachable_controls.py`,
a step in the `lint` job, and a `CONTRIBUTING.md` section.

Explicitly **not** in this PR:

- wiring any of the 401 listed symbols into a live path — each is its own slice;
- any scan root beyond `core/security/` and `core/identity/`;
- any change to `vulture`, `.importlinter`, or
  `tests/unit/test_security_controls_are_wired.py`, all of which stay as they are.

No file under `src/` changes.

## Why

A control that is implemented, unit-tested and merged but never invoked reads as
the opposite of itself. Grepping for the symbol finds it, its tests pass, and the
reader concludes the control runs. Nothing in the repository can currently tell
"a control that runs" from "a control that exists": the 459-entry lazy re-export
map in `src/bernstein/core/__init__.py` stores module paths as *strings*, so every
named module looks imported to any import-graph walk, `vulture` included. A control
that is never called also cannot fail a test, so it never regresses and never gets
noticed.

Concrete case in the current tree: `capability_tokens.mint_root` is called at
`src/bernstein/core/security/permission_delegation.py:442`, inside
`PermissionDelegator.mint_capability`. `PermissionDelegator` itself has no caller
outside tests. The static reference is real; the production path is not. That is
the distinction this check is built to make, and no existing tool in the repo makes it.

## How

**Where it lives.** A standalone script run from the `lint` job, next to the
existing `scripts/check_routes_broad_except.py` step, rather than an
`.importlinter` contract. The issue left this open; import-linter contracts are
expressed over module imports, and the load-bearing rule here is that *an import
is not a reference* — a re-export imports the symbol and reaches nothing. That
rule cannot be written as an import contract.

**What counts as a reference.** Only `ast.Name` loads and attribute accesses
inside `src/bernstein/`. Deliberately not references: `import` / `from ... import`
statements (so `__init__` re-exports contribute nothing), string literals (so
`__all__` and the lazy module map contribute nothing), and anything under `tests/`
— the reference scan never leaves the package.

**Reachability is a fixpoint, not one pass.** A reference counts only when it is
made from module-level code, from a symbol already proved reachable, or from a
file outside the scanned packages. So a symbol called only by another unreachable
symbol stays unreachable, and allowlisting a symbol does not revive what that
symbol calls. Private definitions are tracked but never reported, so a dead
private helper cannot keep the public symbols it calls alive.

**Matching is by bare name, on purpose, and under-reports.** Bindings are not
resolved and a type annotation counts as a reference, so a symbol is reported only
when its bare name appears nowhere in the package outside imports and strings. The
check therefore never fails the build on a symbol that is actually called. This
direction is chosen deliberately: the docstring of
`tests/unit/test_security_controls_are_wired.py` records what the opposite costs —
its first version keyed the index on the binding name and reported forty live
functions dead, and on a security control the natural response to that report is
to delete it.

The price of that choice is visible against the examples in the issue: of the
seven listed, `record_delegation_hop`, `IdentitySpawnAnchor`,
`issue_identity_card`, `check_capability` and `mint_root` are reported;
`ToolCallAttestationInterlock` is not, because its name appears as a type
annotation at `src/bernstein/core/protocols/mcp/mcp_gateway.py:191`; and
`DecisionGraph` is not, because it is genuinely constructed at
`src/bernstein/core/security/guardrails.py:932` — that its *result* is discarded is
a value-flow property, not a reachability one, and out of scope here.
`backend_options` sits in `core/volunteer/`, outside this slice's scan roots.

**The allowlist.** One line per symbol, `path::symbol  # reason`. A missing or
empty reason fails the gate, and so does the literal `REASON REQUIRED` marker that
`--update` writes for a new finding — so a new finding cannot be silenced without
someone writing a sentence. An entry whose symbol became reachable, or was
deleted, fails the gate too, so the list can only shrink. `--update` regenerates
the entry list and preserves the reasons already written.

The 401 entries were produced by the check itself, not transcribed from the issue.
Reasons distinguish the shapes the scan can tell apart — no caller and no test at
all; exercised by tests only; exported in `__all__` as public surface — and the
symbols the issue named individually carry the fuller reason. None carries an issue
link, because no open issue covers any of them by name today.

## Tests

`tests/unit/scripts/test_check_unreachable_controls.py`, 13 functions / 15 cases.
Each builds a miniature `src/bernstein` tree on disk and runs the real `main()`
over it, so the failure path executes rather than being asserted about.

1. `test_uncalled_public_function_fails_the_gate` — **load-bearing**, and the
   acceptance test the issue names: a throwaway uncalled public function under
   `core/security/` makes the gate exit 1; deleting that one file makes it exit 0.
2. `test_symbol_called_from_a_production_module_passes` — a control a shipped
   module actually calls is not a finding (the check must not pass by finding
   everything dead).
3. `test_symbol_called_only_from_tests_is_reported` — a passing unit test is not a
   production caller.
4. `test_symbol_reexported_by_init_only_is_reported` — an `__init__` re-export is
   an import and an `__all__` string, not a call.
5. `test_symbol_named_only_in_the_lazy_module_map_is_reported` — the `core/__init__.py`
   map holds strings, so it reaches nothing.
6. `test_symbol_called_only_from_an_unreachable_symbol_is_reported` — the fixpoint:
   a caller that is itself dead reaches nothing.
7. `test_allowlisted_symbol_does_not_make_its_callee_reachable` — allowlisting
   silences one symbol without reviving what it calls.
8. `test_uncalled_method_of_a_reachable_class_is_reported` — a live class can still
   carry a control method nothing calls.
9. `test_allowlisted_symbol_passes_the_gate` — an entry with a reason silences its
   finding.
10. `test_allowlist_entry_without_a_reason_fails` (×3: no comment, empty comment,
    `REASON REQUIRED` marker) — the reason is the deliverable.
11. `test_allowlist_entry_for_a_reachable_symbol_is_reported_as_stale` — wiring a
    symbol up must retire its entry, so the list cannot rot.
12. `test_update_writes_a_reason_marker_the_gate_rejects` — `--update` records a
    finding but refuses to grant it a reason.
13. `test_repository_tree_matches_the_committed_allowlist` — runs the gate over
    this repository; this is what binds the committed allowlist to the tree.

Every one of them fails on the unmodified tree: `scripts/check_unreachable_controls.py`
does not exist there, so the module fixture cannot load and collection fails. The
discriminating behaviour was also confirmed against the real repository rather than
a fixture — dropping one uncalled public function into `core/security/` made
`uv run python scripts/check_unreachable_controls.py` exit 1 naming it, and removing
that file returned it to `OK (401 known-unreached symbols, all with a reason)`.

Green locally: `run_tests.py --parallel 2 -x tests/unit/scripts/test_check_unreachable_controls.py`
(15 passed) and `run_tests.py --parallel 2 --affected origin/main` (156 files).

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes (`pyright` clean on both new files; no `src/` file changes)
- [x] `uv run python scripts/run_tests.py -x` passes (run as `--parallel 2` on the
      new file and as `--affected origin/main`; CI runs the full suite)
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [ ] User-visible README section updated — N/A, contributor-facing lint, documented
      in `CONTRIBUTING.md`
- [ ] `docs/operations/<area>.md` updated — N/A, no operator-facing surface
- [ ] `docs/api/` schema regenerated — N/A, no public API surface changed
- [x] `uv run bernstein agents-md sync` — `agents-md verify` reports all 15 files in
      sync; no new module under `src/`, so nothing to regenerate
- [x] Tests cover the documented behaviour

Closes #5053
