### PR TITLE
fix: bind audit-range since/until/head_hmac into the signed run-receipt subject

### DIFF
--- a/docs/release-notes/fragments/5269-bind-audit-range-since-until-hmac.md
+++ b/docs/release-notes/fragments/5269-bind-audit-range-since-until-hmac.md
@@ -1,0 +1,8 @@
+## Run receipts bind the declared audit window, not just its content hash
+
+`since`, `until`, and `head_hmac` on an opt-in `audit_range` block described which window
+the embedded audit events came from, but only the recomputed content head was part of the
+signed subject. A receipt could be edited after signing to relabel that window (or swap
+`head_hmac`) with no effect on verification. All three are now bound into the signature the
+same way the content head already was, so relabelling any of them fails closed as tampered
+(#5269).

--- a/src/bernstein/core/replay/run_receipt.py
+++ b/src/bernstein/core/replay/run_receipt.py
@@ -229,6 +229,9 @@ def _binding_block(
     spine_count: int,
     audit_head_sha256: str | None,
     endpoint_identities: list[dict[str, str]] | None = None,
+    audit_since: str | None = None,
+    audit_until: str | None = None,
+    audit_head_hmac: str | None = None,
 ) -> dict[str, Any]:
     """The subject binding: one canonical block over every recomputed head.
 
@@ -238,6 +241,14 @@ def _binding_block(
     ``audit_head_sha256`` is omitted (not nulled) when absent so stripping
     the opt-in audit block from a receipt that was signed with it changes
     the binding bytes and collapses verification.
+
+    ``audit_since``/``audit_until``/``audit_head_hmac`` describe the
+    declared audit window itself, not just its recomputed content head, and
+    are bound alongside it: the verifier cannot re-derive ``head_hmac``
+    without the operator's HMAC key, so it passes through the receipt's own
+    ``audit_range`` values here rather than recomputing them, which is
+    enough to make relabelling the window post-signing fail the signature
+    check the same way mutating the audit events does.
 
     When ``endpoint_identities`` is provided (non-empty), it is included in
     the binding block as an ``endpoints`` array. The verifier will only
@@ -257,6 +268,12 @@ def _binding_block(
         block["endpoints"] = endpoint_identities
     if audit_head_sha256 is not None:
         block["audit_range_head_sha256"] = audit_head_sha256
+        if audit_since is not None:
+            block["audit_range_since"] = audit_since
+        if audit_until is not None:
+            block["audit_range_until"] = audit_until
+        if audit_head_hmac is not None:
+            block["audit_range_head_hmac"] = audit_head_hmac
     return block
 
 
@@ -600,6 +617,9 @@ def build_run_receipt(
         spine_count=len(spine_rows),
         audit_head_sha256=audit_head,
         endpoint_identities=_extract_endpoint_identities(journal_rows),
+        audit_since=audit_block["since"] if audit_block is not None else None,
+        audit_until=audit_block["until"] if audit_block is not None else None,
+        audit_head_hmac=audit_block["head_hmac"] if audit_block is not None else None,
     )
     binding_bytes = _canonical_json_bytes(binding)
     subject_sha256 = hashlib.sha256(binding_bytes).hexdigest()
@@ -817,6 +837,9 @@ def verify_run_receipt(
 
     # 3. Optional audit range: head recomputes from the embedded events.
     audit_head: str | None = None
+    audit_since: str | None = None
+    audit_until: str | None = None
+    audit_head_hmac: str | None = None
     audit_block = receipt.get("audit_range")
     if audit_block is not None:
         if not isinstance(audit_block, dict) or not isinstance(audit_block.get("events"), list):
@@ -830,6 +853,11 @@ def verify_run_receipt(
         if audit_block.get("event_count") != len(audit_events):
             return _tampered(["audit_range.event_count does not match the embedded events"])
         audit_head = recomputed_audit_head
+        # Cannot be recomputed here without the operator's HMAC key, so the
+        # receipt's own values are bound as-is (see _binding_block).
+        audit_since = audit_block.get("since")
+        audit_until = audit_block.get("until")
+        audit_head_hmac = audit_block.get("head_hmac")
 
     # 4. Subject binding: rebuilt from recomputed values only.
     endpoint_identities = _extract_endpoint_identities(events)
@@ -841,6 +869,9 @@ def verify_run_receipt(
         spine_count=len(entries),
         audit_head_sha256=audit_head,
         endpoint_identities=endpoint_identities if endpoint_identities else None,
+        audit_since=audit_since,
+        audit_until=audit_until,
+        audit_head_hmac=audit_head_hmac,
     )
     binding_bytes = _canonical_json_bytes(binding)
     recomputed_subject = hashlib.sha256(binding_bytes).hexdigest()

--- a/tests/unit/test_run_receipt.py
+++ b/tests/unit/test_run_receipt.py
@@ -319,6 +319,38 @@ def test_audit_range_round_trip_and_strip_collapse(tmp_path: Path) -> None:
     assert result_mut.status == "tampered"
 
 
+def test_audit_range_since_until_hmac_relabel_fails(tmp_path: Path) -> None:
+    """Relabelling the declared audit window is tamper, not a silent pass.
+
+    since/until/head_hmac describe which window the embedded audit events
+    were claimed to come from. Before this fix only the recomputed content
+    head (audit_range_head_sha256) was bound into the signed subject, so
+    these three fields could be edited post-signing with no effect on
+    verification.
+    """
+    sdd = tmp_path / ".sdd"
+    _seed_run(sdd)
+    _seed_audit(sdd)
+    receipt = build_run_receipt(
+        _RUN_ID,
+        sdd,
+        _kms(tmp_path),
+        include_audit_range=True,
+        audit_hmac_key=_HMAC_KEY,
+        audit_since="2020-01-01T00:00:00.000000Z",
+        audit_until="2100-01-01T00:00:00.000000Z",
+        write=False,
+    )
+    assert verify_run_receipt(receipt.receipt_bytes).ok
+
+    for field in ("since", "until", "head_hmac"):
+        doc = json.loads(receipt.receipt_bytes)
+        doc["audit_range"][field] = "forged"
+        result = verify_run_receipt(_reserialize(doc))
+        assert not result.ok, f"relabelling audit_range.{field} should fail verification"
+        assert result.status == "tampered"
+
+
 def test_audit_range_requires_build_inputs(tmp_path: Path) -> None:
     """include_audit_range without key/window is refused, never half-built."""
     sdd = tmp_path / ".sdd"


### PR DESCRIPTION
`verify_run_receipt()` recomputes `audit_range.head_sha256` from the embedded events and checks it, but `since`, `until`, and `head_hmac` were never re-derived or bound into the signed subject. Since `_binding_block()` only carried `audit_range_head_sha256`, those three fields could be edited after signing with zero effect on verification: a receipt could be relabelled to claim a different audit window than the one it was actually signed over.

`head_hmac` can't be recomputed at verify time without the operator's HMAC key (build-time only, same as today). So instead of recomputing, `_binding_block()` now binds the receipt's own `since`/`until`/`head_hmac` values as-is, the same way it already treats `audit_range_head_sha256`. Any post-signing edit to any of the three now changes the binding bytes and fails the signature check.

Added `test_audit_range_since_until_hmac_relabel_fails`, which builds a real signed receipt with an audit range and mutates each of the three fields in turn. The new test fails without the change (all three still verify `ok`) and passes with it. The rest of `test_run_receipt.py`, plus `test_run_receipt_format_vectors.py` and `test_receipt_key_chain.py`, still pass (50 total); the committed vector fixtures carry no `audit_range` block so they're unaffected either way.

`ruff check`/`format --check`, `vulture`, and `bandit` are clean on both changed files. Didn't run `pyright` locally (this file isn't in the strict allow-list, so it's advisory-only anyway) or the full suite (impractical at this repo's scale for a two-function change with the relevant tests run directly).

PR #5304 is open and touches `_binding_block()` too, adding an unrelated `extension_set_digest` field. Checked its diff: additive, different optional field, no overlap with the fix here.
