### PR TITLE
schemas: publish the JSON Schema ids under bernstein.run

### DIFF
--- a/schemas/audit-multitenant-export-v1.json
+++ b/schemas/audit-multitenant-export-v1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://bernstein.alexchernysh.com/schemas/audit-multitenant-export-v1.json",
+  "$id": "https://bernstein.run/schemas/audit-multitenant-export-v1.json",
   "title": "Bernstein Multi-Tenant Audit Export",
   "description": "Versioned wire format for tenant-scoped HMAC-chained audit-log slices. The slice is locally re-chained over filtered events so an external auditor can replay-verify offline using only the operator's HMAC key. The chain_anchor + (optional) timestamp_proof together provide tamper evidence even without the key. References W3C Verifiable Credentials Data Model 2.0 conceptually; uses a custom schema because VC v2 is RDF/JSON-LD and heavy for line-oriented JSONL audit chains.",
   "type": "object",

--- a/schemas/audit-multitenant-export-v2.json
+++ b/schemas/audit-multitenant-export-v2.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://bernstein.alexchernysh.com/schemas/audit-multitenant-export-v2.json",
+  "$id": "https://bernstein.run/schemas/audit-multitenant-export-v2.json",
   "title": "Bernstein Multi-Tenant Audit Export (v2)",
   "description": "Versioned wire format for tenant-scoped HMAC-chained audit-log slices. v2 layers two opt-in cryptographic features on top of v1: (a) a verifiable RFC 3161 TimeStampToken - bernstein.core.security.rfc3161_verifier walks the TSA cert chain end-to-end, no longer deferred to operator toolchain - and (b) an Ed25519 signature over the bundle's head_sha256 ('head_signature' block) so a key-less auditor can authenticate the bundle's origin without sharing the operator's HMAC key. v1 readers tolerate v2 bundles by ignoring the additional 'head_signature' field - additionalProperties=true at the top level is intentional.",
   "type": "object",

--- a/schemas/audit-receipt-v1.json
+++ b/schemas/audit-receipt-v1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://bernstein.alexchernysh.com/schemas/audit-receipt-v1.json",
+  "$id": "https://bernstein.run/schemas/audit-receipt-v1.json",
   "title": "Bernstein Audit Receipt (v1)",
   "description": "Standard, offline-verifiable receipt projecting an HMAC-chained audit-log range into off-the-shelf envelope formats (COSE_Sign1 per RFC 9052, in-toto/DSSE, and an RFC 6962 style transparency receipt). The receipt is a projection, not new evidence: its subject digest IS the chain range head_sha256 (never independently recomputed). Every format binds that single subject, and the receipt embeds the re-chained event range so a standard verifier can recompute the head from the embedded range and assert it equals the signed subject. Mutating any embedded entry diverges the recomputed head and every format fails.",
   "type": "object",

--- a/schemas/authority-envelope-v1.json
+++ b/schemas/authority-envelope-v1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://bernstein.alexchernysh.com/schemas/authority-envelope-v1.json",
+  "$id": "https://bernstein.run/schemas/authority-envelope-v1.json",
   "title": "Bernstein Authority Envelope (v1)",
   "description": "A portable, self-describing record of who acted, under which delegated authority, and which policy decision allowed it. The envelope is not run-scoped: nothing in it references a run identifier or a lineage root, so activity Bernstein did not schedule can be carried in the same shape. Canonical form is RFC 8785 JCS; the signature is a detached EdDSA JWS (RFC 7515 Appendix F) over the JCS bytes of the envelope body, where the body is every top-level member except `signature`. Every hash the envelope carries is recomputable from material the envelope itself records: `principal.id_binding` binds the principal identifier to its key, each `grants[].grant_hash` chains to its parent, each `decisions[].inputs_hash` covers the decision's policy inputs and the grant it cites, and `section_digests` lets a verifier name which section diverged rather than reporting only a broken signature. A signature says who asserted the envelope; the recomputation says the assertion follows from its own inputs.",
   "type": "object",

--- a/schemas/sandbox-pool-manifest-v1.json
+++ b/schemas/sandbox-pool-manifest-v1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://bernstein.alexchernysh.com/schemas/sandbox-pool-manifest-v1.json",
+  "$id": "https://bernstein.run/schemas/sandbox-pool-manifest-v1.json",
   "title": "Bernstein Named Sandbox Pool Manifest (v1)",
   "description": "A frozen, canonicalized named sandbox pool (#2547). Its identity is its pool_hash: a sha256 over the canonical JSON of every other field. Pools are registered, updated, and retired only by appending pool.* events to the HMAC audit chain; the runtime pool registry is a deterministic projection rebuilt by replaying those events, and the manifest body is held content-addressed so a tampered body no longer recomputes to its pool_hash.",
   "type": "object",

--- a/schemas/sandbox-pool-placement-receipt-v1.json
+++ b/schemas/sandbox-pool-placement-receipt-v1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://bernstein.alexchernysh.com/schemas/sandbox-pool-placement-receipt-v1.json",
+  "$id": "https://bernstein.run/schemas/sandbox-pool-placement-receipt-v1.json",
   "title": "Bernstein Sandbox Pool Placement Receipt (v1)",
   "description": "A sealed placement decision (#2547). Every pool dispatch seals (pool_hash, template_hash, overrides_hash, effective_manifest_hash, selector_inputs, chosen_backend) into this receipt, whose identity is its own placement_hash: a sha256 over every other field. The receipt is the proof, not a decoration on a log line: a forged backend or a widened effective_manifest_hash recomputes to a different placement_hash and fails verification, exactly like a tampered chain entry. Two hosts holding the same pool manifest and recipe seal a byte-identical receipt.",
   "type": "object",

--- a/tests/unit/test_schema_ids.py
+++ b/tests/unit/test_schema_ids.py
@@ -1,0 +1,43 @@
+"""Every Bernstein-owned JSON Schema is published at its ``$id``.
+
+``$id`` is the canonical retrieval URI of a schema; a validator that
+dereferences it must find the same document. The schemas under ``schemas/``
+are served from https://bernstein.run/schemas/<file name>, so each id has to
+name exactly that location. Vendored third-party schemas keep their own ids.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+SCHEMAS = Path(__file__).resolve().parents[2] / "schemas"
+PUBLISHED_BASE = "https://bernstein.run/schemas/"
+UNSERVED_HOSTS = ("bernstein.alexchernysh.com", "bernstein.dev")
+
+
+def _bernstein_schemas() -> list[Path]:
+    paths = sorted(SCHEMAS.glob("*.json"))
+    assert paths, "no schemas found"
+    return paths
+
+
+def test_no_schema_id_points_at_an_unserved_host() -> None:
+    for path in _bernstein_schemas():
+        schema_id = json.loads(path.read_text(encoding="utf-8")).get("$id", "")
+        assert not any(host in schema_id for host in UNSERVED_HOSTS), (
+            f"{path.name}: $id {schema_id!r} names a host that serves nothing"
+        )
+
+
+def test_bernstein_schema_ids_match_their_published_path() -> None:
+    owned = 0
+    for path in _bernstein_schemas():
+        schema_id = json.loads(path.read_text(encoding="utf-8")).get("$id", "")
+        if "bernstein.run" not in schema_id:
+            continue  # vendored schema with a third-party id
+        owned += 1
+        assert schema_id == PUBLISHED_BASE + path.name, (
+            f"{path.name}: $id {schema_id!r} does not match its published path"
+        )
+    assert owned >= 6, f"expected the Bernstein schemas to carry bernstein.run ids, found {owned}"


### PR DESCRIPTION
The six Bernstein schemas under `schemas/` carried a `$id` on a host that no longer resolves. `$id` is the canonical retrieval URI of a JSON Schema, so a validator that dereferenced it found nothing.

- The ids now name `https://bernstein.run/schemas/<file name>`, where the documents are served.
- `tests/unit/test_schema_ids.py` pins every Bernstein-owned schema to its published path and rejects ids on hosts that serve nothing; vendored third-party schemas keep their own ids.

No schema content changed.