### PR TITLE
fix(adapters): select the Codex sandbox mode instead of hardcoding it

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -14,3 +14,7 @@ rather than as its own attribution is exempted by hand there, with the reason.
 ## Lineage
 
 - Lineage entries carry an additive optional `sensitivity` classification, and the effective sensitivity of an artefact is the maximum class over its lineage closure — so a summary of a confidential document is confidential. Absence fails closed to the highest class, and the verdict names the closure member that raised the level and the path through the graph that reaches it. An entry without the field canonicalises byte-identically to the pre-change schema, so every historical signature and HMAC is untouched (#5042).
+
+## Adapters
+
+- The Codex adapter chooses its sandbox argv from its declared dangerous-mode strategy instead of hardcoding `--sandbox workspace-write`. That profile is implemented with bubblewrap and cannot initialise in a containerised runner that drops capabilities or denies unprivileged user namespaces; every model-issued shell command then fails while `codex exec` still exits 0 with an empty diff, so the run reads as success. An operator whose runner already isolates the process declares `ALWAYS_ON` and the spawn passes `--dangerously-bypass-approvals-and-sandbox`; the default is unchanged and keeps the vendor sandbox. The Claude-tier fallback model moves from `gpt-5.4`, which upstream now rejects with HTTP 400 on the ChatGPT-account auth path, to `gpt-5.5`, and the module's verified-against version is refreshed to @openai/codex 0.152.1.

--- a/src/bernstein/adapters/_contract.py
+++ b/src/bernstein/adapters/_contract.py
@@ -715,7 +715,13 @@ STRATEGY_MATRIX: dict[str, AdapterStrategy] = {
         event_channel=EventChannel.STREAM_JSON,
         session_state=SessionState.PERSISTENT_AGENT,
     ),
-    # Codex drives unattended via its sandbox/full-auto flag.
+    # Codex drives unattended via its sandbox flag: ``--sandbox
+    # workspace-write`` pins the posture, hence CLI_FLAG. The adapter reads
+    # this row to pick the sandbox argv, and ALWAYS_ON is the only value that
+    # selects ``--dangerously-bypass-approvals-and-sandbox`` instead -- for a
+    # runner that already isolates the process, where the bubblewrap-backed
+    # vendor sandbox cannot start at all. Leave this row as CLI_FLAG: an
+    # operator opts into the bypass per adapter instance, not repo-wide.
     "codex": AdapterStrategy(dangerous_mode=DangerousModeStrategy.CLI_FLAG),
     # Everyone else - no native resume, text-signal channel. Dangerous-mode
     # default is ``UNSUPPORTED`` until an adapter declares otherwise.

--- a/src/bernstein/adapters/codex.py
+++ b/src/bernstein/adapters/codex.py
@@ -1,10 +1,33 @@
 """OpenAI Codex CLI adapter.
 
-Last verified against upstream @openai/codex 0.117.x on 2026-05-05.
+Last verified against upstream @openai/codex 0.152.1 on 2026-09-02.
 Install: ``npm i -g @openai/codex`` (or ``brew install --cask codex``).
-Recommended models: ``gpt-5.5`` (GA 2026-04-24) or ``gpt-5.5-mini`` for cheap
-work; ``gpt-5.4`` retained as a pinned fallback.  The o-series reasoning
-models (``o3``, ``o4-mini``) are also accepted by the CLI.
+Recommended models: ``gpt-5.5`` (GA 2026-04-24), which is also the pinned
+fallback, or ``gpt-5.4-mini`` for cheap work.  ``gpt-5.4`` is no longer served
+on the ChatGPT-account auth path.  The o-series reasoning models (``o3``,
+``o4-mini``) are also accepted by the CLI.
+
+Sandbox posture is derived from the adapter's declared
+:class:`~bernstein.adapters._contract.DangerousModeStrategy` rather than
+hardcoded, because the right answer depends on where the CLI runs.
+
+``codex exec --sandbox workspace-write`` is implemented with bubblewrap on
+Linux, and bubblewrap needs an unprivileged user namespace to start. A runner
+that already provides isolation typically denies exactly that: a container
+started with ``--cap-drop ALL --security-opt no-new-privileges:true``, or a
+host with unprivileged user namespaces disabled, makes every model-issued
+shell command fail with ``bwrap: No permissions to create a new namespace``.
+The failure is silent from the orchestrator's side -- ``codex exec`` still
+emits ``turn.completed`` and exits 0 after producing an empty diff -- so the
+run reads as a model that had nothing to do rather than as a sandbox that
+could not initialise.
+
+An operator whose runner is already isolated therefore declares the escalated
+strategy, and the spawn passes ``--dangerously-bypass-approvals-and-sandbox``
+instead. Upstream's own help text scopes that flag the same way: "Intended
+solely for running in environments that are externally sandboxed." The
+un-escalated default stays ``--sandbox workspace-write``, so a spawn on a
+plain host keeps the vendor sandbox.
 """
 
 from __future__ import annotations
@@ -15,6 +38,7 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+from bernstein.adapters._contract import DangerousModeStrategy
 from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
 from bernstein.adapters.env_isolation import build_filtered_env
 from bernstein.core.models import ApiTier, ApiTierInfo, ModelConfig, ProviderType, RateLimit
@@ -32,8 +56,26 @@ _CODEX_AUTH_FILE = Path.home() / ".codex" / "auth.json"
 # selector hands one to this adapter (e.g. the high-stakes-role default), fall
 # back to a Codex model so ``codex exec -m`` receives something the CLI accepts.
 # The real selection fix lives in the spawner; this is a last-resort safety net.
-_DEFAULT_CODEX_MODEL = "gpt-5.4"
+#
+# ``gpt-5.4`` was the pin until 2026-09-02 and no longer works on the
+# ChatGPT-account auth path: the backend rejects it with HTTP 400
+# ``invalid_request_error`` -- "The 'gpt-5.4' model is not supported when using
+# Codex with a ChatGPT account" -- and the account's own model catalogue lists
+# only ``gpt-5.5`` and ``gpt-5.4-mini``. A last-resort fallback that 400s is
+# worse than no fallback, so the pin follows the recommended GA model, which
+# both auth paths accept.
+_DEFAULT_CODEX_MODEL = "gpt-5.5"
 _CLAUDE_TIER_MODELS = frozenset({"opus", "sonnet", "haiku"})
+
+#: Sandbox argv for a spawn that keeps the vendor sandbox. Codex implements
+#: this profile with bubblewrap on Linux, so it needs an unprivileged user
+#: namespace the host must allow.
+_SANDBOXED_ARGS: tuple[str, ...] = ("--sandbox", "workspace-write")
+
+#: Sandbox argv for a spawn whose runner already provides isolation. Upstream
+#: scopes the flag to exactly that case: "Intended solely for running in
+#: environments that are externally sandboxed."
+_BYPASS_SANDBOX_FLAG = "--dangerously-bypass-approvals-and-sandbox"
 
 
 def _has_codex_auth() -> bool:
@@ -47,7 +89,7 @@ def _codex_model(model: str) -> str:
         logger.warning(
             "CodexAdapter: model %r is a Claude tier name Codex cannot run; using %r "
             "instead. Set role_model_policy.<role>.model or default_model to a Codex "
-            "model (e.g. gpt-5.4) to choose explicitly.",
+            "model (e.g. gpt-5.5) to choose explicitly.",
             model,
             _DEFAULT_CODEX_MODEL,
         )
@@ -75,6 +117,38 @@ class CodexAdapter(CLIAdapter):
     # ``insufficient_quota`` error codes; the meter records both under
     # the same provider label.
     rate_limit_provider = "openai"
+
+    def _dangerous_mode(self) -> DangerousModeStrategy:
+        """Return the declared dangerous-mode strategy for this adapter."""
+        declared = getattr(self.strategy(), "dangerous_mode", DangerousModeStrategy.UNSUPPORTED)
+        return declared if isinstance(declared, DangerousModeStrategy) else DangerousModeStrategy.UNSUPPORTED
+
+    def _sandbox_bypassed(self) -> bool:
+        """Whether this spawn runs Codex without its own sandbox.
+
+        Only :attr:`DangerousModeStrategy.ALWAYS_ON` bypasses. That value
+        means "no permission surface exists to skip", which is what the
+        bypass flag produces: no approval prompt and no vendor sandbox. The
+        shipped declaration for this adapter is
+        :attr:`DangerousModeStrategy.CLI_FLAG` -- a flag pins the posture,
+        and the posture it pins is the sandboxed one -- so a default spawn
+        keeps ``--sandbox workspace-write``. An operator whose runner is
+        already isolated declares ``ALWAYS_ON`` instead.
+        """
+        return self._dangerous_mode() is DangerousModeStrategy.ALWAYS_ON
+
+    def _sandbox_args(self) -> tuple[str, ...]:
+        """Return the sandbox argv for one spawn, derived from the declaration."""
+        if not self._sandbox_bypassed():
+            return _SANDBOXED_ARGS
+        logger.warning(
+            "CodexAdapter: dangerous_mode=%s, so this spawn passes %s -- model-issued "
+            "shell commands run with no Codex sandbox. Declare this only when the "
+            "runner itself provides the isolation.",
+            DangerousModeStrategy.ALWAYS_ON,
+            _BYPASS_SANDBOX_FLAG,
+        )
+        return (_BYPASS_SANDBOX_FLAG,)
 
     def spawn(
         self,
@@ -107,8 +181,7 @@ class CodexAdapter(CLIAdapter):
         cmd = [
             "codex",
             "exec",
-            "--sandbox",
-            "workspace-write",
+            *self._sandbox_args(),
             "-m",
             model,
             "--json",

--- a/tests/contract/contracts/codex.yaml
+++ b/tests/contract/contracts/codex.yaml
@@ -1,7 +1,17 @@
 # Contract for the OpenAI Codex CLI (adapter: codex).
 #
 # Always-passed surface from src/bernstein/adapters/codex.py:
-# ``codex exec --sandbox <profile> -m <model> --json -o <path> <prompt>``.
+# ``codex exec <sandbox-argv> -m <model> --json -o <path> <prompt>``.
+#
+# The sandbox argv is one of two forms, chosen by the adapter's declared
+# dangerous-mode strategy, so each flag is required of the *binary* rather
+# than of every spawn:
+#
+#   ``--sandbox workspace-write``  default; keeps the vendor sandbox.
+#   ``--dangerously-bypass-approvals-and-sandbox``  declared ALWAYS_ON only;
+#     for a runner that already isolates the process. ``--sandbox
+#     workspace-write`` is implemented with bubblewrap and cannot start
+#     without an unprivileged user namespace, which such runners deny.
 adapter: codex
 binary: codex
 install:
@@ -14,6 +24,7 @@ auth:
   basis: api_key
 required_flags:
   - "--sandbox"
+  - "--dangerously-bypass-approvals-and-sandbox"
   - "-m"
   - "--json"
   - "-o"

--- a/tests/unit/test_adapter_codex.py
+++ b/tests/unit/test_adapter_codex.py
@@ -10,7 +10,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 from bernstein.core.models import ApiTier, ModelConfig, ProviderType
 
-from bernstein.adapters.codex import CodexAdapter
+from bernstein.adapters._contract import AdapterStrategy, DangerousModeStrategy
+from bernstein.adapters.codex import (
+    _BYPASS_SANDBOX_FLAG,
+    _DEFAULT_CODEX_MODEL,
+    _SANDBOXED_ARGS,
+    CodexAdapter,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -349,8 +355,19 @@ class TestCodexWarningsAndFastExit:
                 session_id="codex-opus",
             )
         inner = _inner_cmd(popen.call_args.args[0])
-        assert inner[inner.index("-m") + 1] == "gpt-5.4"
+        assert inner[inner.index("-m") + 1] == _DEFAULT_CODEX_MODEL
         assert "opus" not in inner
+
+    def test_default_model_is_one_upstream_still_serves(self) -> None:
+        """The fallback pin must be a model Codex accepts, or it 400s on every use.
+
+        ``gpt-5.4`` was the pin until 2026-09-02; the backend now rejects it on
+        the ChatGPT-account auth path and it is absent from the account's model
+        catalogue. Pinning the substitution to a retired identifier turns the
+        Claude-tier safety net into a guaranteed failure.
+        """
+        assert _DEFAULT_CODEX_MODEL == "gpt-5.5"
+        assert CodexAdapter.default_model == _DEFAULT_CODEX_MODEL
 
     def test_fast_exit_rate_limit_raises(self, tmp_path: Path) -> None:
         adapter = CodexAdapter()
@@ -439,3 +456,83 @@ class TestCodexDetectTier:
             info = adapter.detect_tier()
         assert info is not None
         assert info.tier == ApiTier.FREE
+
+
+# ---------------------------------------------------------------------------
+# Sandbox posture selection
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxPosture:
+    """The sandbox argv is chosen by the declared strategy, not hardcoded.
+
+    ``--sandbox workspace-write`` is implemented with bubblewrap, which needs
+    an unprivileged user namespace. A runner that already isolates the process
+    denies exactly that, and the resulting failure is silent: every
+    model-issued command fails inside the turn, the diff is empty, and
+    ``codex exec`` still exits 0 with ``turn.completed``. So the posture has to
+    be selectable, and the escalated form has to be the deliberate opt-in
+    rather than the default a plain host inherits.
+    """
+
+    def _spawn_inner(self, adapter: CodexAdapter, tmp_path: Path, pid: int) -> list[str]:
+        proc_mock = _make_popen_mock(pid=pid)
+        with patch("bernstein.adapters.codex.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="gpt-5.5", effort="high"),
+                session_id=f"codex-sbx{pid}",
+            )
+        return _inner_cmd(popen.call_args.args[0])
+
+    def test_escalated_strategy_bypasses_the_vendor_sandbox(self, tmp_path: Path) -> None:
+        adapter = CodexAdapter()
+        adapter.strategy_override = AdapterStrategy(dangerous_mode=DangerousModeStrategy.ALWAYS_ON)
+
+        inner = self._spawn_inner(adapter, tmp_path, pid=140)
+
+        assert _BYPASS_SANDBOX_FLAG in inner
+        assert "--sandbox" not in inner
+
+    def test_default_strategy_keeps_the_vendor_sandbox(self, tmp_path: Path) -> None:
+        """The shipped declaration is CLI_FLAG, so a plain spawn stays sandboxed."""
+        adapter = CodexAdapter()
+
+        inner = self._spawn_inner(adapter, tmp_path, pid=141)
+
+        assert _BYPASS_SANDBOX_FLAG not in inner
+        assert tuple(inner[inner.index("--sandbox") : inner.index("--sandbox") + 2]) == _SANDBOXED_ARGS
+
+    @pytest.mark.parametrize(
+        "declared",
+        [
+            DangerousModeStrategy.CLI_FLAG,
+            DangerousModeStrategy.ENV_VAR,
+            DangerousModeStrategy.UNSUPPORTED,
+        ],
+    )
+    def test_only_always_on_escalates(self, tmp_path: Path, declared: DangerousModeStrategy) -> None:
+        """Every other declared value keeps the sandbox; only ALWAYS_ON drops it."""
+        adapter = CodexAdapter()
+        adapter.strategy_override = AdapterStrategy(dangerous_mode=declared)
+
+        inner = self._spawn_inner(adapter, tmp_path, pid=142)
+
+        assert _BYPASS_SANDBOX_FLAG not in inner
+        assert inner[inner.index("--sandbox") + 1] == "workspace-write"
+
+    def test_shipped_declaration_is_not_escalated(self) -> None:
+        """Guards the matrix row: flipping it to ALWAYS_ON would drop the sandbox repo-wide."""
+        assert CodexAdapter()._dangerous_mode() is DangerousModeStrategy.CLI_FLAG
+
+    def test_bypass_is_logged_so_the_escalation_is_visible(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        adapter = CodexAdapter()
+        adapter.strategy_override = AdapterStrategy(dangerous_mode=DangerousModeStrategy.ALWAYS_ON)
+
+        with caplog.at_level("WARNING", logger="bernstein.adapters.codex"):
+            self._spawn_inner(adapter, tmp_path, pid=143)
+
+        assert any(_BYPASS_SANDBOX_FLAG in record.getMessage() for record in caplog.records)


### PR DESCRIPTION
## Problem

`CodexAdapter.spawn` hardcoded `--sandbox workspace-write`.

Codex implements that sandbox profile with bubblewrap, and bubblewrap needs an unprivileged user namespace to start. A containerised runner that already provides isolation typically denies exactly that. Inside a container started with `--cap-drop ALL --security-opt no-new-privileges:true`, on a host that disallows unprivileged user namespaces, every model-issued shell command fails with:

```
bwrap: No permissions to create a new namespace, likely because the kernel does not allow non-privileged user namespaces.
```

The orchestrator cannot see this. `codex exec` still emits `turn.completed` and exits 0. A sandbox that cannot initialise is indistinguishable from a model that had nothing to do.

Measured against `@openai/codex` 0.152.1 on 2026-09-02:

| | `--sandbox workspace-write` | `--dangerously-bypass-approvals-and-sandbox` |
|---|---|---|
| Command executions | 16/16 failed | succeeded |
| Diff produced | zero bytes | correct edits |
| Tests | not reached | passing |
| Wall clock | burned ~194k input tokens | 55s |
| Exit code | 0 | 0 |

## Change

The sandbox argv is now derived from the adapter's declared `DangerousModeStrategy`, following the pattern `opencode.py` already uses for its permission posture.

| Declared strategy | Sandbox argv |
|---|---|
| `ALWAYS_ON` | `--dangerously-bypass-approvals-and-sandbox` |
| everything else | `--sandbox workspace-write` |

`ALWAYS_ON` is the value whose documented meaning is "no permission surface exists to skip", which is what the bypass flag produces. Upstream scopes the flag the same way in its own help text: "Intended solely for running in environments that are externally sandboxed."

**The default is unchanged.** The shipped `STRATEGY_MATRIX` row stays `CLI_FLAG`, so a spawn on a plain host keeps the vendor sandbox exactly as before. Escalation is a per-instance opt-in by an operator who knows their runner isolates the process, and it is logged at WARNING so the choice appears in the spawn record rather than only in the process argv.

## Version drift found while verifying against the shipping CLI

- **Docstring** claimed "Last verified against upstream @openai/codex 0.117.x on 2026-05-05". Refreshed to 0.152.1 / 2026-09-02.
- **`_DEFAULT_CODEX_MODEL`** pinned `gpt-5.4`. The backend now rejects it on the ChatGPT-account auth path with HTTP 400 `invalid_request_error` ("The 'gpt-5.4' model is not supported when using Codex with a ChatGPT account"), and it is absent from that account's model catalogue, which lists only `gpt-5.5` and `gpt-5.4-mini`. This constant is the last-resort substitution when a Claude tier name reaches the adapter, so a fallback that 400s is worse than no fallback. Moved to `gpt-5.5`, the model the docstring already recommended and which `model_prices.py` already prices. Probed live: `gpt-5.4` fails model validation, `gpt-5.5` passes it.
- **`tests/contract/contracts/codex.yaml`** listed `--sandbox` unconditionally. It now lists both flags, each required of the *binary* rather than of every spawn. That is the same shape `opencode.yaml` already uses for its conditional `--auto`.

## Not changed

`wire_api` does not appear anywhere in this repository, and nothing here writes a codex `model_providers` block, so there is no documentation or config template suggesting `wire_api = "chat"` to correct. Worth knowing for anyone configuring a custom OpenAI-compatible provider by hand: codex 0.152.x rejects `wire_api = "chat"` at startup, because its `WireApi` enum has only the `Responses` variant.

## Tests

8 new cases in `tests/unit/test_adapter_codex.py` (29 → 37):

- both argv forms, escalated and default
- parametrised proof that `CLI_FLAG`, `ENV_VAR` and `UNSUPPORTED` all keep the sandbox
- a guard on the shipped matrix row, so flipping it to `ALWAYS_ON` fails loudly rather than dropping the sandbox repo-wide
- the escalation WARNING
- the fallback model pin

Verified RED before the fix: with the hardcoded argv restored, `test_escalated_strategy_bypasses_the_vendor_sandbox`, `test_bypass_is_logged_so_the_escalation_is_visible` and `test_default_model_is_one_upstream_still_serves` all fail.

## Verification

```
uv run pytest tests/unit/test_adapter_codex.py tests/unit/test_adapter_opencode.py \
  tests/unit/test_adapter_non_claude.py tests/unit/adapters/ -q
```

| Check | Result |
|---|---|
| Adapter unit suites | 1010 passed |
| Codex, model-coercion, leaderboard suites | 135 passed |
| Contract-check and spec-assertion suites | 88 passed |
| Contract vs. the real `codex exec --help` | 0 failures, both flags matched |
| `ruff check` / `ruff format` | clean |
| `mypy --config-file mypy.gate.ini` | no issues |
| `lint-imports` | 3 contracts kept, 0 broken |
