### PR TITLE
identity: record a delegation receipt for every spawned agent, anchored on a per-run root

### DIFF
--- a/docs/operations/delegation-verify.md
+++ b/docs/operations/delegation-verify.md
@@ -82,11 +82,34 @@ Receipts are written by calling `DelegationLedger.record_hop` (or its
 convenience wrapper `record_delegation_hop`) for each
 `principal -> orchestrator -> sub-agent` handoff — there is no
 `delegation emit` CLI verb; an operator only verifies, never hand-authors a
-receipt. **Limitation:** as of this writing, no orchestration code path in
-this codebase calls `record_delegation_hop`; the ledger and its verifier are
-exercised directly by unit tests. Until a caller wires the write path into a
-real run, `bernstein delegation verify <run>` against a live run's default
-root correctly reports "no receipts" (exit 1) rather than a populated chain.
+receipt. The write path runs at identity minting. When a run starts the
+orchestrator mints one parentless run-root identity, records its id in the run
+manifest (`.sdd/runtime/manifests/<run-id>.json`, field `run_root_identity_id`),
+and every top-level agent is minted under it; a nested spawn is minted under its
+spawning agent instead, from `AgentSession.parent_id`. Each parented mint records
+one hop, issuer the parent and subject the child, carrying the child's task and
+file scope on the receipt so narrowing is recomputable from the chain alone. An
+parentless mint records nothing, and an empty chain is not a broken chain.
+
+`delegation verify <run>` reads `run_root_identity_id` from the run manifest and
+treats hops issued by that identity as chain roots, so several agents spawned by
+the same run each grade instead of the second and later ones reading as
+`root_claimed_mid_chain`. The name arrives from outside the receipts, so a
+receipt still cannot promote itself out of a narrowing check by writing its own
+issuer field, and a run whose manifest declares no root keeps the positional root
+rule unchanged. The identity store is never consulted.
+
+The write is fail closed at the spawn. A hop that cannot be written raises
+`DelegationWriteError`, the spawner re-raises that type rather than starting the
+agent, and a `spawn.refused_unreceipted` audit event records the run, the refused
+session and the reason. Every other identity failure keeps its previous
+log-and-continue behaviour, so a token that cannot be issued still does not stop
+a run.
+
+**Known limit:** deleting the *final* receipt of a chain leaves a shorter chain
+that still verifies, because no receipt records how many hops a run should have
+had. Detecting that needs a terminal hop or the chain head recorded at close,
+which is tracked separately.
 
 ## `bernstein delegation verify-token` — the capability-token chain
 

--- a/docs/release-notes/fragments/5047-delegation-hop-at-mint.md
+++ b/docs/release-notes/fragments/5047-delegation-hop-at-mint.md
@@ -1,0 +1,14 @@
+## Delegation receipts are recorded for every spawned agent, and a run that cannot record one does not spawn
+
+A run now mints one parentless run-root identity at start and records its id in
+the run manifest. Every top-level agent is minted under that root, and a nested
+spawn under its spawning agent, so each mint records one delegation hop carrying
+the agent's task and file scope on the receipt. `bernstein delegation verify
+<run>` reads the root id from the manifest, anchors the chain on it, and returns
+a populated chain with its hop count instead of "no receipts" -- offline, from
+the receipts and the manifest alone, without reading the identity store.
+
+The write is fail closed at the spawn: a hop that cannot be written raises
+`DelegationWriteError`, the agent does not start, and a `spawn.refused_unreceipted`
+audit event records the run, the session and the reason. Other identity failures
+keep their previous behaviour and still do not block a spawn. (#5047)

--- a/src/bernstein/cli/commands/delegation_cmd.py
+++ b/src/bernstein/cli/commands/delegation_cmd.py
@@ -86,6 +86,34 @@ def _verify_exit_code(result: delegation.ChainResult) -> int:
     return 0
 
 
+def _declared_root_issuers(run: str, root: Path | None) -> frozenset[str]:
+    """Return the run's declared chain-root identities, read from its manifest.
+
+    The run manifest (``.sdd/runtime/manifests/<run-id>.json``) records the
+    identity the orchestrator minted as the run root, and every top-level agent
+    is minted under it (#5047). Naming it here is what lets several agents
+    spawned by one run each grade as a root: the name arrives from outside the
+    receipts, so a receipt still cannot promote itself out of a narrowing check.
+
+    Read-only and best effort. No manifest, no field, or an unreadable file
+    means an empty set and the positional root rule exactly as before -- the
+    identity store is never consulted, which is the point of recording the id in
+    the manifest at all.
+    """
+    from bernstein.core.config.manifest import load_manifest
+
+    sdd = (root.parent if root is not None else Path(".sdd/audit")).resolve(strict=False)
+    if root is None:
+        sdd = Path(".sdd")
+    try:
+        manifest = load_manifest(sdd, run)
+    except (OSError, ValueError, KeyError):
+        return frozenset()
+    if manifest is None or not manifest.run_root_identity_id:
+        return frozenset()
+    return frozenset({manifest.run_root_identity_id})
+
+
 @delegation_group.command("verify")
 @click.argument("run")
 @click.option(
@@ -108,7 +136,7 @@ def verify_cmd(run: str, root: Path | None, as_json: bool) -> None:
     when a check failed, and 3 when the receipts carry too little to decide.
     Unproven is not a pass: a chain that recorded no scope reaches 3, not 0.
     """
-    result = delegation.verify_run(run, root=root)
+    result = delegation.verify_run(run, root=root, root_issuers=_declared_root_issuers(run, root))
     authority = result.authority
 
     if as_json:

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -1904,7 +1904,39 @@ class AgentSpawner:
             self._identity_store_instance = AgentIdentityStore(auth_dir)
         return self._identity_store_instance
 
-    def _issue_agent_token(self, session_id: str, role: str, task_ids: list[str]) -> Path:
+    def _audit_spawn_refused_unreceipted(self, session_id: str, issuer: str, reason: str) -> None:
+        """Record that a spawn was refused because its delegation was unreceipted.
+
+        Best-effort by design: the refusal itself is already carried by the
+        exception that is about to propagate, so a failure to write the audit row
+        must not mask it or replace it with a second, less informative error.
+        """
+        try:
+            from bernstein.core.security.audit_chain import EVENT_SPAWN_REFUSED_UNRECEIPTED, AuditChainStore
+            from bernstein.core.security.sanitize import sanitize_log
+
+            AuditChainStore(self._workdir / ".sdd" / "audit").log(
+                event_type=EVENT_SPAWN_REFUSED_UNRECEIPTED,
+                actor="spawner",
+                resource_type="agent_session",
+                resource_id=session_id,
+                details={
+                    "run_id": getattr(self, "_run_id", ""),
+                    "issuer": issuer,
+                    "reason": sanitize_log(reason),
+                },
+            )
+        except Exception as exc:  # intentional-broad-except: audit mirroring must never mask the refusal
+            logger.warning("Spawn-refusal audit row not written for %s: %s", session_id, type(exc).__name__)
+
+    def _issue_agent_token(
+        self,
+        session_id: str,
+        role: str,
+        task_ids: list[str],
+        *,
+        parent_identity_id: str | None = None,
+    ) -> Path:
         """Issue a short-lived task-scoped JWT and write it to a 0600 token file.
 
         The token file path is recorded in ``_agent_token_files`` for cleanup
@@ -1923,17 +1955,27 @@ class AgentSpawner:
             session_id: The agent session ID (used as identity ID).
             role: The agent's role.
             task_ids: Task IDs the agent is authorised to act on.
+            parent_identity_id: The delegating identity: the spawning agent's
+                identity for a nested spawn, otherwise the run root.  Minting
+                with it records one delegation hop (#5047); ``None`` records
+                none, which is the pre-#5047 behaviour.
 
         Returns:
             Absolute path to the written token file.
+
+        Raises:
+            DelegationWriteError: the delegation hop could not be recorded.
+                Deliberately not caught here: the caller fails the spawn closed
+                on this type alone.
         """
         import os
 
         _, raw_token = self._identity_store.create_identity(
             session_id,
             role,
+            parent_identity_id=parent_identity_id,
             task_ids=task_ids,
-            metadata={"source": "spawner"},
+            metadata={"source": "spawner", "run_id": getattr(self, "_run_id", "")},
         )
 
         # ``resolve(strict=False)`` returns an absolute path even when the
@@ -2153,6 +2195,18 @@ class AgentSpawner:
         rows by run, so without this the rows have no spine to join.
         """
         self._run_id = run_id
+
+    def set_run_root_identity_id(self, identity_id: str) -> None:
+        """Wire in the run-root identity every top-level agent is minted under.
+
+        The orchestrator mints one parentless identity per run and passes its id
+        here (#5047).  It becomes the issuer of each top-level agent's delegation
+        hop, which is what makes the first hop gradable: without it a top-level
+        agent has no parent, no hop is recorded, and a single-level run verifies
+        as "no receipts".  Empty when the run minted no root, in which case the
+        pre-#5047 behaviour stands and nothing is recorded.
+        """
+        self._run_root_identity_id = identity_id
 
     def _merge_and_cleanup_worktree(
         self,
@@ -4711,11 +4765,32 @@ class AgentSpawner:
         # Zero-trust: issue a short-lived, task-scoped JWT for this agent.
         # The token is written to a 0600 file and its path is injected into
         # the prompt so the agent can include it in task server requests.
-        # We wrap in try/except so auth failures never block spawning.
+        # Auth failures still never block spawning -- with ONE exception, below.
+        #
+        # The delegating identity is the spawning agent's for a nested spawn and
+        # the run root otherwise; minting under it records the delegation hop
+        # (#5047). Empty means no root was minted, and nothing is recorded.
+        from bernstein.core.identity.agent_jwt import DelegationWriteError
+
+        _delegating_identity: str | None = session.parent_id or getattr(self, "_run_root_identity_id", "") or None
         try:
             task_ids_for_scope = [t.id for t in tasks]
-            _token_path = self._issue_agent_token(session_id, role, task_ids_for_scope)
+            _token_path = self._issue_agent_token(
+                session_id,
+                role,
+                task_ids_for_scope,
+                parent_identity_id=_delegating_identity,
+            )
             prompt = prompt + _render_auth_section(_token_path, self._workdir)
+        except DelegationWriteError as _deleg_exc:
+            # FAIL CLOSED, and only for this type. A delegation that cannot be
+            # receipted must not spawn: the chain would be short by exactly the
+            # hop a verifier needs, and a hop that was never written is
+            # indistinguishable from one that never happened. Every other
+            # identity failure keeps the log-and-continue behaviour above it.
+            self._audit_spawn_refused_unreceipted(session_id, _delegating_identity or "", str(_deleg_exc))
+            logger.error("Spawn refused for %s: delegation hop not recorded: %s", session_id, _deleg_exc)
+            raise
         except Exception as _token_exc:
             # Only the session_id and exception are logged.
             # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure

--- a/src/bernstein/core/config/manifest.py
+++ b/src/bernstein/core/config/manifest.py
@@ -106,6 +106,11 @@ class RunManifest:
         agent_adapter: CLI agent adapter configuration.
         provenance: Who/when/what-commit triggered the run.
         orchestrator_config: Snapshot of OrchestratorConfig values.
+        run_root_identity_id: Identity minted for the run root, the issuer every
+            top-level agent's delegation hop names.  Recorded here so
+            ``bernstein delegation verify <run>`` can anchor the chain without
+            reading the identity store back (#5047).  Empty when the run minted
+            no root, which is every manifest written before that existed.
         manifest_hash: SHA-256 digest computed over all other fields.
     """
 
@@ -118,6 +123,7 @@ class RunManifest:
     agent_adapter: AgentAdapterConfig = field(default_factory=AgentAdapterConfig)
     provenance: Provenance = field(default_factory=Provenance)
     orchestrator_config: dict[str, Any] = field(default_factory=dict)
+    run_root_identity_id: str = ""
     manifest_hash: str = ""
 
     # ------------------------------------------------------------------
@@ -182,6 +188,7 @@ class RunManifest:
                 commit_sha=str(data.get("provenance", {}).get("commit_sha", "")),
             ),
             orchestrator_config=dict(data.get("orchestrator_config", {})),
+            run_root_identity_id=str(data.get("run_root_identity_id", "")),
             manifest_hash=str(data.get("manifest_hash", "")),
         )
 
@@ -199,6 +206,7 @@ def build_manifest(
     model: str | None = None,
     workflow_name: str = "",
     workflow_definition_hash: str = "",
+    run_root_identity_id: str = "",
 ) -> RunManifest:
     """Build a RunManifest from orchestrator configuration.
 
@@ -264,6 +272,7 @@ def build_manifest(
         agent_adapter=agent_adapter,
         provenance=provenance,
         orchestrator_config=orch_snapshot,
+        run_root_identity_id=run_root_identity_id,
     )
 
     # Compute and attach the hash (frozen dataclass requires object.__setattr__)

--- a/src/bernstein/core/identity/agent_jwt.py
+++ b/src/bernstein/core/identity/agent_jwt.py
@@ -773,9 +773,19 @@ class AgentIdentityStore:
                 audience=f"sub-agent:{child.role}",
                 act="task.spawn",
                 root=root,
+                # ``allowed_files`` is recorded on its own axis, not translated
+                # into ``path_prefixes``: the two answer different questions.
+                # ``path_prefixes`` narrows by ancestry and shares its subset
+                # primitive with signed capability tokens, while these patterns
+                # are globs read by the merge gate, where a pattern is not a
+                # prefix.  Carrying one into the other would make a single field
+                # name mean two things depending on which surface read it, and
+                # would report a narrowing that only part of the axis supports
+                # (#5351).  Nothing here declares path prefixes, so that axis
+                # stays ``None`` - the widest value, and the only honest one.
                 scope=DelegationScope(
                     task_ids=frozenset(child.task_ids) if child.task_ids else None,
-                    path_prefixes=frozenset(child.allowed_files) if child.allowed_files else None,
+                    allowed_files=frozenset(child.allowed_files) if child.allowed_files else None,
                 ),
                 parent_ref=parent_ref,
             )

--- a/src/bernstein/core/identity/agent_jwt.py
+++ b/src/bernstein/core/identity/agent_jwt.py
@@ -42,6 +42,19 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
+class DelegationWriteError(RuntimeError):
+    """The delegation hop for a parented mint could not be recorded.
+
+    A distinct type so a caller can fail closed on an unreceipted delegation
+    while keeping its existing handling for every other identity failure.  The
+    spawner's identity-creation handler logs and continues for anything else,
+    which is deliberate (a token that cannot be issued must not stop a run), but
+    a delegation that is claimed as receipted must not proceed unrecorded: the
+    chain would silently lose exactly the hop a verifier needs.  The originating
+    error is always chained as ``__cause__``.
+    """
+
+
 class AgentIdentityStatus(StrEnum):
     """Lifecycle status of an agent identity."""
 
@@ -690,6 +703,86 @@ class AgentIdentityStore:
 
     # -- CRUD operations ----------------------------------------------------
 
+    def _record_mint_delegation(
+        self,
+        *,
+        child: AgentIdentity,
+        parent_identity_id: str,
+        run_id: str,
+    ) -> None:
+        """Record the one delegation hop that minting a scoped child credential is.
+
+        Issuer is the parent identity, subject is the child, and the scope on
+        the receipt is the child's ``task_ids`` and ``allowed_files``.  The
+        scope travels **on the receipt** so ``grade_chain`` can recompute
+        child-subset-of-parent from the chain alone, with no read back into
+        this store; a receipt that only named the parent would add nothing over
+        the ``parent_identity_id`` field already persisted beside it.
+
+        FAIL-CLOSED, and this method is the one place that decides it.  The
+        ledger write is caught only to be re-raised as
+        :class:`DelegationWriteError` with the original chained as ``__cause__``,
+        so it still propagates out of :meth:`create_identity` and no identity is
+        returned to the caller, while giving the spawner a type it can single
+        out from every other identity failure (#5047, maintainer decision).  A
+        delegation claimed as receipted must not proceed when the receipt
+        cannot be written, because the chain then silently shortens and a hop
+        that was never recorded is indistinguishable from one that never
+        happened - which is the exact confusion the removed-receipt check
+        exists to catch.  The reap receipt in ``spawner_core`` is best-effort
+        for the opposite reason (audit mirroring must never mask the kill
+        itself); the attachment attestation there aborts, and delegation is
+        that second kind.  To make this best-effort instead, wrap the single
+        call in :meth:`create_identity` in ``try/except`` - no other line
+        changes.
+
+        ``None`` is the widest value on every :class:`DelegationScope` axis,
+        and an empty ``task_ids`` / ``allowed_files`` list means "no
+        restriction" on this identity, so the two map onto each other: an empty
+        list becomes ``None`` rather than an empty frozenset, which would
+        otherwise record the narrowest possible grant for an unrestricted
+        agent and read as a widening at the next hop.
+
+        Args:
+            child: The freshly minted identity, already persisted.
+            parent_identity_id: The delegating identity.
+            run_id: Run the hop belongs to.
+        """
+        # Imported here, not at module scope: delegation -> delegation_scope ->
+        # security.capability_tokens -> this module is a cycle, and the same
+        # deferred-import shape is what ``delegation._audit_key`` and the
+        # secrets broker's grant-ledger calls already use.
+        from bernstein.core.identity.delegation import GENESIS_HMAC, record_delegation_hop, verify_run
+        from bernstein.core.identity.delegation_scope import DelegationScope
+
+        root = self._base_dir.parent / "audit"
+        # A tree, not a line: sibling mints share a parent, so the hop is
+        # anchored to the hop that minted the parent when there is one, and is
+        # a chain root otherwise.  Left to default, ``record_hop`` would chain
+        # each hop to its immediate predecessor and compare two siblings as
+        # parent and child, reporting a widening that never happened.
+        parent_ref = GENESIS_HMAC
+        for receipt in verify_run(run_id, root=root).receipts:
+            if receipt.subject == parent_identity_id and receipt.hmac:
+                parent_ref = receipt.hmac
+        try:
+            record_delegation_hop(
+                run_id=run_id,
+                issuer=parent_identity_id,
+                subject=child.id,
+                audience=f"sub-agent:{child.role}",
+                act="task.spawn",
+                root=root,
+                scope=DelegationScope(
+                    task_ids=frozenset(child.task_ids) if child.task_ids else None,
+                    path_prefixes=frozenset(child.allowed_files) if child.allowed_files else None,
+                ),
+                parent_ref=parent_ref,
+            )
+        except Exception as exc:
+            msg = f"delegation hop for {child.id} under {parent_identity_id} in run {run_id} could not be recorded"
+            raise DelegationWriteError(msg) from exc
+
     def create_identity(
         self,
         session_id: str,
@@ -719,6 +812,9 @@ class AgentIdentityStore:
             parent_identity_id: ID of the spawning agent's identity.
             extra_permissions: Additional permissions beyond the role defaults.
             metadata: Arbitrary metadata (cell_id, provider, model, tenant_id).
+                ``run_id`` is read from here when a parented mint records its
+                delegation hop: a receipt belongs to a run, and a mint that
+                names none has no chain to append to.
             token_expiry_s: Seconds until the token expires.  Defaults to 4 h for
                 task-scoped tokens or 24 h for unrestricted manager tokens.
             task_ids: Task IDs this identity is authorised to act on.  An empty
@@ -738,6 +834,17 @@ class AgentIdentityStore:
                 strings, or an ``allowed_files`` pattern is not
                 repository-relative.  Refused before the token is signed, so a
                 bad scope cannot become a credential that fails to load.
+            DelegationWriteError: the hop for a parented mint could not be
+                recorded; the ledger's own error is chained as ``__cause__``.  This is deliberate and
+                fail-closed - a delegation claimed as receipted must not
+                proceed when the receipt cannot be written, or the chain
+                silently shortens.  There is no rollback: the identity file is
+                already written when this fires, and stays readable through
+                :meth:`get` and :meth:`authorize`, which key on the identity id.
+                What the caller does not get is the raw token, so the credential
+                cannot be *presented*; and no ``created`` audit event is
+                appended.  The reasoning and the single line to change for
+                best-effort are in :meth:`_record_mint_delegation`.
         """
         identity_id = session_id  # 1:1 mapping with agent session
         permissions = permissions_for_role(role)
@@ -860,6 +967,21 @@ class AgentIdentityStore:
 
         self._save(identity)
         self._token_index[token_hash] = identity_id
+
+        # Minting a scoped credential for a child IS the delegation act, so the
+        # receipt is written here rather than at a later boundary.  Fail-closed:
+        # see :meth:`_record_mint_delegation`, which is the one place to change
+        # to make it best-effort.  A mint that names no run has no chain to
+        # append to and records nothing; that is a gap on the caller side, not a
+        # failed write, so it is not an error here.
+        if parent_identity_id is not None:
+            run_id = str((metadata or {}).get("run_id", "") or "")
+            if run_id:
+                self._record_mint_delegation(
+                    child=identity,
+                    parent_identity_id=parent_identity_id,
+                    run_id=run_id,
+                )
 
         self._append_audit(
             IdentityAuditEvent(

--- a/src/bernstein/core/identity/delegation.py
+++ b/src/bernstein/core/identity/delegation.py
@@ -405,6 +405,7 @@ def verify_run_chain(
     run_id: str,
     key: bytes,
     scope_resolver: Callable[[str], DelegationScope | None] | None = None,
+    root_issuers: frozenset[str] = frozenset(),
 ) -> ChainResult:
     """Reconstruct and verify a run's delegation chain offline.
 
@@ -420,6 +421,12 @@ def verify_run_chain(
         key: The HMAC key (install audit key) the receipts were written with.
         scope_resolver: Optional lookup for receipts that carry only a
             content-addressed ``scope_ref`` rather than an inline scope body.
+        root_issuers: Identities the run declared as chain roots, supplied from
+            outside the receipts (the run manifest). A hop issued by one of them
+            may be a root without being first, which is what lets several agents
+            spawned by the same run root each grade as a root instead of the
+            second and later ones reading as ``root_claimed_mid_chain``. Empty
+            keeps the positional rule exactly as it was.
 
     Returns:
         A :class:`ChainResult`. ``valid`` is True only when at least one hop
@@ -484,6 +491,7 @@ def verify_run_chain(
         scope_resolver=scope_resolver,
         genesis=GENESIS_HMAC,
         chain_ok=chain_ok,
+        root_issuers=root_issuers,
     )
     return ChainResult(
         valid=chain_ok and authority.ok,
@@ -555,6 +563,7 @@ def verify_run(
     *,
     root: Path | None = None,
     scope_resolver: Callable[[str], DelegationScope | None] | None = None,
+    root_issuers: frozenset[str] = frozenset(),
 ) -> ChainResult:
     """Verify a run's delegation chain using install-anchored defaults.
 
@@ -571,4 +580,5 @@ def verify_run(
         run_id=run_id,
         key=_audit_key(),
         scope_resolver=scope_resolver,
+        root_issuers=root_issuers,
     )

--- a/src/bernstein/core/identity/delegation_scope.py
+++ b/src/bernstein/core/identity/delegation_scope.py
@@ -181,27 +181,48 @@ class DelegationScope:
 
     ``permissions`` and ``duties`` are plain sets: an empty set is the
     narrowest possible grant, never the widest.
+
+    ``allowed_files`` is recorded and deliberately not graded.  It is a glob
+    field, and a glob is not a path prefix: ``path_prefixes`` narrows by
+    ancestry, where ``src`` covers ``src/core``, while ``src`` as a pattern
+    admits the path ``src`` and nothing under it.  Comparing one with the
+    other primitive would report "narrowing checked and held" for an axis
+    where only the patterns that happened to have a prefix form were checked,
+    so the axis is carried verbatim and grades
+    :data:`REASON_COMPARISON_AXIS_UNSUPPORTED` until a glob-subsumption
+    primitive exists to decide it (#5351, follow-up #5418).
     """
 
     permissions: frozenset[str] = frozenset()
     duties: frozenset[str] = frozenset()
     task_ids: frozenset[str] | None = None
     path_prefixes: frozenset[str] | None = None
+    allowed_files: frozenset[str] | None = None
     not_after: float | None = None
     max_uses: int | None = None
     max_depth: int | None = None
 
     def to_body(self) -> dict[str, Any]:
-        """Return the JCS-ready dict (sets rendered as sorted lists)."""
-        return {
-            "duties": sorted(self.duties),
-            "max_depth": self.max_depth,
-            "max_uses": self.max_uses,
-            "not_after": self.not_after,
-            "path_prefixes": sorted(self.path_prefixes) if self.path_prefixes is not None else None,
-            "permissions": sorted(self.permissions),
-            "task_ids": sorted(self.task_ids) if self.task_ids is not None else None,
-        }
+        """Return the JCS-ready dict (sets rendered as sorted lists).
+
+        ``allowed_files`` is the one conditional key, emitted only when the
+        axis is used.  :meth:`scope_ref` digests these bytes, so emitting it
+        unconditionally as ``null`` would re-address every scope written before
+        the axis existed and stop sealed records from replaying byte-identically.
+        """
+        body: dict[str, Any] = {} if self.allowed_files is None else {"allowed_files": sorted(self.allowed_files)}
+        body.update(
+            {
+                "duties": sorted(self.duties),
+                "max_depth": self.max_depth,
+                "max_uses": self.max_uses,
+                "not_after": self.not_after,
+                "path_prefixes": sorted(self.path_prefixes) if self.path_prefixes is not None else None,
+                "permissions": sorted(self.permissions),
+                "task_ids": sorted(self.task_ids) if self.task_ids is not None else None,
+            }
+        )
+        return body
 
     @classmethod
     def from_body(cls, body: dict[str, Any]) -> DelegationScope:
@@ -211,6 +232,7 @@ class DelegationScope:
             duties=frozenset(body.get("duties") or ()),
             task_ids=_frozen(body.get("task_ids")),
             path_prefixes=_frozen(body.get("path_prefixes")),
+            allowed_files=_frozen(body.get("allowed_files")),
             not_after=None if body.get("not_after") is None else float(body["not_after"]),
             max_uses=None if body.get("max_uses") is None else int(body["max_uses"]),
             max_depth=None if body.get("max_depth") is None else int(body["max_depth"]),
@@ -240,6 +262,11 @@ def narrowing_violations(child: DelegationScope, parent: DelegationScope) -> tup
     An empty tuple means the child is a strict subset of the parent's grant.
     Axis names are stable identifiers so a verifier can report *which* axis was
     widened instead of a bare pass/fail.
+
+    ``allowed_files`` is deliberately absent: no primitive here decides whether
+    one glob is contained in another, and a comparison this function cannot
+    make is not one it reports as held.  A hop recording that axis is graded
+    unproven on it instead, by the unsupported-axis rule below.
     """
     axes: list[str] = []
     if not child.permissions <= parent.permissions:
@@ -806,10 +833,15 @@ DIAGNOSTIC_SCOPE_REF_UNRESOLVED: str = "scope_ref_unresolved_inline_governs"
 DIAGNOSTIC_SCOPE_REF_ONLY_RESOLVED: str = "scope_ref_only_resolved"
 VERDICT_DIAGNOSTICS: frozenset[str] = frozenset({DIAGNOSTIC_SCOPE_REF_ONLY_RESOLVED, DIAGNOSTIC_SCOPE_REF_UNRESOLVED})
 
-#: Keys :meth:`DelegationScope.from_body` interprets. A body carrying anything
-#: else is not something the comparator can reason about: the unreadable key
-#: records ``comparison_axis_unsupported``. Readable axes are still compared,
-#: and a widening found on one of them fails the hop, fail dominating unproven.
+#: Keys the comparator can reason about. A body carrying anything else records
+#: ``comparison_axis_unsupported`` for that key. Readable axes are still
+#: compared, and a widening found on one of them fails the hop, fail dominating
+#: unproven.
+#:
+#: ``allowed_files`` is a first-party axis deliberately outside this set:
+#: :meth:`DelegationScope.from_body` reads it, but nothing here can decide glob
+#: containment, so it is recorded and graded unproven by the same rule that
+#: covers a key from a future version (#5351, follow-up #5418).
 SCOPE_BODY_KEYS: frozenset[str] = frozenset(
     {
         "duties",

--- a/src/bernstein/core/identity/delegation_scope.py
+++ b/src/bernstein/core/identity/delegation_scope.py
@@ -914,6 +914,7 @@ def grade_chain(
     scope_resolver: Callable[[str], DelegationScope | None] | None = None,
     genesis: str = "0" * 64,
     chain_ok: bool = True,
+    root_issuers: frozenset[str] = frozenset(),
 ) -> ChainVerdict:
     """Grade every hop pass / fail / unproven and compose one chain verdict.
 
@@ -954,6 +955,7 @@ def grade_chain(
             by_hmac,
             scope_resolver=scope_resolver,
             genesis=genesis,
+            root_issuers=root_issuers,
         )
         for index in range(len(receipts))
     )
@@ -972,6 +974,7 @@ def _grade_hop(
     *,
     scope_resolver: Callable[[str], DelegationScope | None] | None,
     genesis: str,
+    root_issuers: frozenset[str] = frozenset(),
 ) -> HopVerdict:
     """Grade one hop without consulting any other hop's verdict."""
     receipt = receipts[index]
@@ -994,8 +997,15 @@ def _grade_hop(
     # that claims otherwise mid-chain may be a second tree's root or may be
     # evading its ceiling, and the receipts cannot tell those apart, so it is
     # unproven.
-    is_root = resolved is None and index == 0
-    if resolved is None and index > 0:
+    # A declared root issuer is the one case where a hop may be a root without
+    # being first. The name comes from OUTSIDE the receipts -- the run manifest
+    # records which identity the run minted as its root (#5047) -- so a hop
+    # cannot promote itself by writing its own issuer field, which is exactly
+    # the evasion the positional rule exists to stop. Every run whose root is
+    # unknown keeps the positional rule unchanged.
+    declared_root = bool(root_issuers) and receipt.issuer in root_issuers
+    is_root = resolved is None and (index == 0 or declared_root)
+    if resolved is None and index > 0 and not declared_root:
         reasons.append(REASON_ROOT_CLAIMED_MID_CHAIN)
     parent_hop_index = None if parent is None else receipts[parent].hop_index
 

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -885,6 +885,46 @@ class Orchestrator:
         if hasattr(self._spawner, "set_max_agent_runtime_s"):
             self._spawner.set_max_agent_runtime_s(config.max_agent_runtime_s)
 
+        # Run-root identity (#5047): one parentless identity per run, the issuer
+        # every top-level agent's delegation hop names. Parentless, so it records
+        # no hop of its own -- an empty chain is not a broken chain -- but it
+        # gives the first real hop a parent to be graded against. Without it,
+        # top-level agents have no issuer, no hop is recorded, and a single-level
+        # run still verifies as "no receipts".
+        #
+        # Scope is left unconstrained on both axes rather than snapshotted. A
+        # run's task set is not bounded at start: tasks are fetched per tick and
+        # created during the run, so a snapshot taken here would make every task
+        # created later a widening on its own agent's hop and fail verification
+        # for a run that did nothing wrong. ``None`` is the widest value on every
+        # DelegationScope axis, so an unconstrained root is exactly "the whole
+        # run" and is a valid ceiling for any child. This codebase has no
+        # run-level file allowlist, so that axis is unconstrained for the same
+        # reason.
+        self._run_root_identity_id = ""
+        try:
+            from bernstein.core.identity.agent_jwt import AgentIdentityStore
+
+            _root_store = AgentIdentityStore(workdir / ".sdd" / "auth")
+            _root_identity, _ = _root_store.create_identity(
+                f"run-root-{run_id}",
+                "manager",
+                metadata={"source": "orchestrator", "run_id": run_id, "run_root": "true"},
+            )
+            self._run_root_identity_id = _root_identity.id
+        except Exception as _root_exc:
+            # Degrades to the pre-#5047 behaviour: no root means no issuer, so
+            # no hop is recorded and `delegation verify` reports "no receipts".
+            # Loud, because a run that silently stops being verifiable is the
+            # thing this change exists to prevent.
+            logger.warning(
+                "Run-root identity not minted for %s: %s. Delegation receipts will not be recorded for this run.",
+                run_id,
+                sanitize_log(str(_root_exc)),
+            )
+        if hasattr(self._spawner, "set_run_root_identity_id"):
+            self._spawner.set_run_root_identity_id(self._run_root_identity_id)
+
         # Convergence guard: blocks spawn waves when merge queue, active
         # agent count, error rate, or spawn rate exceed safe thresholds.
         from bernstein.core.orchestration.convergence_guard import ConvergenceGuard
@@ -965,6 +1005,7 @@ class Orchestrator:
                 model=None,
                 workflow_name=_wf_name,
                 workflow_definition_hash=_wf_hash,
+                run_root_identity_id=self._run_root_identity_id,
             )
             save_manifest(self._manifest, workdir / ".sdd")
         except Exception:

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -160,6 +160,14 @@ EVENT_SKILL_USAGE = "skill.usage"
 #: :mod:`bernstein.core.skills.catalog.revocation`.
 EVENT_SKILL_VERIFICATION_REFUSAL = "skill.verification_refusal"
 
+#: Issue #5047 -- emitted when a spawn is refused because the delegation hop for
+#: the agent's identity could not be written. Fail-closed: an agent whose
+#: delegation cannot be receipted must not run, because the chain would then be
+#: short by exactly the hop a verifier needs and a missing hop is
+#: indistinguishable from a delegation that never happened. Carries the run, the
+#: refused session and the reason; never a token or a key.
+EVENT_SPAWN_REFUSED_UNRECEIPTED = "spawn.refused_unreceipted"
+
 #: Issue #2306 -- emitted whenever a payment is authorized under a signed
 #: spending mandate. The event carries the consent receipt binding
 #: ``{mandate_hash, authorized_tool_calls_hash, settlement_ref,

--- a/tests/unit/identity/test_delegation_mint_hop.py
+++ b/tests/unit/identity/test_delegation_mint_hop.py
@@ -1,0 +1,279 @@
+"""The delegation hop recorded when a child agent identity is minted (#5047).
+
+``AgentIdentityStore.create_identity`` records one hop per parented mint, so
+``bernstein delegation verify <run>`` reads a populated chain instead of "no
+receipts".  One test per acceptance criterion, named for the property it
+protects, plus the fail-closed path the issue left to the implementer.
+
+Two tests record limits of the existing model rather than criteria met.
+``test_removing_the_tail_receipt_yields_valid_true_and_one_fewer_hop`` shows the
+one case AC4 cannot reach without a receipt-format change, and
+``test_multi_sibling_grading_limitation`` is deliberately attached to no
+criterion number at all: AC6 asks only that the CLI exit 0 and print the hop
+count, and that is covered on its own.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.delegation_cmd import delegation_group
+from bernstein.core.identity.agent_jwt import AgentIdentityStore, DelegationWriteError
+from bernstein.core.identity import delegation
+from bernstein.core.identity.delegation_scope import VERDICT_PASS, grade_chain
+
+KEY = b"k" * 32
+RUN = "run-5047"
+
+
+@pytest.fixture
+def audit_root(tmp_path):
+    """The delegation root the store writes to (sibling of its own ``auth`` dir)."""
+    return tmp_path / "audit"
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    monkeypatch.setattr(delegation, "_audit_key", lambda: KEY)
+    return AgentIdentityStore(tmp_path / "auth")
+
+
+def _receipt_lines(audit_root) -> list[str]:
+    path = audit_root / "delegation" / f"{RUN}.jsonl"
+    if not path.is_file():
+        return []
+    return [line for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _write_manifest(sdd_dir, root_identity_id: str) -> None:
+    """Write the run manifest declaring ``root_identity_id`` as the run root.
+
+    The real orchestrator writes this at run start via ``save_manifest``; the
+    tests use the same public builder so the field name and the on-disk location
+    cannot drift apart from production.
+    """
+    from bernstein.core.config.manifest import RunManifest, save_manifest
+
+    save_manifest(RunManifest(run_id=RUN, run_root_identity_id=root_identity_id), sdd_dir)
+
+
+def _mint_orchestrator(store):
+    identity, _ = store.create_identity("orch-1", "manager", metadata={"run_id": RUN})
+    return identity
+
+
+def _mint_child(store, name, parent, *, task_ids, allowed_files):
+    identity, _ = store.create_identity(
+        name,
+        "backend",
+        parent_identity_id=parent.id,
+        task_ids=task_ids,
+        allowed_files=allowed_files,
+        metadata={"run_id": RUN},
+    )
+    return identity
+
+
+def test_parented_mint_writes_exactly_one_receipt(store, audit_root):
+    """AC1: one named parent, one receipt in the run's delegation root."""
+    parent = _mint_orchestrator(store)
+    _mint_child(store, "child-1", parent, task_ids=["t1"], allowed_files=["src/**"])
+    assert len(_receipt_lines(audit_root)) == 1
+
+
+def test_chain_over_several_spawned_agents_passes_with_one_hop_per_mint(store, audit_root):
+    """AC2: several spawned agents verify, one hop each, no sibling read as a child."""
+    parent = _mint_orchestrator(store)
+    for index in range(3):
+        _mint_child(store, f"child-{index}", parent, task_ids=[f"t{index}"], allowed_files=["src/**"])
+    result = delegation.verify_run_chain(root=audit_root, run_id=RUN, key=KEY)
+    assert result.hops == 3
+    assert result.valid, result.errors + [str(v) for v in result.authority.violations]
+
+
+def test_narrowing_grades_from_the_receipt_with_the_store_deleted(store, tmp_path, audit_root):
+    """AC3: the scope rides on the receipt, so narrowing grades without the store.
+
+    The identity store directory is deleted before grading, so the test cannot
+    reach it even by accident, and ``grade_chain`` is called with no
+    ``scope_resolver``: the receipts are the only input.
+    """
+    parent = _mint_orchestrator(store)
+    # Directory prefixes, not globs: ``prefixes_narrow`` decides ``path_prefixes``
+    # by component-wise path ancestry, so "src" covers "src/core" while "src/**"
+    # does not cover "src/a/**".  The helper it calls is deliberately not named
+    # here: tests/unit/test_security_controls_are_wired.py greps bare identifiers
+    # across tests/, and naming it would retire an unrelated security exemption.
+    child = _mint_child(store, "child-1", parent, task_ids=["t1", "t2"], allowed_files=["src"])
+    _mint_child(store, "grand-1", child, task_ids=["t1"], allowed_files=["src/core"])
+
+    shutil.rmtree(tmp_path / "auth")
+    assert not (tmp_path / "auth").exists()
+
+    receipts = delegation.verify_run_chain(root=audit_root, run_id=RUN, key=KEY).receipts
+    assert len(receipts) == 2
+    assert receipts[0].scope is not None
+    assert receipts[0].scope["task_ids"] == ["t1", "t2"]
+    assert receipts[0].scope["path_prefixes"] == ["src"]
+    assert receipts[1].scope["task_ids"] == ["t1"]
+    assert receipts[1].scope["path_prefixes"] == ["src/core"]
+
+    verdict = grade_chain(receipts)
+    assert verdict.verdict == VERDICT_PASS, verdict.reasons
+    assert verdict.unproven_hops == 0
+
+
+def test_removing_the_tail_receipt_yields_valid_true_and_one_fewer_hop(store, audit_root):
+    """AC4 holds for every receipt except the tail, which this model cannot detect (#5352).
+
+    The loop removes each receipt in turn.  Removing the first or any interior
+    receipt breaks ``prev_hmac`` linkage and verification fails, which is AC4.
+    Removing the TAIL yields ``valid=True`` with ``hops == n - 1``: the shorter
+    chain is internally consistent, because no receipt records how many hops the
+    run should have had, so an end truncation is indistinguishable from a run
+    that simply delegated one fewer time.
+
+    This is a demonstrated limit of the existing receipt model, not a defect
+    introduced here and not something to engineer around.  Detecting it needs a
+    hop count, a terminator, a sidecar or some other completeness state on the
+    receipt, and #5047 excludes changing the receipt format.  The assertion is
+    written the way the behaviour actually is, so a future format change that
+    closes the gap will trip this test rather than pass unnoticed.
+    """
+    parent = _mint_orchestrator(store)
+    for index in range(3):
+        _mint_child(store, f"child-{index}", parent, task_ids=[f"t{index}"], allowed_files=["src/**"])
+    original = _receipt_lines(audit_root)
+    assert len(original) == 3
+    path = audit_root / "delegation" / f"{RUN}.jsonl"
+
+    for removed in range(len(original)):
+        kept = [line for index, line in enumerate(original) if index != removed]
+        path.write_text("\n".join(kept) + "\n", encoding="utf-8")
+        result = delegation.verify_run_chain(root=audit_root, run_id=RUN, key=KEY)
+        if removed == len(original) - 1:
+            assert result.valid, "tail truncation is expected to remain undetectable"
+            assert result.hops == len(original) - 1
+        else:
+            assert not result.valid, f"removing receipt {removed} left the chain passing"
+
+
+def test_parentless_mint_writes_no_receipt_and_leaves_no_broken_chain(store, audit_root):
+    """AC5: no parent, no receipt; an empty chain is absent, never broken."""
+    store.create_identity("orch-1", "manager", metadata={"run_id": RUN})
+    store.create_identity("orch-2", "manager", metadata={"run_id": RUN})
+    assert _receipt_lines(audit_root) == []
+
+    result = delegation.verify_run_chain(root=audit_root, run_id=RUN, key=KEY)
+    assert result.hops == 0
+    assert result.errors == ["no delegation receipts for run"]
+    assert not any("linkage" in err or "HMAC" in err for err in result.errors)
+
+
+def test_failed_hop_write_aborts_the_mint_and_writes_no_partial_receipt(store, tmp_path, audit_root, monkeypatch):
+    """The fail-closed path, including the residue it leaves.
+
+    The ledger's error is re-raised as :class:`DelegationWriteError` so the
+    spawner can single this failure out from every other identity failure and
+    refuse the spawn; the original is chained as ``__cause__``.
+
+    A ledger that raises takes the mint down with it: ``create_identity``
+    propagates and returns nothing, so the caller never receives the raw token
+    and the credential cannot be presented.  There is no rollback, and this
+    pins what survives: the identity JSON is already written, no ``created``
+    audit event is appended, and no receipt exists.  #5047 says nothing about
+    rollback and the repository has no transaction convention to borrow, so the
+    residue is recorded rather than swept up.
+    """
+    parent = _mint_orchestrator(store)
+
+    def _boom(**_kwargs):
+        msg = "ledger unavailable"
+        raise OSError(msg)
+
+    monkeypatch.setattr(delegation, "record_delegation_hop", _boom)
+
+    with pytest.raises(DelegationWriteError) as caught:
+        _mint_child(store, "child-1", parent, task_ids=["t1"], allowed_files=["src"])
+    # The ledger's own error is chained, so nothing about the cause is lost.
+    assert isinstance(caught.value.__cause__, OSError)
+    assert "ledger unavailable" in str(caught.value.__cause__)
+
+    # The property the issue asks for: nothing partial reaches the chain.
+    assert _receipt_lines(audit_root) == []
+
+    # The residue, asserted so it cannot change unnoticed.
+    assert (tmp_path / "auth" / "agent_identities" / "child-1.json").is_file()
+    audit_rows = (tmp_path / "auth" / "agent_identity_audit.jsonl").read_text(encoding="utf-8")
+    assert "child-1" not in audit_rows
+
+
+def test_cli_verify_exits_zero_and_prints_the_hop_count(store, audit_root, monkeypatch):
+    """AC6: `bernstein delegation verify <run>` exits 0 and prints the hop count."""
+    monkeypatch.setattr(delegation, "_audit_key", lambda: KEY)
+    parent = _mint_orchestrator(store)
+    _mint_child(store, "child-0", parent, task_ids=["t0"], allowed_files=["src"])
+
+    result = CliRunner().invoke(delegation_group, ["verify", RUN, "--root", str(audit_root)])
+    assert result.exit_code == 0, result.output
+    assert "1 hop(s)" in result.output
+
+
+def test_siblings_grade_when_the_manifest_declares_the_run_root(store, tmp_path, audit_root, monkeypatch):
+    """Two children of one run root now BOTH grade, anchored from the manifest.
+
+    Last pass this was ``test_multi_sibling_grading_limitation`` and asserted
+    exit 3: root status is positional, so the second sibling read as
+    ``root_claimed_mid_chain`` -> unproven. It is no longer a limitation. The run
+    manifest records the identity the orchestrator minted as the run root, and
+    ``delegation verify`` reads that name from the manifest, so a hop issued by
+    the declared root may be a root without being first.
+
+    The name comes from OUTSIDE the receipts, which is why this does not reopen
+    the evasion the positional rule exists to stop: a receipt still cannot
+    promote itself by writing its own issuer field.
+    """
+    monkeypatch.setattr(delegation, "_audit_key", lambda: KEY)
+    root_identity, _ = store.create_identity("run-root-1", "manager", metadata={"run_id": RUN})
+    _write_manifest(tmp_path, root_identity.id)
+
+    for index in range(2):
+        store.create_identity(
+            f"child-{index}",
+            "backend",
+            parent_identity_id=root_identity.id,
+            task_ids=[f"t{index}"],
+            allowed_files=["src"],
+            metadata={"run_id": RUN},
+        )
+
+    result = CliRunner().invoke(delegation_group, ["verify", RUN, "--root", str(audit_root)])
+    assert result.exit_code == 0, result.output
+    assert "2 hop(s)" in result.output
+    assert "root_claimed_mid_chain" not in result.output
+
+
+def test_without_a_manifest_the_positional_root_rule_is_unchanged(store, audit_root, monkeypatch):
+    """No manifest, no declared root: the second sibling is unproven, as before.
+
+    The anchor is additive. A run whose root is not declared keeps exactly the
+    grading it had, which is what stops this from being a general loosening of
+    the positional rule.
+    """
+    monkeypatch.setattr(delegation, "_audit_key", lambda: KEY)
+    root_identity, _ = store.create_identity("run-root-1", "manager", metadata={"run_id": RUN})
+    for index in range(2):
+        store.create_identity(
+            f"child-{index}",
+            "backend",
+            parent_identity_id=root_identity.id,
+            task_ids=[f"t{index}"],
+            allowed_files=["src"],
+            metadata={"run_id": RUN},
+        )
+    result = CliRunner().invoke(delegation_group, ["verify", RUN, "--root", str(audit_root)])
+    assert result.exit_code == 3, result.output
+    assert "root_claimed_mid_chain" in result.output

--- a/tests/unit/identity/test_delegation_mint_hop.py
+++ b/tests/unit/identity/test_delegation_mint_hop.py
@@ -23,7 +23,11 @@ from click.testing import CliRunner
 from bernstein.cli.commands.delegation_cmd import delegation_group
 from bernstein.core.identity.agent_jwt import AgentIdentityStore, DelegationWriteError
 from bernstein.core.identity import delegation
-from bernstein.core.identity.delegation_scope import VERDICT_PASS, grade_chain
+from bernstein.core.identity.delegation_scope import (
+    REASON_COMPARISON_AXIS_UNSUPPORTED,
+    VERDICT_UNPROVEN,
+    grade_chain,
+)
 
 KEY = b"k" * 32
 RUN = "run-5047"
@@ -95,19 +99,27 @@ def test_chain_over_several_spawned_agents_passes_with_one_hop_per_mint(store, a
 
 
 def test_narrowing_grades_from_the_receipt_with_the_store_deleted(store, tmp_path, audit_root):
-    """AC3: the scope rides on the receipt, so narrowing grades without the store.
+    """AC3: the scope rides on the receipt, so it grades without the store.
 
     The identity store directory is deleted before grading, so the test cannot
     reach it even by accident, and ``grade_chain`` is called with no
-    ``scope_resolver``: the receipts are the only input.
+    ``scope_resolver``: the receipts are the only input.  ``task_ids`` narrowing
+    is proven from those receipts alone; the file scope is recorded and not
+    graded, which is what the chain verdict says.
     """
     parent = _mint_orchestrator(store)
-    # Directory prefixes, not globs: ``prefixes_narrow`` decides ``path_prefixes``
-    # by component-wise path ancestry, so "src" covers "src/core" while "src/**"
-    # does not cover "src/a/**".  The helper it calls is deliberately not named
-    # here: tests/unit/test_security_controls_are_wired.py greps bare identifiers
+    # ``allowed_files`` rides on the receipt verbatim and is deliberately not
+    # graded: it is a glob field, and a glob is not a path prefix, so it cannot
+    # be decided by the ancestry primitive ``path_prefixes`` uses.  The hop
+    # grades ``unproven`` on that axis with a named reason rather than reporting
+    # a narrowing nothing checked (#5351; the grading primitive is #5418).  The
+    # helper that decides ``path_prefixes`` is deliberately not named here:
+    # tests/unit/test_security_controls_are_wired.py greps bare identifiers
     # across tests/, and naming it would retire an unrelated security exemption.
-    child = _mint_child(store, "child-1", parent, task_ids=["t1", "t2"], allowed_files=["src"])
+    # The parent scope is the tree ``src/**`` because the mint-time check reads
+    # these patterns the way the merge gate does, where ``src`` admits the path
+    # ``src`` and nothing under it.
+    child = _mint_child(store, "child-1", parent, task_ids=["t1", "t2"], allowed_files=["src/**"])
     _mint_child(store, "grand-1", child, task_ids=["t1"], allowed_files=["src/core"])
 
     shutil.rmtree(tmp_path / "auth")
@@ -117,13 +129,18 @@ def test_narrowing_grades_from_the_receipt_with_the_store_deleted(store, tmp_pat
     assert len(receipts) == 2
     assert receipts[0].scope is not None
     assert receipts[0].scope["task_ids"] == ["t1", "t2"]
-    assert receipts[0].scope["path_prefixes"] == ["src"]
+    assert receipts[0].scope["allowed_files"] == ["src/**"]
+    assert receipts[0].scope["path_prefixes"] is None
     assert receipts[1].scope["task_ids"] == ["t1"]
-    assert receipts[1].scope["path_prefixes"] == ["src/core"]
+    assert receipts[1].scope["allowed_files"] == ["src/core"]
+    assert receipts[1].scope["path_prefixes"] is None
 
     verdict = grade_chain(receipts)
-    assert verdict.verdict == VERDICT_PASS, verdict.reasons
-    assert verdict.unproven_hops == 0
+    assert verdict.verdict == VERDICT_UNPROVEN, verdict.reasons
+    assert verdict.unproven_hops == 2
+    rows = {row.hop_index: row for row in verdict.hops}
+    assert rows[1].axes == ("allowed_files",)
+    assert REASON_COMPARISON_AXIS_UNSUPPORTED in rows[1].reasons
 
 
 def test_removing_the_tail_receipt_yields_valid_true_and_one_fewer_hop(store, audit_root):

--- a/tests/unit/identity/test_delegation_mint_hop.py
+++ b/tests/unit/identity/test_delegation_mint_hop.py
@@ -21,8 +21,8 @@ import pytest
 from click.testing import CliRunner
 
 from bernstein.cli.commands.delegation_cmd import delegation_group
-from bernstein.core.identity.agent_jwt import AgentIdentityStore, DelegationWriteError
 from bernstein.core.identity import delegation
+from bernstein.core.identity.agent_jwt import AgentIdentityStore, DelegationWriteError
 from bernstein.core.identity.delegation_scope import (
     REASON_COMPARISON_AXIS_UNSUPPORTED,
     VERDICT_UNPROVEN,

--- a/tests/unit/identity/test_delegation_mint_hop.py
+++ b/tests/unit/identity/test_delegation_mint_hop.py
@@ -69,7 +69,7 @@ def _mint_orchestrator(store):
     return identity
 
 
-def _mint_child(store, name, parent, *, task_ids, allowed_files):
+def _mint_child(store, name, parent, *, task_ids, allowed_files=None):
     identity, _ = store.create_identity(
         name,
         "backend",
@@ -232,11 +232,42 @@ def test_cli_verify_exits_zero_and_prints_the_hop_count(store, audit_root, monke
     """AC6: `bernstein delegation verify <run>` exits 0 and prints the hop count."""
     monkeypatch.setattr(delegation, "_audit_key", lambda: KEY)
     parent = _mint_orchestrator(store)
-    _mint_child(store, "child-0", parent, task_ids=["t0"], allowed_files=["src"])
+    # The production shape: the spawner mints with ``task_ids`` and no file
+    # scope, and every axis on that receipt is one the comparator reads.  A
+    # recorded ``allowed_files`` is graded unproven and exits 3, which is
+    # pinned separately below rather than folded into this criterion.
+    _mint_child(store, "child-0", parent, task_ids=["t0"])
 
     result = CliRunner().invoke(delegation_group, ["verify", RUN, "--root", str(audit_root)])
     assert result.exit_code == 0, result.output
     assert "1 hop(s)" in result.output
+
+
+def test_a_recorded_file_scope_is_unproven_and_the_cli_exits_three(store, audit_root, monkeypatch):
+    """A recorded ``allowed_files`` is not graded, so the chain is unproven.
+
+    The axis is carried verbatim and grades ``comparison_axis_unsupported``: a
+    glob is not a path prefix, and no primitive here decides whether one glob
+    contains another (#5351, follow-up #5418).  The CLI's exit map is the one it
+    already had - 0 pass, 1 fail, 3 unproven - so a chain that records a file
+    scope reports 3 until that axis can be graded.
+    """
+    monkeypatch.setattr(delegation, "_audit_key", lambda: KEY)
+    parent = _mint_orchestrator(store)
+    _mint_child(store, "child-0", parent, task_ids=["t0"], allowed_files=["src/**"])
+
+    receipts = delegation.verify_run_chain(root=audit_root, run_id=RUN, key=KEY).receipts
+    assert receipts[0].scope["allowed_files"] == ["src/**"]
+
+    verdict = grade_chain(receipts)
+    assert verdict.verdict == VERDICT_UNPROVEN
+    assert verdict.unproven_hops == 1
+    assert verdict.hops[0].axes == ("allowed_files",)
+    assert REASON_COMPARISON_AXIS_UNSUPPORTED in verdict.hops[0].reasons
+
+    result = CliRunner().invoke(delegation_group, ["verify", RUN, "--root", str(audit_root)])
+    assert result.exit_code == 3, result.output
+    assert "comparison_axis_unsupported" in result.output
 
 
 def test_siblings_grade_when_the_manifest_declares_the_run_root(store, tmp_path, audit_root, monkeypatch):
@@ -263,7 +294,6 @@ def test_siblings_grade_when_the_manifest_declares_the_run_root(store, tmp_path,
             "backend",
             parent_identity_id=root_identity.id,
             task_ids=[f"t{index}"],
-            allowed_files=["src"],
             metadata={"run_id": RUN},
         )
 

--- a/tests/unit/identity/test_delegation_scope_allowed_files.py
+++ b/tests/unit/identity/test_delegation_scope_allowed_files.py
@@ -62,13 +62,20 @@ PRE_CHANGE_BODY = {
 }
 
 #: The canonical bytes ``scope_ref()`` hashes, on the pre-change class.
+#:
+#: Frozen under ``JCS_CANONICALIZATION_VERSION`` 3. The literal moved once, when
+#: #5494 made integral floats follow RFC 8785 3.2.2.3 (`not_after` serialises as
+#: ``1``, not ``1.0``); that bump is versioned and deliberate. If these two
+#: literals fail, decide which happened before touching them: a member was added
+#: to the body, which is the thing this group exists to catch, or the number
+#: grammar moved again, which shows up only in a payload carrying a float.
 PRE_CHANGE_JCS = (
-    b'{"duties":["spawn"],"max_depth":3,"max_uses":2,"not_after":1.0,'
+    b'{"duties":["spawn"],"max_depth":3,"max_uses":2,"not_after":1,'
     b'"path_prefixes":["src"],"permissions":["repo.read"],"task_ids":["t1"]}'
 )
 
 #: ``REPRESENTATIVE.scope_ref()`` on the pre-change class.
-PRE_CHANGE_REF = "sha256:1a46652e64715a2daf47eb654351b1f9809322f4cee965559d91585156485231"
+PRE_CHANGE_REF = "sha256:82809a0d877bc91da391c41b349a8a5ec405fdb1bc92613adf5a4654b1af6d58"
 
 #: ``DelegationScope().scope_ref()`` on the pre-change class.
 PRE_CHANGE_EMPTY_REF = "sha256:0215f133c471eb217982555a27f131a3d94f1b3764ee4679a79c5a2021e875b1"

--- a/tests/unit/identity/test_delegation_scope_allowed_files.py
+++ b/tests/unit/identity/test_delegation_scope_allowed_files.py
@@ -1,0 +1,200 @@
+"""The recorded-but-ungraded ``allowed_files`` axis on ``DelegationScope`` (#5351).
+
+``allowed_files`` is a glob field: a pattern is not a path prefix, so it cannot
+be decided by the ancestry primitive ``path_prefixes`` uses, and translating one
+into the other would report "narrowing checked and held" for an axis where only
+the patterns that happened to have a prefix form were checked.  The axis is
+therefore recorded verbatim on the receipt and graded
+``comparison_axis_unsupported``: the hop reads unproven with a named reason
+until a glob-subsumption primitive exists to grade it (follow-up #5418).
+
+The compatibility group pins the axis against the implementation exactly as it
+stood at the commit this change is written on top of.  ``scope_ref()`` digests
+the canonical bytes of ``to_body()``, so emitting a new key unconditionally
+would move every stored reference and stop sealed records from replaying
+byte-identically.  The literals below were computed on that pre-change class and
+are the oracle: a scope that does not use the axis must still produce these
+exact bytes and this exact digest.
+
+The presence matrix records what the module actually produces for the three
+ways two hops can carry the axis.  Grading keys off each hop's OWN recorded
+body, so the three cases are not symmetric, and the asymmetry is recorded here
+rather than engineered away.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from bernstein.core.identity import delegation
+from bernstein.core.identity.delegation_scope import (
+    REASON_COMPARISON_AXIS_UNSUPPORTED,
+    REASON_ROOT_STRUCTURAL_ONLY,
+    VERDICT_PASS,
+    VERDICT_UNPROVEN,
+    ChainVerdict,
+    DelegationScope,
+    HopVerdict,
+    grade_chain,
+)
+from bernstein.core.security.agent_card_signer import canonicalize_jcs
+
+#: A scope exercising every axis that existed before ``allowed_files`` did.
+REPRESENTATIVE = DelegationScope(
+    permissions=frozenset({"repo.read"}),
+    duties=frozenset({"spawn"}),
+    task_ids=frozenset({"t1"}),
+    path_prefixes=frozenset({"src"}),
+    not_after=1.0,
+    max_uses=2,
+    max_depth=3,
+)
+
+#: ``REPRESENTATIVE.to_body()`` on the pre-change class.
+PRE_CHANGE_BODY = {
+    "duties": ["spawn"],
+    "max_depth": 3,
+    "max_uses": 2,
+    "not_after": 1.0,
+    "path_prefixes": ["src"],
+    "permissions": ["repo.read"],
+    "task_ids": ["t1"],
+}
+
+#: The canonical bytes ``scope_ref()`` hashes, on the pre-change class.
+PRE_CHANGE_JCS = (
+    b'{"duties":["spawn"],"max_depth":3,"max_uses":2,"not_after":1.0,'
+    b'"path_prefixes":["src"],"permissions":["repo.read"],"task_ids":["t1"]}'
+)
+
+#: ``REPRESENTATIVE.scope_ref()`` on the pre-change class.
+PRE_CHANGE_REF = "sha256:1a46652e64715a2daf47eb654351b1f9809322f4cee965559d91585156485231"
+
+#: ``DelegationScope().scope_ref()`` on the pre-change class.
+PRE_CHANGE_EMPTY_REF = "sha256:0215f133c471eb217982555a27f131a3d94f1b3764ee4679a79c5a2021e875b1"
+
+
+def _receipt(
+    index: int,
+    *,
+    scope: DelegationScope | None = None,
+) -> delegation.DelegationReceipt:
+    """Build one receipt directly; the reference is the body's own address."""
+    return delegation.DelegationReceipt(
+        run_id="run",
+        hop_index=index,
+        issuer=f"p{index}",
+        subject=f"p{index}",
+        audience=f"p{index + 1}",
+        act="task.delegate",
+        created=1_700_000_000 + index,
+        hmac=f"{index + 1:064x}",
+        scope_ref=None if scope is None else scope.scope_ref(),
+        scope=None if scope is None else scope.to_body(),
+    )
+
+
+def _rows(verdict: ChainVerdict) -> dict[int, HopVerdict]:
+    return {row.hop_index: row for row in verdict.hops}
+
+
+CEILING_WITH = DelegationScope(task_ids=frozenset({"t1", "t2"}), allowed_files=frozenset({"src/**"}))
+CEILING_WITHOUT = DelegationScope(task_ids=frozenset({"t1", "t2"}))
+CHILD_WITH = DelegationScope(task_ids=frozenset({"t1"}), allowed_files=frozenset({"src/core"}))
+CHILD_WITHOUT = DelegationScope(task_ids=frozenset({"t1"}))
+
+
+class TestAScopeThatDoesNotUseTheAxisHashesUnchanged:
+    """The trap: a new key that is always emitted re-addresses every scope."""
+
+    def test_the_body_carries_no_allowed_files_key(self):
+        assert "allowed_files" not in REPRESENTATIVE.to_body()
+        assert REPRESENTATIVE.to_body() == PRE_CHANGE_BODY
+
+    def test_the_canonical_bytes_are_byte_identical(self):
+        assert canonicalize_jcs(REPRESENTATIVE.to_body()) == PRE_CHANGE_JCS
+
+    def test_the_reference_is_the_literal_pre_change_digest(self):
+        assert REPRESENTATIVE.scope_ref() == PRE_CHANGE_REF
+
+    def test_the_default_scope_reference_is_unchanged_too(self):
+        assert "allowed_files" not in DelegationScope().to_body()
+        assert DelegationScope().scope_ref() == PRE_CHANGE_EMPTY_REF
+
+    def test_using_the_axis_is_serialized_and_moves_the_reference(self):
+        used = replace(REPRESENTATIVE, allowed_files=frozenset({"x"}))
+        assert used.to_body()["allowed_files"] == ["x"]
+        assert used.scope_ref() != PRE_CHANGE_REF
+
+
+class TestTheAxisSurvivesTheRoundTrip:
+    """``from_body`` is an explicit constructor: an unlisted key is dropped."""
+
+    def test_a_present_value_comes_back(self):
+        scope = replace(REPRESENTATIVE, allowed_files=frozenset({"src/**", "docs/*.md"}))
+        assert DelegationScope.from_body(scope.to_body()).allowed_files == scope.allowed_files
+        assert DelegationScope.from_body(scope.to_body()) == scope
+
+    def test_an_absent_key_reads_as_the_widest_value(self):
+        assert DelegationScope.from_body(REPRESENTATIVE.to_body()).allowed_files is None
+
+    def test_the_round_trip_reproduces_the_reference(self):
+        """What a dropped key would cost: the grader re-derives the body's address.
+
+        A recorded reference that is not the content address of the inline scope
+        is read as one signed body contradicting itself, which fails the hop -
+        so a receipt recording this axis would grade ``fail`` rather than
+        ``unproven`` if the constructor could not read the key back.
+        """
+        scope = replace(REPRESENTATIVE, allowed_files=frozenset({"src/**"}))
+        assert DelegationScope.from_body(scope.to_body()).scope_ref() == scope.scope_ref()
+        assert grade_chain([_receipt(0, scope=scope)]).hops[0].verdict == VERDICT_UNPROVEN
+
+
+class TestPresenceMatrix:
+    """What the module produces when one, both, or neither hop records the axis."""
+
+    def test_both_sides_record_it(self):
+        verdict = grade_chain([_receipt(0, scope=CEILING_WITH), _receipt(1, scope=CHILD_WITH)])
+        rows = _rows(verdict)
+        assert verdict.verdict == VERDICT_UNPROVEN
+        assert verdict.unproven_hops == 2
+        assert rows[0].verdict == VERDICT_UNPROVEN
+        assert rows[0].axes == ("allowed_files",)
+        assert set(rows[0].reasons) == {REASON_COMPARISON_AXIS_UNSUPPORTED, REASON_ROOT_STRUCTURAL_ONLY}
+        assert rows[1].verdict == VERDICT_UNPROVEN
+        assert rows[1].axes == ("allowed_files",)
+        assert rows[1].reasons == (REASON_COMPARISON_AXIS_UNSUPPORTED,)
+
+    def test_the_child_records_it_and_the_ceiling_does_not(self):
+        verdict = grade_chain([_receipt(0, scope=CEILING_WITHOUT), _receipt(1, scope=CHILD_WITH)])
+        rows = _rows(verdict)
+        assert verdict.verdict == VERDICT_UNPROVEN
+        assert verdict.unproven_hops == 1
+        assert rows[0].verdict == VERDICT_PASS
+        assert rows[0].axes == ()
+        assert rows[1].verdict == VERDICT_UNPROVEN
+        assert rows[1].axes == ("allowed_files",)
+        assert REASON_COMPARISON_AXIS_UNSUPPORTED in rows[1].reasons
+
+    def test_the_ceiling_records_it_and_the_child_does_not(self):
+        """The asymmetric case, recorded rather than fixed.
+
+        Grading keys off each hop's own body, and the comparator is not asked
+        about this axis, so the child's row carries no reason to be unproven:
+        an axis the ceiling bounded goes uncompared while that row reads pass.
+        The chain is still unproven, on the ceiling's own row.  Whether the
+        child's row should also be unproven is a semantics call, not something
+        to decide inside a test; on this repository's own minting path a child
+        that names no file scope under a restricted parent is refused before any
+        receipt is written.
+        """
+        verdict = grade_chain([_receipt(0, scope=CEILING_WITH), _receipt(1, scope=CHILD_WITHOUT)])
+        rows = _rows(verdict)
+        assert verdict.verdict == VERDICT_UNPROVEN
+        assert verdict.unproven_hops == 1
+        assert rows[0].verdict == VERDICT_UNPROVEN
+        assert rows[0].axes == ("allowed_files",)
+        assert rows[1].verdict == VERDICT_PASS
+        assert rows[1].axes == ()
+        assert rows[1].reasons == ()

--- a/tests/unit/identity/test_delegation_spawn_wiring.py
+++ b/tests/unit/identity/test_delegation_spawn_wiring.py
@@ -18,10 +18,10 @@ import pytest
 from click.testing import CliRunner
 
 from bernstein.cli.commands.delegation_cmd import delegation_group
-from bernstein.core.identity.agent_jwt import AgentIdentityStore, DelegationWriteError
 from bernstein.core.agents.spawner_core import AgentSpawner
 from bernstein.core.config.manifest import RunManifest, save_manifest
 from bernstein.core.identity import delegation
+from bernstein.core.identity.agent_jwt import AgentIdentityStore, DelegationWriteError
 
 KEY = b"k" * 32
 RUN = "run-5047-live"

--- a/tests/unit/identity/test_delegation_spawn_wiring.py
+++ b/tests/unit/identity/test_delegation_spawn_wiring.py
@@ -1,0 +1,184 @@
+"""The live spawn path records delegation hops, and refuses when it cannot (#5047).
+
+Driven through ``AgentSpawner._issue_agent_token``, the real production method
+that calls ``create_identity``, using the same spawner construction
+``tests/unit/test_spawner_agent_token.py`` already uses.  The public entry
+``spawn_for_tasks`` has no existing harness in this repository, so the handler
+branch that re-raises :class:`DelegationWriteError` is covered by proving the
+type reaches it rather than by driving a whole spawn; building a harness for it
+was out of scope.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.delegation_cmd import delegation_group
+from bernstein.core.identity.agent_jwt import AgentIdentityStore, DelegationWriteError
+from bernstein.core.agents.spawner_core import AgentSpawner
+from bernstein.core.config.manifest import RunManifest, save_manifest
+from bernstein.core.identity import delegation
+
+KEY = b"k" * 32
+RUN = "run-5047-live"
+
+
+class _NoopAdapter:
+    """Minimal adapter: the spawner only needs a name for token issuance."""
+
+    def name(self) -> str:
+        return "noop"
+
+    def spawn(self, **_kwargs: object) -> object:  # pragma: no cover - never called here
+        raise NotImplementedError
+
+    def is_alive(self, pid: int) -> bool:  # pragma: no cover - never called here
+        return False
+
+    def kill(self, pid: int) -> object:  # pragma: no cover - never called here
+        raise NotImplementedError
+
+
+def _make_spawner(workdir: Path) -> AgentSpawner:
+    templates_dir = workdir / "templates"
+    templates_dir.mkdir(parents=True, exist_ok=True)
+    return AgentSpawner(
+        adapter=_NoopAdapter(),
+        templates_dir=templates_dir,
+        workdir=workdir,
+        use_worktrees=False,
+    )
+
+
+@pytest.fixture
+def wired(tmp_path, monkeypatch):
+    """A spawner wired the way the orchestrator wires it at run start."""
+    monkeypatch.setattr(delegation, "_audit_key", lambda: KEY)
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    spawner = _make_spawner(workdir)
+
+    # What the orchestrator does in __init__: mint one parentless run root,
+    # record its id in the run manifest, hand it to the spawner with the run id.
+    store = AgentIdentityStore(workdir / ".sdd" / "auth")
+    root_identity, _ = store.create_identity(
+        f"run-root-{RUN}", "manager", metadata={"source": "orchestrator", "run_id": RUN}
+    )
+    save_manifest(RunManifest(run_id=RUN, run_root_identity_id=root_identity.id), workdir / ".sdd")
+    spawner.set_run_id(RUN)
+    spawner.set_run_root_identity_id(root_identity.id)
+    return spawner, workdir, root_identity.id
+
+
+def _audit_root(workdir: Path) -> Path:
+    return workdir / ".sdd" / "audit"
+
+
+def test_live_spawn_path_records_hops_and_the_run_verifies_from_the_manifest(wired):
+    """THE HEADLINE: a run spawned through the real path verifies, exit 0, hops printed.
+
+    Two agents are issued tokens through ``_issue_agent_token``, the method the
+    spawn path calls.  The identity store is then deleted outright, so the
+    verifier cannot consult it even by accident, and ``delegation verify`` is
+    driven through its own CLI.  The run root is recovered from the manifest,
+    which is the whole reason its id is recorded there.
+    """
+    spawner, workdir, _root_id = wired
+
+    for index in range(2):
+        spawner._issue_agent_token(
+            f"agent-{index}",
+            "backend",
+            [f"T-{index}"],
+            parent_identity_id=spawner._run_root_identity_id,
+        )
+
+    # The store is unavailable from here on.
+    shutil.rmtree(workdir / ".sdd" / "auth")
+    assert not (workdir / ".sdd" / "auth").exists()
+
+    result = CliRunner().invoke(delegation_group, ["verify", RUN, "--root", str(_audit_root(workdir))])
+    assert result.exit_code == 0, result.output
+    assert "2 hop(s)" in result.output
+    assert "No delegation receipts" not in result.output
+
+
+def test_hop_failure_raises_delegation_write_error_through_the_spawn_path(wired, monkeypatch):
+    """The distinct type the spawner's handler discriminates on reaches it."""
+    spawner, _workdir, root_id = wired
+
+    def _boom(**_kwargs):
+        msg = "ledger unavailable"
+        raise OSError(msg)
+
+    monkeypatch.setattr(delegation, "record_delegation_hop", _boom)
+
+    with pytest.raises(DelegationWriteError) as caught:
+        spawner._issue_agent_token("agent-0", "backend", ["T-0"], parent_identity_id=root_id)
+    assert isinstance(caught.value.__cause__, OSError)
+
+
+def test_a_non_delegation_identity_failure_is_not_the_fail_closed_type(wired, monkeypatch):
+    """The narrowing is meaningful: other identity failures keep their old type.
+
+    The handler re-raises only :class:`DelegationWriteError` and keeps
+    log-and-continue for everything else, so this asserts that an unrelated
+    identity failure does NOT arrive as that type and therefore still takes the
+    old path.
+    """
+    spawner, _workdir, root_id = wired
+
+    class _Failing:
+        def create_identity(self, *_args, **_kwargs):
+            msg = "jwt signing unavailable"
+            raise RuntimeError(msg)
+
+    spawner._identity_store_instance = _Failing()
+
+    with pytest.raises(RuntimeError) as caught:
+        spawner._issue_agent_token("agent-0", "backend", ["T-0"], parent_identity_id=root_id)
+    assert not isinstance(caught.value, DelegationWriteError)
+
+
+def test_spawn_refusal_writes_an_audit_event_naming_run_and_reason(wired):
+    """The refusal is visible in the run's audit chain, not only in an exception."""
+    from bernstein.core.security.audit_chain import EVENT_SPAWN_REFUSED_UNRECEIPTED, AuditChainStore
+
+    spawner, workdir, root_id = wired
+    spawner._audit_spawn_refused_unreceipted("agent-0", root_id, "ledger unavailable")
+
+    events = AuditChainStore(workdir / ".sdd" / "audit").query(
+        event_type=EVENT_SPAWN_REFUSED_UNRECEIPTED, include_archived=True
+    )
+    assert len(events) == 1
+    assert events[0].resource_id == "agent-0"
+    assert events[0].details["run_id"] == RUN
+    assert events[0].details["issuer"] == root_id
+    assert "ledger unavailable" in events[0].details["reason"]
+
+
+def test_nested_spawn_prefers_the_session_parent_over_the_run_root(wired):
+    """A nested spawn names its spawning agent, not the run root.
+
+    ``AgentSession.parent_id`` is the delegation-tree field; the spawn path reads
+    ``session.parent_id or self._run_root_identity_id``, so a populated
+    ``parent_id`` wins and the receipt records parent -> child rather than
+    root -> child.  Nothing in ``src/`` populates ``parent_id`` today, so this
+    covers the branch directly.
+    """
+    spawner, workdir, root_id = wired
+
+    spawner._issue_agent_token("agent-parent", "backend", ["T-0"], parent_identity_id=root_id)
+    spawner._issue_agent_token("agent-child", "backend", ["T-0"], parent_identity_id="agent-parent")
+
+    receipts = delegation.verify_run_chain(root=_audit_root(workdir), run_id=RUN, key=KEY).receipts
+    assert [(r.issuer, r.subject) for r in receipts] == [
+        (root_id, "agent-parent"),
+        ("agent-parent", "agent-child"),
+    ]
+    # The nested hop anchors to its parent's hop, not to genesis.
+    assert receipts[1].parent_ref == receipts[0].hmac


### PR DESCRIPTION
Closes #5047.

Implements the two decisions from the issue thread.

**Run-root identity.** The orchestrator mints one unparented identity per run beside the existing manifest write, and every top-level agent is minted under it. Its id is recorded in `RunManifest.run_root_identity_id` (one field, backward-compatible default, covered by `manifest_hash`), so `bernstein delegation verify <run>` anchors the chain from the manifest without the identity store. Nested spawns set `AgentSession.parent_id` from the parent that mints them and pass it as `parent_identity_id`; the field stays on the minted identity as the provenance mirror, the receipt is the evidence.

**Fail closed at the spawn.** The ledger write raises `DelegationWriteError`; the spawner's identity-creation handler re-raises that type only, keeps log-and-continue for every other identity failure, and writes a `spawn.refused_unreceipted` audit event with the reason.

**What the receipt carries.** Issuer the parent, subject the child, `act="task.spawn"`, `audience="sub-agent:<role>"`, the child's `task_ids` and `allowed_files` as `DelegationScope`. `task_ids` is graded by `grade_chain` from the chain alone; `allowed_files` is recorded verbatim on its own scope axis and grades `unproven / comparison_axis_unsupported` until the glob-subsumption primitive lands (#5418), per option C in the thread. A scope that does not use the axis serialises to the same bytes and the same `scope_ref` as before, pinned as literals in the tests.

**Headline proof.** `test_live_spawn_path_records_hops_and_the_run_verifies_from_the_manifest` drives the real `AgentSpawner._issue_agent_token`, deletes the identity store, and runs the CLI: exit 0, "2 hop(s)". Siblings now grade (they anchor on the root hop named by the manifest, which comes from outside the receipts, so a receipt still cannot promote itself); a companion test pins the unchanged positional rule for a run with no declared root. 14 new tests; the six existing files covering touched code stay green (`test_delegation_verdict` 38 over `grade_chain`, `test_manifest` 27, `test_spawner_agent_token` 7, and the rest); security guard green with `KNOWN_UNCALLED` untouched.

**One deviation from the thread, deliberate and reversible.** The root leaves `task_ids` and `path_prefixes` unconstrained rather than snapshotting the run's task set and file allowlist. A run's task set is not bounded at start, and there is no run-level file allowlist. `None` is the widest value on those two axes, so later-created tasks do not become artificial widening. Two lines to change if you want the literal form.

**Tail truncation**, unchanged as agreed: removing an interior receipt fails verification; removing the final receipt still leaves a shorter valid chain. `test_removing_the_tail_receipt_yields_valid_true_and_one_fewer_hop` demonstrates it; the follow-up issue (terminal hop or chain head in the manifest at close) is next, linked from that test.

**One limit of the proof.** `spawn_for_tasks` has no existing test harness, so the handler branch is proven by type reachability rather than by driving a whole spawn.

Rebased onto current main; the identity-module rename (#5097) and #5415 are under it. The touched files pass ruff, lint-imports and `tests/unit/identity` (362) on the rebased head; CI on this head is the full-suite evidence.