### PR TITLE
fix(cost): dedupe the unpriced-model warning and label estimates "unpriced" (#5337)

### DIFF
--- a/docs/release-notes/fragments/5337-unpriced-model-warning-once.md
+++ b/docs/release-notes/fragments/5337-unpriced-model-warning-once.md
@@ -1,0 +1,8 @@
+## Unpriced model names warn once and read `unpriced`, not `$0.00`
+
+A model name with no pricing-table entry (a gateway alias, for example) logged the full
+`no pricing-table entry` warning on every priced call, and the cost-estimate lines quoted
+`$0.00` as if the run were free. The warning now fires once per distinct name per process,
+later calls meter at `$0` silently with `priced=False` so totals still carry the tokens, and
+the dry-run, preflight and bootstrap estimate lines say `unpriced` for such a name. A real
+`:free` route is unchanged (#5337).

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -43,7 +43,7 @@ from bernstein.cli.run_preflight import (
     _show_run_summary,
     validate_seed_or_exit,
 )
-from bernstein.core.cost import estimate_run_cost
+from bernstein.core.cost import estimate_run_cost, model_cost_is_known
 from bernstein.core.errors import BernsteinFirstRunError
 from bernstein.core.manager_parsing import _resolve_depends_on  # pyright: ignore[reportPrivateUsage]
 from bernstein.core.orchestration.process_utils import (
@@ -750,9 +750,13 @@ def _show_dry_run_plan(
             console.print(f"  {task.title} -> [{dep_str}]")
 
     est_model = model_override or "sonnet"
-    low_usd, high_usd = estimate_run_cost(len(tasks), est_model)
     console.print(f"\n  Total tasks: {len(tasks)}")
-    console.print(f"  Estimated cost: ${(low_usd + high_usd) / 2:.2f} (${low_usd:.2f}-${high_usd:.2f})")
+    if not model_cost_is_known(est_model):
+        # No pricing-table entry: meters at $0 but is not free (issue #5337).
+        console.print(f"  Estimated cost: unpriced ({est_model} not in pricing table)")
+    else:
+        low_usd, high_usd = estimate_run_cost(len(tasks), est_model)
+        console.print(f"  Estimated cost: ${(low_usd + high_usd) / 2:.2f} (${low_usd:.2f}-${high_usd:.2f})")
 
     console.print("\n[green]Dry run complete. No agents were spawned.[/green]")
 

--- a/src/bernstein/cli/run_preflight.py
+++ b/src/bernstein/cli/run_preflight.py
@@ -22,7 +22,7 @@ from bernstein.cli.helpers import (
 from bernstein.cli.run import render_run_summary_from_dict
 from bernstein.cli.ui import make_console
 from bernstein.core.cost import estimate_run_cost
-from bernstein.core.cost.model_prices import is_free_route
+from bernstein.core.cost.model_prices import is_free_route, model_cost_is_known
 from bernstein.core.cost.preflight import CostBand, compute_band, format_band
 from bernstein.core.plan_loader import load_plan_from_yaml
 from bernstein.core.runtime_state import directory_size_bytes
@@ -271,10 +271,12 @@ class RunCostEstimate:
         high_usd: Legacy single-point high estimate (kept for back-compat).
         band: Optional calibrated p50/p90 band. Populated for new callers;
             legacy callers can leave it unset.
-        free_route: True when the resolved model is a zero-cost route (a
-            ``:free`` id or a model the run's own metering prices at $0). The
-            estimate is then a hard $0 rather than a phantom fixed rate
-            (issue #3013).
+        free_route: True when the resolved model is a genuinely zero-cost
+            route (a ``:free`` id or a $0 local adapter). The estimate is
+            then a hard $0 rather than a phantom fixed rate (issue #3013).
+        unpriced: True when the resolved model has no pricing-table entry -
+            it meters at $0 but that is a missing price, not a free run. The
+            banner then reads ``unpriced`` instead of ``$0.00`` (issue #5337).
     """
 
     task_count: int | None
@@ -283,6 +285,7 @@ class RunCostEstimate:
     high_usd: float
     band: CostBand | None = None
     free_route: bool = False
+    unpriced: bool = False
 
 
 def _estimate_task_count(workdir: Path, plan_file: Path | None, goal: str | None) -> int | None:
@@ -434,8 +437,14 @@ def _estimate_run_preview(
     # resolved model, not a fixed Anthropic rate, keeps the pre-run banner
     # and the final ``total_cost`` drawn from the same pricing source, so a
     # free route is never quoted a phantom estimate (issue #3013).
-    free_route = est_cli in _FREE_ADAPTERS or is_free_route(est_model)
-    if free_route:
+    # A run is free when a $0 local adapter or a ``:free`` id resolves; it is
+    # merely *unpriced* when the model has no pricing-table entry - the same
+    # $0 estimate, but the banner must say "unpriced" rather than quote
+    # "$0.00" as if the run cost nothing (issue #5337).
+    zero_cost = est_cli in _FREE_ADAPTERS or is_free_route(est_model)
+    unpriced = zero_cost and est_cli not in _FREE_ADAPTERS and not model_cost_is_known(est_model)
+    free_route = zero_cost and not unpriced
+    if zero_cost:
         low_usd, high_usd = 0.0, 0.0
         band = CostBand(
             p50=0.0,
@@ -463,6 +472,7 @@ def _estimate_run_preview(
         high_usd=high_usd,
         band=band,
         free_route=free_route,
+        unpriced=unpriced,
     )
 
 
@@ -505,15 +515,28 @@ def _emit_preflight_runtime_warnings(
         else:
             basis = f"per task at {estimate.model} pricing, task count not yet planned"
         if estimate.free_route:
-            # A zero-cost route (:free / unpriced) must not be quoted a
-            # phantom rate: the real run meters it at $0 (issue #3013).
+            # A genuinely zero-cost route (:free id / $0 local adapter) must
+            # not be quoted a phantom rate: the real run meters it at $0
+            # (issue #3013).
             if estimate.task_count is not None:
                 basis = f"free route - no cost ({estimate.model}), based on {estimate.task_count} task(s)"
             else:
                 basis = f"free route - no cost ({estimate.model}), task count not yet planned"
+        elif estimate.unpriced:
+            # No pricing-table entry: meters at $0, but that is a missing
+            # price, not a free run - say so instead of quoting $0.00
+            # (issue #5337).
+            not_priced = f"unpriced - {estimate.model} is not in the pricing table"
+            if estimate.task_count is not None:
+                basis = f"{not_priced}, based on {estimate.task_count} task(s)"
+            else:
+                basis = f"{not_priced}, task count not yet planned"
         if band is not None:
-            console.print(f"[bold yellow]{format_band(band)}[/bold yellow]")
-            if estimate.free_route:
+            if estimate.unpriced:
+                console.print("[bold yellow]Estimated cost:[/bold yellow] unpriced")
+            else:
+                console.print(f"[bold yellow]{format_band(band)}[/bold yellow]")
+            if estimate.free_route or estimate.unpriced:
                 console.print(f"[dim]{basis}[/dim]")
             else:
                 samples_note = (
@@ -522,6 +545,8 @@ def _emit_preflight_runtime_warnings(
                     else "no history yet - using heuristic"
                 )
                 console.print(f"[dim]{basis}, {samples_note}[/dim]")
+        elif estimate.unpriced:
+            console.print(f"[bold yellow]Estimated cost:[/bold yellow] unpriced {basis}")
         else:
             console.print(
                 f"[bold yellow]Estimated cost:[/bold yellow] ${estimate.low_usd:.2f}-${estimate.high_usd:.2f} {basis}"

--- a/src/bernstein/core/cost/cost.py
+++ b/src/bernstein/core/cost/cost.py
@@ -50,6 +50,12 @@ from bernstein.core.cost.model_prices import (
     UsagePriceResult as UsagePriceResult,
 )
 from bernstein.core.cost.model_prices import (
+    model_cost_is_known as model_cost_is_known,
+)
+from bernstein.core.cost.model_prices import (
+    model_has_pricing_entry as model_has_pricing_entry,
+)
+from bernstein.core.cost.model_prices import (
     price_model_usage as price_model_usage,
 )
 from bernstein.core.models import Complexity, Scope, Task, TaskStatus

--- a/src/bernstein/core/cost/model_prices.py
+++ b/src/bernstein/core/cost/model_prices.py
@@ -143,6 +143,41 @@ class UsagePriceResult:
     model_call_id: str = ""
 
 
+# Model names ``price_model_usage`` has already logged a "no pricing-table
+# entry" warning for in this process. The warning is deduped against this set
+# so a gateway/alias route with no entry does not repeat it on every call.
+_UNPRICED_MODELS_WARNED: set[str] = set()
+
+
+def _reset_unpriced_model_warnings() -> None:
+    """Clear the once-per-process warning cache. Tests only."""
+    _UNPRICED_MODELS_WARNED.clear()
+
+
+def model_has_pricing_entry(model: str) -> bool:
+    """Return ``True`` when *model* matches an entry in the pricing table.
+
+    Same substring rule :func:`price_model_usage` uses to price a call, so a
+    name this returns ``False`` for is exactly one that would meter at an
+    explicit ``$0`` with ``priced=False``. Display code uses this to print
+    the word ``unpriced`` for such a name instead of quoting ``$0.00`` as if
+    the route were free.
+    """
+    model_lower = model.lower()
+    return any(key in model_lower for key in MODEL_COSTS_PER_1M_TOKENS)
+
+
+def model_cost_is_known(model: str) -> bool:
+    """Return ``True`` when a dollar figure for *model* is meaningful.
+
+    That is either a table entry (:func:`model_has_pricing_entry`) or a
+    ``:free`` id, whose ``$0`` is a real price rather than a missing one.
+    A name this returns ``False`` for should be shown as ``unpriced`` in a
+    cost-estimate line, not quoted ``$0.00``.
+    """
+    return model.strip().lower().endswith(":free") or model_has_pricing_entry(model)
+
+
 def price_model_usage(
     model: str,
     input_tokens: int,
@@ -196,15 +231,25 @@ def price_model_usage(
                 priced=True,
                 model_call_id=model_call_id,
             )
-    logger.warning(
-        "price_model_usage: no pricing-table entry for model %r - metering at "
-        "$0/token so this call's tokens stay visible instead of vanishing from "
-        "cost totals (input_tokens=%d, output_tokens=%d). Add an entry to "
-        "MODEL_COSTS_PER_1M_TOKENS to price this model.",
-        model,
-        input_tokens,
-        output_tokens,
-    )
+    # Warn once per distinct model name per process. A gateway/alias route
+    # with no table entry is priced at $0 on every call; without this guard
+    # the warning repeats for every call and every cost estimate in a
+    # non-interactive run (scheduler, CI) and buries the lines an operator
+    # actually needs. Later calls for the same name meter at $0 silently;
+    # ``priced`` stays ``False`` so totals still carry the tokens and the
+    # run summary still reports the model as unpriced.
+    if model not in _UNPRICED_MODELS_WARNED:
+        _UNPRICED_MODELS_WARNED.add(model)
+        logger.warning(
+            "price_model_usage: no pricing-table entry for model %r - metering at "
+            "$0/token so this call's tokens stay visible instead of vanishing from "
+            "cost totals (input_tokens=%d, output_tokens=%d). Add an entry to "
+            "MODEL_COSTS_PER_1M_TOKENS to price this model. This warning is "
+            "emitted once per model name per process.",
+            model,
+            input_tokens,
+            output_tokens,
+        )
     return UsagePriceResult(
         model=model,
         input_tokens=input_tokens,

--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -580,17 +580,24 @@ def _describe_cost_estimate(backlog_count: int, model: str | None) -> str:
     Returns:
         Plain-text fragment for the startup cost line.
     """
-    from bernstein.core.cost import estimate_run_cost
+    from bernstein.core.cost import estimate_run_cost, model_cost_is_known
+
+    count_note = f"{backlog_count} task(s)" if backlog_count > 0 else "task count pending planning"
+
+    if not model:
+        return f"unknown (no model configured, {count_note})"
+
+    # A model with no pricing-table entry (a gateway alias / self-hosted
+    # route) meters at $0 but is not free - say "unpriced" rather than quote
+    # "$0.00" as if the run cost nothing (issue #5337).
+    if not model_cost_is_known(model):
+        return f"unpriced ({model} not in pricing table, {count_note})"
 
     if backlog_count > 0:
-        if model:
-            low, high = estimate_run_cost(backlog_count, model)
-            return f"~${low:.2f}-${high:.2f} ({backlog_count} task(s), {model})"
-        return f"unknown (no model configured, {backlog_count} task(s))"
-    if model:
-        low, high = estimate_run_cost(1, model)
-        return f"~${low:.2f}-${high:.2f} per task ({model}, task count pending planning)"
-    return "unknown (no model configured, task count pending planning)"
+        low, high = estimate_run_cost(backlog_count, model)
+        return f"~${low:.2f}-${high:.2f} ({backlog_count} task(s), {model})"
+    low, high = estimate_run_cost(1, model)
+    return f"~${low:.2f}-${high:.2f} per task ({model}, task count pending planning)"
 
 
 def _record_team_manifest_lineage(seed: SeedConfig, workdir: Path) -> None:

--- a/tests/unit/test_inventory_render.py
+++ b/tests/unit/test_inventory_render.py
@@ -12,6 +12,7 @@ import json
 from pathlib import Path
 
 import pytest
+
 from bernstein.core.govern.inventory_render import render_inventory
 
 FIXTURE_STORE = Path(__file__).resolve().parents[1] / "fixtures" / "govern" / "inventory-store.json"

--- a/tests/unit/test_unpriced_model_warning_dedup_5337.py
+++ b/tests/unit/test_unpriced_model_warning_dedup_5337.py
@@ -1,0 +1,164 @@
+"""Regression tests for issue #5337.
+
+Two defects on the unpriced-model path:
+
+* ``price_model_usage`` logged the full "no pricing-table entry" warning on
+  *every* call for a gateway/alias route with no table entry. In a
+  non-interactive run the line repeats for every call and every cost
+  estimate and buries the output an operator needs. The warning must fire
+  once per distinct model name per process; later calls meter at $0
+  silently, ``priced`` stays ``False`` and totals still carry the tokens.
+* Cost-estimate lines quoted ``$0.00`` for such a name as if the run were
+  free. They must read ``unpriced`` instead. A ``:free`` id and a priced
+  model are unaffected.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.cost.model_prices import (
+    _reset_unpriced_model_warnings,
+    model_cost_is_known,
+    model_has_pricing_entry,
+    price_model_usage,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_warning_cache() -> object:
+    """The once-per-process cache is module-global; isolate each test."""
+    _reset_unpriced_model_warnings()
+    yield
+    _reset_unpriced_model_warnings()
+
+
+# ---------------------------------------------------------------------------
+# price_model_usage: warn once per name per process
+# ---------------------------------------------------------------------------
+
+
+def test_unpriced_model_warns_only_once_for_the_same_name(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level("WARNING"):
+        first = price_model_usage("fleet-live", 1, 1)
+        second = price_model_usage("fleet-live", 500, 250)
+
+    records = [r for r in caplog.records if "no pricing-table entry" in r.message]
+    assert len(records) == 1
+
+    # Metering itself is unchanged on every call.
+    for result in (first, second):
+        assert result.priced is False
+        assert result.cost_usd == 0.0
+    assert second.input_tokens == 500
+    assert second.output_tokens == 250
+
+
+def test_two_distinct_unpriced_names_each_warn_once(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level("WARNING"):
+        price_model_usage("fleet-live", 1, 1)
+        price_model_usage("fleet-live", 1, 1)
+        price_model_usage("lb-alias-eu", 1, 1)
+        price_model_usage("lb-alias-eu", 1, 1)
+
+    warned = sorted(r.args[0] for r in caplog.records if "no pricing-table entry" in r.message)
+    assert warned == ["fleet-live", "lb-alias-eu"]
+
+
+def test_priced_model_never_warns(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level("WARNING"):
+        result = price_model_usage("gpt-5-mini", 1_000, 1_000)
+
+    assert result.priced is True
+    assert not [r for r in caplog.records if "no pricing-table entry" in r.message]
+
+
+# ---------------------------------------------------------------------------
+# The predicates the display code keys on
+# ---------------------------------------------------------------------------
+
+
+def test_model_has_pricing_entry_matches_price_model_usage() -> None:
+    assert model_has_pricing_entry("gpt-5-mini") is True
+    assert model_has_pricing_entry("claude-sonnet-5") is True
+    assert model_has_pricing_entry("fleet-live") is False
+    assert model_has_pricing_entry("openai/gpt-oss-20b:free") is False
+
+
+def test_model_cost_is_known_treats_free_id_as_known_zero() -> None:
+    # A ``:free`` id has a real price ($0); an alias with no entry does not.
+    assert model_cost_is_known("openai/gpt-oss-20b:free") is True
+    assert model_cost_is_known("SomeVendor/Model-X:FREE") is True
+    assert model_cost_is_known("gpt-5-mini") is True
+    assert model_cost_is_known("fleet-live") is False
+
+
+# ---------------------------------------------------------------------------
+# Cost-estimate lines: "unpriced", not "$0.00"
+# ---------------------------------------------------------------------------
+
+
+def test_describe_cost_estimate_says_unpriced_for_no_entry_model() -> None:
+    from bernstein.core.orchestration.bootstrap import _describe_cost_estimate
+
+    known_count = _describe_cost_estimate(3, "fleet-live")
+    assert "unpriced" in known_count
+    assert "$0.00" not in known_count
+
+    pending = _describe_cost_estimate(0, "fleet-live")
+    assert "unpriced" in pending
+    assert "$0.00" not in pending
+
+
+def test_describe_cost_estimate_unaffected_for_priced_model() -> None:
+    from bernstein.core.orchestration.bootstrap import _describe_cost_estimate
+
+    line = _describe_cost_estimate(3, "sonnet")
+    assert "unpriced" not in line
+    assert line.startswith("~$")
+
+
+def _render_preflight_banner(workdir: Path, model_override: str) -> str:
+    from bernstein.cli.run_preflight import (
+        _emit_preflight_runtime_warnings,
+        _estimate_run_preview,
+        console,
+    )
+
+    estimate = _estimate_run_preview(
+        workdir=workdir,
+        plan_file=None,
+        goal=None,
+        seed_file=None,
+        model_override=model_override,
+    )
+    with console.capture() as cap:
+        _emit_preflight_runtime_warnings(
+            workdir=workdir,
+            estimate=estimate,
+            auto_approve=True,
+            quiet=False,
+        )
+    return cap.get()
+
+
+def test_preflight_banner_reads_unpriced_for_no_entry_model(tmp_path: Path) -> None:
+    out = _render_preflight_banner(tmp_path, "fleet-live")
+    assert "unpriced" in out.lower()
+    assert "$0.00" not in out
+    assert "free route" not in out.lower()
+    assert "fleet-live" in out
+
+
+def test_preflight_banner_still_zero_for_colon_free_route(tmp_path: Path) -> None:
+    # Issue #3013 behaviour is untouched: a real :free route is $0, not "unpriced".
+    out = _render_preflight_banner(tmp_path, "openai/gpt-oss-20b:free")
+    assert "free route" in out.lower()
+    assert "$0.00" in out
+    assert "unpriced" not in out.lower()


### PR DESCRIPTION
Fixes #5337.

## Problem

`price_model_usage` logs the full `no pricing-table entry` warning on **every** priced call for a model name that has no entry in `MODEL_COSTS_PER_1M_TOKENS` — e.g. a route resolved by an OpenAI-compatible gateway (a load-balanced alias rather than a vendor model id). In a non-interactive run (scheduler, CI) the line repeats for every call and every cost estimate and drowns out the lines an operator actually needs.

The cost-estimate lines also quote `$0.00` for such a name as if the run were free, when the truth is the cost is simply unknown.

## Change

- **`price_model_usage` warns once per distinct model name per process.** A module-level set (`_UNPRICED_MODELS_WARNED`) tracks which names have been warned about; later calls for the same name meter at `$0` silently. `UsagePriceResult.priced` stays `False` and the token counts are unchanged, so totals still carry the tokens and the run summary still reports the model as unpriced. Metering is untouched.
- **New predicates `model_has_pricing_entry()` / `model_cost_is_known()`** next to the table (re-exported from `bernstein.core.cost`). `model_has_pricing_entry` uses the same substring rule `price_model_usage` prices with; `model_cost_is_known` also treats a `:free` id as known (its `$0` is a real price).
- **Cost-estimate lines read `unpriced` instead of `$0.00`** for a name with no entry:
  - `_describe_cost_estimate` (startup banner / `Cost estimate:` line)
  - the `bernstein run --dry-run` plan line
  - the preflight banner (`_emit_preflight_runtime_warnings`); `RunCostEstimate` gains an `unpriced` flag, kept distinct from `free_route`
- A `:free` id and a priced model are unaffected. The issue #3013 free-route banner behaviour (`$0.00` + `free route - no cost` for a genuine `:free` route) is unchanged — covered by the existing regression test and a new assertion here.

## Scope note

The issue's brief also mentions routing the unpriced case through *every* `Estimated cost` / `Cost estimate` string in `src/bernstein`. Most of those hits are docstrings or the final run-summary total (an aggregated float, which the issue says should keep reporting the model as unpriced separately). This PR covers the three pre-run human-readable estimate lines that actually build a `$` figure from `estimate_run_cost` for a resolved model — the ones that quote `$0.00`. Happy to widen if you'd prefer a different cut.

## Tests

New `tests/unit/test_unpriced_model_warning_dedup_5337.py`:
- two calls for one unpriced name → one warning record; two distinct names → two records
- `priced` / `cost_usd` / token counts unchanged across repeated calls
- a priced model never warns
- `model_has_pricing_entry` / `model_cost_is_known` behaviour, including `:free`
- `_describe_cost_estimate` and the preflight banner read `unpriced` for a no-entry model and never `$0.00`
- the preflight banner still shows `$0.00` / `free route` for a real `:free` route (issue #3013 guard)

Local gates green:
- `uv run pytest tests/unit/test_unpriced_model_warning_dedup_5337.py tests/unit/test_cost_price_model_usage.py tests/unit/test_issue_3013_free_route_banner_pricing.py tests/unit/test_preflight.py tests/unit/test_cost_preflight_v2.py tests/unit/test_run_preflight_model_resolution.py tests/unit/test_bootstrap.py tests/unit/test_startup_task_count_consistency.py tests/unit/test_plan_approval.py tests/unit/test_cost_estimate.py tests/unit/test_cost_estimation.py tests/unit/test_orchestrator.py tests/unit/adapters/test_openai_agents.py` — all pass
- `uv run ruff check` / `uv run ruff format --check` on the touched files
- `uv run mypy` on the touched source files