### PR TITLE
feat: project agent principals from the audit chain into a listable registry (#4969)

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -906,7 +906,7 @@ The group also accepts `--web [host:]port` to run the web view instead of the TU
 | `bernstein policy` | Policy mgmt (group). | `cli/commands/policy_cmd.py:12` |
 | `bernstein compliance` | Compliance reports (group). | `cli/commands/compliance_cmd.py:26` |
 | `bernstein audit` | Audit-log ops (group). | `cli/commands/audit_cmd.py:25` |
-| `bernstein identity` | Install-identity ops (group): fingerprint helpers plus `keydir`. | `cli/commands/identity_cmd.py:identity_group` |
+| `bernstein identity` | Install-identity ops (group): fingerprint helpers, `keydir`, plus `agents` (the agent-principal registry projected from the chain). | `cli/commands/identity_cmd.py:identity_group` |
 | `bernstein delegation` | Delegation-receipt verification (group). | `cli/commands/delegation_cmd.py:delegation_group` |
 | `bernstein lineage` | Artifact-provenance lineage-spine ops (group). | `cli/commands/lineage_cmd.py` |
 | `bernstein credential` | C2PA content credentials projected from the lineage spine (group). | `cli/commands/credential_cmd.py` |
@@ -935,11 +935,17 @@ The group also accepts `--web [host:]port` to run the web view instead of the TU
 | `verify TOKEN [--nonce HEX]` | Full HMAC-strength verify when the operator holds the install nonce. |
 | `keydir` | Print the install-identity key directory (JWKS) used to verify outbound HTTP Message Signatures. Mirrors `/.well-known/http-message-signatures-directory`. |
 | `disable` | Print the env line that suppresses every fingerprint emit site. |
+| `agents` | List the agent principals the grant and delegation chains establish: derived SPIFFE ID, the capability ceiling in force at `--as-of`, the grants issued to each, the delegations each made, and the chain events behind every entry. `--root DIR`, `--json`, `--trust-domain` + `--install-key` for id derivation. `--verify FILE` recomputes a stored projection from the chain and refuses any entry no chain event establishes (exit 0 verified, 2 mismatch). Read-only. |
 
 Outbound agent-facing requests (A2A card fetch, browser/research rendering)
 carry an RFC 9421 Ed25519 signature keyed to the install-identity thumbprint.
 `BERNSTEIN_HTTP_SIGNING_REQUIRED=1` turns an unsigned outbound path into a hard
 error. `BERNSTEIN_AGENT_CARD_KEY_DIR` overrides the key directory location.
+
+`identity agents` is a projection, not a directory: deleting the rendered
+output and rebuilding it from the same chain at the same `--as-of` instant
+reproduces identical bytes, and a run whose chain does not verify contributes
+no principals at all.
 
 #### `bernstein delegation`
 

--- a/docs/release-notes/fragments/4969-agent-principal-registry.md
+++ b/docs/release-notes/fragments/4969-agent-principal-registry.md
@@ -1,0 +1,5 @@
+## Project agent principals from the audit chain
+
+`bernstein identity agents` now lists every agent principal that has appeared in a verified grant or delegation record, folded from the tamper-evident audit chain under a chosen install root. Each entry names the principals that issued, were granted, or were delegated to, the grant ids that produced the principal, and the capability ceiling in force at the requested point in time. The subcommand supports `--root`, `--json`, `--as-of`, `--trust-domain`, `--install-key`, and `--verify` for scripted and offline verification.
+
+(#4969)

--- a/src/bernstein/cli/commands/identity_cmd.py
+++ b/src/bernstein/cli/commands/identity_cmd.py
@@ -15,6 +15,10 @@ Subcommands:
   paste into their shell to suppress all emit sites.
 * ``bernstein identity attest show|verify --run <id>`` - project or verify a
   run-attestation receipt without overloading install-rev verification.
+* ``bernstein identity agents`` - list the agent principals the grant and
+  delegation chains establish, with the capability ceiling in force now and
+  the chain events behind each entry.  ``--verify <file>`` recomputes a stored
+  projection from the chain and refuses any entry the chain does not establish.
 
 The install-rev verbs are read-only and never open a network connection.  This
 is the project's hard rule: no telemetry, ever.  The nested ``attest verify``
@@ -26,9 +30,12 @@ playbook (seed generation, storage, rotation, decode).
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import click
 
 from bernstein.cli.commands.identity_attest_cmd import attest_group
+from bernstein.core.identity import agent_registry
 from bernstein.core.identity import install_rev as _identity
 from bernstein.core.identity.install_rev import (
     DISABLED_SENTINEL,
@@ -61,6 +68,7 @@ def identity_group() -> None:
       bernstein identity disable
       bernstein identity attest show --run r-1234 \\
           --signing-key-path key.pem
+      bernstein identity agents --json
     """
 
 
@@ -184,6 +192,115 @@ def disable_cmd() -> None:
     disabled sentinel without touching code.
     """
     click.echo("export BERNSTEIN_DISABLE_IDENTITY=1")
+
+
+def _audit_key_for_read() -> bytes:
+    """Return the install audit key, read-only.
+
+    A verifier that minted its own key would fail every HMAC check against a
+    chain written under the real one, so a missing key is an operator error
+    rather than something to paper over with fresh key material -- the same
+    rule ``bernstein spiffe verify-binding`` follows.
+    """
+    from bernstein.core.security.audit import load_audit_key
+
+    return load_audit_key()
+
+
+@identity_group.command("agents")
+@click.option(
+    "--root",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Audit root holding grants/ and delegation/ (default: .sdd/audit).",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit the canonical JSON projection.")
+@click.option(
+    "--as-of",
+    "as_of",
+    type=int,
+    default=None,
+    help="Epoch second the capability ceiling is resolved at (default: now).",
+)
+@click.option("--trust-domain", "trust_domain", default=None, help="SPIFFE trust domain for id derivation.")
+@click.option(
+    "--install-key",
+    "install_key",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Install public key PEM (SPKI Ed25519) for SPIFFE id derivation.",
+)
+@click.option(
+    "--verify",
+    "verify_file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Recompute a stored projection from the chain instead of printing one.",
+)
+def agents_cmd(
+    root: Path | None,
+    as_json: bool,
+    as_of: int | None,
+    trust_domain: str | None,
+    install_key: Path | None,
+    verify_file: Path | None,
+) -> None:
+    """List the agent principals the audit chain establishes.
+
+    The listing is a projection over the grant and delegation chains, not a
+    stored directory: every entry names the chain events behind it, and the
+    capability ceiling is the one in force at ``--as-of``, not the one the
+    widest grant carried when it was issued.
+
+    With ``--verify`` the stored projection is recomputed from the chain.
+    Exit codes: 0 verified, 1 no records or unreadable input, 2 mismatch.
+    """
+    import time
+
+    if (trust_domain is None) != (install_key is None):
+        raise click.UsageError("--trust-domain and --install-key must be given together")
+
+    audit_root = root if root is not None else Path(".sdd/audit")
+    moment = int(as_of if as_of is not None else time.time())
+    install_pem = install_key.read_bytes() if install_key is not None else None
+    key = _audit_key_for_read()
+
+    if verify_file is not None:
+        verification = agent_registry.verify_registry(
+            verify_file,
+            root=audit_root,
+            key=key,
+            now=moment,
+            trust_domain=trust_domain,
+            install_public_key_pem=install_pem,
+        )
+        if verification.ok:
+            click.echo(f"verified: {verification.reason}")
+            raise SystemExit(0)
+        click.echo(f"mismatch: {verification.reason}", err=True)
+        raise SystemExit(2)
+
+    projection = agent_registry.project_agents(
+        root=audit_root,
+        key=key,
+        now=moment,
+        trust_domain=trust_domain,
+        install_public_key_pem=install_pem,
+    )
+    if as_json:
+        click.echo(agent_registry.render_registry(projection))
+        return
+
+    if not projection.agents:
+        click.echo("no agent principals: the chain under this root establishes none", err=True)
+    for entry in projection.agents:
+        ceiling = ", ".join(entry.capability_ceiling) or "(nothing in force)"
+        click.echo(f"{entry.agent_id}\t{entry.spiffe_id or '-'}\t{ceiling}")
+        click.echo(
+            f"  grants={len(entry.grants)} delegations={len(entry.delegations)} events={len(entry.chain_events)}"
+        )
+    for err in projection.errors:
+        click.echo(err, err=True)
 
 
 # ``identity attest`` is a separate group rather than new verbs here because

--- a/src/bernstein/core/identity/agent_registry.py
+++ b/src/bernstein/core/identity/agent_registry.py
@@ -51,7 +51,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, get_args
+from typing import TYPE_CHECKING, Any, Final, cast, get_args
 
 from bernstein.core.identity import delegation, grants
 from bernstein.core.identity.delegation_scope import DelegationScope
@@ -225,10 +225,10 @@ class _Builder:
     """Mutable accumulator for one principal while the fold runs."""
 
     agent_id: str
-    events: list[ChainEventRef] = field(default_factory=list)
-    ceiling: set[str] = field(default_factory=set)
-    grant_ids: list[str] = field(default_factory=list)
-    delegation_refs: list[str] = field(default_factory=list)
+    events: list[ChainEventRef] = field(default_factory=list[ChainEventRef])
+    ceiling: set[str] = field(default_factory=set[str])
+    grant_ids: list[str] = field(default_factory=list[str])
+    delegation_refs: list[str] = field(default_factory=list[str])
 
 
 def _expand_ceiling(names: Iterable[str]) -> set[str]:
@@ -467,9 +467,12 @@ def verify_registry(
     canonical rendering leaves nowhere for it to hide.
     """
     try:
-        stored = json.loads(Path(path).read_text(encoding="utf-8"))
+        parsed: object = json.loads(Path(path).read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         return RegistryVerification(ok=False, reason=f"cannot read stored projection: {exc}")
+    if not isinstance(parsed, dict):
+        return RegistryVerification(ok=False, reason="stored projection is not a JSON object")
+    stored = cast("dict[str, Any]", parsed)
 
     recomputed = project_agents(
         root=Path(root),
@@ -479,10 +482,13 @@ def verify_registry(
         install_public_key_pem=install_public_key_pem,
     )
     expected_ids = {a.agent_id for a in recomputed.agents}
-    stored_agents = stored.get("agents") if isinstance(stored, dict) else None
-    if not isinstance(stored_agents, list):
+    raw_agents = stored.get("agents")
+    if not isinstance(raw_agents, list):
         return RegistryVerification(ok=False, reason="stored projection has no agents list")
-    stored_ids = {str(a.get("agent_id", "")) for a in stored_agents if isinstance(a, dict)}
+    stored_ids: set[str] = set()
+    for entry in cast("list[Any]", raw_agents):
+        if isinstance(entry, dict):
+            stored_ids.add(str(cast("dict[str, Any]", entry).get("agent_id", "")))
 
     invented = tuple(sorted(stored_ids - expected_ids))
     missing = tuple(sorted(expected_ids - stored_ids))

--- a/src/bernstein/core/identity/agent_registry.py
+++ b/src/bernstein/core/identity/agent_registry.py
@@ -339,15 +339,17 @@ def _fold_grants(builders: dict[str, _Builder], *, root: Path, key: bytes, now: 
 
         issued = {r.grant_id: r for r in result.records if r.kind == grants.GRANT_ISSUED}
         for grant_id, state in result.lifecycles().items():
-            record = issued.get(grant_id)
-            if record is None or not state["issued"] or state["revoked"]:
+            issued_record = issued.get(grant_id)
+            if issued_record is None or not state["issued"] or state["revoked"]:
                 continue
             expiry = int(state["expiry"])
             if expiry and now >= expiry:
                 continue
-            builder = builders.get(record.audience)
+            if issued_record.audience is None:
+                continue
+            builder = builders.get(issued_record.audience)
             if builder is not None:
-                builder.ceiling |= _expand_ceiling(record.capability_ceiling)
+                builder.ceiling |= _expand_ceiling(issued_record.capability_ceiling)
 
 
 def _fold_delegation(builders: dict[str, _Builder], *, root: Path, key: bytes, now: int, errors: list[str]) -> None:

--- a/src/bernstein/core/identity/agent_registry.py
+++ b/src/bernstein/core/identity/agent_registry.py
@@ -1,0 +1,502 @@
+"""Agent-principal registry projected from the grant and delegation chains (#4969).
+
+Bernstein already treats agents as principals: ``bernstein spiffe id`` derives a
+deterministic identity per install and agent, :mod:`bernstein.core.identity.grants`
+issues Ed25519-signed, chain-anchored per-task credential grants, and
+:mod:`bernstein.core.identity.delegation` records which principal authorized
+which sub-agent action. What was missing is the noun -- an object an operator
+can list, describe, or hand to an auditor that answers *which agents exist
+here, what may each one do, and who decided that*.
+
+This module supplies that noun as a **projection**, never a second source of
+truth. :func:`project_agents` folds the verified grant and delegation chains
+under one audit root into :class:`AgentPrincipal` entries; :func:`render_registry`
+renders the fold as canonical JSON; :func:`verify_registry` recomputes the fold
+and refuses a stored projection that names an agent the chain does not
+establish. Delete the rendered projection and rebuild it from the same chain at
+the same ``as_of`` instant and the bytes are identical -- a registry that is its
+own authority drifts from what happened; a fold over the chain cannot.
+
+What establishes a principal
+----------------------------
+A principal is any non-empty party a **tamper-verified** chain event names in an
+authority-bearing role: ``issuer`` / ``subject`` / ``audience`` on a delegation
+receipt, ``issuer`` / ``audience`` on a grant record. A chain whose HMAC linkage
+does not hold establishes nothing at all -- its runs contribute no principals
+and its failure is reported in :attr:`AgentRegistryProjection.errors`, so a
+writer without the install audit key cannot mint an agent by appending a line.
+
+What "the ceiling currently in force" means
+-------------------------------------------
+The ceiling is recomputed at the projection's ``as_of`` instant, not read off
+the grant that was widest at issue time. A grant contributes only while it is
+issued, unrevoked, and unexpired; a delegation scope contributes only while its
+``not_after`` has not passed. Both vocabularies are projected onto the
+``PERM_*`` set through :func:`~bernstein.core.security.capability_tokens.scope_permissions`,
+so a coarse ``read``/``write``/``execute``/``full`` ceiling recorded on a grant
+and an explicit permission set recorded on a delegation scope are comparable
+rather than re-derived here. Delegation scopes contribute only from runs whose
+recomputed authority checks also passed: a hop that widened its parent is a real
+event (so its parties are listed) but is not evidence of authority in force.
+
+An agent with nothing in force is listed with an empty ceiling rather than
+dropped -- an agent that exists and may currently do nothing is exactly what an
+auditor needs to see.
+
+This slice reads. Nothing here writes to either chain.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final, get_args
+
+from bernstein.core.identity import delegation, grants
+from bernstein.core.identity.delegation_scope import DelegationScope
+from bernstein.core.identity.spiffe.spiffe_id import (
+    SpiffeIdError,
+    derive_spiffe_id_from_key,
+    parse_spiffe_id,
+    validate_path_segment,
+)
+from bernstein.core.security.capability_tokens import scope_permissions
+from bernstein.core.security.permission_delegation import DelegationScope as _CoarseScope
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from collections.abc import Iterable
+
+__all__ = [
+    "REGISTRY_VERSION",
+    "SOURCE_DELEGATION",
+    "SOURCE_GRANT",
+    "AgentPrincipal",
+    "AgentRegistryProjection",
+    "ChainEventRef",
+    "RegistryError",
+    "RegistryVerification",
+    "project_agents",
+    "render_registry",
+    "verify_registry",
+]
+
+#: Schema version carried in the rendered projection so a stored file that was
+#: produced by an older fold is recognisable rather than silently mis-compared.
+REGISTRY_VERSION: Final[int] = 1
+
+SOURCE_GRANT: Final[str] = "grant"
+SOURCE_DELEGATION: Final[str] = "delegation"
+
+#: The coarse scope vocabulary grant records use for ``capability_ceiling``.
+#: Read off the ``DelegationScope`` literal in
+#: :mod:`bernstein.core.security.permission_delegation` rather than restated,
+#: so the two surfaces cannot drift apart.
+_COARSE_SCOPES: Final[frozenset[str]] = frozenset(get_args(_CoarseScope))
+
+_ROLE_ISSUER: Final[str] = "issuer"
+_ROLE_SUBJECT: Final[str] = "subject"
+_ROLE_AUDIENCE: Final[str] = "audience"
+
+
+class RegistryError(ValueError):
+    """Raised when a registry entry is not established by any chain event."""
+
+
+@dataclass(frozen=True)
+class ChainEventRef:
+    """A pointer to the one chain event that named a principal in one role.
+
+    Attributes:
+        source: :data:`SOURCE_GRANT` or :data:`SOURCE_DELEGATION`.
+        run_id: Run whose ledger file carries the event.
+        index: ``record_index`` (grant) or ``hop_index`` (delegation).
+        kind: Grant record kind, or the delegated ``act`` for a delegation hop.
+        role: Which field of the event named the principal.
+        anchor: The event's HMAC -- the chain position the entry rests on.
+    """
+
+    source: str
+    run_id: str
+    index: int
+    kind: str
+    role: str
+    anchor: str
+
+    def to_body(self) -> dict[str, Any]:
+        """Return the canonical dict rendered into the projection."""
+        return {
+            "anchor": self.anchor,
+            "index": self.index,
+            "kind": self.kind,
+            "role": self.role,
+            "run_id": self.run_id,
+            "source": self.source,
+        }
+
+    def sort_key(self) -> tuple[str, str, int, str]:
+        """Return the deterministic ordering key for rendering."""
+        return (self.source, self.run_id, self.index, self.role)
+
+
+@dataclass(frozen=True)
+class AgentPrincipal:
+    """One agent principal, with the chain events that established it.
+
+    Attributes:
+        agent_id: The principal name exactly as the chain recorded it.
+        chain_events: Every event that named this principal (never empty).
+        spiffe_id: The derived SPIFFE ID, or ``None`` when no id is derivable
+            without coining one (see :func:`project_agents`).
+        capability_ceiling: The ``PERM_*`` ceiling in force at the projection's
+            ``as_of`` instant.
+        grants: Ids of grants issued to this principal, oldest first.
+        delegations: ``<run>#<hop>`` refs of the delegation hops it issued.
+    """
+
+    agent_id: str
+    chain_events: tuple[ChainEventRef, ...]
+    spiffe_id: str | None = None
+    capability_ceiling: tuple[str, ...] = ()
+    grants: tuple[str, ...] = ()
+    delegations: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        """Refuse an entry no chain event establishes.
+
+        The registry is a fold, so an entry with nothing behind it is not an
+        incomplete record -- it is an invented one, and inventing is the single
+        failure mode a projection must not have.
+        """
+        if not self.agent_id:
+            raise RegistryError("agent principal must have a non-empty id")
+        if not self.chain_events:
+            raise RegistryError(f"agent {self.agent_id!r} is not established by any chain event")
+
+    def to_body(self) -> dict[str, Any]:
+        """Return the canonical dict rendered into the projection."""
+        return {
+            "agent_id": self.agent_id,
+            "capability_ceiling": list(self.capability_ceiling),
+            "chain_events": [e.to_body() for e in self.chain_events],
+            "delegations": list(self.delegations),
+            "grants": list(self.grants),
+            "spiffe_id": self.spiffe_id,
+        }
+
+
+@dataclass(frozen=True)
+class AgentRegistryProjection:
+    """The whole fold: every principal the chains under one root establish."""
+
+    agents: tuple[AgentPrincipal, ...] = ()
+    errors: tuple[str, ...] = ()
+    as_of: int = 0
+
+    def agent(self, agent_id: str) -> AgentPrincipal | None:
+        """Return the entry for ``agent_id``, or ``None`` when it is absent."""
+        for entry in self.agents:
+            if entry.agent_id == agent_id:
+                return entry
+        return None
+
+    def to_body(self) -> dict[str, Any]:
+        """Return the canonical dict :func:`render_registry` serialises."""
+        return {
+            "agents": [a.to_body() for a in self.agents],
+            "as_of": self.as_of,
+            "errors": list(self.errors),
+            "version": REGISTRY_VERSION,
+        }
+
+
+@dataclass(frozen=True)
+class RegistryVerification:
+    """Outcome of recomputing a stored projection from the chain."""
+
+    ok: bool
+    reason: str
+    invented: tuple[str, ...] = ()
+    missing: tuple[str, ...] = ()
+
+
+@dataclass
+class _Builder:
+    """Mutable accumulator for one principal while the fold runs."""
+
+    agent_id: str
+    events: list[ChainEventRef] = field(default_factory=list)
+    ceiling: set[str] = field(default_factory=set)
+    grant_ids: list[str] = field(default_factory=list)
+    delegation_refs: list[str] = field(default_factory=list)
+
+
+def _expand_ceiling(names: Iterable[str]) -> set[str]:
+    """Project recorded ceiling tokens onto the ``PERM_*`` vocabulary.
+
+    A grant records the coarse ``read``/``write``/``execute``/``full`` enum; a
+    delegation scope records explicit ``PERM_*`` names. Expanding the former
+    through the existing enum-to-permission map makes the two comparable
+    without a second mapping living here. A token that is neither is carried
+    through unchanged rather than dropped or guessed at.
+    """
+    expanded: set[str] = set()
+    for name in names:
+        if name in _COARSE_SCOPES:
+            expanded |= set(scope_permissions(name))
+        else:
+            expanded.add(name)
+    return expanded
+
+
+def _run_ids(directory: Path) -> list[str]:
+    """Return the ledger run ids under ``directory``, sorted for determinism."""
+    if not directory.is_dir():
+        return []
+    return sorted(p.stem for p in directory.glob("*.jsonl"))
+
+
+def _derive_spiffe_id(
+    agent_id: str,
+    *,
+    trust_domain: str | None,
+    install_public_key_pem: bytes | None,
+) -> str | None:
+    """Return the SPIFFE ID for ``agent_id``, or ``None`` when none is derivable.
+
+    Three cases, in order:
+
+    * the principal name already *is* a Bernstein SPIFFE ID (grant issuers run
+      that way under the SPIFFE profile) -- it is carried through verbatim;
+    * the caller supplied a trust domain and install key and the name is a
+      valid SPIFFE path segment -- the id is derived the same way
+      ``bernstein spiffe id`` derives it;
+    * otherwise ``None``. A name like ``manager:test`` is not a SPIFFE path
+      segment under this repository's grammar, and coining a substitute for it
+      would be the same invention the projection refuses everywhere else.
+    """
+    try:
+        return parse_spiffe_id(agent_id).uri
+    except SpiffeIdError:
+        pass
+    if trust_domain is None or install_public_key_pem is None:
+        return None
+    try:
+        validate_path_segment(agent_id)
+        return derive_spiffe_id_from_key(
+            trust_domain=trust_domain,
+            install_public_key_pem=install_public_key_pem,
+            agent_id=agent_id,
+        )
+    except SpiffeIdError:
+        return None
+
+
+def _note(builders: dict[str, _Builder], agent_id: str, event: ChainEventRef) -> _Builder | None:
+    """Record ``event`` against ``agent_id``, creating the accumulator on demand."""
+    if not agent_id:
+        return None
+    builder = builders.get(agent_id)
+    if builder is None:
+        builder = _Builder(agent_id=agent_id)
+        builders[agent_id] = builder
+    builder.events.append(event)
+    return builder
+
+
+def _fold_grants(builders: dict[str, _Builder], *, root: Path, key: bytes, now: int, errors: list[str]) -> None:
+    """Fold every verified grant chain under ``root`` into ``builders``."""
+    for run_id in _run_ids(Path(root) / "grants"):
+        result = grants.verify_grant_chain(root=Path(root), run_id=run_id, key=key)
+        if not result.valid:
+            errors.append(f"grants/{run_id}: " + "; ".join(result.errors))
+            continue
+        for record in result.records:
+            event_issuer = ChainEventRef(
+                source=SOURCE_GRANT,
+                run_id=run_id,
+                index=record.record_index,
+                kind=record.kind,
+                role=_ROLE_ISSUER,
+                anchor=record.hmac,
+            )
+            _note(builders, record.issuer, event_issuer)
+            if record.audience:
+                _note(
+                    builders,
+                    record.audience,
+                    ChainEventRef(
+                        source=SOURCE_GRANT,
+                        run_id=run_id,
+                        index=record.record_index,
+                        kind=record.kind,
+                        role=_ROLE_AUDIENCE,
+                        anchor=record.hmac,
+                    ),
+                )
+            if record.kind == grants.GRANT_ISSUED and record.audience:
+                builders[record.audience].grant_ids.append(record.grant_id)
+
+        issued = {r.grant_id: r for r in result.records if r.kind == grants.GRANT_ISSUED}
+        for grant_id, state in result.lifecycles().items():
+            record = issued.get(grant_id)
+            if record is None or not state["issued"] or state["revoked"]:
+                continue
+            expiry = int(state["expiry"])
+            if expiry and now >= expiry:
+                continue
+            builder = builders.get(record.audience)
+            if builder is not None:
+                builder.ceiling |= _expand_ceiling(record.capability_ceiling)
+
+
+def _fold_delegation(builders: dict[str, _Builder], *, root: Path, key: bytes, now: int, errors: list[str]) -> None:
+    """Fold every tamper-verified delegation chain under ``root`` into ``builders``."""
+    for run_id in _run_ids(Path(root) / "delegation"):
+        result = delegation.verify_run_chain(root=Path(root), run_id=run_id, key=key)
+        if not result.chain_ok:
+            errors.append(f"delegation/{run_id}: " + "; ".join(result.errors))
+            continue
+        if not result.valid:
+            # Tamper evidence held, so the hops are real events and their
+            # parties are listed; the recomputed authority checks did not, so
+            # nothing in this run is evidence of a ceiling in force.
+            errors.append(f"delegation/{run_id}: authority checks did not pass; scopes not counted toward a ceiling")
+        for receipt in result.receipts:
+            for role, name in (
+                (_ROLE_ISSUER, receipt.issuer),
+                (_ROLE_SUBJECT, receipt.subject),
+                (_ROLE_AUDIENCE, receipt.audience),
+            ):
+                _note(
+                    builders,
+                    name,
+                    ChainEventRef(
+                        source=SOURCE_DELEGATION,
+                        run_id=run_id,
+                        index=receipt.hop_index,
+                        kind=receipt.act,
+                        role=role,
+                        anchor=receipt.hmac,
+                    ),
+                )
+            if receipt.issuer:
+                builders[receipt.issuer].delegation_refs.append(f"{run_id}#{receipt.hop_index}")
+            if not result.valid or receipt.scope is None or not receipt.audience:
+                continue
+            scope = DelegationScope.from_body(receipt.scope)
+            if scope.not_after is not None and now >= scope.not_after:
+                continue
+            builders[receipt.audience].ceiling |= _expand_ceiling(scope.permissions)
+
+
+def project_agents(
+    *,
+    root: Path,
+    key: bytes,
+    now: int,
+    trust_domain: str | None = None,
+    install_public_key_pem: bytes | None = None,
+) -> AgentRegistryProjection:
+    """Fold the grant and delegation chains under ``root`` into a registry.
+
+    Args:
+        root: Audit root holding ``grants/`` and ``delegation/`` ledgers.
+        key: The install audit HMAC key both chains were written with.
+        now: The instant the ceiling is resolved at, as epoch seconds. Passed
+            explicitly so two operators folding the same chain at the same
+            instant render byte-identical output.
+        trust_domain: Optional SPIFFE trust domain for id derivation.
+        install_public_key_pem: Optional install public key (SPKI PEM bytes)
+            for id derivation. Both must be supplied for a name to be derived.
+
+    Returns:
+        An :class:`AgentRegistryProjection` whose agents are sorted by id and
+        whose per-agent lists are sorted, so the fold is a pure function of the
+        chain content and ``now``.
+    """
+    builders: dict[str, _Builder] = {}
+    errors: list[str] = []
+    _fold_grants(builders, root=Path(root), key=key, now=now, errors=errors)
+    _fold_delegation(builders, root=Path(root), key=key, now=now, errors=errors)
+
+    agents = tuple(
+        AgentPrincipal(
+            agent_id=builder.agent_id,
+            chain_events=tuple(sorted(builder.events, key=ChainEventRef.sort_key)),
+            spiffe_id=_derive_spiffe_id(
+                builder.agent_id,
+                trust_domain=trust_domain,
+                install_public_key_pem=install_public_key_pem,
+            ),
+            capability_ceiling=tuple(sorted(builder.ceiling)),
+            grants=tuple(sorted(set(builder.grant_ids))),
+            delegations=tuple(sorted(set(builder.delegation_refs))),
+        )
+        for builder in sorted(builders.values(), key=lambda b: b.agent_id)
+    )
+    return AgentRegistryProjection(agents=agents, errors=tuple(errors), as_of=int(now))
+
+
+def render_registry(projection: AgentRegistryProjection) -> str:
+    """Render ``projection`` as canonical JSON.
+
+    Same construction as :func:`bernstein.core.identity.grants.render_report`:
+    sorted keys, no incidental whitespace, so two verifiers folding the same
+    chain at the same ``as_of`` produce byte-identical text that can be diffed
+    across environments or handed to a third party.
+    """
+    return json.dumps(projection.to_body(), sort_keys=True, separators=(",", ":"))
+
+
+def verify_registry(
+    path: Path,
+    *,
+    root: Path,
+    key: bytes,
+    now: int,
+    trust_domain: str | None = None,
+    install_public_key_pem: bytes | None = None,
+) -> RegistryVerification:
+    """Recompute the projection from the chain and match it against ``path``.
+
+    An agent the stored file lists but the chain does not establish is reported
+    as *invented*; an agent the chain establishes but the file omits is
+    reported as *missing*. Any remaining difference (a widened ceiling, a
+    rewritten chain-event pointer) surfaces as a byte mismatch, because the
+    canonical rendering leaves nowhere for it to hide.
+    """
+    try:
+        stored = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return RegistryVerification(ok=False, reason=f"cannot read stored projection: {exc}")
+
+    recomputed = project_agents(
+        root=Path(root),
+        key=key,
+        now=now,
+        trust_domain=trust_domain,
+        install_public_key_pem=install_public_key_pem,
+    )
+    expected_ids = {a.agent_id for a in recomputed.agents}
+    stored_agents = stored.get("agents") if isinstance(stored, dict) else None
+    if not isinstance(stored_agents, list):
+        return RegistryVerification(ok=False, reason="stored projection has no agents list")
+    stored_ids = {str(a.get("agent_id", "")) for a in stored_agents if isinstance(a, dict)}
+
+    invented = tuple(sorted(stored_ids - expected_ids))
+    missing = tuple(sorted(expected_ids - stored_ids))
+    if invented or missing:
+        parts: list[str] = []
+        if invented:
+            parts.append("not established by any chain event: " + ", ".join(invented))
+        if missing:
+            parts.append("established by the chain but absent: " + ", ".join(missing))
+        return RegistryVerification(ok=False, reason="; ".join(parts), invented=invented, missing=missing)
+
+    if json.dumps(stored, sort_keys=True, separators=(",", ":")) != render_registry(recomputed):
+        return RegistryVerification(
+            ok=False,
+            reason="stored projection does not match the recomputation from the chain",
+        )
+    return RegistryVerification(ok=True, reason="every entry recomputes from the chain")

--- a/tests/unit/identity/test_agent_registry.py
+++ b/tests/unit/identity/test_agent_registry.py
@@ -1,0 +1,264 @@
+"""Tests for the agent-principal registry projection (issue #4969).
+
+The registry is a fold over the grant and delegation chains, not a second
+source of truth. These tests pin that: the projection names exactly the
+principals the chains name, rebuilding it after deletion reproduces the same
+bytes, an expired grant no longer contributes to the ceiling in force, and an
+entry with no supporting chain event is refused rather than invented.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bernstein.core.identity import agent_registry, delegation, grants
+from bernstein.core.identity.delegation_scope import DelegationScope
+
+KEY = b"k" * 32
+NOW = 1_800_000_000
+
+
+@pytest.fixture
+def signer() -> grants.GrantSigner:
+    return grants.GrantSigner.generate(issuer="manager:test")
+
+
+@pytest.fixture
+def chain_root(tmp_path, signer):
+    """Write a fixture chain naming three principals across both ledgers."""
+    root = tmp_path / "audit"
+    grant_ledger = grants.GrantLedger(root=root, key=KEY, signer=signer)
+    grant_ledger.issue_grant(
+        run_id="run-1",
+        task_id="t-1",
+        secret_name="ANTHROPIC_API_KEY",
+        audience="sub-agent-backend",
+        expiry=NOW + 3600,
+        capability_ceiling=("read",),
+        grant_id="g-live",
+        created=NOW - 100,
+    )
+    deleg = delegation.DelegationLedger(root=root, key=KEY)
+    deleg.record_hop(
+        run_id="run-1",
+        issuer="principal-alex",
+        subject="orchestrator",
+        audience="orchestrator",
+        act="run.authorize",
+        created=NOW - 90,
+        scope=DelegationScope(permissions=frozenset({"tasks:read", "files:write"})),
+    )
+    deleg.record_hop(
+        run_id="run-1",
+        issuer="orchestrator",
+        subject="orchestrator",
+        audience="sub-agent-backend",
+        act="task.spawn",
+        created=NOW - 80,
+        scope=DelegationScope(permissions=frozenset({"tasks:read"})),
+    )
+    return root
+
+
+def _project(root, **kwargs):
+    return agent_registry.project_agents(root=root, key=KEY, now=NOW, **kwargs)
+
+
+class TestProjectionCoversTheChain:
+    def test_projection_lists_every_chain_principal_and_no_others(self, chain_root) -> None:
+        projection = _project(chain_root)
+        assert [a.agent_id for a in projection.agents] == [
+            "manager:test",
+            "orchestrator",
+            "principal-alex",
+            "sub-agent-backend",
+        ]
+        assert projection.errors == ()
+
+    def test_every_listed_agent_names_the_chain_events_that_established_it(self, chain_root) -> None:
+        projection = _project(chain_root)
+        backend = projection.agent("sub-agent-backend")
+        assert backend is not None
+        sources = {(e.source, e.run_id, e.index, e.role) for e in backend.chain_events}
+        assert ("grant", "run-1", 0, "audience") in sources
+        assert ("delegation", "run-1", 1, "audience") in sources
+        assert backend.grants == ("g-live",)
+        assert all(e.anchor for e in backend.chain_events)
+
+    def test_unverifiable_chain_establishes_no_principals(self, chain_root) -> None:
+        path = chain_root / "delegation" / "run-1.jsonl"
+        lines = path.read_text(encoding="utf-8").splitlines()
+        tampered = json.loads(lines[0])
+        tampered["audience"] = "sub-agent-smuggled"
+        lines[0] = json.dumps(tampered, sort_keys=True)
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        projection = _project(chain_root)
+        assert "sub-agent-smuggled" not in [a.agent_id for a in projection.agents]
+        assert "principal-alex" not in [a.agent_id for a in projection.agents]
+        assert any("delegation/run-1" in err for err in projection.errors)
+
+
+class TestProjectionIsAFoldNotAStore:
+    def test_rebuilding_the_deleted_projection_is_byte_identical(self, chain_root, tmp_path) -> None:
+        out = tmp_path / "agents.json"
+        out.write_bytes(agent_registry.render_registry(_project(chain_root)).encode("utf-8"))
+        first = out.read_bytes()
+
+        out.unlink()
+        assert not out.exists()
+
+        out.write_bytes(agent_registry.render_registry(_project(chain_root)).encode("utf-8"))
+        assert out.read_bytes() == first
+
+    def test_expired_grant_drops_from_the_ceiling_in_force_now(self, tmp_path, signer) -> None:
+        root = tmp_path / "audit"
+        ledger = grants.GrantLedger(root=root, key=KEY, signer=signer)
+        ledger.issue_grant(
+            run_id="run-1",
+            task_id="t-1",
+            secret_name="K",
+            audience="sub-agent-backend",
+            expiry=NOW - 1,
+            capability_ceiling=("write",),
+            grant_id="g-expired",
+            created=NOW - 5_000,
+        )
+        ledger.issue_grant(
+            run_id="run-1",
+            task_id="t-2",
+            secret_name="K",
+            audience="sub-agent-backend",
+            expiry=NOW + 5_000,
+            capability_ceiling=("read",),
+            grant_id="g-live",
+            created=NOW - 100,
+        )
+
+        backend = _project(root).agent("sub-agent-backend")
+        assert backend is not None
+        # Both grants are listed -- the chain recorded both -- but only the
+        # unexpired one contributes to the ceiling in force now.
+        assert backend.grants == ("g-expired", "g-live")
+        assert "files:write" not in backend.capability_ceiling
+        assert "files:read" in backend.capability_ceiling
+
+    def test_revoked_grant_drops_from_the_ceiling_in_force_now(self, tmp_path, signer) -> None:
+        root = tmp_path / "audit"
+        ledger = grants.GrantLedger(root=root, key=KEY, signer=signer)
+        ledger.issue_grant(
+            run_id="run-1",
+            task_id="t-1",
+            secret_name="K",
+            audience="sub-agent-backend",
+            expiry=NOW + 5_000,
+            capability_ceiling=("write",),
+            grant_id="g-revoked",
+            created=NOW - 100,
+        )
+        ledger.revoke_grant(run_id="run-1", grant_id="g-revoked", reason="rotated", created=NOW - 50)
+
+        backend = _project(root).agent("sub-agent-backend")
+        assert backend is not None
+        assert backend.capability_ceiling == ()
+
+
+class TestRefusalRatherThanInvention:
+    def test_agent_absent_from_the_chain_is_refused_not_listed(self, chain_root, tmp_path) -> None:
+        out = tmp_path / "agents.json"
+        payload = json.loads(agent_registry.render_registry(_project(chain_root)))
+        payload["agents"].append(
+            {
+                "agent_id": "sub-agent-ghost",
+                "capability_ceiling": ["files:write"],
+                "chain_events": [],
+                "delegations": [],
+                "grants": [],
+                "spiffe_id": None,
+            }
+        )
+        out.write_text(json.dumps(payload, sort_keys=True, separators=(",", ":")), encoding="utf-8")
+
+        verification = agent_registry.verify_registry(out, root=chain_root, key=KEY, now=NOW)
+        assert not verification.ok
+        assert verification.invented == ("sub-agent-ghost",)
+        assert "sub-agent-ghost" in verification.reason
+
+    def test_principal_without_a_supporting_chain_event_cannot_be_constructed(self) -> None:
+        with pytest.raises(agent_registry.RegistryError, match="sub-agent-ghost"):
+            agent_registry.AgentPrincipal(agent_id="sub-agent-ghost", chain_events=())
+
+    def test_verify_registry_accepts_a_projection_it_recomputes(self, chain_root, tmp_path) -> None:
+        out = tmp_path / "agents.json"
+        out.write_text(agent_registry.render_registry(_project(chain_root)), encoding="utf-8")
+        verification = agent_registry.verify_registry(out, root=chain_root, key=KEY, now=NOW)
+        assert verification.ok
+        assert verification.invented == ()
+        assert verification.missing == ()
+
+
+class TestSpiffeProjection:
+    def test_spiffe_id_is_derived_only_for_a_valid_path_segment(self, chain_root) -> None:
+        projection = _project(
+            chain_root,
+            trust_domain="example.org",
+            install_public_key_pem=b"-----BEGIN PUBLIC KEY-----\nAAAA\n-----END PUBLIC KEY-----\n",
+        )
+        backend = projection.agent("sub-agent-backend")
+        manager = projection.agent("manager:test")
+        assert backend is not None and manager is not None
+        assert backend.spiffe_id is not None
+        assert backend.spiffe_id.startswith("spiffe://example.org/bernstein/")
+        assert backend.spiffe_id.endswith("/sub-agent-backend")
+        # "manager:test" is not a SPIFFE path segment; no name is coined for it.
+        assert manager.spiffe_id is None
+
+
+class TestIdentityAgentsCommand:
+    def test_identity_agents_renders_the_projection_as_canonical_json(self, chain_root, monkeypatch) -> None:
+        from click.testing import CliRunner
+
+        from bernstein.cli.commands import identity_cmd
+
+        monkeypatch.setattr(identity_cmd, "_audit_key_for_read", lambda: KEY)
+        result = CliRunner().invoke(
+            identity_cmd.identity_group,
+            ["agents", "--root", str(chain_root), "--json", "--as-of", str(NOW)],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert [a["agent_id"] for a in payload["agents"]] == [
+            "manager:test",
+            "orchestrator",
+            "principal-alex",
+            "sub-agent-backend",
+        ]
+
+    def test_identity_agents_verify_exits_two_on_an_invented_entry(self, chain_root, tmp_path, monkeypatch) -> None:
+        from click.testing import CliRunner
+
+        from bernstein.cli.commands import identity_cmd
+
+        monkeypatch.setattr(identity_cmd, "_audit_key_for_read", lambda: KEY)
+        out = tmp_path / "agents.json"
+        payload = json.loads(agent_registry.render_registry(_project(chain_root)))
+        payload["agents"].append(
+            {
+                "agent_id": "sub-agent-ghost",
+                "capability_ceiling": [],
+                "chain_events": [],
+                "delegations": [],
+                "grants": [],
+                "spiffe_id": None,
+            }
+        )
+        out.write_text(json.dumps(payload, sort_keys=True, separators=(",", ":")), encoding="utf-8")
+
+        result = CliRunner().invoke(
+            identity_cmd.identity_group,
+            ["agents", "--root", str(chain_root), "--as-of", str(NOW), "--verify", str(out)],
+        )
+        assert result.exit_code == 2, result.output
+        assert "sub-agent-ghost" in result.output


### PR DESCRIPTION
## What

Adds `src/bernstein/core/identity/agent_registry.py` and the `bernstein identity agents`
verb: a listable registry of the agent principals the grant and delegation
chains already establish — derived SPIFFE ID, the capability ceiling in force
at a given instant, the grants issued to each principal, the delegations each
made, and the chain events behind every entry.

**This PR does:**

- fold the verified grant ledger (`core/identity/grants.py`) and the
  tamper-verified delegation ledger (`core/identity/delegation.py`) under one
  audit root into `AgentPrincipal` entries;
- resolve the capability ceiling at an explicit `as_of` instant, reusing
  `core/security/capability_tokens.scope_permissions` to project the coarse
  grant vocabulary and the explicit delegation-scope permissions onto one
  comparable `PERM_*` set;
- render the fold as canonical JSON (sorted keys, no incidental whitespace),
  the same construction `grants.render_report` uses;
- `verify_registry(path, ...)` recomputes the fold from the chain and refuses a
  stored projection that names a principal the chain does not establish;
- expose all of it read-only as `bernstein identity agents` with `--root`,
  `--json`, `--as-of`, `--trust-domain` + `--install-key`, and `--verify FILE`
  (exit 0 verified, 2 mismatch), following the shape of
  `bernstein governance verify`.

**This PR explicitly does not:**

- write to either chain — nothing here mutates;
- persist the projection anywhere; it is recomputed on every invocation;
- touch any external directory integration (that is #4970);
- add a second source of truth: there is no store to drift, only a fold.

**Decisions this PR makes, since the issue left them open:**

1. *`as_of` is a required argument of the fold, not `time.time()` read inside
   it.* A ceiling "currently in force" is only reproducible if the instant is
   part of the input; two operators folding the same chain at the same instant
   must produce the same bytes, which a hidden clock read would break. The CLI
   defaults it to now and prints it into the rendered output.
2. *A principal name that is not a SPIFFE path segment gets `spiffe_id: null`,
   not a coined substitute.* Grant issuers such as `manager:test` are not
   derivable under this repository's SPIFFE grammar, and minting a plausible id
   for them would be exactly the invention the projection refuses elsewhere. A
   name that already is a Bernstein SPIFFE ID is carried through verbatim.
3. *An agent with nothing in force is listed with an empty ceiling, not
   dropped.* "This principal exists and may currently do nothing" is the answer
   an auditor needs; silence is not.
4. *A delegation run whose HMAC linkage holds but whose recomputed authority
   checks fail contributes its parties but not its scopes.* The hops happened,
   so the principals are real; a hop that widened its parent is not evidence of
   authority in force. The failure is reported in `errors`.
5. *A run whose chain does not verify at all contributes nothing* — no
   principals, no ceiling — so a writer without the install audit key cannot
   mint an agent by appending a line.

## Why

Bernstein already treats agents as principals everywhere it matters and nowhere
it is visible. `bernstein spiffe id` derives a deterministic identity per
install and agent, `core/identity/grants.py` issues Ed25519-signed
chain-anchored per-task credential grants, `delegation.py` records who
authorized which sub-agent action, agent cards are signed, capability tokens are
scoped. All of those facts are in the chain and none of them are a noun an
operator can list or hand to an auditor. There is currently no way to answer
"which agents exist on this install, what may each one do, and who decided
that" without reading the ledgers by hand.

The registry has to be a projection rather than a stored directory, because a
registry that is its own authority drifts from what actually happened, and the
drift is silent. A fold over the audit chain cannot drift: delete the rendered
output, recompute it, and the bytes are the same or the chain changed.

## How

`project_agents(root=..., key=..., now=...)` walks `grants/*.jsonl` and
`delegation/*.jsonl` under the audit root in sorted order. Each run goes through
its existing verifier (`grants.verify_grant_chain`,
`delegation.verify_run_chain`) before it contributes anything; a run whose
linkage fails is skipped and named in `errors`.

Every authority-bearing field of a verified event (`issuer` / `audience` on a
grant record, `issuer` / `subject` / `audience` on a delegation receipt) names a
principal and produces a `ChainEventRef` carrying the event's HMAC — the chain
position the entry rests on. Grants contribute to the ceiling only while
`lifecycles()` reports them issued, unrevoked, and unexpired at `now`;
delegation scopes contribute only while `not_after` has not passed and only from
runs whose authority checks also passed. The coarse `read`/`write`/`execute`/
`full` enum recorded on a grant is expanded through the existing
`scope_permissions` map rather than a second mapping living here, and the coarse
vocabulary itself is read off the `DelegationScope` literal in
`core/security/permission_delegation` with `get_args` so the two surfaces cannot
drift apart.

`AgentPrincipal.__post_init__` raises `RegistryError` when an entry has no
supporting chain event, so an invented entry cannot be constructed at all — not
merely rejected at the boundary. `verify_registry` reports the difference in two
named shapes (`invented`, `missing`) and falls back to a canonical-bytes
comparison for everything else, so a widened ceiling or a rewritten event
pointer has nowhere to hide.

## Tests

`tests/unit/identity/test_agent_registry.py`, 12 tests. All of them fail on the
unmodified tree with `ImportError: cannot import name 'agent_registry' from
'bernstein.core.identity'` — the module and the CLI verb do not exist on `main`
(verified by removing both from the working tree and re-running the file).

1. `test_projection_lists_every_chain_principal_and_no_others` — the fold names
   exactly the four principals a fixture chain names across both ledgers.
2. `test_every_listed_agent_names_the_chain_events_that_established_it` — every
   entry carries the grant and delegation events behind it, each with a
   non-empty HMAC anchor.
3. `test_unverifiable_chain_establishes_no_principals` — tampering with one
   delegation line drops the whole run: neither the smuggled principal nor the
   legitimate ones from that run are listed, and the failure is reported.
4. `test_rebuilding_the_deleted_projection_is_byte_identical` — **load-bearing.**
   Render, delete the file, recompute, compare bytes. This is the property that
   makes the registry a projection rather than a second source of truth; if it
   ever fails, the object has started keeping its own opinions.
5. `test_expired_grant_drops_from_the_ceiling_in_force_now` — an agent holding
   an expired `write` grant and a live `read` grant lists both grants but has
   only the read permissions in its ceiling.
6. `test_revoked_grant_drops_from_the_ceiling_in_force_now` — a revoked grant
   leaves the ceiling empty rather than latched at issue time.
7. `test_agent_absent_from_the_chain_is_refused_not_listed` — a hand-added entry
   in a stored projection verifies as `invented`, named in the reason.
8. `test_principal_without_a_supporting_chain_event_cannot_be_constructed` — the
   invented entry is unconstructible, not merely rejected downstream.
9. `test_verify_registry_accepts_a_projection_it_recomputes` — the honest case
   verifies, so test 7 is not passing for the wrong reason.
10. `test_spiffe_id_is_derived_only_for_a_valid_path_segment` — a derivable name
    gets the same id `bernstein spiffe id` derives; `manager:test` gets `null`.
11. `test_identity_agents_renders_the_projection_as_canonical_json` — the CLI
    verb emits the canonical fold.
12. `test_identity_agents_verify_exits_two_on_an_invented_entry` — `--verify`
    exits 2 and names the offending principal.

Green locally:

- `uv run python scripts/run_tests.py --parallel 2 -x tests/unit/identity/test_agent_registry.py` — 12 passed
- `uv run python scripts/run_tests.py --parallel 2 tests/unit/identity/ tests/unit/cli/test_identity_attest_cmd.py tests/unit/test_cli_command_registration.py tests/unit/test_feature_matrix_drift.py tests/unit/test_readme_api_coverage.py tests/unit/test_regen_contract_drift.py tests/unit/test_contract_drift_autofix_workflow_yaml.py` — the touched modules plus their importers and the CLI/doc-drift checks
- `uv run ruff check src/` · `uv run ruff format --check` on the changed files
- `uv run pyright` on both changed source files — 0 errors

`--affected origin/main` was not used for the local gate: it selects far more
than ~300 files for a diff that adds a module under `core/identity/`. CI runs
the full suite.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes (run on the two changed source files)
- [x] `uv run python scripts/run_tests.py -x` passes for the touched modules and
      their importers; the full suite runs on CI
- [x] New code has type hints

### Documentation duty

- [x] User-visible README section updated — N/A (no README surface changes)
- [x] `docs/operations/<area>.md` updated — N/A; the verb is documented in
      `docs/reference/cli-reference.md` beside the rest of `bernstein identity`
- [x] `docs/api/` schema regenerated if a public surface changed — N/A (no HTTP
      or schema surface)
- [x] `uv run bernstein agents-md sync` run — run; it produced no changes
- [x] Tests cover the documented behaviour

Closes #4969
