### PR TITLE
fix(adapters): detect a codex run whose every shell call the sandbox refused

### DIFF
--- a/docs/adapters/ADAPTER_GUIDE.md
+++ b/docs/adapters/ADAPTER_GUIDE.md
@@ -116,6 +116,16 @@ npm install -g @openai/codex
 
 **Env vars:** `OPENAI_API_KEY` (required), `OPENAI_ORG_ID` (optional, triggers Enterprise tier), `OPENAI_BASE_URL` (optional).
 
+> **`OPENAI_BASE_URL` requires a Responses API endpoint.** codex >= 0.152 speaks only
+> the Responses API — `wire_api = "chat"` is a hard startup error, not a fallback. An
+> endpoint that serves only `/v1/chat/completions` cannot drive codex at all, however
+> OpenAI-compatible it is otherwise. See [#5314](https://github.com/sipyourdrink-ltd/bernstein/issues/5314).
+>
+> **Sandbox.** codex implements `--sandbox workspace-write` with bubblewrap, which cannot
+> start in a capability-dropped container on a kernel without unprivileged user namespaces.
+> Every shell call is then refused while the run still exits 0. The adapter now detects
+> that and marks the run `permission_denied` rather than reporting success.
+
 **Best for:** Tasks that benefit from OpenAI's reasoning models. Good complement to Claude for provider diversity.
 
 ---

--- a/docs/release-notes/fragments/5314-codex-sandbox-refusal-detected.md
+++ b/docs/release-notes/fragments/5314-codex-sandbox-refusal-detected.md
@@ -1,0 +1,15 @@
+## Codex adapter reports a sandbox refusal as a failed run, not a success
+
+A codex run whose sandbox denied every shell command previously exited 0 and
+reported success. Bubblewrap needs an unprivileged user namespace to start;
+in a capability-dropped container without one, every model-issued command
+failed while `codex exec` still emitted `turn.completed`. The adapter now
+reads the event stream after the run and marks it `permission_denied` when
+every `command_execution` carries bubblewrap's specific refusal, leaving a
+partial failure or an ordinary non-zero exit (a failing test, a bad flag)
+unmarked.
+
+Also documented: codex >= 0.152 speaks only the Responses API. `OPENAI_BASE_URL`
+is allow-listed for custom endpoints, but one serving only
+`/v1/chat/completions` cannot drive codex at all -- now stated in the module
+docstring and the adapter guide next to the env var (#5314).

--- a/src/bernstein/adapters/codex.py
+++ b/src/bernstein/adapters/codex.py
@@ -2,6 +2,19 @@
 
 Last verified against upstream @openai/codex 0.152.1 on 2026-09-02.
 Install: ``npm i -g @openai/codex`` (or ``brew install --cask codex``).
+
+.. important::
+   **codex >= 0.152 speaks only the Responses API.** ``wire_api = "chat"`` in a
+   custom provider block is a hard startup error, not a fallback::
+
+       Error loading config.toml: `wire_api = "chat"` is no longer supported.
+       How to fix: set `wire_api = "responses"` in your provider config.
+
+   This adapter allow-lists ``OPENAI_BASE_URL``, which advertises support for
+   custom OpenAI-compatible endpoints. That support is narrower than it looks:
+   an endpoint serving only ``/v1/chat/completions`` **cannot drive codex at
+   all**, however compatible it is otherwise. Point ``OPENAI_BASE_URL`` at a
+   deployment that implements ``/v1/responses`` (issue #5314).
 Recommended models: ``gpt-5.5`` (GA 2026-04-24), which is also the pinned
 fallback, or ``gpt-5.4-mini`` for cheap work.  ``gpt-5.4`` is no longer served
 on the ChatGPT-account auth path.  The o-series reasoning models (``o3``,
@@ -32,9 +45,11 @@ plain host keeps the vendor sandbox.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import subprocess
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -95,6 +110,80 @@ def _codex_model(model: str) -> str:
         )
         return _DEFAULT_CODEX_MODEL
     return model
+
+
+#: Bubblewrap's refusal when the kernel disallows unprivileged user namespaces.
+#: Codex implements ``--sandbox workspace-write`` with bubblewrap, so in a
+#: capability-dropped container every shell call the model issues fails with
+#: this while ``codex exec`` still emits ``turn.completed`` and exits 0.
+_BWRAP_DENIED = "No permissions to create a new namespace"
+
+
+def detect_sandbox_failure(log_text: str) -> tuple[str, int, int] | None:
+    """Return ``(detail, failed, total)`` when EVERY shell call was refused.
+
+    Issue #5314: a run in which all 16 shell commands failed, nothing changed
+    and ~194k tokens were spent still exited 0 and reported ``turn.completed``.
+    That is indistinguishable from a model that had nothing to do, which makes
+    it the worst of the available failure modes.
+
+    ``_probe_fast_exit`` cannot catch this: it treats an early NON-ZERO exit as
+    a spawn failure, and here the exit code is zero. So the signal has to come
+    from the event stream rather than the status.
+
+    Deliberately narrow, because the cost of a false positive is aborting a run
+    that actually worked:
+
+    * at least one ``command_execution`` item must be present -- a run that
+      shelled out zero times is not evidence of anything;
+    * EVERY one of them must have failed;
+    * at least one must carry bubblewrap's specific refusal, so an agent whose
+      commands merely returned non-zero (a failing test suite, a missing file)
+      is not reported as a sandbox failure.
+
+    Returns ``None`` when the run does not match, so the caller leaves the
+    result untouched.
+    """
+    if not log_text or _BWRAP_DENIED not in log_text:
+        return None
+
+    total = 0
+    failed = 0
+    saw_bwrap = False
+    for line in log_text.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            event = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(event, dict):
+            continue
+        nested = event.get("item")
+        item: dict[str, Any] = nested if isinstance(nested, dict) else event
+        if "command_execution" not in (item.get("item_type"), item.get("type")):
+            continue
+        total += 1
+        exit_code = item.get("exit_code")
+        output = str(item.get("aggregated_output") or item.get("output") or "")
+        if _BWRAP_DENIED in output:
+            saw_bwrap = True
+        if exit_code not in (0, None):
+            failed += 1
+
+    if total == 0 or failed != total or not saw_bwrap:
+        return None
+
+    detail = (
+        f"every shell command was refused by the sandbox ({failed}/{total}). "
+        "codex implements --sandbox workspace-write with bubblewrap, which "
+        "cannot start in a capability-dropped container on a kernel without "
+        "unprivileged user namespaces. The run exited 0 and reported success "
+        "while changing nothing. Re-run with a sandbox mode the environment "
+        "supports, or enable unprivileged user namespaces on the host."
+    )
+    return detail, failed, total
 
 
 class CodexAdapter(CLIAdapter):
@@ -231,7 +320,43 @@ class CodexAdapter(CLIAdapter):
         result = SpawnResult(pid=proc.pid, log_path=log_path, proc=proc)
         if timeout_seconds > 0:
             result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+
+        # #5314 - the fast-exit probe above only catches an early NON-ZERO exit.
+        # A sandbox that refuses every shell call still exits 0, so the run has
+        # to be judged from the event stream after it finishes.
+        thread = threading.Thread(target=self._flag_sandbox_failure, args=(proc, log_path, result), daemon=True)
+        thread.start()
+        result.post_exit_thread = thread
         return result
+
+    def _flag_sandbox_failure(self, proc: subprocess.Popen, log_path: Path, result: SpawnResult) -> None:
+        """Mark a run whose every shell call the sandbox refused (#5314).
+
+        Runs after the process exits. Sets ``abort_reason`` so a caller sees a
+        refused run rather than a successful one that happened to change
+        nothing; it does not raise, because by this point the process is gone
+        and there is nothing left to fail.
+        """
+        try:
+            proc.wait()
+            detected = detect_sandbox_failure(log_path.read_text(encoding="utf-8", errors="replace"))
+        except Exception as exc:  # bookkeeping must never wedge the worker
+            logger.debug("codex: sandbox-failure check skipped (%s)", type(exc).__name__)
+            return
+
+        if detected is None:
+            return
+        from bernstein.core.models import AbortReason
+
+        detail, failed, total = detected
+        result.abort_reason = AbortReason.PERMISSION_DENIED
+        result.abort_detail = detail
+        logger.error("CodexAdapter: %s", detail)
+        logger.error(
+            "CodexAdapter: %d/%d shell commands refused; the run reported success regardless",
+            failed,
+            total,
+        )
 
     def name(self) -> str:
         return "Codex"

--- a/tests/unit/test_adapter_codex.py
+++ b/tests/unit/test_adapter_codex.py
@@ -555,14 +555,16 @@ class TestSandboxFailureDetection:
     def _event(self, exit_code, output=""):
         import json
 
-        return json.dumps({
-            "item": {
-                "item_type": "command_execution",
-                "command": "pytest",
-                "exit_code": exit_code,
-                "aggregated_output": output,
+        return json.dumps(
+            {
+                "item": {
+                    "item_type": "command_execution",
+                    "command": "pytest",
+                    "exit_code": exit_code,
+                    "aggregated_output": output,
+                }
             }
-        })
+        )
 
     def test_all_commands_refused_is_detected(self):
         from bernstein.adapters.codex import detect_sandbox_failure
@@ -620,11 +622,13 @@ class TestSandboxFailureDetection:
         from bernstein.adapters.codex import detect_sandbox_failure
 
         log = "\n".join(
-            json.dumps({
-                "type": "command_execution",
-                "exit_code": 1,
-                "output": self.BWRAP,
-            })
+            json.dumps(
+                {
+                    "type": "command_execution",
+                    "exit_code": 1,
+                    "output": self.BWRAP,
+                }
+            )
             for _ in range(3)
         )
         detected = detect_sandbox_failure(log)

--- a/tests/unit/test_adapter_codex.py
+++ b/tests/unit/test_adapter_codex.py
@@ -536,3 +536,96 @@ class TestSandboxPosture:
             self._spawn_inner(adapter, tmp_path, pid=143)
 
         assert any(_BYPASS_SANDBOX_FLAG in record.getMessage() for record in caplog.records)
+
+
+class TestSandboxFailureDetection:
+    """#5314 - a run whose every shell call the sandbox refused still exits 0.
+
+    ``_probe_fast_exit`` cannot catch it: that probe treats an early NON-ZERO
+    exit as a spawn failure, and the exit code here is zero. The signal has to
+    come from the event stream, and the reported run showed why it matters:
+    16/16 commands refused, 0 files changed, ~194k tokens, ``turn.completed``.
+    """
+
+    BWRAP = (
+        "bwrap: No permissions to create a new namespace, likely because the "
+        "kernel does not allow non-privileged user namespaces."
+    )
+
+    def _event(self, exit_code, output=""):
+        import json
+
+        return json.dumps({
+            "item": {
+                "item_type": "command_execution",
+                "command": "pytest",
+                "exit_code": exit_code,
+                "aggregated_output": output,
+            }
+        })
+
+    def test_all_commands_refused_is_detected(self):
+        from bernstein.adapters.codex import detect_sandbox_failure
+
+        log = "\n".join(self._event(1, self.BWRAP) for _ in range(16))
+        detected = detect_sandbox_failure(log)
+
+        assert detected is not None
+        detail, failed, total = detected
+        assert (failed, total) == (16, 16)
+        assert "every shell command was refused" in detail
+
+    def test_a_successful_run_is_untouched(self):
+        from bernstein.adapters.codex import detect_sandbox_failure
+
+        log = "\n".join(self._event(0, "ok") for _ in range(5))
+        assert detect_sandbox_failure(log) is None
+
+    def test_ordinary_command_failures_are_not_a_sandbox_failure(self):
+        """The control that matters. A failing test suite, a missing file, a
+        bad flag - every command can legitimately exit non-zero without the
+        sandbox being at fault. Reporting those as permission_denied would
+        abort real runs, so the bwrap signature is required."""
+        from bernstein.adapters.codex import detect_sandbox_failure
+
+        log = "\n".join(self._event(1, "FAILED tests/test_x.py") for _ in range(9))
+        assert detect_sandbox_failure(log) is None
+
+    def test_a_partial_failure_is_not_reported(self):
+        """One refused command among working ones is not this defect: the run
+        did real work, and aborting it would lose that."""
+        from bernstein.adapters.codex import detect_sandbox_failure
+
+        log = "\n".join([self._event(0, "ok"), self._event(1, self.BWRAP)])
+        assert detect_sandbox_failure(log) is None
+
+    def test_a_run_with_no_shell_calls_is_not_reported(self):
+        """Zero commands is not evidence of anything, even if the bwrap string
+        appears somewhere else in the log."""
+        from bernstein.adapters.codex import detect_sandbox_failure
+
+        assert detect_sandbox_failure(f"some prose mentioning {self.BWRAP}") is None
+
+    def test_empty_and_malformed_logs_do_not_raise(self):
+        from bernstein.adapters.codex import detect_sandbox_failure
+
+        for log in ("", "not json at all", "{broken", "{}\n[]\nnull"):
+            assert detect_sandbox_failure(log) is None
+
+    def test_the_flat_event_shape_is_also_understood(self):
+        """codex has emitted both a nested ``item`` and a flat event; accept
+        either rather than silently seeing zero commands."""
+        import json
+
+        from bernstein.adapters.codex import detect_sandbox_failure
+
+        log = "\n".join(
+            json.dumps({
+                "type": "command_execution",
+                "exit_code": 1,
+                "output": self.BWRAP,
+            })
+            for _ in range(3)
+        )
+        detected = detect_sandbox_failure(log)
+        assert detected is not None and detected[1:] == (3, 3)


### PR DESCRIPTION
Refs #5314

**First: #5323 already landed the sandbox-selection fix**, so defect 1 of this issue is done and I have not touched it. This addresses the two that remain.

## The silent success — described after #5323, but not detected

The adapter's docstring now explains the failure. Nothing notices it at runtime.

`_probe_fast_exit` structurally cannot: it treats an early **non-zero** exit as a spawn failure, and the whole point of this defect is that codex exits **zero**. The signal has to come from the event stream after the run, which is what `post_exit_thread` already exists for (`letta_code` uses the same mechanism).

`detect_sandbox_failure()` is deliberately narrow, because a false positive aborts a run that actually worked. All three must hold:

1. at least one `command_execution` item — a run that shelled out zero times is not evidence of anything;
2. **every** one of them failed;
3. at least one carries bubblewrap's specific refusal.

Condition 3 is the important one. A failing test suite, a missing file or a bad flag makes every command exit non-zero without the sandbox being at fault — `test_ordinary_command_failures_are_not_a_sandbox_failure` pins that, and without it this would abort legitimate runs. A partial failure is also left alone: that run did real work and aborting it would lose it.

On a match the run is marked `AbortReason.PERMISSION_DENIED` with the counts and the remedy, so a caller sees a refused run rather than a successful one that happened to change nothing.

I could not reproduce the bubblewrap condition — it needs a kernel without unprivileged user namespaces plus a capability-dropped container — so the detector is built against the event shapes your report documents (16/16, `exit_code: 1`, the `bwrap:` string) and tested against both the nested `item` and flat event shapes. If codex emits a third shape in the wild, that is where this would miss.

## The wire API constraint

Documented nowhere, while `OPENAI_BASE_URL` is allow-listed and so advertises support for custom OpenAI-compatible endpoints. codex ≥ 0.152 speaks only the Responses API — `wire_api = "chat"` is a hard startup error, not a fallback — so an endpoint serving only `/v1/chat/completions` **cannot drive codex at all**.

Now stated in the module docstring and in `docs/adapters/ADAPTER_GUIDE.md` directly beside the env var that implies otherwise, which is where someone configuring it will actually look.

## Left for you

The contract still pins `@openai/codex@latest`. That is how a breaking upstream flag change reaches you as a red CI run rather than a deliberate bump — but changing it changes how your CI behaves, so I have raised it rather than done it. Say the word and I will add the pin here.

Marked `Refs` rather than `Closes` since defect 1 was closed by #5323 and you may want to reconcile the issue rather than have this close it.

## Checks

```
tests/unit/test_adapter_codex.py   44 passed
ruff check src/                    All checks passed
ruff format --check src/           2037 files already formatted
mypy src/bernstein/adapters/codex.py   Success
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
