### PR TITLE
adapters: declare host isolation for codex and drop its vendor sandbox only when the host isolates

### DIFF
--- a/docs/adapters/ADAPTER_GUIDE.md
+++ b/docs/adapters/ADAPTER_GUIDE.md
@@ -125,6 +125,37 @@ npm install -g @openai/codex
 > start in a capability-dropped container on a kernel without unprivileged user namespaces.
 > Every shell call is then refused while the run still exits 0. The adapter now detects
 > that and marks the run `permission_denied` rather than reporting success.
+>
+> **Declared host isolation.** An operator running the CLI inside a container or VM they
+> control can state that the process is already isolated, and the adapter then spawns
+> without codex's own sandbox instead of failing inside it. Two config keys carry the
+> declaration, resolved through the usual precedence chain
+> ([global config](../operations/global-config.md)):
+>
+> | Key | Env var | Values |
+> |---|---|---|
+> | `host_isolation_tier` | `BERNSTEIN_HOST_ISOLATION_TIER` | `none` (default), `process`, `container`, `vm` |
+> | `host_isolation_evidence` | `BERNSTEIN_HOST_ISOLATION_EVIDENCE` | Free text describing the isolation |
+>
+> ```bash
+> bernstein config set host_isolation_tier container
+> bernstein config set host_isolation_evidence "read-only rootfs, cap-drop ALL, no-new-privileges"
+> ```
+>
+> `container` and `vm` drop codex's sandbox: both are a boundary that replaces what
+> bubblewrap would have supplied. `process` and `none` keep it — seccomp or a restricted
+> user confines the agent's own commands without giving codex the user namespace it needs.
+> A value outside that set is rejected and the sandbox stays on.
+>
+> The declaration is written to the HMAC audit chain as a
+> `sandbox.host_isolation_declared` event before the first spawn, recording the tier, the
+> evidence, the config layer it came from, and whether the sandbox was consequently
+> dropped — so a run can be reconstructed afterwards without guessing which posture was in
+> force. The adapter also logs one warning per run naming the tier and the evidence.
+>
+> This is narrower than the escalated dangerous-mode strategy, which drops the sandbox and
+> the approval surface together and records no reason. Prefer the declaration.
+> See [#5341](https://github.com/sipyourdrink-ltd/bernstein/issues/5341).
 
 **Best for:** Tasks that benefit from OpenAI's reasoning models. Good complement to Claude for provider diversity.
 

--- a/docs/architecture/sandbox.md
+++ b/docs/architecture/sandbox.md
@@ -114,6 +114,43 @@ work.
 - **Supported exec semantics.** Every first-party backend handles
   argv-based exec with exit-code, stdout, and stderr capture.
 
+### Declared host isolation
+
+The backends above are isolation Bernstein *provides*. Some CLI agents also
+ship a sandbox of their own — codex spawns under `--sandbox workspace-write`,
+implemented with bubblewrap — and that sandbox needs an unprivileged user
+namespace to start. An operator running the CLI inside a container or VM they
+control has usually removed exactly that (`--cap-drop ALL`,
+`no-new-privileges`, unprivileged user namespaces disabled), so the agent's
+sandbox cannot initialise and every command it issues is refused while the run
+still exits 0.
+
+The operator declares the isolation the host already applies, once, in the
+normal config chain:
+
+| Key | Env var | Default |
+|---|---|---|
+| `host_isolation_tier` | `BERNSTEIN_HOST_ISOLATION_TIER` | `none` |
+| `host_isolation_evidence` | `BERNSTEIN_HOST_ISOLATION_EVIDENCE` | empty |
+
+The tier vocabulary is `SandboxTier` (`none` < `process` < `container` <
+`vm`), so it cannot drift from the tiers the rest of this layer ranks against;
+anything outside it is rejected rather than assumed. `container` and `vm`
+replace what the agent's own sandbox would have supplied, so an adapter that
+advertises `consumes_host_isolation` drops it. `process` and `none` do not, so
+it stays.
+
+The declaration is anchored in the HMAC audit chain as a
+`sandbox.host_isolation_declared` event carrying the tier, the operator's
+evidence for it, the config layer it resolved from, and whether the agent's
+sandbox was consequently dropped. Dropping a sandbox is a posture change, and
+the record is what makes it a statement somebody made from a named source
+rather than an unexplained flag flip.
+
+- Resolver: `src/bernstein/core/config/host_isolation.py`
+- Injection seam: `AgentSpawner._get_adapter_by_name`
+- Consumer today: `src/bernstein/adapters/codex.py`
+
 ## MicroVM backend and deterministic fork-and-race
 
 The `microvm` backend (`src/bernstein/core/sandbox/backends/microvm.py`)

--- a/docs/operations/global-config.md
+++ b/docs/operations/global-config.md
@@ -99,7 +99,8 @@ highest to lowest precedence:
 1. **seed** — the run-seed (`bernstein.yaml`) value actually enforced by the
    orchestrator, when present.
 2. **session** — environment overrides (`BERNSTEIN_CLI`, `BERNSTEIN_BUDGET`,
-   `BERNSTEIN_MAX_AGENTS`, `BERNSTEIN_EFFORT`, `BERNSTEIN_MODEL`) or
+   `BERNSTEIN_MAX_AGENTS`, `BERNSTEIN_EFFORT`, `BERNSTEIN_MODEL`,
+   `BERNSTEIN_HOST_ISOLATION_TIER`, `BERNSTEIN_HOST_ISOLATION_EVIDENCE`) or
    caller-provided session overrides.
 3. **project** — `<project>/.sdd/config.yaml`.
 4. **context** — the active operating context, when one is selected (see
@@ -107,7 +108,8 @@ highest to lowest precedence:
 5. **global** — `~/.bernstein/config.yaml`, the file `bernstein config set`
    writes to.
 6. **default** — built-in defaults (`cli=claude`, `budget=None`,
-   `max_agents=6`, `effort=max`, `model=None`).
+   `max_agents=6`, `effort=max`, `model=None`,
+   `host_isolation_tier=none`, `host_isolation_evidence=""`).
 
 Only `bernstein config set`/`get`/`list`/`conflicts`/`view-mode` operate on
 this precedence chain. `bernstein config diff` is a separate, narrower tool
@@ -122,6 +124,16 @@ that only compares the project seed file to built-in defaults.
 | `max_agents` | `6` | Default max concurrent agents. |
 | `effort` | `max` | Default effort level (`max`/`medium`/`low`). |
 | `model` | `null` | Default model override (`null` = adapter default). |
+| `host_isolation_tier` | `none` | Isolation the host already applies to this process (`none`, `process`, `container`, `vm`). Env: `BERNSTEIN_HOST_ISOLATION_TIER`. |
+| `host_isolation_evidence` | `""` | Free-text description of that isolation, recorded verbatim in the audit chain. Env: `BERNSTEIN_HOST_ISOLATION_EVIDENCE`. |
+
+`host_isolation_tier` is read by adapters that ship a sandbox of their own. An
+operator running the CLI inside a container or VM they control declares the
+tier once; `container` and `vm` make the agent's own sandbox redundant and it
+is dropped, `process` and `none` keep it. A value outside the four is rejected
+and the sandbox stays on. Each declaration reaching an adapter is written to
+the audit chain as `sandbox.host_isolation_declared`. See
+[the sandbox architecture note](../architecture/sandbox.md#declared-host-isolation).
 
 ## Source
 
@@ -129,6 +141,8 @@ that only compares the project seed file to built-in defaults.
   subcommands.
 - `src/bernstein/core/config/home.py` — `BernsteinHome`, `resolve_config`,
   `resolve_config_bundle`, `explain_conflicts`, `check_source_policies`.
+- `src/bernstein/core/config/host_isolation.py` — `resolve_host_isolation`,
+  the closed tier vocabulary for `host_isolation_tier`.
 - `src/bernstein/cli/config_diff_cli.py` — `bernstein config diff`.
 
 ## Related

--- a/docs/release-notes/fragments/5341-host-isolation-declaration.md
+++ b/docs/release-notes/fragments/5341-host-isolation-declaration.md
@@ -1,0 +1,30 @@
+## Declare the isolation your host already provides, instead of bypassing everything
+
+An operator running the CLI inside a container or VM they control hits a
+specific wall with the codex adapter: `--sandbox workspace-write` is built on
+bubblewrap, bubblewrap needs an unprivileged user namespace, and a host that
+already isolates the process has usually removed exactly that. Every command
+the agent issued was refused while the run still exited 0.
+
+The only way to drop that sandbox used to be the escalated dangerous-mode
+strategy — one switch that removes the sandbox and the approval surface
+together and records no reason for it. There is now a narrower statement:
+
+```bash
+bernstein config set host_isolation_tier container
+bernstein config set host_isolation_evidence "read-only rootfs, cap-drop ALL, no-new-privileges"
+```
+
+Both keys resolve through the normal precedence chain (environment > project >
+user > default) and have env vars of their own, `BERNSTEIN_HOST_ISOLATION_TIER`
+and `BERNSTEIN_HOST_ISOLATION_EVIDENCE`. `container` and `vm` are a boundary
+that replaces what bubblewrap would have supplied, so codex spawns without its
+own sandbox; `process` and `none` are not, so it stays. A tier outside those
+four is rejected and the sandbox stays on rather than being dropped on a typo.
+
+Every declaration that reaches an adapter is written to the HMAC audit chain as
+a `sandbox.host_isolation_declared` event recording the tier, the evidence, the
+config layer the declaration came from, and whether the sandbox was
+consequently dropped — so the posture a run used can be reconstructed
+afterwards from the chain rather than inferred. Adapters with no sandbox of
+their own are unaffected. (#5341)

--- a/src/bernstein/adapters/codex.py
+++ b/src/bernstein/adapters/codex.py
@@ -41,6 +41,20 @@ instead. Upstream's own help text scopes that flag the same way: "Intended
 solely for running in environments that are externally sandboxed." The
 un-escalated default stays ``--sandbox workspace-write``, so a spawn on a
 plain host keeps the vendor sandbox.
+
+The escalated strategy is a blunt instrument, though: it means "no permission
+surface exists to skip" and says nothing about *why* skipping is safe. The
+narrower route is the host-isolation declaration (issue #5341). An operator
+running inside a container or VM they control states the isolation tier the
+host applies and the evidence for it -- ``host_isolation_tier`` and
+``host_isolation_evidence``, resolved through the normal config precedence
+chain -- and the spawner injects it into this adapter, which advertises that
+it consumes one via :attr:`CodexAdapter.consumes_host_isolation`. A declared
+``container`` or ``vm`` tier is a boundary that replaces what bubblewrap would
+have supplied, so the vendor sandbox is dropped; ``process`` and ``none`` are
+not, so it stays. The declaration is written to the HMAC audit chain at the
+dispatch seam, which is what makes it an operator statement on the record
+rather than an unexplained flag flip.
 """
 
 from __future__ import annotations
@@ -97,6 +111,27 @@ _SANDBOXED_ARGS: tuple[str, ...] = ("--sandbox", "workspace-write")
 #: scopes the flag to exactly that case: "Intended solely for running in
 #: environments that are externally sandboxed."
 _BYPASS_SANDBOX_FLAG = "--dangerously-bypass-approvals-and-sandbox"
+
+#: Declared host-isolation tiers that make the vendor sandbox redundant (#5341).
+#:
+#: These are ``SandboxTier`` values, held as plain strings because
+#: ``SandboxTier`` lives in :mod:`bernstein.adapters.capability_profile` and the
+#: ``adapters-independent`` import-linter contract forbids one adapter module
+#: from reaching another. ``SandboxTier`` is a ``StrEnum``, so a member
+#: assigned to :attr:`CodexAdapter.host_isolation` compares equal to its value
+#: here; ``tests/unit/test_adapter_codex.py`` pins these names against the enum
+#: so a rename cannot leave this set silently stale.
+#:
+#: Which tiers belong is an adapter judgement, not a vocabulary one: the vendor
+#: sandbox is dropped only for a boundary that replaces what bubblewrap would
+#: have supplied. ``container`` and ``vm`` do. ``process`` does not -- seccomp
+#: or a restricted user confines the agent's own commands without giving codex
+#: the user namespace it needs -- and neither does ``none``.
+_TIERS_REPLACING_VENDOR_SANDBOX = frozenset({"container", "vm"})
+
+#: The tier assumed when no operator declaration reaches the adapter: no
+#: isolation, so every vendor sandbox stays on.
+_UNDECLARED_HOST_ISOLATION = "none"
 
 
 def _has_codex_auth() -> bool:
@@ -212,6 +247,25 @@ class CodexAdapter(CLIAdapter):
     # ``insufficient_quota`` error codes; the meter records both under
     # the same provider label.
     rate_limit_provider = "openai"
+    #: Marker the spawner looks for before injecting the operator's
+    #: host-isolation declaration (#5341). Only an adapter that owns a vendor
+    #: sandbox has anything to do with one; every other adapter leaves this at
+    #: the inherited default and is never touched by the injection.
+    consumes_host_isolation: bool = True
+
+    def __init__(self) -> None:
+        super().__init__()
+        #: Isolation the host is declared to apply to this process. Carries a
+        #: ``SandboxTier`` value (see ``_TIERS_REPLACING_VENDOR_SANDBOX`` for
+        #: why it is typed as the string rather than the enum). Set by the
+        #: spawner from resolved config; left at "no declaration" otherwise, so
+        #: an adapter constructed directly keeps the vendor sandbox.
+        self.host_isolation: str = _UNDECLARED_HOST_ISOLATION
+        #: The operator's description of that isolation, recorded verbatim.
+        self.host_isolation_evidence: str = ""
+        # The drop is one posture decision, not a per-spawn one: warning on
+        # every spawn would bury the single line an operator has to read.
+        self._host_isolation_warned = False
 
     def _dangerous_mode(self) -> DangerousModeStrategy:
         """Return the declared dangerous-mode strategy for this adapter."""
@@ -229,20 +283,50 @@ class CodexAdapter(CLIAdapter):
         and the posture it pins is the sandboxed one -- so a default spawn
         keeps ``--sandbox workspace-write``. An operator whose runner is
         already isolated declares ``ALWAYS_ON`` instead.
+
+        The second route is the operator's host-isolation declaration
+        (#5341): a host declared at ``container`` or ``vm`` supplies the
+        boundary the vendor sandbox would have supplied, so the vendor
+        sandbox is redundant rather than merely inconvenient. ``process``
+        and ``none`` are not that boundary and keep it.
         """
-        return self._dangerous_mode() is DangerousModeStrategy.ALWAYS_ON
+        return self._dangerous_mode() is DangerousModeStrategy.ALWAYS_ON or self.host_isolation_drops_vendor_sandbox()
+
+    def host_isolation_drops_vendor_sandbox(self) -> bool:
+        """Whether the declared host isolation supersedes Codex's own sandbox.
+
+        Part of the ``consumes_host_isolation`` contract rather than an
+        internal detail: the spawner records whether the declaration it
+        injected actually dropped a sandbox, and only the adapter knows which
+        tiers replace the one it ships.
+        """
+        return str(self.host_isolation) in _TIERS_REPLACING_VENDOR_SANDBOX
+
+    def _warn_host_isolation_drop_once(self) -> None:
+        """Name the declaration the drop rests on, once per adapter instance."""
+        if self._host_isolation_warned:
+            return
+        self._host_isolation_warned = True
+        logger.warning(
+            "codex: vendor sandbox dropped; host isolation declared tier=%s evidence=%s",
+            str(self.host_isolation),
+            self.host_isolation_evidence or "none given",
+        )
 
     def _sandbox_args(self) -> tuple[str, ...]:
         """Return the sandbox argv for one spawn, derived from the declaration."""
         if not self._sandbox_bypassed():
             return _SANDBOXED_ARGS
-        logger.warning(
-            "CodexAdapter: dangerous_mode=%s, so this spawn passes %s -- model-issued "
-            "shell commands run with no Codex sandbox. Declare this only when the "
-            "runner itself provides the isolation.",
-            DangerousModeStrategy.ALWAYS_ON,
-            _BYPASS_SANDBOX_FLAG,
-        )
+        if self.host_isolation_drops_vendor_sandbox():
+            self._warn_host_isolation_drop_once()
+        if self._dangerous_mode() is DangerousModeStrategy.ALWAYS_ON:
+            logger.warning(
+                "CodexAdapter: dangerous_mode=%s, so this spawn passes %s -- model-issued "
+                "shell commands run with no Codex sandbox. Declare this only when the "
+                "runner itself provides the isolation.",
+                DangerousModeStrategy.ALWAYS_ON,
+                _BYPASS_SANDBOX_FLAG,
+            )
         return (_BYPASS_SANDBOX_FLAG,)
 
     def spawn(

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -2722,12 +2722,70 @@ class AgentSpawner:
             return cached
 
         adapter = get_adapter(adapter_name)
+        if getattr(adapter, "consumes_host_isolation", False):
+            self._apply_host_isolation(adapter_name, adapter)
         if self._enable_caching:
             from bernstein.adapters.caching_adapter import CachingAdapter
 
             adapter = CachingAdapter(adapter, self._workdir)
         self._adapter_cache[adapter_name] = adapter
         return adapter
+
+    def _apply_host_isolation(self, adapter_name: str, adapter: CLIAdapter) -> None:
+        """Hand the operator's host-isolation declaration to *adapter* (#5341).
+
+        Only adapters that own a vendor sandbox advertise
+        ``consumes_host_isolation``; everything else is left untouched, so an
+        adapter with nothing to drop neither gains an attribute nor produces a
+        record.
+
+        Runs before the :class:`CachingAdapter` wrap so the attributes land on
+        the adapter that actually builds the argv, and behind the adapter cache
+        so one run records the declaration once per adapter rather than once
+        per spawn.
+
+        A misdeclared tier is reported and then dropped: the resolver raises
+        rather than guess, and the safe interpretation of "we could not read
+        the declaration" is that no isolation was declared, which leaves the
+        vendor sandbox on. Wedging every spawn over a typo in a config key
+        would be the worse failure.
+        """
+        from bernstein.core.config.host_isolation import resolve_host_isolation
+
+        try:
+            declaration = resolve_host_isolation(self._workdir)
+        except ValueError as exc:
+            logger.warning(
+                "host isolation declaration ignored for %s: %s; the vendor sandbox stays on",
+                adapter_name,
+                exc,
+            )
+            return
+
+        adapter.host_isolation = declaration.tier  # type: ignore[attr-defined]
+        adapter.host_isolation_evidence = declaration.evidence  # type: ignore[attr-defined]
+
+        try:
+            from bernstein.core.security.audit_chain import (
+                AuditChainStore,
+                record_host_isolation_declaration,
+            )
+
+            record_host_isolation_declaration(
+                chain=AuditChainStore(self._workdir / ".sdd" / "audit"),
+                run_id=getattr(self, "_run_id", ""),
+                adapter=adapter_name,
+                tier=str(declaration.tier),
+                evidence=declaration.evidence,
+                source=str(declaration.source),
+                vendor_sandbox_dropped=bool(adapter.host_isolation_drops_vendor_sandbox()),  # type: ignore[attr-defined]
+            )
+        except Exception as exc:
+            logger.warning(
+                "host isolation recording failed for %s: %s",
+                adapter_name,
+                type(exc).__name__,
+            )
 
     def _run_bridge_call(self, awaitable: Any) -> Any:
         """Run a bridge coroutine from the sync orchestration path."""

--- a/src/bernstein/core/config/home.py
+++ b/src/bernstein/core/config/home.py
@@ -11,6 +11,9 @@ Environment overrides (take priority over all file-based config layers):
   BERNSTEIN_MAX_AGENTS  Maximum concurrent agents (default 6).
   BERNSTEIN_EFFORT      Default effort level (max | medium | low).
   BERNSTEIN_MODEL       Default model override (empty = adapter default).
+  BERNSTEIN_HOST_ISOLATION_TIER      Isolation the host already provides
+                                     (none | process | container | vm).
+  BERNSTEIN_HOST_ISOLATION_EVIDENCE  Operator's description of that isolation.
 """
 
 from __future__ import annotations
@@ -35,6 +38,14 @@ _DEFAULTS: dict[str, Any] = {
     "max_agents": 6,
     "effort": "max",
     "model": None,
+    # Isolation the runner already applies to this process, declared by the
+    # operator (#5341). Adapters that ship their own vendor sandbox read it to
+    # decide whether that sandbox is redundant. The vocabulary is the
+    # ``SandboxTier`` value set; parsing and validation live in
+    # ``bernstein.core.config.host_isolation`` so this table stays a plain
+    # key -> default map like every other row.
+    "host_isolation_tier": "none",
+    "host_isolation_evidence": "",
 }
 
 _DEFAULT_CONFIG_YAML = """\
@@ -268,6 +279,8 @@ _ENV_OVERRIDE_MAP: dict[str, str] = {
     "max_agents": "BERNSTEIN_MAX_AGENTS",
     "effort": "BERNSTEIN_EFFORT",
     "model": "BERNSTEIN_MODEL",
+    "host_isolation_tier": "BERNSTEIN_HOST_ISOLATION_TIER",
+    "host_isolation_evidence": "BERNSTEIN_HOST_ISOLATION_EVIDENCE",
 }
 
 

--- a/src/bernstein/core/config/host_isolation.py
+++ b/src/bernstein/core/config/host_isolation.py
@@ -1,0 +1,138 @@
+"""Operator declaration of the isolation the host already provides (#5341).
+
+Some CLI agents ship a sandbox of their own. ``codex exec --sandbox
+workspace-write`` is one: on Linux it is implemented with bubblewrap, which
+needs an unprivileged user namespace to start. An operator running Bernstein
+inside a container or VM they control has typically removed exactly that --
+``--cap-drop ALL``, ``no-new-privileges``, unprivileged user namespaces off --
+so the vendor sandbox cannot initialise and every model-issued shell command
+is refused while the run still exits 0 (see ``detect_sandbox_failure`` in the
+codex adapter).
+
+The blunt way to fix that is the escalated dangerous-mode strategy, which
+means "no permission surface exists to skip" and says nothing about why that
+is safe. This module is the narrow alternative: the operator states which tier
+of isolation the host applies and what the evidence for it is, and an adapter
+that owns a vendor sandbox drops that sandbox only when the declared tier
+actually replaces it.
+
+The declaration is ordinary layered config -- two flat keys resolved through
+:func:`~bernstein.core.config.home.resolve_config`, so ``bernstein config
+get`` / ``set`` / ``list`` already operate on it and the precedence chain is
+the documented one (environment > project ``.sdd/config.yaml`` > user
+``~/.bernstein/config.yaml`` > built-in default). What this module adds is the
+closed vocabulary: the allowed values are derived from
+:class:`~bernstein.adapters.capability_profile.SandboxTier` rather than
+restated, so a tier added to the enum cannot be missing here, and a value
+outside it is a hard :exc:`ValueError` rather than a silently ignored typo
+that would leave the operator believing a sandbox was dropped.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from bernstein.adapters.capability_profile import SandboxTier
+from bernstein.core.config.home import BernsteinHome, ConfigSource, resolve_config
+
+#: Config key naming the isolation tier the host already applies.
+HOST_ISOLATION_TIER_KEY = "host_isolation_tier"
+
+#: Config key carrying the operator's free-text evidence for that isolation.
+HOST_ISOLATION_EVIDENCE_KEY = "host_isolation_evidence"
+
+
+def allowed_tier_values() -> tuple[str, ...]:
+    """Return the accepted tier names, weakest first.
+
+    Derived from :class:`SandboxTier` rather than restated, so the vocabulary
+    cannot drift from the enum the rest of the sandbox layer ranks against.
+    """
+    return tuple(tier.value for tier in SandboxTier)
+
+
+@dataclass(frozen=True)
+class HostIsolationDeclaration:
+    """What the operator declared about the host, and where they declared it.
+
+    Attributes:
+        tier: Isolation the host applies to this process.
+        evidence: The operator's description of that isolation. Free text --
+            it is recorded verbatim into the audit chain so a later reader can
+            judge the claim, not parsed.
+        source: The config layer the *tier* was resolved from, as
+            :func:`resolve_config` reports it.
+    """
+
+    tier: SandboxTier
+    evidence: str
+    source: ConfigSource
+
+
+def _parse_tier(raw: object) -> SandboxTier:
+    """Coerce a resolved config value into a :class:`SandboxTier`.
+
+    ``None`` maps to :attr:`SandboxTier.NONE`: the session layer coerces the
+    literal strings ``none`` and ``null`` to ``None`` before this sees them
+    (see ``_coerce_config_value``), and both spellings mean the same thing here
+    -- no declared isolation, so the vendor sandbox stays. Everything else is
+    matched against the closed vocabulary and raises when it does not fit.
+
+    Raises:
+        ValueError: *raw* is not one of :func:`allowed_tier_values`.
+    """
+    if raw is None:
+        return SandboxTier.NONE
+    text = str(raw).strip().lower()
+    if not text:
+        return SandboxTier.NONE
+    try:
+        return SandboxTier(text)
+    except ValueError:
+        allowed = ", ".join(allowed_tier_values())
+        raise ValueError(
+            f"{HOST_ISOLATION_TIER_KEY}: {raw!r} is not a declared isolation tier. Allowed values: {allowed}."
+        ) from None
+
+
+def resolve_host_isolation(
+    project_dir: Path | None = None,
+    home: BernsteinHome | None = None,
+) -> HostIsolationDeclaration:
+    """Resolve the host-isolation declaration for *project_dir*.
+
+    Args:
+        project_dir: Project root whose ``.sdd/config.yaml`` participates in
+            the chain. Defaults to the current working directory.
+        home: Global config home. Defaults to ``~/.bernstein``.
+
+    Returns:
+        The declared :class:`HostIsolationDeclaration`. An undeclared host
+        resolves to :attr:`SandboxTier.NONE` with empty evidence, which is the
+        posture that keeps every vendor sandbox in place.
+
+    Raises:
+        ValueError: The declared tier is outside :func:`allowed_tier_values`.
+            Guessing is not an option: the value decides whether a sandbox is
+            dropped, so a typo has to be visible rather than absorbed.
+    """
+    resolved_home = home if home is not None else BernsteinHome.default()
+    resolved_project = project_dir if project_dir is not None else Path.cwd()
+
+    tier_resolution = resolve_config(
+        HOST_ISOLATION_TIER_KEY,
+        home=resolved_home,
+        project_dir=resolved_project,
+    )
+    evidence_resolution = resolve_config(
+        HOST_ISOLATION_EVIDENCE_KEY,
+        home=resolved_home,
+        project_dir=resolved_project,
+    )
+    raw_evidence = evidence_resolution["value"]
+    return HostIsolationDeclaration(
+        tier=_parse_tier(tier_resolution["value"]),
+        evidence="" if raw_evidence is None else str(raw_evidence),
+        source=tier_resolution["source"],
+    )

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -510,6 +510,16 @@ EVENT_ADAPTER_CAPABILITY_SELECTION = "adapter.capability_selection"
 #: ``error`` marker is recorded when the classifier raises at the call site.
 EVENT_TASK_TIER_DECISION = "task.tier_decision"
 
+#: Issue #5341 -- emitted when an operator's host-isolation declaration reaches
+#: an adapter that owns a vendor sandbox. Records the declared tier, the
+#: operator's evidence for it, the config layer the declaration came from, and
+#: whether the adapter consequently dropped its vendor sandbox. Dropping a
+#: sandbox is a posture change, so it belongs on the record as a statement
+#: somebody made from a named source rather than as an unexplained flag flip:
+#: a reader reconstructing a run can prove offline which declaration was in
+#: force and what it was based on.
+EVENT_HOST_ISOLATION_DECLARED = "sandbox.host_isolation_declared"
+
 #: Issue #2663 -- emitted when capability-aware routing refuses a task because
 #: no candidate adapter's declared profile satisfied its requirements. The event
 #: anchors the content-addressed refusal receipt (its hash, the unmet axes, and
@@ -5490,6 +5500,61 @@ def record_task_tier_decision(
     )
 
 
+def record_host_isolation_declaration(
+    *,
+    chain: AuditChainStore,
+    run_id: str,
+    adapter: str,
+    tier: str,
+    evidence: str,
+    source: str,
+    vendor_sandbox_dropped: bool,
+    actor: str = "host_isolation",
+) -> AuditEvent:
+    """Append a ``sandbox.host_isolation_declared`` event into *chain* (#5341).
+
+    Anchors one operator declaration at the dispatch seam
+    :func:`record_capability_selection` already uses. An adapter that ships its
+    own sandbox drops it when the host is declared to isolate the process
+    already; without this record the drop is invisible after the fact, and the
+    difference between "the operator declared a container" and "somebody
+    escalated the adapter" cannot be reconstructed.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        run_id: The run the declaration was resolved for.
+        adapter: Adapter the declaration was injected into.
+        tier: Declared isolation tier (a ``SandboxTier`` value).
+        evidence: The operator's description of the isolation, verbatim. Free
+            text, recorded so a reader can judge the claim rather than take the
+            tier on faith.
+        source: Config layer the tier resolved from (``session``, ``project``,
+            ``global``, ``default``, ...), so the declaration names where it
+            was made and not only what it said.
+        vendor_sandbox_dropped: Whether the adapter consequently spawned
+            without its own sandbox. ``False`` for a tier that does not replace
+            it, which keeps the weak-tier declarations on the record too.
+        actor: Recorded actor; defaults to ``"host_isolation"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_HOST_ISOLATION_DECLARED,
+        actor=actor,
+        resource_type="sandbox",
+        resource_id=adapter,
+        details={
+            "run_id": run_id,
+            "adapter": adapter,
+            "tier": tier,
+            "evidence": evidence,
+            "source": source,
+            "vendor_sandbox_dropped": vendor_sandbox_dropped,
+        },
+    )
+
+
 def record_capability_refusal(
     *,
     chain: AuditChainStore,
@@ -9708,6 +9773,7 @@ __all__ = [
     "EVENT_FORK_SNAPSHOT",
     "EVENT_GATE_ADJUDICATION",
     "EVENT_GOVERNANCE_DECISION",
+    "EVENT_HOST_ISOLATION_DECLARED",
     "EVENT_IDENTITY_REVOKED",
     "EVENT_INPUT_REFUSAL",
     "EVENT_INTENT_CAPSULE",
@@ -9868,6 +9934,7 @@ __all__ = [
     "record_fork_snapshot",
     "record_gate_adjudication",
     "record_governance_decision",
+    "record_host_isolation_declaration",
     "record_input_refusal",
     "record_intent_capsule",
     "record_intent_drift",

--- a/tests/unit/test_adapter_codex.py
+++ b/tests/unit/test_adapter_codex.py
@@ -10,11 +10,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 from bernstein.core.models import ApiTier, ModelConfig, ProviderType
 
-from bernstein.adapters._contract import AdapterStrategy, DangerousModeStrategy
+from bernstein.adapters._contract import STRATEGY_MATRIX, AdapterStrategy, DangerousModeStrategy
+from bernstein.adapters.capability_profile import SandboxTier
 from bernstein.adapters.codex import (
     _BYPASS_SANDBOX_FLAG,
     _DEFAULT_CODEX_MODEL,
     _SANDBOXED_ARGS,
+    _TIERS_REPLACING_VENDOR_SANDBOX,
+    _UNDECLARED_HOST_ISOLATION,
     CodexAdapter,
 )
 
@@ -37,6 +40,19 @@ def _inner_cmd(full_cmd: list[str]) -> list[str]:
     """Extract the actual CLI command after the '--' worker separator."""
     sep = full_cmd.index("--")
     return full_cmd[sep + 1 :]
+
+
+def _spawn_inner_cmd(adapter: CodexAdapter, tmp_path: Path, pid: int) -> list[str]:
+    """Spawn with Popen mocked and return the codex argv the adapter built."""
+    proc_mock = _make_popen_mock(pid=pid)
+    with patch("bernstein.adapters.codex.subprocess.Popen", return_value=proc_mock) as popen:
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="gpt-5.5", effort="high"),
+            session_id=f"codex-sbx{pid}",
+        )
+    return _inner_cmd(popen.call_args.args[0])
 
 
 # ---------------------------------------------------------------------------
@@ -525,15 +541,7 @@ class TestSandboxPosture:
     """
 
     def _spawn_inner(self, adapter: CodexAdapter, tmp_path: Path, pid: int) -> list[str]:
-        proc_mock = _make_popen_mock(pid=pid)
-        with patch("bernstein.adapters.codex.subprocess.Popen", return_value=proc_mock) as popen:
-            adapter.spawn(
-                prompt="hello",
-                workdir=tmp_path,
-                model_config=ModelConfig(model="gpt-5.5", effort="high"),
-                session_id=f"codex-sbx{pid}",
-            )
-        return _inner_cmd(popen.call_args.args[0])
+        return _spawn_inner_cmd(adapter, tmp_path, pid)
 
     def test_escalated_strategy_bypasses_the_vendor_sandbox(self, tmp_path: Path) -> None:
         adapter = CodexAdapter()
@@ -585,6 +593,96 @@ class TestSandboxPosture:
             self._spawn_inner(adapter, tmp_path, pid=143)
 
         assert any(_BYPASS_SANDBOX_FLAG in record.getMessage() for record in caplog.records)
+
+
+class TestHostIsolationDeclaration:
+    """#5341 - an operator whose host already isolates the process says so.
+
+    Before this, the only way to drop the vendor sandbox was the escalated
+    dangerous-mode strategy, a blunt "bypass everything" switch that says
+    nothing about *why* it is safe. The declaration is narrower and auditable:
+    it names the isolation tier the host provides and the evidence for it, and
+    only a tier at or above ``container`` -- a boundary that actually replaces
+    what bubblewrap would have given -- drops the vendor sandbox.
+    """
+
+    def _adapter(self, tier: SandboxTier, evidence: str = "") -> CodexAdapter:
+        adapter = CodexAdapter()
+        adapter.host_isolation = tier
+        adapter.host_isolation_evidence = evidence
+        return adapter
+
+    def test_the_tiers_that_drop_the_sandbox_are_real_tiers(self) -> None:
+        """The adapter keys on tier names it cannot import; a rename must not pass."""
+        assert set(_TIERS_REPLACING_VENDOR_SANDBOX) <= {tier.value for tier in SandboxTier}
+        assert SandboxTier.NONE.value == _UNDECLARED_HOST_ISOLATION
+
+    def test_undeclared_host_keeps_the_vendor_sandbox(self, tmp_path: Path) -> None:
+        """The constructor default is the weakest tier, so nothing changes by accident."""
+        adapter = CodexAdapter()
+
+        assert adapter.host_isolation == SandboxTier.NONE
+        inner = _spawn_inner_cmd(adapter, tmp_path, pid=160)
+
+        assert _BYPASS_SANDBOX_FLAG not in inner
+        assert tuple(inner[inner.index("--sandbox") : inner.index("--sandbox") + 2]) == _SANDBOXED_ARGS
+
+    def test_process_tier_keeps_the_vendor_sandbox(self, tmp_path: Path) -> None:
+        """Process-level confinement does not supply the namespace bubblewrap needs."""
+        inner = _spawn_inner_cmd(self._adapter(SandboxTier.PROCESS, "seccomp profile"), tmp_path, pid=161)
+
+        assert _BYPASS_SANDBOX_FLAG not in inner
+        assert inner[inner.index("--sandbox") + 1] == "workspace-write"
+
+    @pytest.mark.parametrize("tier", [SandboxTier.CONTAINER, SandboxTier.VM])
+    def test_container_and_vm_tiers_drop_the_vendor_sandbox(self, tmp_path: Path, tier: SandboxTier) -> None:
+        inner = _spawn_inner_cmd(self._adapter(tier, "read-only rootfs"), tmp_path, pid=162)
+
+        assert _BYPASS_SANDBOX_FLAG in inner
+        assert "--sandbox" not in inner
+
+    def test_drop_names_the_tier_and_the_evidence(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        adapter = self._adapter(SandboxTier.CONTAINER, "read-only rootfs, cap-drop ALL")
+
+        with caplog.at_level("WARNING", logger="bernstein.adapters.codex"):
+            _spawn_inner_cmd(adapter, tmp_path, pid=163)
+
+        messages = [record.getMessage() for record in caplog.records]
+        declared = [m for m in messages if "host isolation declared" in m]
+        assert len(declared) == 1
+        assert "tier=container" in declared[0]
+        assert "read-only rootfs, cap-drop ALL" in declared[0]
+
+    def test_drop_without_evidence_says_so(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level("WARNING", logger="bernstein.adapters.codex"):
+            _spawn_inner_cmd(self._adapter(SandboxTier.VM), tmp_path, pid=164)
+
+        declared = [m for m in (r.getMessage() for r in caplog.records) if "host isolation declared" in m]
+        assert len(declared) == 1
+        assert "evidence=none given" in declared[0]
+
+    def test_the_warning_is_emitted_once_per_adapter_not_per_spawn(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A per-spawn warning would bury the one line an operator has to read."""
+        adapter = self._adapter(SandboxTier.CONTAINER, "read-only rootfs")
+
+        with caplog.at_level("WARNING", logger="bernstein.adapters.codex"):
+            first = _spawn_inner_cmd(adapter, tmp_path, pid=165)
+            second = _spawn_inner_cmd(adapter, tmp_path, pid=166)
+
+        assert _BYPASS_SANDBOX_FLAG in first
+        assert _BYPASS_SANDBOX_FLAG in second
+        declared = [m for m in (r.getMessage() for r in caplog.records) if "host isolation declared" in m]
+        assert len(declared) == 1
+
+    def test_the_adapter_advertises_that_it_consumes_the_declaration(self) -> None:
+        """The spawner injects only into adapters carrying this marker."""
+        assert CodexAdapter.consumes_host_isolation is True
+
+    def test_the_declared_strategy_is_unchanged(self) -> None:
+        """The declaration is a second, narrower route -- it does not escalate the matrix."""
+        assert STRATEGY_MATRIX["codex"].dangerous_mode is DangerousModeStrategy.CLI_FLAG
 
 
 class TestSandboxFailureDetection:

--- a/tests/unit/test_host_isolation_config.py
+++ b/tests/unit/test_host_isolation_config.py
@@ -1,0 +1,140 @@
+"""The host-isolation declaration is layered config, not a bespoke file (#5341).
+
+An operator running the CLI inside a container or VM they control states that
+fact once, in the same precedence chain every other setting uses, and adapters
+that own a vendor sandbox read it from there. These tests pin the vocabulary to
+:class:`SandboxTier` so a tier can never be added in one place only.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.adapters.capability_profile import SandboxTier
+from bernstein.core.config.home import _DEFAULTS, _ENV_OVERRIDE_MAP, BernsteinHome  # type: ignore[reportPrivateUsage]
+from bernstein.core.config.host_isolation import (
+    HOST_ISOLATION_EVIDENCE_KEY,
+    HOST_ISOLATION_TIER_KEY,
+    allowed_tier_values,
+    resolve_host_isolation,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_declaration(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A declaration inherited from the developer's shell would fake a pass."""
+    monkeypatch.delenv("BERNSTEIN_HOST_ISOLATION_TIER", raising=False)
+    monkeypatch.delenv("BERNSTEIN_HOST_ISOLATION_EVIDENCE", raising=False)
+
+
+def _home(tmp_path: Path) -> BernsteinHome:
+    return BernsteinHome(tmp_path / ".bernstein")
+
+
+def _write_project_config(project_dir: Path, body: str) -> None:
+    sdd_config = project_dir / ".sdd" / "config.yaml"
+    sdd_config.parent.mkdir(parents=True, exist_ok=True)
+    sdd_config.write_text(body)
+
+
+class TestVocabulary:
+    """The allowed values are the sandbox tiers, derived rather than restated."""
+
+    def test_allowed_values_equal_the_sandbox_tiers(self) -> None:
+        assert set(allowed_tier_values()) == {tier.value for tier in SandboxTier}
+
+    def test_keys_are_registered_as_known_config(self) -> None:
+        """`config get`/`set`/`list` operate on `_DEFAULTS`, so absence is invisibility."""
+        assert _DEFAULTS[HOST_ISOLATION_TIER_KEY] == SandboxTier.NONE.value
+        assert _DEFAULTS[HOST_ISOLATION_EVIDENCE_KEY] == ""
+
+    def test_keys_have_environment_overrides(self) -> None:
+        assert _ENV_OVERRIDE_MAP[HOST_ISOLATION_TIER_KEY] == "BERNSTEIN_HOST_ISOLATION_TIER"
+        assert _ENV_OVERRIDE_MAP[HOST_ISOLATION_EVIDENCE_KEY] == "BERNSTEIN_HOST_ISOLATION_EVIDENCE"
+
+
+class TestPrecedence:
+    """Resolution rides the existing chain: env > project > user > default."""
+
+    def test_default_is_no_isolation_and_no_evidence(self, tmp_path: Path) -> None:
+        decl = resolve_host_isolation(tmp_path, home=_home(tmp_path))
+
+        assert decl.tier is SandboxTier.NONE
+        assert decl.evidence == ""
+        assert decl.source == "default"
+
+    def test_user_config_declares_the_tier(self, tmp_path: Path) -> None:
+        home = _home(tmp_path)
+        home.set(HOST_ISOLATION_TIER_KEY, "container")
+        home.set(HOST_ISOLATION_EVIDENCE_KEY, "read-only rootfs, cap-drop ALL")
+
+        decl = resolve_host_isolation(tmp_path, home=home)
+
+        assert decl.tier is SandboxTier.CONTAINER
+        assert decl.evidence == "read-only rootfs, cap-drop ALL"
+        assert decl.source == "global"
+
+    def test_project_config_overrides_user_config(self, tmp_path: Path) -> None:
+        home = _home(tmp_path)
+        home.set(HOST_ISOLATION_TIER_KEY, "container")
+        _write_project_config(tmp_path, "host_isolation_tier: vm\nhost_isolation_evidence: firecracker microVM\n")
+
+        decl = resolve_host_isolation(tmp_path, home=home)
+
+        assert decl.tier is SandboxTier.VM
+        assert decl.evidence == "firecracker microVM"
+        assert decl.source == "project"
+
+    def test_environment_overrides_project_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        home = _home(tmp_path)
+        home.set(HOST_ISOLATION_TIER_KEY, "container")
+        _write_project_config(tmp_path, "host_isolation_tier: vm\n")
+        monkeypatch.setenv("BERNSTEIN_HOST_ISOLATION_TIER", "process")
+        monkeypatch.setenv("BERNSTEIN_HOST_ISOLATION_EVIDENCE", "seccomp profile")
+
+        decl = resolve_host_isolation(tmp_path, home=home)
+
+        assert decl.tier is SandboxTier.PROCESS
+        assert decl.evidence == "seccomp profile"
+        assert decl.source == "session"
+
+    def test_explicit_none_stays_the_weakest_tier(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``none`` is a real tier name, not a request to unset the key."""
+        monkeypatch.setenv("BERNSTEIN_HOST_ISOLATION_TIER", "none")
+
+        decl = resolve_host_isolation(tmp_path, home=_home(tmp_path))
+
+        assert decl.tier is SandboxTier.NONE
+
+    def test_tier_is_case_and_whitespace_insensitive(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_HOST_ISOLATION_TIER", "  Container ")
+
+        assert resolve_host_isolation(tmp_path, home=_home(tmp_path)).tier is SandboxTier.CONTAINER
+
+
+class TestInvalidTier:
+    """A misdeclared tier fails loudly; guessing would drop a vendor sandbox."""
+
+    def test_unknown_tier_raises_naming_every_allowed_value(self, tmp_path: Path) -> None:
+        home = _home(tmp_path)
+        home.set(HOST_ISOLATION_TIER_KEY, "kubernetes")
+
+        with pytest.raises(ValueError) as excinfo:
+            resolve_host_isolation(tmp_path, home=home)
+
+        message = str(excinfo.value)
+        assert "kubernetes" in message
+        assert HOST_ISOLATION_TIER_KEY in message
+        for value in allowed_tier_values():
+            assert value in message
+
+    def test_non_string_tier_raises(self, tmp_path: Path) -> None:
+        _write_project_config(tmp_path, "host_isolation_tier: true\n")
+
+        with pytest.raises(ValueError, match=HOST_ISOLATION_TIER_KEY):
+            resolve_host_isolation(tmp_path, home=_home(tmp_path))

--- a/tests/unit/test_spawner_host_isolation.py
+++ b/tests/unit/test_spawner_host_isolation.py
@@ -1,0 +1,126 @@
+"""The spawner hands the host-isolation declaration to adapters that ask (#5341).
+
+Only an adapter that owns a vendor sandbox consumes the declaration, and the
+hand-off is anchored in the HMAC audit chain: dropping a vendor sandbox is a
+posture change, so it has to be a signed record rather than a silent
+constructor argument. Adapters without the marker are left untouched.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from bernstein.core.spawner import AgentSpawner
+
+from bernstein.adapters.base import CLIAdapter
+from bernstein.adapters.capability_profile import SandboxTier
+from bernstein.adapters.codex import CodexAdapter
+from bernstein.core.security.audit_chain import EVENT_HOST_ISOLATION_DECLARED, AuditChainStore
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _declared_container(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BERNSTEIN_HOST_ISOLATION_TIER", "container")
+    monkeypatch.setenv("BERNSTEIN_HOST_ISOLATION_EVIDENCE", "read-only rootfs, cap-drop ALL")
+
+
+def _spawner(tmp_path: Path) -> AgentSpawner:
+    adapter = MagicMock(spec=CLIAdapter)
+    adapter.name.return_value = "MockCLI"
+    templates_dir = tmp_path / "templates" / "roles"
+    templates_dir.mkdir(parents=True)
+    return AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, default_model="mock-model")
+
+
+def _events(tmp_path: Path) -> list:
+    chain = AuditChainStore(tmp_path / ".sdd" / "audit")
+    return chain.query(event_type=EVENT_HOST_ISOLATION_DECLARED)
+
+
+def test_consuming_adapter_receives_the_declaration(tmp_path: Path) -> None:
+    spawner = _spawner(tmp_path)
+
+    with patch("bernstein.core.agents.spawner_core.get_adapter", return_value=CodexAdapter()):
+        adapter = spawner._get_adapter_by_name("codex")  # type: ignore[reportPrivateUsage]
+
+    assert adapter.host_isolation is SandboxTier.CONTAINER
+    assert adapter.host_isolation_evidence == "read-only rootfs, cap-drop ALL"
+
+
+def test_declaration_is_anchored_in_the_audit_chain(tmp_path: Path) -> None:
+    spawner = _spawner(tmp_path)
+    spawner.set_run_id("run-5341")
+
+    with patch("bernstein.core.agents.spawner_core.get_adapter", return_value=CodexAdapter()):
+        spawner._get_adapter_by_name("codex")  # type: ignore[reportPrivateUsage]
+
+    events = _events(tmp_path)
+    assert len(events) == 1
+    details = events[0].details
+    assert details["adapter"] == "codex"
+    assert details["tier"] == "container"
+    assert details["evidence"] == "read-only rootfs, cap-drop ALL"
+    assert details["vendor_sandbox_dropped"] is True
+    assert details["source"] == "session"
+    assert details["run_id"] == "run-5341"
+
+
+def test_declaration_is_recorded_once_per_adapter(tmp_path: Path) -> None:
+    """The adapter cache makes the second lookup a cache hit, not a second record."""
+    spawner = _spawner(tmp_path)
+
+    with patch("bernstein.core.agents.spawner_core.get_adapter", return_value=CodexAdapter()):
+        first = spawner._get_adapter_by_name("codex")  # type: ignore[reportPrivateUsage]
+        second = spawner._get_adapter_by_name("codex")  # type: ignore[reportPrivateUsage]
+
+    assert first is second
+    assert len(_events(tmp_path)) == 1
+
+
+def test_weak_tier_records_that_the_vendor_sandbox_stayed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BERNSTEIN_HOST_ISOLATION_TIER", "process")
+    spawner = _spawner(tmp_path)
+
+    with patch("bernstein.core.agents.spawner_core.get_adapter", return_value=CodexAdapter()):
+        adapter = spawner._get_adapter_by_name("codex")  # type: ignore[reportPrivateUsage]
+
+    assert adapter.host_isolation is SandboxTier.PROCESS
+    events = _events(tmp_path)
+    assert len(events) == 1
+    assert events[0].details["vendor_sandbox_dropped"] is False
+
+
+def test_adapter_without_the_marker_is_untouched(tmp_path: Path) -> None:
+    """qwen has no vendor sandbox to drop, so nothing is injected and nothing recorded."""
+    plain = MagicMock(spec=CLIAdapter)
+    plain.name.return_value = "Qwen"
+    spawner = _spawner(tmp_path)
+
+    with patch("bernstein.core.agents.spawner_core.get_adapter", return_value=plain):
+        adapter = spawner._get_adapter_by_name("qwen")  # type: ignore[reportPrivateUsage]
+
+    assert not hasattr(adapter, "host_isolation")
+    assert _events(tmp_path) == []
+
+
+def test_a_broken_declaration_does_not_wedge_the_spawn(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A misdeclared tier is loud, but the adapter still spawns sandboxed."""
+    monkeypatch.setenv("BERNSTEIN_HOST_ISOLATION_TIER", "kubernetes")
+    spawner = _spawner(tmp_path)
+
+    with (
+        patch("bernstein.core.agents.spawner_core.get_adapter", return_value=CodexAdapter()),
+        caplog.at_level("WARNING", logger="bernstein.core.agents.spawner_core"),
+    ):
+        adapter = spawner._get_adapter_by_name("codex")  # type: ignore[reportPrivateUsage]
+
+    assert adapter.host_isolation == SandboxTier.NONE
+    assert any("kubernetes" in record.getMessage() for record in caplog.records)
+    assert _events(tmp_path) == []


### PR DESCRIPTION
Closes #5341

The codex adapter always launches `codex exec` with the vendor sandbox on. That sandbox needs unprivileged user namespaces; inside a container that already isolates the process (read-only root, dropped capabilities, no new privileges) it cannot start, and the run exits 0 having done no work. The only way to drop it was the dangerous-mode switch, which says nothing about why dropping it is safe.

This adds an explicit, audited operator declaration of the isolation the host applies:

- Two layered config keys, `host_isolation_tier` (`none` | `process` | `container` | `vm`, the existing sandbox tiers) and `host_isolation_evidence` (free text), with the usual precedence and the env overrides `BERNSTEIN_HOST_ISOLATION_TIER` / `BERNSTEIN_HOST_ISOLATION_EVIDENCE`. `bernstein config get/set/list` handle them like every other key.
- `resolve_host_isolation()` returns the declaration with its provenance; an unknown tier is rejected with the allowed values named.
- The spawner injects the declaration into adapters that advertise `consumes_host_isolation` and writes one `sandbox.host_isolation_declared` event to the audit chain per adapter (tier, evidence, source, whether a vendor sandbox was dropped). A malformed tier is logged and leaves the vendor sandbox on.
- The codex adapter drops its sandbox only for `container` and `vm`; `none` and `process` keep it. One warning per adapter names the tier and evidence the drop rests on. The dangerous-mode path is unchanged, and so is the planning-time refusal for hosts without an OS sandbox.

Tests cover the resolver precedence and vocabulary, the adapter's argv per tier, the spawner injection and audit record, and that adapters without the marker are untouched. Docs: adapter guide, sandbox architecture, global config keys, and a release-note fragment.