### PR TITLE
fix: dedupe unpriced-model cost warning, show "unpriced" instead of $0.00 (#5337)

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,47 @@
+Closes #5337
+
+## Summary
+`price_model_usage` logged the "no pricing-table entry" warning on every
+call for an unpriced model/route name, flooding logs in non-interactive
+runs. Cost-estimate lines also showed `$0.00` for these, implying free
+rather than unpriced.
+
+## Changes
+- `model_prices.py` — module-level `_WARNED_UNPRICED_MODELS` set gates the
+  warning to once per distinct model name per process. No change to
+  wording, log level, or metering; `priced` stays `False`, tokens still
+  count in totals.
+- `run_preflight.py`, `bootstrap.py`, `run_bootstrap.py` — cost-estimate
+  lines print `unpriced` instead of `$0.00` when `priced=False`. Free
+  routes (`:free` suffix / free adapters) unaffected.
+- `test_cost_price_model_usage.py` — new tests: dedup same name, dedup
+  per distinct name, unpriced display (bootstrap + preflight), priced
+  display unaffected.
+- `test_openai_agents.py` — clears warned-set before its test to avoid
+  cross-test leakage.
+- `docs/release-notes/fragments/5337-cost-warning-dedup.md` — release note.
+
+## Acceptance criteria
+- [x] Same unpriced name warns once; repeat calls silent.
+- [x] Different unpriced names each warn once.
+- [x] Unpriced cost-estimate lines read `unpriced`, not `$0.00`; priced
+      models unaffected.
+- [x] `priced` stays `False`; totals still include unpriced tokens.
+
+## Out of scope
+Token metering, `MODEL_COSTS_PER_1M_TOKENS`, no config flags, no
+persistence for the warned-names set.
+
+## Testing
+```
+uv run pytest tests/unit/test_cost_price_model_usage.py \
+  tests/unit/test_issue_3013_free_route_banner_pricing.py \
+  tests/unit/test_cost_engine.py \
+  tests/unit/cost/test_model_call_ledger.py -q
+# 90 passed
+
+uv run ruff check src tests
+# clean
+```
+Pre-existing Windows failure (`test_append_tokens_sidecar_survives_unwritable_path`)
+also fails on `main`, unrelated to this change.

--- a/docs/release-notes/fragments/5337-cost-warning-dedup.md
+++ b/docs/release-notes/fragments/5337-cost-warning-dedup.md
@@ -1,0 +1,3 @@
+## Cost warning dedup and unpriced estimate display
+
+`price_model_usage` now warns once per distinct unpriced model name per process instead of on every call, so gateway aliases like `fleet-live` no longer spam the log and bury goal, plan, and task-state lines. Cost-estimate lines (`Estimated cost:`, `Cost estimate:`) now show `unpriced` for such models instead of `$0.00`, while priced models and legitimately free (`:free`) routes are unchanged. Token metering is untouched — unpriced calls still report their tokens in totals.

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -752,9 +752,9 @@ def _show_dry_run_plan(
     est_model = model_override or "sonnet"
     low_usd, high_usd = estimate_run_cost(len(tasks), est_model)
     console.print(f"\n  Total tasks: {len(tasks)}")
-    from bernstein.core.cost.model_prices import price_model_usage
+    from bernstein.core.cost.model_prices import is_unpriced_model
 
-    _is_unpriced = not est_model.lower().endswith(":free") and not price_model_usage(est_model, 1, 1).priced
+    _is_unpriced = is_unpriced_model(est_model)
     if _is_unpriced:
         console.print("  Estimated cost: unpriced")
     else:

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -752,7 +752,13 @@ def _show_dry_run_plan(
     est_model = model_override or "sonnet"
     low_usd, high_usd = estimate_run_cost(len(tasks), est_model)
     console.print(f"\n  Total tasks: {len(tasks)}")
-    console.print(f"  Estimated cost: ${(low_usd + high_usd) / 2:.2f} (${low_usd:.2f}-${high_usd:.2f})")
+    from bernstein.core.cost.model_prices import price_model_usage
+
+    _is_unpriced = not est_model.lower().endswith(":free") and not price_model_usage(est_model, 1, 1).priced
+    if _is_unpriced:
+        console.print("  Estimated cost: unpriced")
+    else:
+        console.print(f"  Estimated cost: ${(low_usd + high_usd) / 2:.2f} (${low_usd:.2f}-${high_usd:.2f})")
 
     console.print("\n[green]Dry run complete. No agents were spawned.[/green]")
 

--- a/src/bernstein/cli/run_preflight.py
+++ b/src/bernstein/cli/run_preflight.py
@@ -390,6 +390,29 @@ def _resolve_model_and_cli(
 _FREE_ADAPTERS = frozenset(("qwen", "gemini", "ollama"))
 
 
+def _is_unpriced_model(display_model: str) -> bool:
+    """Return True when *display_model* has no pricing-table entry (priced=False).
+
+    ``display_model`` may be ``"adapter/model"`` or just ``"model"``.
+    A ``:free`` suffix or a free adapter (qwen/gemini/ollama) is treated as
+    genuinely free, not unpriced, so it still displays ``$0.00``.
+    """
+    model_part = display_model.split("/")[-1] if "/" in display_model else display_model
+    model_part = model_part.strip()
+    if not model_part:
+        return False
+    if model_part.lower().endswith(":free"):
+        return False
+    lower_disp = display_model.lower()
+    for adapter in _FREE_ADAPTERS:
+        if lower_disp == adapter or lower_disp.startswith(adapter + "/"):
+            return False
+    from bernstein.core.cost.model_prices import price_model_usage
+
+    probe = price_model_usage(model_part, 1, 1)
+    return not probe.priced
+
+
 def _estimate_run_preview(
     *,
     workdir: Path,
@@ -507,12 +530,22 @@ def _emit_preflight_runtime_warnings(
         if estimate.free_route:
             # A zero-cost route (:free / unpriced) must not be quoted a
             # phantom rate: the real run meters it at $0 (issue #3013).
-            if estimate.task_count is not None:
+            # For an *unpriced* gateway alias (e.g. fleet-live) the cost is
+            # unknown, not free — show "unpriced" instead of $0.00 (issue #5337).
+            if _is_unpriced_model(estimate.model):
+                if estimate.task_count is not None:
+                    basis = f"unpriced ({estimate.model}), based on {estimate.task_count} task(s)"
+                else:
+                    basis = f"unpriced ({estimate.model}), task count not yet planned"
+            elif estimate.task_count is not None:
                 basis = f"free route - no cost ({estimate.model}), based on {estimate.task_count} task(s)"
             else:
                 basis = f"free route - no cost ({estimate.model}), task count not yet planned"
         if band is not None:
-            console.print(f"[bold yellow]{format_band(band)}[/bold yellow]")
+            if _is_unpriced_model(estimate.model):
+                console.print("[bold yellow]Estimated cost: unpriced[/bold yellow]")
+            else:
+                console.print(f"[bold yellow]{format_band(band)}[/bold yellow]")
             if estimate.free_route:
                 console.print(f"[dim]{basis}[/dim]")
             else:
@@ -523,9 +556,15 @@ def _emit_preflight_runtime_warnings(
                 )
                 console.print(f"[dim]{basis}, {samples_note}[/dim]")
         else:
-            console.print(
-                f"[bold yellow]Estimated cost:[/bold yellow] ${estimate.low_usd:.2f}-${estimate.high_usd:.2f} {basis}"
-            )
+            if _is_unpriced_model(estimate.model):
+                console.print(
+                    f"[bold yellow]Estimated cost:[/bold yellow] unpriced {basis}"
+                )
+            else:
+                console.print(
+                    f"[bold yellow]Estimated cost:[/bold yellow] "
+                    f"${estimate.low_usd:.2f}-${estimate.high_usd:.2f} {basis}"
+                )
         if disk_usage_gb >= 1.0:
             console.print(
                 "[yellow]Warning:[/yellow] "

--- a/src/bernstein/cli/run_preflight.py
+++ b/src/bernstein/cli/run_preflight.py
@@ -531,9 +531,7 @@ def _emit_preflight_runtime_warnings(
                 console.print(f"[dim]{basis}, {samples_note}[/dim]")
         else:
             if is_unpriced_model(estimate.model):
-                console.print(
-                    f"[bold yellow]Estimated cost:[/bold yellow] unpriced {basis}"
-                )
+                console.print(f"[bold yellow]Estimated cost:[/bold yellow] unpriced {basis}")
             else:
                 console.print(
                     f"[bold yellow]Estimated cost:[/bold yellow] "

--- a/src/bernstein/cli/run_preflight.py
+++ b/src/bernstein/cli/run_preflight.py
@@ -22,7 +22,7 @@ from bernstein.cli.helpers import (
 from bernstein.cli.run import render_run_summary_from_dict
 from bernstein.cli.ui import make_console
 from bernstein.core.cost import estimate_run_cost
-from bernstein.core.cost.model_prices import is_free_route
+from bernstein.core.cost.model_prices import _FREE_ADAPTERS, is_free_route, is_unpriced_model
 from bernstein.core.cost.preflight import CostBand, compute_band, format_band
 from bernstein.core.plan_loader import load_plan_from_yaml
 from bernstein.core.runtime_state import directory_size_bytes
@@ -387,32 +387,6 @@ def _resolve_model_and_cli(
     return est_model, est_cli, est_role
 
 
-_FREE_ADAPTERS = frozenset(("qwen", "gemini", "ollama"))
-
-
-def _is_unpriced_model(display_model: str) -> bool:
-    """Return True when *display_model* has no pricing-table entry (priced=False).
-
-    ``display_model`` may be ``"adapter/model"`` or just ``"model"``.
-    A ``:free`` suffix or a free adapter (qwen/gemini/ollama) is treated as
-    genuinely free, not unpriced, so it still displays ``$0.00``.
-    """
-    model_part = display_model.split("/")[-1] if "/" in display_model else display_model
-    model_part = model_part.strip()
-    if not model_part:
-        return False
-    if model_part.lower().endswith(":free"):
-        return False
-    lower_disp = display_model.lower()
-    for adapter in _FREE_ADAPTERS:
-        if lower_disp == adapter or lower_disp.startswith(adapter + "/"):
-            return False
-    from bernstein.core.cost.model_prices import price_model_usage
-
-    probe = price_model_usage(model_part, 1, 1)
-    return not probe.priced
-
-
 def _estimate_run_preview(
     *,
     workdir: Path,
@@ -532,7 +506,7 @@ def _emit_preflight_runtime_warnings(
             # phantom rate: the real run meters it at $0 (issue #3013).
             # For an *unpriced* gateway alias (e.g. fleet-live) the cost is
             # unknown, not free — show "unpriced" instead of $0.00 (issue #5337).
-            if _is_unpriced_model(estimate.model):
+            if is_unpriced_model(estimate.model):
                 if estimate.task_count is not None:
                     basis = f"unpriced ({estimate.model}), based on {estimate.task_count} task(s)"
                 else:
@@ -542,7 +516,7 @@ def _emit_preflight_runtime_warnings(
             else:
                 basis = f"free route - no cost ({estimate.model}), task count not yet planned"
         if band is not None:
-            if _is_unpriced_model(estimate.model):
+            if is_unpriced_model(estimate.model):
                 console.print("[bold yellow]Estimated cost: unpriced[/bold yellow]")
             else:
                 console.print(f"[bold yellow]{format_band(band)}[/bold yellow]")
@@ -556,7 +530,7 @@ def _emit_preflight_runtime_warnings(
                 )
                 console.print(f"[dim]{basis}, {samples_note}[/dim]")
         else:
-            if _is_unpriced_model(estimate.model):
+            if is_unpriced_model(estimate.model):
                 console.print(
                     f"[bold yellow]Estimated cost:[/bold yellow] unpriced {basis}"
                 )

--- a/src/bernstein/core/cost/model_prices.py
+++ b/src/bernstein/core/cost/model_prices.py
@@ -16,6 +16,8 @@ logger = logging.getLogger(__name__)
 
 _WARNED_UNPRICED_MODELS: set[str] = set()
 
+_FREE_ADAPTERS = frozenset(("qwen", "gemini", "ollama"))
+
 
 # Model name constants (used across pricing tables and cache tiers)
 MODEL_GPT_5_4 = "gpt-5.4"
@@ -252,3 +254,25 @@ def is_free_route(model: str) -> bool:
     # mean the run's own metering would report no cost for this route.
     probe = price_model_usage(model, 1, 1)
     return (not probe.priced) or probe.cost_usd == 0.0
+
+
+def is_unpriced_model(display_model: str | None) -> bool:
+    """Return True when *display_model* has no pricing-table entry (priced=False).
+
+    *display_model* may be ``"adapter/model"`` or just ``"model"``.
+    A ``:free`` suffix or a free adapter (qwen/gemini/ollama) is treated as
+    genuinely free, not unpriced.
+    """
+    if not display_model:
+        return False
+    model_part = display_model.split("/")[-1] if "/" in display_model else display_model
+    model_part = model_part.strip()
+    if not model_part:
+        return False
+    if model_part.lower().endswith(":free"):
+        return False
+    lower_disp = display_model.lower()
+    for adapter in _FREE_ADAPTERS:
+        if lower_disp == adapter or lower_disp.startswith(adapter + "/"):
+            return False
+    return not price_model_usage(model_part, 1, 1).priced

--- a/src/bernstein/core/cost/model_prices.py
+++ b/src/bernstein/core/cost/model_prices.py
@@ -14,6 +14,8 @@ from typing import TypedDict
 
 logger = logging.getLogger(__name__)
 
+_WARNED_UNPRICED_MODELS: set[str] = set()
+
 
 # Model name constants (used across pricing tables and cache tiers)
 MODEL_GPT_5_4 = "gpt-5.4"
@@ -196,15 +198,17 @@ def price_model_usage(
                 priced=True,
                 model_call_id=model_call_id,
             )
-    logger.warning(
-        "price_model_usage: no pricing-table entry for model %r - metering at "
-        "$0/token so this call's tokens stay visible instead of vanishing from "
-        "cost totals (input_tokens=%d, output_tokens=%d). Add an entry to "
-        "MODEL_COSTS_PER_1M_TOKENS to price this model.",
-        model,
-        input_tokens,
-        output_tokens,
-    )
+    if model not in _WARNED_UNPRICED_MODELS:
+        logger.warning(
+            "price_model_usage: no pricing-table entry for model %r - metering at "
+            "$0/token so this call's tokens stay visible instead of vanishing from "
+            "cost totals (input_tokens=%d, output_tokens=%d). Add an entry to "
+            "MODEL_COSTS_PER_1M_TOKENS to price this model.",
+            model,
+            input_tokens,
+            output_tokens,
+        )
+        _WARNED_UNPRICED_MODELS.add(model)
     return UsagePriceResult(
         model=model,
         input_tokens=input_tokens,

--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -566,15 +566,12 @@ def _sync_and_plan_tasks(
 def _is_model_unpriced(model: str | None) -> bool:
     """Return True when *model* has no pricing-table entry.
 
-    A ``:free`` suffix is treated as genuinely free, not unpriced.
+    A ``:free`` suffix or a free adapter (qwen/gemini/ollama) is treated as
+    genuinely free, not unpriced.
     """
-    if not model:
-        return False
-    if model.strip().lower().endswith(":free"):
-        return False
-    from bernstein.core.cost.model_prices import price_model_usage
+    from bernstein.core.cost.model_prices import is_unpriced_model
 
-    return not price_model_usage(model.strip(), 1, 1).priced
+    return is_unpriced_model(model)
 
 
 def _describe_cost_estimate(backlog_count: int, model: str | None) -> str:

--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -563,6 +563,20 @@ def _sync_and_plan_tasks(
     return backlog_count, manager_task_id, prior_session
 
 
+def _is_model_unpriced(model: str | None) -> bool:
+    """Return True when *model* has no pricing-table entry.
+
+    A ``:free`` suffix is treated as genuinely free, not unpriced.
+    """
+    if not model:
+        return False
+    if model.strip().lower().endswith(":free"):
+        return False
+    from bernstein.core.cost.model_prices import price_model_usage
+
+    return not price_model_usage(model.strip(), 1, 1).priced
+
+
 def _describe_cost_estimate(backlog_count: int, model: str | None) -> str:
     """Build the startup cost-estimate fragment from the synced task count.
 
@@ -584,10 +598,14 @@ def _describe_cost_estimate(backlog_count: int, model: str | None) -> str:
 
     if backlog_count > 0:
         if model:
+            if _is_model_unpriced(model):
+                return f"unpriced ({backlog_count} task(s), {model})"
             low, high = estimate_run_cost(backlog_count, model)
             return f"~${low:.2f}-${high:.2f} ({backlog_count} task(s), {model})"
         return f"unknown (no model configured, {backlog_count} task(s))"
     if model:
+        if _is_model_unpriced(model):
+            return f"unpriced per task ({model}, task count pending planning)"
         low, high = estimate_run_cost(1, model)
         return f"~${low:.2f}-${high:.2f} per task ({model}, task count pending planning)"
     return "unknown (no model configured, task count pending planning)"

--- a/tests/unit/adapters/test_openai_agents.py
+++ b/tests/unit/adapters/test_openai_agents.py
@@ -2362,6 +2362,9 @@ class TestBug13CostMetering:
         """A model with no pricing-table entry must not vanish from cost
         totals: cost is an explicit $0, a WARNING is logged, and the token
         counts still flow through to the usage event and the sidecar."""
+        from bernstein.core.cost import model_prices as _mp
+
+        _mp._WARNED_UNPRICED_MODELS.clear()
         heartbeat_dir = tmp_path / ".sdd" / "runtime" / "heartbeats"
         manifest = self._manifest(model="totally-unknown-model-xyz", heartbeat_dir=str(heartbeat_dir))
 

--- a/tests/unit/test_cost_price_model_usage.py
+++ b/tests/unit/test_cost_price_model_usage.py
@@ -263,3 +263,28 @@ class TestCostEstimateUnpricedDisplay:
         out = cap.get()
         assert "$" in out
         assert "unpriced" not in out.lower()
+
+
+class TestFreeAdapterConsistency:
+    """qwen/gemini/ollama and :free must show $0.00, not unpriced, everywhere (issue #5337 follow-up)."""
+
+    @pytest.mark.parametrize("model_str", ["qwen", "gemini", "ollama", "qwen/some-model", "sonnet:free"])
+    def test_shared_helper_treats_free_adapters_as_free(self, model_str: str) -> None:
+        from bernstein.core.cost.model_prices import is_unpriced_model
+
+        assert is_unpriced_model(model_str) is False
+
+    def test_bootstrap_describe_cost_estimate_free_adapter_not_unpriced(self) -> None:
+        from bernstein.core.orchestration.bootstrap import _describe_cost_estimate
+
+        for model_str in ["qwen", "gemini", "ollama", "qwen/some-model", "sonnet:free"]:
+            out = _describe_cost_estimate(3, model_str)
+            assert "unpriced" not in out.lower(), f"model={model_str} out={out}"
+
+    def test_run_bootstrap_dry_run_free_adapter_not_unpriced(self) -> None:
+        """Dry-run cost line in run_bootstrap.py uses the shared helper."""
+        from bernstein.core.cost.model_prices import is_unpriced_model
+
+        # The dry-run path calls is_unpriced_model(est_model) directly
+        for model_str in ["qwen", "gemini", "ollama", "qwen/some-model", "sonnet:free"]:
+            assert is_unpriced_model(model_str) is False, f"model={model_str}"

--- a/tests/unit/test_cost_price_model_usage.py
+++ b/tests/unit/test_cost_price_model_usage.py
@@ -148,3 +148,118 @@ class TestPriceModelUsage:
             assert result.cost_usd >= 0.0
             if pricing.get("input", 0.0) > 0 or pricing.get("output", 0.0) > 0:
                 assert result.cost_usd > 0.0, f"{key} priced to exactly zero"
+
+
+class TestPriceModelUsageDedup:
+    """Dedup: warning once per distinct model name per process (issue #5337)."""
+
+    def test_price_model_usage_warns_once_per_model_name(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from bernstein.core.cost import model_prices as mp
+
+        mp._WARNED_UNPRICED_MODELS.clear()
+        try:
+            with caplog.at_level("WARNING"):
+                mp.price_model_usage("fleet-live", input_tokens=1, output_tokens=1)
+                mp.price_model_usage("fleet-live", input_tokens=1, output_tokens=1)
+            records = [r for r in caplog.records if "fleet-live" in r.message]
+            assert len(records) == 1
+            # priced False and tokens still visible
+            result = mp.price_model_usage("fleet-live", input_tokens=2, output_tokens=3)
+            assert result.priced is False
+            assert result.input_tokens == 2
+            assert result.output_tokens == 3
+            assert result.cost_usd == 0.0
+        finally:
+            mp._WARNED_UNPRICED_MODELS.clear()
+
+    def test_price_model_usage_warns_once_per_distinct_model_name(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from bernstein.core.cost import model_prices as mp
+
+        mp._WARNED_UNPRICED_MODELS.clear()
+        try:
+            with caplog.at_level("WARNING"):
+                mp.price_model_usage("fleet-alpha", input_tokens=1, output_tokens=1)
+                mp.price_model_usage("fleet-beta", input_tokens=1, output_tokens=1)
+            records = [r for r in caplog.records if "no pricing-table entry" in r.message]
+            assert len(records) == 2
+            assert any("fleet-alpha" in r.message for r in records)
+            assert any("fleet-beta" in r.message for r in records)
+        finally:
+            mp._WARNED_UNPRICED_MODELS.clear()
+
+
+class TestCostEstimateUnpricedDisplay:
+    """Cost-estimate lines for an unpriced model say 'unpriced', not '$0.00'."""
+
+    def test_describe_cost_estimate_unpriced_says_unpriced(self) -> None:
+        from bernstein.core.cost import model_prices as mp
+        from bernstein.core.orchestration.bootstrap import _describe_cost_estimate
+
+        mp._WARNED_UNPRICED_MODELS.clear()
+        try:
+            out = _describe_cost_estimate(3, "fleet-live")
+            assert "unpriced" in out.lower()
+            assert "$0.00" not in out
+            assert "fleet-live" in out
+        finally:
+            mp._WARNED_UNPRICED_MODELS.clear()
+
+    def test_describe_cost_estimate_priced_still_shows_dollars(self) -> None:
+        from bernstein.core.orchestration.bootstrap import _describe_cost_estimate
+
+        out = _describe_cost_estimate(3, "sonnet")
+        assert "$" in out
+        assert "unpriced" not in out.lower()
+
+    def test_run_preflight_unpriced_banner_says_unpriced(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+
+        from bernstein.cli.run_preflight import _emit_preflight_runtime_warnings, _estimate_run_preview, console
+        from bernstein.core.cost import model_prices as mp
+
+        mp._WARNED_UNPRICED_MODELS.clear()
+        try:
+            estimate = _estimate_run_preview(
+                workdir=tmp_path,
+                plan_file=None,
+                goal=None,
+                seed_file=None,
+                model_override="fleet-live",
+            )
+            assert estimate.free_route is True
+            with console.capture() as cap:
+                _emit_preflight_runtime_warnings(
+                    workdir=tmp_path,
+                    estimate=estimate,
+                    auto_approve=True,
+                    quiet=False,
+                )
+            out = cap.get()
+            assert "unpriced" in out.lower()
+            assert "$0.00" not in out
+        finally:
+            mp._WARNED_UNPRICED_MODELS.clear()
+
+    def test_run_preflight_priced_banner_unaffected(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        from bernstein.cli.run_preflight import _emit_preflight_runtime_warnings, _estimate_run_preview, console
+
+        estimate = _estimate_run_preview(
+            workdir=tmp_path,
+            plan_file=None,
+            goal=None,
+            seed_file=None,
+            model_override="sonnet",
+        )
+        with console.capture() as cap:
+            _emit_preflight_runtime_warnings(
+                workdir=tmp_path,
+                estimate=estimate,
+                auto_approve=True,
+                quiet=False,
+            )
+        out = cap.get()
+        assert "$" in out
+        assert "unpriced" not in out.lower()


### PR DESCRIPTION
Closes #5337

## Summary
`price_model_usage` logged the "no pricing-table entry" warning on every
call for an unpriced model/route name, flooding logs in non-interactive
runs. Cost-estimate lines also showed `$0.00` for these, implying free
rather than unpriced.

## Changes
- `model_prices.py` — module-level `_WARNED_UNPRICED_MODELS` set gates the
  warning to once per distinct model name per process. No change to
  wording, log level, or metering; `priced` stays `False`, tokens still
  count in totals.
- `run_preflight.py`, `bootstrap.py`, `run_bootstrap.py` — cost-estimate
  lines print `unpriced` instead of `$0.00` when `priced=False`. Free
  routes (`:free` suffix / free adapters) unaffected.
- `test_cost_price_model_usage.py` — new tests: dedup same name, dedup
  per distinct name, unpriced display (bootstrap + preflight), priced
  display unaffected.
- `test_openai_agents.py` — clears warned-set before its test to avoid
  cross-test leakage.
- `docs/release-notes/fragments/5337-cost-warning-dedup.md` — release note.

## Acceptance criteria
- [x] Same unpriced name warns once; repeat calls silent.
- [x] Different unpriced names each warn once.
- [x] Unpriced cost-estimate lines read `unpriced`, not `$0.00`; priced
      models unaffected.
- [x] `priced` stays `False`; totals still include unpriced tokens.

## Out of scope
Token metering, `MODEL_COSTS_PER_1M_TOKENS`, no config flags, no
persistence for the warned-names set.

## Testing

Verified locally with:
- `uv run pytest tests/unit/test_cost_price_model_usage.py tests/unit/test_issue_3013_free_route_banner_pricing.py tests/unit/test_cost_engine.py tests/unit/cost/test_model_call_ledger.py -q` → 90 passed
- `uv run ruff check src tests` → clean

Pre-existing Windows failure (`test_append_tokens_sidecar_survives_unwritable_path`)
also fails on `main`, unrelated to this change.