### PR TITLE
ci: render the project pulse as a card with weekly history and trend charts

### DIFF
--- a/.github/workflows/project-pulse.yml
+++ b/.github/workflows/project-pulse.yml
@@ -14,20 +14,24 @@ name: Project pulse
 #     bucketed into outside / maintainer / automation and reported as counts,
 #     with a unit test asserting the rendered page names no account.
 #   * The aggregation and rendering live in scripts/project_pulse.py
-#     (unit-tested, deterministic) so a re-run produces a byte-identical body
-#     and the weekly upsert does not thrash the issue.
+#     (unit-tested, deterministic) so a re-run produces byte-identical
+#     output and the weekly upsert does not thrash the issue.
 #
 # Fails closed: `collect` exits non-zero and writes no file if any API call
 # fails, so a broken query can never publish zeros that read as a quiet week.
-# The publish step only runs on a successful collection.
+# Every later step only runs on a successful collection.
 #
 # Rolling, not proliferating: exactly one issue titled "Project pulse
 # (weekly)" is created on the first run and edited in place afterwards. It is
 # labelled `docs` and deliberately not pinned.
 #
-# The rendered page is also uploaded as a workflow artifact. Nothing is
-# committed to the repository: the page is generated output, and a workflow
-# that pushes to main to publish a report is a merge-queue hazard for no gain.
+# Where the generated output lives: the rendered page, the SVG card the page
+# embeds (a light and a dark variant), the collected JSON and the weekly
+# history are committed to the `project-pulse` branch. That branch carries no
+# code and is never merged anywhere; it exists because GitHub only shows an
+# image it can fetch from a URL, and a branch is the one place this workflow
+# can publish a file without touching main or the merge queue. The same files
+# are also uploaded as a workflow artifact.
 
 on:
   schedule:
@@ -42,13 +46,20 @@ concurrency:
 
 permissions: {}
 
+env:
+  # Must match DATA_BRANCH in scripts/project_pulse.py (a unit test checks).
+  DATA_BRANCH: project-pulse
+
 jobs:
   pulse:
     name: Collect and publish the project pulse
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
-      contents: read
+      # contents: write is what pushing to the data branch needs. main is
+      # protected by the repository ruleset (pull request + merge queue
+      # required), which this token cannot bypass.
+      contents: write
       issues: write
     steps:
       - name: Harden runner (audit mode)
@@ -78,14 +89,72 @@ jobs:
             --out pulse.json \
             --repo-root .
 
-      - name: Render the page
+      - name: Load the weekly history from the data branch
         run: |
           set -euo pipefail
-          uv run python scripts/project_pulse.py render pulse.json > project-pulse.md
+          # `ls-remote --exit-code` separates "the branch does not exist yet"
+          # (exit 2, first run: start a fresh history) from "the remote could
+          # not be reached" (any other failure). Treating a network error as
+          # an empty history would restart the series and, on push, erase it.
+          set +e
+          git ls-remote --exit-code --heads origin "${DATA_BRANCH}" >/dev/null
+          rc=$?
+          set -e
+          if [ "${rc}" -eq 0 ]; then
+            git fetch --quiet --depth=1 origin "${DATA_BRANCH}"
+            git show "FETCH_HEAD:history.json" > history.json
+          elif [ "${rc}" -eq 2 ]; then
+            echo "no ${DATA_BRANCH} branch yet; starting a fresh history"
+            echo '{"weeks": []}' > history.json
+          else
+            echo "could not list ${DATA_BRANCH} on the remote (exit ${rc})"
+            exit "${rc}"
+          fi
+
+      - name: Append this week and render the page and the card
+        run: |
+          set -euo pipefail
+          uv run python scripts/project_pulse.py history pulse.json --history history.json
+          mkdir -p out
+          uv run python scripts/project_pulse.py render pulse.json \
+            --history history.json \
+            --svg-dir out > out/project-pulse.md
           # A renderer that produced an empty page would otherwise blank the
           # issue body in place, which reads as "the project died" rather than
-          # "the render broke".
-          test -s project-pulse.md
+          # "the render broke". Same for the card the page embeds.
+          test -s out/project-pulse.md
+          test -s out/pulse.svg
+          test -s out/pulse-dark.svg
+          cp pulse.json history.json out/
+
+      - name: Publish the card, the page and the history to the data branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          DATE=$(python3 -c 'import json; print(json.load(open("pulse.json"))["generated_at"])')
+          rm -rf publish
+          mkdir publish
+          cd publish
+          git init --quiet --initial-branch "${DATA_BRANCH}"
+          if git fetch --quiet "https://github.com/${REPO}.git" "${DATA_BRANCH}" 2>/dev/null; then
+            # Keep the branch history: this week's commit sits on last week's.
+            git reset --quiet --soft FETCH_HEAD
+          fi
+          cp ../out/* .
+          git add --all
+          if git diff --cached --quiet; then
+            echo "the data branch already carries this collection"
+          else
+            git -c user.name="github-actions[bot]" \
+                -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+                commit --quiet --message "Project pulse ${DATE}"
+          fi
+          # Not a force push: a remote that moved since the fetch is rejected,
+          # and the run fails rather than overwriting a week it never saw.
+          git push --quiet "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" \
+            "HEAD:refs/heads/${DATA_BRANCH}"
 
       - name: Upsert the rolling pulse issue
         env:
@@ -106,7 +175,7 @@ jobs:
 
           if [ -n "${EXISTING}" ]; then
             echo "Updating existing pulse issue #${EXISTING}"
-            gh issue edit "${EXISTING}" --repo "${REPO}" --body-file project-pulse.md
+            gh issue edit "${EXISTING}" --repo "${REPO}" --body-file out/project-pulse.md
             PULSE_NUMBER="${EXISTING}"
           else
             echo "Creating the pulse issue"
@@ -118,12 +187,12 @@ jobs:
             if grep -qxF "docs" <<<"${LABELS}"; then
               PULSE_URL=$(gh issue create --repo "${REPO}" \
                 --title "${TITLE}" \
-                --body-file project-pulse.md \
+                --body-file out/project-pulse.md \
                 --label "docs")
             else
               PULSE_URL=$(gh issue create --repo "${REPO}" \
                 --title "${TITLE}" \
-                --body-file project-pulse.md)
+                --body-file out/project-pulse.md)
             fi
             PULSE_NUMBER=$(basename "${PULSE_URL}")
           fi
@@ -133,15 +202,13 @@ jobs:
             echo ""
             echo "- Pulse issue: #${PULSE_NUMBER}"
             echo ""
-            cat project-pulse.md
+            cat out/project-pulse.md
           } >> "${GITHUB_STEP_SUMMARY}"
 
-      - name: Upload the rendered page and its inputs
+      - name: Upload the rendered page, the card and its inputs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: project-pulse
-          path: |
-            project-pulse.md
-            pulse.json
+          path: out/
           if-no-files-found: error
           retention-days: 90

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -208,7 +208,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/pr-labels.yml | workflow: {"contents": "read"}<br>label: {"contents": "read", "issues": "write", "pull-requests": "write"} | GITHUB_TOKEN |
 | .github/workflows/pr-observability-summary.yml | workflow: {"contents": "read"}<br>summary: {"checks": "read", "contents": "read", "pull-requests": "write", "security-events": "read"} | GITHUB_TOKEN |
 | .github/workflows/pr-policy.yml | workflow: {"contents": "read"}<br>pr-policy: {"actions": "read", "contents": "write", "issues": "read", "pull-requests": "read"} | BERNSTEIN_AUTOSYNC_TOKEN |
-| .github/workflows/project-pulse.yml | pulse: {"contents": "read", "issues": "write"} | - |
+| .github/workflows/project-pulse.yml | pulse: {"contents": "write", "issues": "write"} | - |
 | .github/workflows/publish-docker.yml | publish: {"attestations": "write", "contents": "read", "id-token": "write", "packages": "write"} | GITHUB_TOKEN |
 | .github/workflows/publish-extension.yml | workflow: {"contents": "read"}<br>publish: {"contents": "read"} | OPEN_VSX_TOKEN, VS_MARKETPLACE_TOKEN |
 | .github/workflows/publish-homebrew.yml | workflow: {"contents": "read"}<br>update-formula: {"contents": "read"} | HOMEBREW_TAP_TOKEN |

--- a/docs/project-pulse.md
+++ b/docs/project-pulse.md
@@ -4,10 +4,15 @@ A weekly public snapshot of this repository's health, written to answer the ques
 prospective contributor has before opening a pull request: will it be looked at? The headline
 is the median time from PR opened to merged over the last 30 days, then a link to grabbable issues.
 
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/project-pulse/pulse-dark.svg">
+  <img alt="The current project pulse card: merge lag, share merged within 24 hours, merged pull requests, issues free to pick up, merged pull requests by author class, issue close lag, and project state." src="https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/project-pulse/pulse.svg" width="880">
+</picture>
+
 [`.github/workflows/project-pulse.yml`](https://github.com/sipyourdrink-ltd/bernstein/blob/main/.github/workflows/project-pulse.yml)
 publishes it every Monday at 09:19 UTC into one rolling issue titled `Project pulse (weekly)`,
 labelled `docs` -- created on the first run, edited in place afterwards.
-Find it with [`is:issue "Project pulse (weekly)"`](https://github.com/sipyourdrink-ltd/bernstein/issues?q=is%3Aissue+%22Project+pulse+%28weekly%29%22), or as a workflow artifact on any run.
+Find it with [`is:issue "Project pulse (weekly)"`](https://github.com/sipyourdrink-ltd/bernstein/issues?q=is%3Aissue+%22Project+pulse+%28weekly%29%22).
 
 ## What it reports
 
@@ -29,12 +34,38 @@ That table is the whole allow-list, restated as a comment block at the top of
 logins, e-mail addresses, per-person rankings, commit-hour histograms and review-comment
 attribution are out of scope and must not be added.
 
+## What the page is made of
+
+The issue body carries the same ten fields in three shapes, all rendered from one
+`pulse.json` by a pure function, so a re-run on the same input produces the same bytes:
+
+- **The card.** An SVG in a light and a dark variant, chosen by the reader's colour scheme.
+  It draws itself once on load with CSS alone: no script, no font or image fetched from
+  anywhere, and it holds still for readers who prefer reduced motion.
+- **The trend.** Two charts over the last eight weekly collections -- merged pull requests
+  per week and the median merge lag -- as Mermaid blocks, which GitHub renders inline. They
+  appear once a second week exists.
+- **The tables.** Every field as a number, for readers and tools that do not render images.
+
+## The `project-pulse` branch
+
+GitHub only shows an image it can fetch from a URL, so the workflow commits its output to a
+branch of its own, `project-pulse`. It holds the card (`pulse.svg`, `pulse-dark.svg`), the
+page (`project-pulse.md`), the collected `pulse.json` and `history.json`, one row per
+collection date, capped at two years. The branch carries no code, is never merged anywhere,
+and its history is one commit per week. The same files are uploaded as a workflow artifact.
+
+The card above and the issue body are the branch's current contents.
+
 ## Regenerate locally
 
 `collect` needs `GH_TOKEN` with public read access and fails closed: a failed query
-aborts the run and writes nothing. `render` is pure -- identical input, identical bytes.
+aborts the run and writes nothing. `history` upserts this collection into `history.json`
+(a re-run on the same date replaces its own row). `render` is pure -- identical input,
+identical bytes -- and writes the two cards next to the page when given `--svg-dir`.
 
 ```bash
 uv run python scripts/project_pulse.py collect --repo sipyourdrink-ltd/bernstein --out pulse.json
-uv run python scripts/project_pulse.py render pulse.json
+uv run python scripts/project_pulse.py history pulse.json --history history.json
+uv run python scripts/project_pulse.py render pulse.json --history history.json --svg-dir out > out/project-pulse.md
 ```

--- a/scripts/project_pulse.py
+++ b/scripts/project_pulse.py
@@ -1,17 +1,21 @@
 #!/usr/bin/env python3
 """Publish a weekly, deterministic snapshot of this repository's public health.
 
-Consumed by ``.github/workflows/project-pulse.yml``. Two stages, deliberately
-split so the numbers and the page are separable concerns:
+Consumed by ``.github/workflows/project-pulse.yml``. Three stages, deliberately
+split so the numbers, the history and the page are separable concerns:
 
 * ``collect`` queries the public GitHub REST API plus two in-repo sources and
   writes ``pulse.json``. It fails closed: any HTTP error, unexpected payload,
   or unreadable local source aborts with a non-zero exit and leaves no output
   file behind, so a partial page can never be published as a complete one.
-* ``render`` is a pure function of that JSON. Identical input yields a
-  byte-identical page (sorted keys, fixed number formatting, ISO dates, and no
-  clock reads other than the collected ``generated_at`` date), so the weekly
-  idempotent upsert does not thrash the issue body.
+* ``history`` appends this week's row to ``history.json``, one row per
+  collection date, so the page can show movement instead of a single number.
+  A re-run on the same date replaces its own row rather than duplicating it.
+* ``render`` is a pure function of that JSON. Identical input yields
+  byte-identical output (sorted keys, fixed number formatting, ISO dates, and
+  no clock reads other than the collected ``generated_at`` date), so the weekly
+  idempotent upsert does not thrash the issue body. It produces the Markdown
+  page and, with ``--svg-dir``, a light and a dark SVG card the page embeds.
 
 The page answers one question a prospective contributor has before opening a
 pull request: will it be looked at? The headline is the median time from PR
@@ -47,6 +51,10 @@ the code it describes.
 #   9.  latest_release                 tag name and publication date
 #  10.  readme_translations            translated READMEs in sync vs stale
 #
+# The weekly history, the SVG card and the charts on the page are projections
+# of these same fields over time (one row per collection date); they add no
+# field of their own.
+#
 # Explicitly out of scope, and not to be added: individual logins, e-mail
 # addresses, per-person leaderboards, commit-hour or timezone histograms,
 # review-comment attribution, anything sourced outside the public API and this
@@ -57,6 +65,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import shutil
 import statistics
@@ -70,6 +79,7 @@ import urllib.request
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
+from xml.sax.saxutils import escape as _xml_escape
 
 API_ROOT = "https://api.github.com"
 USER_AGENT = "bernstein-project-pulse"
@@ -104,6 +114,31 @@ AUTOMATION_LOGIN = "bernstein-orchestrator[bot]"
 CLASS_OUTSIDE = "outside"
 CLASS_MAINTAINER = "maintainer"
 CLASS_AUTOMATION = "automation"
+
+#: Branch that carries the rendered card, the page and the weekly history.
+#: The workflow pushes there; nothing on it is ever merged anywhere.
+DATA_BRANCH = "project-pulse"
+
+#: Weeks of history kept. Two years is enough to see a trend and small enough
+#: that the file never needs pagination.
+HISTORY_KEEP_WEEKS = 104
+
+#: Weeks shown in the card sparklines and in the trend charts on the page.
+TREND_WEEKS = 8
+
+#: Per-week fields copied into the history. A strict subset of the allow-list
+#: above: the history introduces no field of its own.
+HISTORY_FIELDS = (
+    "commits_main_7d",
+    "distinct_outside_authors",
+    "grabbable",
+    "issue_close_lag_hours_median",
+    "issues_closed_count",
+    "merged_prs_by_author_class",
+    "pr_merge_lag_hours_median",
+    "pr_merged_count",
+    "pr_merged_within_24h_pct",
+)
 
 
 class PulseError(RuntimeError):
@@ -416,7 +451,52 @@ def collect(client: GitHubClient, repo: str, repo_root: Path, now: datetime) -> 
 
 
 # ---------------------------------------------------------------------------
-# Rendering (pure)
+# History (one row per collection date)
+# ---------------------------------------------------------------------------
+
+
+def history_row(data: dict[str, Any]) -> dict[str, Any]:
+    """Project one collection onto its history row (allow-listed fields only)."""
+    row: dict[str, Any] = {"generated_at": str(data["generated_at"])}
+    for key in HISTORY_FIELDS:
+        row[key] = data[key]
+    return row
+
+
+def load_history(path: Path) -> dict[str, Any]:
+    """Read *path*, or an empty history when it does not exist yet.
+
+    A file that exists but does not parse as a history is an error, not an
+    empty history: silently restarting the series would erase the trend.
+    """
+    if not path.exists():
+        return {"weeks": []}
+    try:
+        history = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise PulseError(f"history {path} is unreadable: {exc}") from exc
+    weeks = history.get("weeks") if isinstance(history, dict) else None
+    if not isinstance(weeks, list) or not all(isinstance(w, dict) and "generated_at" in w for w in weeks):
+        raise PulseError(f"history {path} is not a list of dated rows")
+    return history
+
+
+def append_history(history: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
+    """Return *history* with *data*'s row upserted, sorted by date, capped."""
+    fresh = history_row(data)
+    rows = [row for row in history.get("weeks", []) if row.get("generated_at") != fresh["generated_at"]]
+    rows.append(fresh)
+    rows.sort(key=lambda row: str(row["generated_at"]))
+    return {"weeks": rows[-HISTORY_KEEP_WEEKS:]}
+
+
+def _trend_rows(data: dict[str, Any], history: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """The last :data:`TREND_WEEKS` rows, always ending with the current one."""
+    return append_history(history or {"weeks": []}, data)["weeks"][-TREND_WEEKS:]
+
+
+# ---------------------------------------------------------------------------
+# Formatting (shared by the page and the card)
 # ---------------------------------------------------------------------------
 
 
@@ -435,8 +515,77 @@ def _pct(value: float | None) -> str:
     return "n/a" if value is None else f"{value:.1f}%"
 
 
-def render(data: dict[str, Any]) -> str:
-    """Render *data* as Markdown. Pure: same input, byte-identical output."""
+def _split_unit(text: str) -> tuple[str, str]:
+    """``"3.4 h"`` -> ``("3.4", "h")``; ``"88.2%"`` -> ``("88.2", "%")``."""
+    if text.endswith("%"):
+        return text[:-1], "%"
+    number, _, unit = text.partition(" ")
+    return number, unit
+
+
+def _nice_ceiling(value: float) -> int:
+    """Smallest round axis maximum comfortably above *value* (deterministic)."""
+    if value <= 0:
+        return 10
+    magnitude = 10 ** max(len(str(int(value))) - 1, 0)
+    return int(math.ceil(value * 1.1 / magnitude) * magnitude)
+
+
+def _image_base(data: dict[str, Any], image_base: str | None) -> str:
+    base = image_base or f"https://raw.githubusercontent.com/{data['repo']}/{DATA_BRANCH}"
+    return base.rstrip("/")
+
+
+# ---------------------------------------------------------------------------
+# Rendering: the page (pure Markdown)
+# ---------------------------------------------------------------------------
+
+
+def _mermaid_trend(rows: list[dict[str, Any]]) -> list[str]:
+    """Two small charts over the weekly history; nothing when there is no trend."""
+    if len(rows) < 2:
+        return []
+    labels = ", ".join(f'"{str(row["generated_at"])[5:]}"' for row in rows)
+    merged = [int(row["pr_merged_count"]) for row in rows]
+    lines = [
+        "## Trend",
+        "",
+        f"The last {len(rows)} weekly collections. The full series is `history.json` on the",
+        f"`{DATA_BRANCH}` branch.",
+        "",
+        "```mermaid",
+        "xychart-beta",
+        '    title "Merged pull requests per week"',
+        f"    x-axis [{labels}]",
+        f'    y-axis "Merged" 0 --> {_nice_ceiling(max(merged))}',
+        f"    bar [{', '.join(str(v) for v in merged)}]",
+        "```",
+    ]
+    lagged = [row for row in rows if row.get("pr_merge_lag_hours_median") is not None]
+    if len(lagged) >= 2:
+        lag_labels = ", ".join(f'"{str(row["generated_at"])[5:]}"' for row in lagged)
+        lags = [float(row["pr_merge_lag_hours_median"]) for row in lagged]
+        lines += [
+            "",
+            "```mermaid",
+            "xychart-beta",
+            '    title "Median merge lag, hours"',
+            f"    x-axis [{lag_labels}]",
+            f'    y-axis "Hours" 0 --> {_nice_ceiling(max(lags))}',
+            f"    line [{', '.join(f'{v:.1f}' for v in lags)}]",
+            "```",
+        ]
+    lines.append("")
+    return lines
+
+
+def render(data: dict[str, Any], history: dict[str, Any] | None = None, image_base: str | None = None) -> str:
+    """Render *data* as Markdown. Pure: same input, byte-identical output.
+
+    *history* adds the trend section and is optional; *image_base* is where
+    the workflow publishes the card (defaults to the raw URL of the data
+    branch). Both are inputs, not clock or network reads.
+    """
     repo = str(data["repo"])
     generated = str(data["generated_at"])
     windows = data["windows"]
@@ -446,7 +595,13 @@ def render(data: dict[str, Any]) -> str:
     release = data["latest_release"]
     l10n = data["readme_translations"]
     base = f"https://github.com/{repo}"
+    images = _image_base(data, image_base)
     grabbable_query = f"{base}/issues?q=is%3Aissue+is%3Aopen+label%3Aup-for-grabs+no%3Aassignee"
+    alt = (
+        f"Project pulse for {repo}, {generated}: median merge lag {_hours(data['pr_merge_lag_hours_median'])}, "
+        f"{_pct(data['pr_merged_within_24h_pct'])} merged within 24 hours, {data['pr_merged_count']} merged "
+        f"pull requests in {windows['pr_days']} days, {grab['up_for_grabs_unassigned']} unassigned up-for-grabs issues."
+    )
 
     lines: list[str] = [
         "# Project pulse",
@@ -454,9 +609,19 @@ def render(data: dict[str, Any]) -> str:
         f"Median time from pull request opened to merged over the last {windows['pr_days']} days: "
         f"**{_hours(data['pr_merge_lag_hours_median'])}**.",
         "",
-        f"[Issues that are free to pick up]({grabbable_query}) "
-        f"({grab['up_for_grabs_unassigned']} unassigned of {grab['up_for_grabs_open']} labelled up-for-grabs).",
+        "<picture>",
+        f'  <source media="(prefers-color-scheme: dark)" srcset="{images}/pulse-dark.svg?v={generated}">',
+        f'  <img alt="{_xml_escape(alt, {chr(34): "&quot;"})}" src="{images}/pulse.svg?v={generated}" width="880">',
+        "</picture>",
         "",
+        "> [!TIP]",
+        f"> [Issues that are free to pick up]({grabbable_query}): "
+        f"{grab['up_for_grabs_unassigned']} unassigned of {grab['up_for_grabs_open']} labelled up-for-grabs, "
+        f"{grab['good_first_issue_unassigned']} unassigned good first issues.",
+        "",
+    ]
+    lines += _mermaid_trend(_trend_rows(data, history))
+    lines += [
         "## Review and merge",
         "",
         "| Metric | Value |",
@@ -472,11 +637,13 @@ def render(data: dict[str, Any]) -> str:
         "Counts only, by account class. Outside contributions are everything that is neither the",
         "maintainer account nor an automation account, so the outside number is never flattered.",
         "",
-        "| Author class | Merged PRs |",
-        "| --- | --- |",
-        f"| Outside contributors | {classes[CLASS_OUTSIDE]} |",
-        f"| Maintainer | {classes[CLASS_MAINTAINER]} |",
-        f"| Automation | {classes[CLASS_AUTOMATION]} |",
+        "```mermaid",
+        "pie showData",
+        f"    title Merged pull requests by author class, {windows['pr_days']} d",
+        f'    "Outside contributors" : {classes[CLASS_OUTSIDE]}',
+        f'    "Maintainer" : {classes[CLASS_MAINTAINER]}',
+        f'    "Automation" : {classes[CLASS_AUTOMATION]}',
+        "```",
         "",
         f"Distinct outside authors with a merged PR in the last {windows['outside_author_days']} days: "
         f"**{data['distinct_outside_authors']}**.",
@@ -498,14 +665,445 @@ def render(data: dict[str, Any]) -> str:
         f"| Latest release | {release['tag']} ({release['date']}) |",
         f"| Translated READMEs | {l10n['in_sync']} in sync, {l10n['stale']} stale, of {l10n['total']} |",
         "",
-        "---",
+        "<details>",
+        "<summary>How this page is made</summary>",
         "",
         f"Generated {generated} from the public GitHub API and this repository's own tree.",
         "Aggregates only: no individual logins, no per-person ranking, no data that is not already public.",
-        "Regenerate with `scripts/project_pulse.py`; the field allow-list is documented at the top of that",
-        f"file and in [docs/project-pulse.md]({base}/blob/main/docs/project-pulse.md).",
+        f"The card, the charts and the weekly history on the `{DATA_BRANCH}` branch are projections of the",
+        "same ten fields. Regenerate with `scripts/project_pulse.py`; the field allow-list is documented at",
+        f"the top of that file and in [docs/project-pulse.md]({base}/blob/main/docs/project-pulse.md).",
+        "",
+        "</details>",
     ]
     return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Rendering: the card (pure SVG, one file per colour scheme)
+# ---------------------------------------------------------------------------
+
+CARD_WIDTH = 880
+CARD_HEIGHT = 432
+
+#: The same stacks GitHub's own interface uses, so the card reads as part of
+#: the page it is embedded in. An SVG shown through ``<img>`` cannot load a
+#: web font, and must not try.
+_FONT = "-apple-system,BlinkMacSystemFont,'Segoe UI','Noto Sans',Helvetica,Arial,sans-serif"
+_MONO = "ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,'Liberation Mono',monospace"
+
+THEMES: dict[str, dict[str, str]] = {
+    "light": {
+        "bg": "#ffffff",
+        "border": "#d0d7de",
+        "tile": "#f6f8fa",
+        "fg": "#1f2328",
+        "muted": "#656d76",
+        "faint": "#afb8c1",
+        "track": "#d8dee4",
+        "green": "#1a7f37",
+        "green_fill": "#2da44e",
+        "purple": "#8250df",
+        "blue": "#0969da",
+        "orange": "#bc4c00",
+    },
+    "dark": {
+        "bg": "#0d1117",
+        "border": "#30363d",
+        "tile": "#161b22",
+        "fg": "#e6edf3",
+        "muted": "#8b949e",
+        "faint": "#484f58",
+        "track": "#30363d",
+        "green": "#3fb950",
+        "green_fill": "#3fb950",
+        "purple": "#a371f7",
+        "blue": "#58a6ff",
+        "orange": "#d29922",
+    },
+}
+
+
+def _esc(value: Any) -> str:
+    return _xml_escape(str(value), {'"': "&quot;"})
+
+
+def _num(value: float) -> str:
+    """Coordinate formatting: one decimal, no ``-0.0``, no float noise."""
+    text = f"{value:.1f}"
+    return "0.0" if text == "-0.0" else text
+
+
+def _polyline(values: list[float], x: float, y: float, width: float, height: float) -> str:
+    """Points of a sparkline through *values*, left to right, in a box."""
+    if len(values) < 2:
+        return ""
+    low, high = min(values), max(values)
+    span = (high - low) or 1.0
+    step = width / (len(values) - 1)
+    return " ".join(
+        f"{_num(x + step * i)},{_num(y + height - height * (value - low) / span)}" for i, value in enumerate(values)
+    )
+
+
+def _delta(current: float | None, previous: float | None, *, lower_is_better: bool | None, fmt: Any) -> tuple[str, str]:
+    """``(text, colour-key)`` for a week-over-week change, or ``("", "")``."""
+    if current is None or previous is None:
+        return "", ""
+    diff = current - previous
+    if abs(diff) < 0.05:
+        return "no change vs last week", "muted"
+    arrow = "▲" if diff > 0 else "▼"
+    text = f"{arrow} {fmt(abs(diff))} vs last week"
+    if lower_is_better is None:
+        return text, "muted"
+    improved = (diff < 0) == lower_is_better
+    return text, "green" if improved else "orange"
+
+
+def _card_style(c: dict[str, str], ring_offset: float) -> str:
+    return (
+        "<style>"
+        f"text{{font-family:{_FONT};fill:{c['fg']}}}"
+        ".mono{font-family:" + _MONO + "}"
+        ".muted{fill:" + c["muted"] + "}"
+        ".green{fill:" + c["green"] + "}"
+        ".orange{fill:" + c["orange"] + "}"
+        "@keyframes rise{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:none}}"
+        "@keyframes grow{from{transform:scaleX(0)}to{transform:scaleX(1)}}"
+        "@keyframes draw{to{stroke-dashoffset:0}}"
+        f"@keyframes ring{{to{{stroke-dashoffset:{_num(ring_offset)}}}}}"
+        ".rise{animation:rise .6s cubic-bezier(.2,.7,.2,1) both}"
+        ".d1{animation-delay:.05s}.d2{animation-delay:.12s}.d3{animation-delay:.19s}.d4{animation-delay:.26s}"
+        ".d5{animation-delay:.33s}.d6{animation-delay:.4s}"
+        ".grow{transform-box:fill-box;transform-origin:left center;"
+        "animation:grow .9s cubic-bezier(.2,.7,.2,1) both .35s}"
+        ".spark{fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;"
+        "stroke-dasharray:600;stroke-dashoffset:600;animation:draw 1.4s ease-out forwards .45s}"
+        ".pulse{fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;"
+        "stroke-dasharray:120;stroke-dashoffset:120;animation:draw 1.2s ease-out forwards .1s}"
+        ".ring{fill:none;stroke-linecap:round;animation:ring 1.3s cubic-bezier(.2,.7,.2,1) forwards .4s}"
+        "@media (prefers-reduced-motion:reduce){*{animation:none!important;stroke-dashoffset:0!important}"
+        f".ring{{stroke-dashoffset:{_num(ring_offset)}!important}}}}"
+        "</style>"
+    )
+
+
+def _tile(
+    c: dict[str, str],
+    x: int,
+    y: int,
+    width: int,
+    height: int,
+    delay: str,
+    label: str,
+    value: str,
+    unit: str,
+    caption: str,
+    delta: tuple[str, str],
+    extra: str = "",
+) -> str:
+    value_width = 17.5 * len(value)
+    text, colour = delta
+    parts = [
+        f'<g class="rise {delay}">',
+        f'<rect x="{x}" y="{y}" width="{width}" height="{height}" rx="8" fill="{c["tile"]}" stroke="{c["border"]}"/>',
+        f'<text x="{x + 16}" y="{y + 24}" font-size="12" class="muted">{_esc(label)}</text>',
+        f'<text x="{x + 16}" y="{y + 64}" font-size="30" font-weight="600" class="mono">{_esc(value)}</text>',
+    ]
+    if unit:
+        parts.append(
+            f'<text x="{_num(x + 20 + value_width)}" y="{y + 64}" font-size="14" class="muted">{_esc(unit)}</text>'
+        )
+    parts.append(f'<text x="{x + 16}" y="{y + 84}" font-size="11" class="muted">{_esc(caption)}</text>')
+    if text:
+        parts.append(f'<text x="{x + 16}" y="{y + 100}" font-size="11" class="{colour}">{_esc(text)}</text>')
+    parts.append(extra)
+    parts.append("</g>")
+    return "".join(parts)
+
+
+def _chip(c: dict[str, str], x: int, y: int, text: str, delay: str) -> tuple[str, int]:
+    width = round(len(text) * 6.5 + 20)
+    svg = (
+        f'<g class="rise {delay}">'
+        f'<rect x="{x}" y="{y}" width="{width}" height="28" rx="6" fill="{c["tile"]}" stroke="{c["border"]}"/>'
+        f'<text x="{x + 10}" y="{y + 18}" font-size="11">{_esc(text)}</text>'
+        "</g>"
+    )
+    return svg, width
+
+
+def render_svg(data: dict[str, Any], history: dict[str, Any] | None = None, theme: str = "light") -> str:
+    """Render the card as SVG. Pure: same input and theme, byte-identical output.
+
+    The card is a picture of the same allow-listed fields the page carries,
+    styled to sit inside GitHub's own interface in either colour scheme. It
+    animates once on load with CSS only (no script, nothing loaded from
+    anywhere), and holds still for readers who prefer reduced motion.
+    """
+    if theme not in THEMES:
+        raise PulseError(f"unknown card theme {theme!r}; expected one of {', '.join(sorted(THEMES))}")
+    c = THEMES[theme]
+    repo = str(data["repo"])
+    generated = str(data["generated_at"])
+    windows = data["windows"]
+    classes = data["merged_prs_by_author_class"]
+    grab = data["grabbable"]
+    adapters = data["adapters"]
+    release = data["latest_release"]
+    l10n = data["readme_translations"]
+    rows = _trend_rows(data, history)
+    previous = rows[-2] if len(rows) >= 2 else None
+
+    lag = data["pr_merge_lag_hours_median"]
+    within = data["pr_merged_within_24h_pct"]
+    merged = int(data["pr_merged_count"])
+    ring_radius = 26.0
+    circumference = 2 * math.pi * ring_radius
+    ring_offset = circumference * (1 - (within or 0.0) / 100.0)
+
+    title = f"Project pulse for {repo}, {generated}"
+    desc = (
+        f"Median merge lag {_hours(lag)}; {_pct(within)} merged within 24 hours; {merged} merged pull requests "
+        f"in {windows['pr_days']} days; {grab['up_for_grabs_unassigned']} unassigned up-for-grabs issues."
+    )
+    out: list[str] = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{CARD_WIDTH}" height="{CARD_HEIGHT}" '
+        f'viewBox="0 0 {CARD_WIDTH} {CARD_HEIGHT}" role="img" aria-labelledby="pulse-title pulse-desc">',
+        f'<title id="pulse-title">{_esc(title)}</title>',
+        f'<desc id="pulse-desc">{_esc(desc)}</desc>',
+        _card_style(c, ring_offset),
+        f'<rect x="0.5" y="0.5" width="{CARD_WIDTH - 1}" height="{CARD_HEIGHT - 1}" rx="12" '
+        f'fill="{c["bg"]}" stroke="{c["border"]}"/>',
+    ]
+
+    # Header: a heartbeat trace that draws itself, the title, the repository.
+    out.append(
+        f'<polyline class="pulse" stroke="{c["green"]}" '
+        'points="24,34 34,34 39,22 45,46 51,28 56,34 68,34"/>'
+        f'<text x="80" y="39" font-size="16" font-weight="600">Project pulse</text>'
+        f'<text x="{CARD_WIDTH - 24}" y="39" font-size="12" text-anchor="end" class="muted">'
+        f"{_esc(repo)} · {_esc(generated)}</text>"
+    )
+
+    # Row 1: four tiles.
+    tile_y, tile_h, tile_w, gap = 60, 140, 196, 16
+    xs = [24 + i * (tile_w + gap) for i in range(4)]
+
+    # Tile 1: median merge lag with a sparkline of the recent weeks.
+    lag_series = [
+        float(row["pr_merge_lag_hours_median"]) for row in rows if row.get("pr_merge_lag_hours_median") is not None
+    ]
+    lag_value, lag_unit = _split_unit(_hours(lag))
+    spark = ""
+    points = _polyline(lag_series, xs[0] + 16, tile_y + 110, 160, 16)
+    if points:
+        last_x, last_y = points.rsplit(" ", 1)[-1].split(",")
+        spark = (
+            f'<polyline class="spark" stroke="{c["green"]}" points="{points}"/>'
+            f'<circle cx="{last_x}" cy="{last_y}" r="3" fill="{c["green"]}"/>'
+        )
+    out.append(
+        _tile(
+            c,
+            xs[0],
+            tile_y,
+            tile_w,
+            tile_h,
+            "d1",
+            "Median merge lag",
+            lag_value,
+            lag_unit,
+            f"PR opened → merged, {windows['pr_days']} d",
+            _delta(
+                lag, previous.get("pr_merge_lag_hours_median") if previous else None, lower_is_better=True, fmt=_hours
+            ),
+            spark,
+        )
+    )
+
+    # Tile 2: share merged within 24 hours, as a ring gauge.
+    ring_cx, ring_cy = xs[1] + tile_w - 40, tile_y + 70
+    ring = (
+        f'<circle cx="{ring_cx}" cy="{ring_cy}" r="{_num(ring_radius)}" fill="none" '
+        f'stroke="{c["track"]}" stroke-width="6"/>'
+        f'<circle class="ring" cx="{ring_cx}" cy="{ring_cy}" r="{_num(ring_radius)}" '
+        f'stroke="{c["green_fill"]}" stroke-width="6" '
+        f'stroke-dasharray="{_num(circumference)}" stroke-dashoffset="{_num(circumference)}" '
+        f'transform="rotate(-90 {ring_cx} {ring_cy})"/>'
+    )
+    within_value, within_unit = _split_unit(_pct(within))
+    out.append(
+        _tile(
+            c,
+            xs[1],
+            tile_y,
+            tile_w,
+            tile_h,
+            "d2",
+            "Merged within 24 h",
+            within_value,
+            within_unit,
+            f"of merged PRs, {windows['pr_days']} d",
+            _delta(
+                within,
+                previous.get("pr_merged_within_24h_pct") if previous else None,
+                lower_is_better=False,
+                fmt=lambda v: f"{v:.1f} pt",
+            ),
+            ring,
+        )
+    )
+
+    # Tile 3: merged pull requests with weekly bars.
+    merged_series = [int(row["pr_merged_count"]) for row in rows]
+    bars = ""
+    if len(merged_series) >= 2:
+        top = max(merged_series) or 1
+        slot = 160 / len(merged_series)
+        bar_w = max(int(slot) - 4, 4)
+        pieces = []
+        for i, count in enumerate(merged_series):
+            h = max(round(16 * count / top, 1), 1.0)
+            bx = xs[2] + 16 + slot * i
+            fill = c["blue"] if i == len(merged_series) - 1 else c["track"]
+            pieces.append(
+                f'<rect x="{_num(bx)}" y="{_num(tile_y + 126 - h)}" width="{bar_w}" height="{_num(h)}" '
+                f'rx="1.5" fill="{fill}"/>'
+            )
+        bars = "".join(pieces)
+    out.append(
+        _tile(
+            c,
+            xs[2],
+            tile_y,
+            tile_w,
+            tile_h,
+            "d3",
+            "Merged pull requests",
+            str(merged),
+            "",
+            f"last {windows['pr_days']} d · {data['issues_closed_count']} issues closed",
+            _delta(
+                float(merged),
+                float(previous["pr_merged_count"]) if previous else None,
+                lower_is_better=None,
+                fmt=lambda v: f"{round(v)}",
+            ),
+            bars,
+        )
+    )
+
+    # Tile 4: what a newcomer can take today.
+    open_count = int(grab["up_for_grabs_open"])
+    unassigned = int(grab["up_for_grabs_unassigned"])
+    share = (unassigned / open_count) if open_count else 0.0
+    grab_bar = (
+        f'<rect x="{xs[3] + 16}" y="{tile_y + 114}" width="160" height="8" rx="4" fill="{c["track"]}"/>'
+        f'<rect class="grow" x="{xs[3] + 16}" y="{tile_y + 114}" width="{_num(160 * share)}" height="8" '
+        f'rx="4" fill="{c["purple"]}"/>'
+    )
+    out.append(
+        _tile(
+            c,
+            xs[3],
+            tile_y,
+            tile_w,
+            tile_h,
+            "d4",
+            "Free to pick up",
+            str(unassigned),
+            "",
+            f"unassigned of {open_count} up-for-grabs",
+            (f"{grab['good_first_issue_unassigned']} good first issues unassigned", "muted"),
+            grab_bar,
+        )
+    )
+
+    # Row 2: who merges what (stacked bar) and the issue side.
+    row_y, row_h = 216, 104
+    left_w, right_x = 520, 24 + 520 + 16
+    out.append(
+        f'<g class="rise d5">'
+        f'<rect x="24" y="{row_y}" width="{left_w}" height="{row_h}" rx="8" fill="{c["tile"]}" stroke="{c["border"]}"/>'
+        f'<text x="40" y="{row_y + 26}" font-size="12" class="muted">'
+        f"Merged pull requests by author class · {windows['pr_days']} d</text>"
+    )
+    total = sum(int(classes[k]) for k in (CLASS_OUTSIDE, CLASS_MAINTAINER, CLASS_AUTOMATION))
+    inner = left_w - 32
+    segments = (
+        (CLASS_OUTSIDE, "Outside", c["purple"]),
+        (CLASS_MAINTAINER, "Maintainer", c["blue"]),
+        (CLASS_AUTOMATION, "Automation", c["faint"]),
+    )
+    cursor = 40.0
+    out.append(f'<rect x="40" y="{row_y + 42}" width="{inner}" height="14" rx="7" fill="{c["track"]}"/>')
+    for key, _label, colour in segments:
+        count = int(classes[key])
+        width = inner * count / total if total else 0.0
+        if width > 0:
+            out.append(
+                f'<rect class="grow" x="{_num(cursor)}" y="{row_y + 42}" width="{_num(width)}" height="14" '
+                f'fill="{colour}"/>'
+            )
+        cursor += width
+    out.append(
+        f'<rect x="40" y="{row_y + 42}" width="{inner}" height="14" rx="7" fill="none" '
+        f'stroke="{c["tile"]}" stroke-width="3"/>'
+    )
+    legend_x = 40
+    for key, label, colour in segments:
+        count = int(classes[key])
+        pct = f"{100.0 * count / total:.1f}%" if total else "n/a"
+        text = f"{label} {count} · {pct}"
+        out.append(
+            f'<circle cx="{legend_x + 5}" cy="{row_y + 79}" r="5" fill="{colour}"/>'
+            f'<text x="{legend_x + 16}" y="{row_y + 83}" font-size="11">{_esc(text)}</text>'
+        )
+        legend_x += int(len(text) * 6.4) + 30
+    out.append("</g>")
+
+    close_value, close_unit = _split_unit(_hours(data["issue_close_lag_hours_median"]))
+    out.append(
+        f'<g class="rise d6">'
+        f'<rect x="{right_x}" y="{row_y}" width="{CARD_WIDTH - 24 - right_x}" height="{row_h}" rx="8" '
+        f'fill="{c["tile"]}" stroke="{c["border"]}"/>'
+        f'<text x="{right_x + 16}" y="{row_y + 26}" font-size="12" class="muted">'
+        f"Issues · {windows['issue_days']} d</text>"
+        f'<text x="{right_x + 16}" y="{row_y + 62}" font-size="24" font-weight="600" class="mono">'
+        f"{_esc(close_value)}</text>"
+        f'<text x="{_num(right_x + 20 + 14 * len(close_value))}" y="{row_y + 62}" font-size="13" class="muted">'
+        f"{_esc(close_unit)}</text>"
+        f'<text x="{right_x + 16}" y="{row_y + 83}" font-size="11" class="muted">median opened → closed</text>'
+        f'<text x="{right_x + 156}" y="{row_y + 62}" font-size="24" font-weight="600" class="mono">'
+        f"{data['distinct_outside_authors']}</text>"
+        f'<text x="{right_x + 156}" y="{row_y + 83}" font-size="11" class="muted">'
+        f"outside authors, {windows['outside_author_days']} d</text>"
+        "</g>"
+    )
+
+    # Row 3: project state chips.
+    chip_y, chip_x = 336, 24
+    chips = [
+        f"{data['commits_main_7d']} commits · {windows['commit_days']} d",
+        f"last commit {data['days_since_last_commit']} d ago",
+        f"{adapters['registered']} adapters · {adapters['selectable']} selectable",
+        f"{release['tag']} · {release['date']}",
+        f"READMEs {l10n['in_sync']}/{l10n['total']} in sync",
+    ]
+    for i, text in enumerate(chips):
+        svg, width = _chip(c, chip_x, chip_y, text, f"d{min(i + 2, 6)}")
+        out.append(svg)
+        chip_x += width + 8
+
+    out.append(
+        f'<text x="24" y="{CARD_HEIGHT - 20}" font-size="11" class="muted">'
+        "Counts only — no logins, no per-person ranking. Source: scripts/project_pulse.py"
+        "</text>"
+    )
+    out.append("</svg>\n")
+    return "".join(out)
 
 
 # ---------------------------------------------------------------------------
@@ -518,6 +1116,16 @@ def _token() -> str:
     if not token:
         raise PulseError("GH_TOKEN or GITHUB_TOKEN must be set")
     return token
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise PulseError(f"{path} is unreadable: {exc}") from exc
+    if not isinstance(data, dict):
+        raise PulseError(f"{path} is not a JSON object")
+    return data
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -534,8 +1142,20 @@ def main(argv: list[str] | None = None) -> int:
         help="repository checkout used for the adapter and translation counts",
     )
 
+    history_parser = sub.add_parser("history", help="upsert this collection into history.json")
+    history_parser.add_argument("input", type=Path, help="path to a pulse.json produced by `collect`")
+    history_parser.add_argument("--history", required=True, type=Path, help="history.json to create or update")
+
     render_parser = sub.add_parser("render", help="render a collected pulse.json to Markdown on stdout")
     render_parser.add_argument("input", type=Path, help="path to a pulse.json produced by `collect`")
+    render_parser.add_argument("--history", type=Path, help="history.json for the trend section and sparklines")
+    render_parser.add_argument("--image-base", help="URL prefix the page loads the card from")
+    render_parser.add_argument("--svg-dir", type=Path, help="also write pulse.svg and pulse-dark.svg here")
+
+    svg_parser = sub.add_parser("render-svg", help="render the card to SVG on stdout")
+    svg_parser.add_argument("input", type=Path, help="path to a pulse.json produced by `collect`")
+    svg_parser.add_argument("--history", type=Path, help="history.json for the sparklines")
+    svg_parser.add_argument("--theme", choices=sorted(THEMES), default="light")
 
     args = parser.parse_args(argv)
     try:
@@ -545,8 +1165,22 @@ def main(argv: list[str] | None = None) -> int:
             # leaves no half-collected file for `render` to publish.
             args.out.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
             print(f"collected {len(data)} fields for {args.repo} -> {args.out}", file=sys.stderr)
+        elif args.stage == "history":
+            history = append_history(load_history(args.history), _read_json(args.input))
+            args.history.write_text(json.dumps(history, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            print(f"history now holds {len(history['weeks'])} week(s) -> {args.history}", file=sys.stderr)
+        elif args.stage == "render":
+            data = _read_json(args.input)
+            history = load_history(args.history) if args.history else None
+            if args.svg_dir:
+                args.svg_dir.mkdir(parents=True, exist_ok=True)
+                (args.svg_dir / "pulse.svg").write_text(render_svg(data, history, "light"), encoding="utf-8")
+                (args.svg_dir / "pulse-dark.svg").write_text(render_svg(data, history, "dark"), encoding="utf-8")
+            sys.stdout.write(render(data, history, args.image_base))
         else:
-            sys.stdout.write(render(json.loads(args.input.read_text(encoding="utf-8"))))
+            data = _read_json(args.input)
+            history = load_history(args.history) if args.history else None
+            sys.stdout.write(render_svg(data, history, args.theme))
     except PulseError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2

--- a/tests/unit/test_project_pulse.py
+++ b/tests/unit/test_project_pulse.py
@@ -1,18 +1,23 @@
 """Unit tests for ``scripts/project_pulse.py``.
 
-Three properties carry the weight here, because the page is published
+Four properties carry the weight here, because the page is published
 unattended every week into an issue everyone can read:
 
-* ``render`` is a pure function -- identical input, byte-identical output.
-  The weekly job upserts one issue body, so a renderer that reorders a dict
-  or formats a float differently would rewrite the body on every run and
-  bury real movement in the noise.
+* ``render`` and ``render_svg`` are pure functions -- identical input,
+  byte-identical output. The weekly job upserts one issue body and pushes
+  the card to a data branch, so a renderer that reorders a dict or formats a
+  float differently would rewrite both on every run and bury real movement
+  in the noise.
 * ``collect`` fails closed. A page built from a partly-failed collection
   would publish zeros that read as "quiet week" instead of "the query
   broke", so any API failure must abort with a non-zero exit and leave no
-  output file behind.
-* The rendered page carries aggregates only: no individual logins beyond the
-  two documented account labels, and no e-mail addresses.
+  output file behind. The history is held to the same standard: a corrupt
+  file is an error, never a silently restarted series.
+* The rendered page and card carry aggregates only: no individual logins
+  beyond the two documented account labels, and no e-mail addresses. The
+  history is a strict subset of the same allow-list.
+* The card loads nothing from anywhere: no script, no font, no image, no
+  URL. It is a picture of the numbers, not a web page.
 """
 
 from __future__ import annotations
@@ -21,6 +26,7 @@ import importlib.util
 import itertools
 import json
 import re
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Any
 
@@ -38,12 +44,50 @@ FIXTURE = _REPO_ROOT / "tests" / "fixtures" / "ci" / "project_pulse.json"
 #: count. Keep in step with the allow-list at the top of the script.
 DOCUMENTED_ACCOUNTS = frozenset({"chernistry", "bernstein-orchestrator"})
 
+#: The collected fields, i.e. the allow-list as it appears on disk.
+ALLOW_LIST = frozenset(
+    {
+        "adapters",
+        "commits_main_7d",
+        "days_since_last_commit",
+        "distinct_outside_authors",
+        "generated_at",
+        "grabbable",
+        "issue_close_lag_hours_median",
+        "issues_closed_count",
+        "latest_release",
+        "merged_prs_by_author_class",
+        "pr_merge_lag_hours_median",
+        "pr_merged_count",
+        "pr_merged_within_24h_pct",
+        "readme_translations",
+        "repo",
+        "windows",
+    }
+)
+
 _LOGIN_RE = re.compile(r"@([A-Za-z0-9](?:[A-Za-z0-9-]{0,38}))")
 _EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+_SVG_NS = "{http://www.w3.org/2000/svg}"
 
 
 def _fixture() -> dict[str, Any]:
     return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def _history(weeks: int) -> dict[str, Any]:
+    """*weeks* earlier collections, one per week, with moving numbers."""
+    history: dict[str, Any] = {"weeks": []}
+    for i in range(weeks, 0, -1):
+        data = _fixture()
+        data["generated_at"] = (
+            (_MOD.datetime(2026, 9, 2, tzinfo=_MOD.UTC) - _MOD.timedelta(days=7 * i)).date().isoformat()
+        )
+        data["pr_merged_count"] = 900 + 13 * i
+        data["pr_merge_lag_hours_median"] = 3.0 + 0.4 * i
+        data["pr_merged_within_24h_pct"] = 80.0 + i
+        history = _MOD.append_history(history, data)
+    return history
 
 
 # ---------------------------------------------------------------------------
@@ -76,6 +120,16 @@ def test_render_carries_no_timestamp_beyond_the_collected_date() -> None:
     assert not re.search(r"\d{2}:\d{2}:\d{2}", page), "a wall-clock time would change the body on every run"
 
 
+def test_card_is_byte_identical_across_calls_and_themes_differ() -> None:
+    """The card is as pure as the page, in both colour schemes."""
+    light = _MOD.render_svg(_fixture(), _history(7), "light")
+    assert light == _MOD.render_svg(_fixture(), _history(7), "light")
+    dark = _MOD.render_svg(_fixture(), _history(7), "dark")
+    assert dark == _MOD.render_svg(_fixture(), _history(7), "dark")
+    assert light != dark
+    assert not re.search(r"\d{2}:\d{2}:\d{2}", light)
+
+
 def test_headline_states_the_median_merge_lag_and_links_grabbable_issues() -> None:
     """The page answers 'will my PR be reviewed?' before anything else."""
     page = _MOD.render(_fixture())
@@ -93,6 +147,113 @@ def test_absent_medians_render_as_not_available_rather_than_zero() -> None:
     page = _MOD.render(data)
     assert "n/a" in page
     assert "0.0 h" not in page
+    card = _MOD.render_svg(data)
+    assert "n/a" in card
+    assert "0.0 h" not in card
+    ET.fromstring(card)
+
+
+# ---------------------------------------------------------------------------
+# The page embeds the card and charts the history
+# ---------------------------------------------------------------------------
+
+
+def test_page_embeds_the_card_for_both_colour_schemes() -> None:
+    """One ``<picture>``, light and dark, cache-busted by the collection date."""
+    page = _MOD.render(_fixture())
+    base = f"https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/{_MOD.DATA_BRANCH}"
+    assert "<picture>" in page
+    assert f'srcset="{base}/pulse-dark.svg?v=2026-09-02"' in page
+    assert f'src="{base}/pulse.svg?v=2026-09-02"' in page
+    assert 'media="(prefers-color-scheme: dark)"' in page
+
+
+def test_page_honours_an_explicit_image_base() -> None:
+    page = _MOD.render(_fixture(), image_base="https://example.invalid/cards/")
+    assert 'src="https://example.invalid/cards/pulse.svg?v=2026-09-02"' in page
+
+
+def test_page_without_history_has_no_trend_section() -> None:
+    """A first run has nothing to chart and must not show an empty chart."""
+    page = _MOD.render(_fixture())
+    assert "## Trend" not in page
+    assert "xychart" not in page
+
+
+def test_page_with_history_charts_the_weekly_series() -> None:
+    """The trend charts the last weeks, oldest to newest, current week last."""
+    page = _MOD.render(_fixture(), _history(7))
+    assert "## Trend" in page
+    assert page.count("xychart-beta") == 2
+    bars = re.search(r"bar \[([^\]]+)\]", page)
+    assert bars is not None
+    values = [int(v) for v in bars.group(1).split(", ")]
+    assert len(values) == _MOD.TREND_WEEKS
+    assert values[-1] == _fixture()["pr_merged_count"]
+    assert values[0] == 900 + 13 * 7
+
+
+def test_page_charts_author_classes_with_counts_only() -> None:
+    page = _MOD.render(_fixture())
+    assert "pie showData" in page
+    assert '"Outside contributors" : 11' in page
+    assert '"Maintainer" : 920' in page
+
+
+# ---------------------------------------------------------------------------
+# The card
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("theme", ["light", "dark"])
+def test_card_is_well_formed_svg(theme: str) -> None:
+    root = ET.fromstring(_MOD.render_svg(_fixture(), _history(7), theme))
+    assert root.tag == f"{_SVG_NS}svg"
+    assert root.get("viewBox") == f"0 0 {_MOD.CARD_WIDTH} {_MOD.CARD_HEIGHT}"
+    assert root.get("role") == "img"
+    assert root.find(f"{_SVG_NS}title") is not None
+    assert root.find(f"{_SVG_NS}desc") is not None
+
+
+def test_card_loads_nothing_and_runs_nothing() -> None:
+    """A picture of the numbers: no script, no fetch, no external resource."""
+    card = _MOD.render_svg(_fixture(), _history(7))
+    stripped = card.replace('xmlns="http://www.w3.org/2000/svg"', "")
+    assert "http://" not in stripped
+    assert "https://" not in stripped
+    for forbidden in ("<script", "<image", "<foreignObject", "@import", "url(", "<a ", "xlink:href"):
+        assert forbidden not in card, f"card must not contain {forbidden!r}"
+
+
+def test_card_sparklines_need_a_history() -> None:
+    """Without earlier weeks there is no line to draw and none is drawn."""
+    bare = _MOD.render_svg(_fixture())
+    assert 'class="spark"' not in bare
+    assert "vs last week" not in bare
+    trended = _MOD.render_svg(_fixture(), _history(7))
+    assert 'class="spark"' in trended
+    points = re.search(r'class="spark"[^>]*points="([^"]+)"', trended)
+    assert points is not None
+    assert len(points.group(1).split(" ")) == _MOD.TREND_WEEKS
+    assert "vs last week" in trended
+
+
+def test_card_rejects_an_unknown_theme() -> None:
+    with pytest.raises(_MOD.PulseError, match="theme"):
+        _MOD.render_svg(_fixture(), None, "sepia")
+
+
+def test_week_over_week_delta_reads_direction_against_what_is_better() -> None:
+    """A shorter lag is an improvement; a higher 24-hour share is too."""
+    assert _MOD._delta(3.0, 4.0, lower_is_better=True, fmt=_MOD._hours) == ("▼ 1.0 h vs last week", "green")
+    assert _MOD._delta(5.0, 4.0, lower_is_better=True, fmt=_MOD._hours) == ("▲ 1.0 h vs last week", "orange")
+    assert _MOD._delta(90.0, 88.0, lower_is_better=False, fmt=lambda v: f"{v:.1f} pt") == (
+        "▲ 2.0 pt vs last week",
+        "green",
+    )
+    assert _MOD._delta(4.0, 4.02, lower_is_better=True, fmt=_MOD._hours) == ("no change vs last week", "muted")
+    assert _MOD._delta(None, 4.0, lower_is_better=True, fmt=_MOD._hours) == ("", "")
+    assert _MOD._delta(4.0, None, lower_is_better=True, fmt=_MOD._hours) == ("", "")
 
 
 # ---------------------------------------------------------------------------
@@ -102,14 +263,23 @@ def test_absent_medians_render_as_not_available_rather_than_zero() -> None:
 
 def test_rendered_page_names_no_undocumented_account() -> None:
     """No ``@login`` other than the two documented account labels."""
-    page = _MOD.render(_fixture())
+    page = _MOD.render(_fixture(), _history(7))
     found = {match.lower() for match in _LOGIN_RE.findall(page)}
     assert found <= DOCUMENTED_ACCOUNTS, f"page names undocumented account(s): {sorted(found - DOCUMENTED_ACCOUNTS)}"
 
 
 def test_rendered_page_carries_no_email_address() -> None:
-    page = _MOD.render(_fixture())
+    page = _MOD.render(_fixture(), _history(7))
     assert not _EMAIL_RE.findall(page)
+
+
+def test_rendered_card_names_no_account_and_no_email() -> None:
+    """The card's text carries no ``@login`` and no address (CSS at-rules aside)."""
+    for theme in ("light", "dark"):
+        card = _MOD.render_svg(_fixture(), _history(7), theme)
+        text = re.sub(r"<style>.*?</style>", "", card, flags=re.S)
+        assert not _LOGIN_RE.findall(text)
+        assert not _EMAIL_RE.findall(text)
 
 
 def test_collected_fields_stay_inside_the_allow_list() -> None:
@@ -118,25 +288,73 @@ def test_collected_fields_stay_inside_the_allow_list() -> None:
     A new top-level key means someone widened what gets published without
     widening the allow-list comment the page's privacy claim rests on.
     """
-    expected = {
-        "adapters",
-        "commits_main_7d",
-        "days_since_last_commit",
-        "distinct_outside_authors",
-        "generated_at",
-        "grabbable",
-        "issue_close_lag_hours_median",
-        "issues_closed_count",
-        "latest_release",
-        "merged_prs_by_author_class",
-        "pr_merge_lag_hours_median",
-        "pr_merged_count",
-        "pr_merged_within_24h_pct",
-        "readme_translations",
-        "repo",
-        "windows",
-    }
-    assert set(_fixture()) == expected
+    assert set(_fixture()) == ALLOW_LIST
+
+
+def test_history_rows_are_a_subset_of_the_allow_list() -> None:
+    """The history introduces no field the page could not already show."""
+    row = _MOD.history_row(_fixture())
+    assert set(row) <= ALLOW_LIST
+    assert set(_MOD.HISTORY_FIELDS) < ALLOW_LIST
+
+
+# ---------------------------------------------------------------------------
+# History: one row per collection date, capped, never silently restarted
+# ---------------------------------------------------------------------------
+
+
+def test_history_upsert_replaces_the_same_date_and_keeps_order() -> None:
+    history = _history(3)
+    dates = [row["generated_at"] for row in history["weeks"]]
+    assert dates == sorted(dates)
+    again = _MOD.append_history(history, _fixture())
+    assert len(again["weeks"]) == 4
+    twice = _MOD.append_history(again, _fixture())
+    assert len(twice["weeks"]) == 4, "a re-run on the same date must replace its row, not duplicate it"
+    assert twice["weeks"][-1]["generated_at"] == "2026-09-02"
+
+
+def test_history_is_capped_to_the_documented_number_of_weeks() -> None:
+    history: dict[str, Any] = {"weeks": []}
+    for i in range(_MOD.HISTORY_KEEP_WEEKS + 5):
+        data = _fixture()
+        data["generated_at"] = (
+            (_MOD.datetime(2020, 1, 6, tzinfo=_MOD.UTC) + _MOD.timedelta(days=7 * i)).date().isoformat()
+        )
+        history = _MOD.append_history(history, data)
+    assert len(history["weeks"]) == _MOD.HISTORY_KEEP_WEEKS
+
+
+def test_history_cli_creates_then_updates_the_file(tmp_path: Path) -> None:
+    path = tmp_path / "history.json"
+    assert _MOD.main(["history", str(FIXTURE), "--history", str(path)]) == 0
+    assert len(json.loads(path.read_text(encoding="utf-8"))["weeks"]) == 1
+    assert _MOD.main(["history", str(FIXTURE), "--history", str(path)]) == 0
+    assert len(json.loads(path.read_text(encoding="utf-8"))["weeks"]) == 1
+
+
+def test_history_cli_refuses_a_corrupt_file(tmp_path: Path) -> None:
+    """A history that does not parse is an error, not a fresh start.
+
+    Restarting the series on a read error would, on push, erase two years
+    of weekly rows behind a green run.
+    """
+    path = tmp_path / "history.json"
+    path.write_text("{not json", encoding="utf-8")
+    assert _MOD.main(["history", str(FIXTURE), "--history", str(path)]) == 2
+    assert path.read_text(encoding="utf-8") == "{not json"
+    path.write_text(json.dumps({"weeks": [{"no_date": 1}]}), encoding="utf-8")
+    assert _MOD.main(["history", str(FIXTURE), "--history", str(path)]) == 2
+
+
+def test_render_cli_writes_the_page_and_both_cards(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    out = tmp_path / "out"
+    assert _MOD.main(["render", str(FIXTURE), "--svg-dir", str(out)]) == 0
+    page = capsys.readouterr().out
+    assert page.startswith("# Project pulse\n")
+    assert page == _MOD.render(_fixture())
+    assert (out / "pulse.svg").read_text(encoding="utf-8") == _MOD.render_svg(_fixture(), None, "light")
+    assert (out / "pulse-dark.svg").read_text(encoding="utf-8") == _MOD.render_svg(_fixture(), None, "dark")
 
 
 # ---------------------------------------------------------------------------
@@ -256,10 +474,10 @@ def test_workflow_runs_weekly_and_on_demand() -> None:
 
 
 def test_workflow_asks_for_no_more_than_it_needs() -> None:
-    """Default-deny at the top, read + issues:write on the one job."""
+    """Default-deny at the top; the one job writes the data branch and the issue."""
     doc = _workflow()
     assert doc["permissions"] == {}
-    assert doc["jobs"]["pulse"]["permissions"] == {"contents": "read", "issues": "write"}
+    assert doc["jobs"]["pulse"]["permissions"] == {"contents": "write", "issues": "write"}
 
 
 def test_workflow_uses_only_the_built_in_token() -> None:
@@ -267,15 +485,27 @@ def test_workflow_uses_only_the_built_in_token() -> None:
     assert "secrets." not in WORKFLOW.read_text(encoding="utf-8")
 
 
-def test_workflow_does_not_commit_the_generated_page() -> None:
-    """Generated output is upserted into an issue and uploaded, never pushed."""
+def test_workflow_publishes_generated_output_only_to_the_data_branch() -> None:
+    """Generated output goes to the data branch and the artifact, never to main.
+
+    The branch name is pinned in one place per side -- ``DATA_BRANCH`` in the
+    workflow and in the script -- and the two must agree, or the page would
+    embed a card from a branch the workflow never writes.
+    """
     body = WORKFLOW.read_text(encoding="utf-8")
-    assert "git push" not in body
-    assert "git commit" not in body
+    assert _workflow()["env"]["DATA_BRANCH"] == _MOD.DATA_BRANCH
+    assert "HEAD:refs/heads/${DATA_BRANCH}" in body
+    assert "--force" not in body
+    assert "HEAD:main" not in body
+    assert "refs/heads/main" not in body
     assert "upload-artifact" in body
 
 
-def test_documented_page_exists_and_is_in_the_nav() -> None:
+def test_documented_page_exists_embeds_the_card_and_is_in_the_nav() -> None:
     doc_path = _REPO_ROOT / "docs" / "project-pulse.md"
     assert doc_path.is_file()
+    body = doc_path.read_text(encoding="utf-8")
+    assert "<picture>" in body
+    assert f"/{_MOD.DATA_BRANCH}/pulse.svg" in body
+    assert f"`{_MOD.DATA_BRANCH}` branch" in body
     assert "project-pulse.md" in (_REPO_ROOT / "mkdocs.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## What changes

The weekly pulse issue (#5334) carried ten numbers in tables and nothing else. The page is now rendered from one `pulse.json` into three shapes:

- **A card**: an SVG in a light and a dark variant, embedded through `<picture>` so the reader's colour scheme picks one. It draws itself once on load with CSS alone: no script, no font or image fetched from anywhere, still for readers who prefer reduced motion. A unit test asserts the card loads nothing.
- **A trend**: two Mermaid `xychart` blocks over the last eight weekly collections (merged pull requests per week, median merge lag), which GitHub renders inline. They appear once a second week exists.
- **The tables**, unchanged in content, for readers and tools that do not render images.

## The `project-pulse` branch

GitHub only shows an image it can fetch from a URL, so the workflow now commits the card, the page, `pulse.json` and `history.json` (one row per collection date, capped at two years) to a branch of its own. The branch carries no code, is never merged anywhere, and grows by one commit per week. The same files are still uploaded as a workflow artifact.

That is what the `contents: write` scope on the job is for. It is a deliberate widening from the previous `issues: write` only. `main` stays behind the repository ruleset (pull request and merge queue required), which this token cannot bypass, and the publish step is a plain push, not a force push: a data branch that moved since the fetch is rejected and the run fails rather than overwriting a week it never saw.

## What stays the same

- The allow-list of ten aggregates. `history.json` keeps a subset of them; a test pins that subset to the allow-list.
- The renderer is a pure function: same input, same bytes (tests cover the page and both cards).
- Counts, never people: a test asserts neither the page nor the card names an account or an address.
- Fail-closed collection.

## Tests

`tests/unit/test_project_pulse.py`: 42 tests, covering determinism, the picture embed, the trend gating, the history upsert and cap, the card's well-formedness and self-containment, the workflow's permissions and push target (no `--force`, never `main`), and the docs page.

## After merge

Dispatch the workflow once to create the branch and the first history row; the card in #5334 and on the docs page appears from that run on.
