### PR TITLE
fix(spawner): show active file locks in agent prompts

### DIFF
--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -13,6 +13,7 @@ import shutil
 import threading
 import time
 import uuid
+from collections.abc import Callable
 from contextlib import suppress
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any, cast
@@ -1107,6 +1108,7 @@ def _render_prompt_with_receipt(
     meta_messages: list[str] | None = None,
     max_turns: int | None = None,
     mailbox_section: str = "",
+    file_ownership: dict[str, str] | None = None,
     model: str = "",
     context_policy: Any = None,
 ) -> tuple[str, ContextReceipt]:
@@ -1340,6 +1342,16 @@ def _render_prompt_with_receipt(
     # every adapter type receives byte-identical context.
     if mailbox_section and mailbox_section.strip():
         named_sections.append(("mailbox", deduplicate_section(mailbox_section)))
+    file_ownership_section = ""
+    if file_ownership:
+        other_files = {path: owner for path, owner in file_ownership.items() if owner != session_id}
+        if other_files:
+            lines = ["\n## Files currently being edited by other agents (do NOT modify):"]
+            lines.extend(f"- {path} (by {owner})" for path, owner in sorted(other_files.items()))
+            lines.append(
+                "\nIf you need changes in these files, post a bulletin requesting the owning agent to make them.\n"
+            )
+            file_ownership_section = "\n".join(lines)
     try:
         rec_engine = RecommendationEngine(workdir)
         rec_engine.build()
@@ -1490,6 +1502,9 @@ def _render_prompt_with_receipt(
             policy = policy_dict
     else:
         policy = {}
+
+    if file_ownership_section:
+        named_sections.append(("file ownership", file_ownership_section))
 
     receipt = build_context_receipt(named_sections, policy=policy)
 
@@ -1676,6 +1691,7 @@ class AgentSpawner:
         self._workspace = workspace
         self._bulletin = bulletin
         self._context_builder = TaskContextBuilder(workdir)
+        self._file_ownership_provider: Callable[[], dict[str, str]] | None = None
         self._procs: dict[str, subprocess.Popen[bytes] | None] = {}
         # Per-session baseline of operator-checkout untracked paths, captured
         # at manager/planning spawn so the reap-time sweep can quarantine any
@@ -2055,6 +2071,10 @@ class AgentSpawner:
         per-repo lock dict -- fixing.
         """
         self._merge_queue = merge_queue
+
+    def set_file_ownership_provider(self, provider: Callable[[], dict[str, str]]) -> None:
+        """Provide the lock-manager ownership snapshot used in spawn prompts."""
+        self._file_ownership_provider = provider
 
     def set_quality_gate_config(self, config: Any) -> None:
         """Wire in the orchestrator's :class:`QualityGatesConfig` (#4393)."""
@@ -4330,6 +4350,7 @@ class AgentSpawner:
                 tasks[0].id,
             )
         else:
+            file_ownership = self._file_ownership_provider() if self._file_ownership_provider is not None else None
             prompt, receipt = _render_prompt_with_receipt(
                 tasks,
                 self._templates_dir,
@@ -4344,6 +4365,7 @@ class AgentSpawner:
                 meta_messages=meta_messages,
                 max_turns=_effective_max_turns,
                 mailbox_section=mailbox_section,
+                file_ownership=file_ownership,
                 model=model_config.model,
                 context_policy=self._context_policy,
             )

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -876,6 +876,8 @@ class Orchestrator:
         # orchestrator, so the hook is applied here via a setter.
         if hasattr(self._spawner, "set_merge_queue"):
             self._spawner.set_merge_queue(self._merge_queue)
+        if hasattr(self._spawner, "set_file_ownership_provider"):
+            self._spawner.set_file_ownership_provider(lambda: dict(self._file_ownership))
         if hasattr(self._spawner, "set_quality_gate_config"):
             self._spawner.set_quality_gate_config(self._quality_gate_config)
         if hasattr(self._spawner, "set_run_id"):

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -2107,6 +2107,30 @@ class TestFileOwnership:
         orch.tick()
 
         assert "src/owned.py" not in orch._file_ownership
+        from bernstein.core.persistence.file_locks import FileLockManager
+
+        assert FileLockManager(tmp_path).all_locks() == []
+
+    def test_spawn_prompt_includes_file_lock_manager_ownership(self, tmp_path: Path) -> None:
+        """A prompt reads ownership from the orchestrator's lock manager."""
+        task = _make_task(id="T-spawn", role="backend")
+        adapter = _mock_adapter()
+        orch = _build_orchestrator(
+            tmp_path,
+            _mock_transport({"GET /tasks": httpx.Response(200, json=[_task_as_dict(task)])}),
+            adapter=adapter,
+        )
+        orch._lock_manager.acquire(
+            ["src/locked.py"],
+            agent_id="backend-owner",
+            task_id="T-owner",
+            task_title="Owns locked file",
+        )
+
+        orch.tick()
+
+        prompt = adapter.spawn.call_args.kwargs["prompt"]
+        assert "src/locked.py (by backend-owner)" in prompt
 
 
 # --- Feature 3: Metrics Emission ---


### PR DESCRIPTION
## What

Show files held by another agent from the orchestrator's file-lock manager in newly spawned agent prompts.

## Why

The prompt previously had no production path to the authoritative lock snapshot, so an active file lock was invisible to a newly spawned agent.

Fixes #4672

## How

- Wire the orchestrator's read-only lock projection into the spawner at construction time.
- Render that snapshot after context-policy selection so a lock warning remains present in the prompt.
- Assert the heartbeat-reap path also removes the persisted lock state.

## Verification

- Before: `uv run pytest tests/unit/test_orchestrator.py::TestFileOwnership::test_spawn_prompt_includes_file_lock_manager_ownership -q` failed because the prompt omitted the locked file.
- After: `uv run python scripts/run_tests.py tests/unit/test_orchestrator.py`
- After: `uv run pytest tests/unit/test_orchestrator.py::TestFileOwnership::test_ownership_released_on_reap -q` repeated 50 times.
- After: `uv run ruff check src/` and `uv run ruff format --check src/ tests/unit/test_orchestrator.py`

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run python scripts/run_tests.py -x` passes for the changed test file
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (N/A: internal prompt wiring)
- [x] `docs/operations/<area>.md` updated (N/A: no operator workflow change)
- [x] `docs/api/` schema regenerated if a public surface changed (N/A)
- [x] `uv run bernstein agents-md sync` run so AGENTS.md, CLAUDE.md, `.goosehints`, `CONVENTIONS.md`, and `.cursor/rules/*.mdc` reflect any new module (N/A: no new module)
- [x] Tests cover the documented behaviour
