### PR TITLE
refactor(cli): one audit-key loader, not twenty (#5095)

### DIFF
--- a/src/bernstein/cli/commands/artifacts_cmd.py
+++ b/src/bernstein/cli/commands/artifacts_cmd.py
@@ -22,12 +22,7 @@ from pathlib import Path
 import click
 
 from bernstein.cli.helpers import console
-
-
-def _load_hmac_key() -> bytes:
-    from bernstein.core.security.audit import load_or_create_audit_key
-
-    return load_or_create_audit_key()
+from bernstein.core.security.audit import load_or_create_audit_key
 
 
 def _render_report_provenance(payload: dict[str, object], sdd: Path) -> None:
@@ -134,7 +129,7 @@ def artifacts_list_cmd(task: str, workdir: str, output_json: bool) -> None:
     # Read WITHOUT the fail-closed filter so a tampered journal renders as
     # tampered, not as "no artifacts". Verdicts drive the displayed state.
     records = read_artifact_rows(sdd, task, verify=False)
-    verdict_list = verify_run_artifacts(sdd, task, hmac_key=_load_hmac_key())
+    verdict_list = verify_run_artifacts(sdd, task, hmac_key=load_or_create_audit_key())
     verdicts = {(r.key, r.version): r for r in verdict_list}
 
     def _emit_json(rows: list[dict[str, object]], *, verified: bool, reason: str | None) -> None:
@@ -235,7 +230,7 @@ def artifacts_show_cmd(task: str, key: str, workdir: str, provenance: bool) -> N
     sdd = Path(workdir).resolve() / ".sdd"
     # Unverified read so a broken journal reaches the tampered (exit 2) path
     # instead of masquerading as a missing artifact.
-    verdict_list = verify_run_artifacts(sdd, task, hmac_key=_load_hmac_key())
+    verdict_list = verify_run_artifacts(sdd, task, hmac_key=load_or_create_audit_key())
     verdicts = {(r.key, r.version): r for r in verdict_list}
     records = [r for r in read_artifact_rows(sdd, task, verify=False) if r.key == key]
     if not records:

--- a/src/bernstein/cli/commands/conn_cmd.py
+++ b/src/bernstein/cli/commands/conn_cmd.py
@@ -19,12 +19,7 @@ from pathlib import Path
 import click
 
 from bernstein.cli.helpers import console
-
-
-def _load_hmac_key() -> bytes:
-    from bernstein.core.security.audit import load_or_create_audit_key
-
-    return load_or_create_audit_key()
+from bernstein.core.security.audit import load_or_create_audit_key
 
 
 def _sdd(workdir: Path) -> Path:
@@ -34,7 +29,7 @@ def _sdd(workdir: Path) -> Path:
 def _chain(workdir: Path):
     from bernstein.core.security.audit_chain import AuditChainStore
 
-    return AuditChainStore(_sdd(workdir) / "audit", key=_load_hmac_key())
+    return AuditChainStore(_sdd(workdir) / "audit", key=load_or_create_audit_key())
 
 
 def _store(workdir: Path):

--- a/src/bernstein/cli/commands/context_cmd.py
+++ b/src/bernstein/cli/commands/context_cmd.py
@@ -38,15 +38,10 @@ from typing import TYPE_CHECKING
 import click
 
 from bernstein.cli.helpers import console
+from bernstein.core.security.audit import load_or_create_audit_key
 
 if TYPE_CHECKING:
     from bernstein.core.tasks.models import Task
-
-
-def _load_hmac_key() -> bytes:
-    from bernstein.core.security.audit import load_or_create_audit_key
-
-    return load_or_create_audit_key()
 
 
 def _sdd_dir(workdir: Path) -> Path:
@@ -69,7 +64,7 @@ def _load_task(workdir: Path, task_id: str) -> Task | None:
 def _chain(workdir: Path):
     from bernstein.core.security.audit_chain import AuditChainStore
 
-    return AuditChainStore(_sdd_dir(workdir) / "audit", key=_load_hmac_key())
+    return AuditChainStore(_sdd_dir(workdir) / "audit", key=load_or_create_audit_key())
 
 
 @click.group("context")

--- a/src/bernstein/cli/commands/credential_cmd.py
+++ b/src/bernstein/cli/commands/credential_cmd.py
@@ -37,6 +37,7 @@ from bernstein.core.lineage.c2pa import (
     verify_manifest,
 )
 from bernstein.core.lineage.spine import LineageSpine
+from bernstein.core.security.audit import load_or_create_audit_key
 from bernstein.core.security.install_key import (
     InstallKeyError,
     load_or_create_install_key,
@@ -233,13 +234,7 @@ def _read_artifact(root: Path, artifact_path: str) -> bytes:
 
 def _load_spine(root: Path, run_id: str) -> LineageSpine:
     lineage_root = root / ".sdd" / "lineage"
-    return LineageSpine(lineage_root, run_id=run_id, hmac_key=_load_hmac_key())
-
-
-def _load_hmac_key() -> bytes:
-    from bernstein.core.security.audit import load_or_create_audit_key
-
-    return load_or_create_audit_key()
+    return LineageSpine(lineage_root, run_id=run_id, hmac_key=load_or_create_audit_key())
 
 
 def _signing_key_path(root: Path) -> Path:

--- a/src/bernstein/cli/commands/ctx_cmd.py
+++ b/src/bernstein/cli/commands/ctx_cmd.py
@@ -23,12 +23,7 @@ from urllib.parse import urlsplit, urlunsplit
 import click
 
 from bernstein.cli.helpers import console
-
-
-def _load_hmac_key() -> bytes:
-    from bernstein.core.security.audit import load_or_create_audit_key
-
-    return load_or_create_audit_key()
+from bernstein.core.security.audit import load_or_create_audit_key
 
 
 def _store(workdir: Path):
@@ -36,7 +31,7 @@ def _store(workdir: Path):
     from bernstein.core.security.audit_chain import AuditChainStore
 
     sdd = Path(workdir) / ".sdd"
-    chain = AuditChainStore(sdd / "audit", key=_load_hmac_key())
+    chain = AuditChainStore(sdd / "audit", key=load_or_create_audit_key())
     return ContextStore(sdd / "fleet" / "contexts", chain=chain)
 
 

--- a/src/bernstein/cli/commands/escalation_cmd.py
+++ b/src/bernstein/cli/commands/escalation_cmd.py
@@ -23,12 +23,7 @@ from pathlib import Path
 import click
 
 from bernstein.cli.helpers import console
-
-
-def _load_hmac_key() -> bytes:
-    from bernstein.core.security.audit import load_or_create_audit_key
-
-    return load_or_create_audit_key()
+from bernstein.core.security.audit import load_or_create_audit_key
 
 
 def _sdd_dir(workdir: Path) -> Path:
@@ -120,7 +115,7 @@ def escalation_verify_cmd(receipt_id: str, workdir: str) -> None:
     result = verify_escalation_receipt(
         sdd_dir=_sdd_dir(root),
         lineage_root=_lineage_root(root),
-        hmac_key=_load_hmac_key(),
+        hmac_key=load_or_create_audit_key(),
         receipt_id=receipt_id,
     )
     console.print()

--- a/src/bernstein/cli/commands/evidence_cmd.py
+++ b/src/bernstein/cli/commands/evidence_cmd.py
@@ -22,15 +22,10 @@ from typing import TYPE_CHECKING
 import click
 
 from bernstein.cli.helpers import console
+from bernstein.core.security.audit import load_or_create_audit_key
 
 if TYPE_CHECKING:
     from bernstein.core.evidence.output_diff import OutputDiff
-
-
-def _load_hmac_key() -> bytes:
-    from bernstein.core.security.audit import load_or_create_audit_key
-
-    return load_or_create_audit_key()
 
 
 @click.group("evidence")
@@ -152,7 +147,7 @@ def evidence_verify_cmd(task: str, workdir: str) -> None:
     result = verify_evidence_bundle(
         workdir=root,
         lineage_root=root / ".sdd" / "lineage",
-        hmac_key=_load_hmac_key(),
+        hmac_key=load_or_create_audit_key(),
         task_id=task,
     )
     console.print()

--- a/src/bernstein/cli/commands/gate_cmd.py
+++ b/src/bernstein/cli/commands/gate_cmd.py
@@ -22,12 +22,7 @@ from pathlib import Path
 import click
 
 from bernstein.cli.helpers import console
-
-
-def _load_hmac_key() -> bytes:
-    from bernstein.core.security.audit import load_or_create_audit_key
-
-    return load_or_create_audit_key()
+from bernstein.core.security.audit import load_or_create_audit_key
 
 
 def _lineage_root(workdir: Path) -> Path:
@@ -73,7 +68,7 @@ def gate_verify_cmd(run_id: str, inputs_file: str, workdir: str) -> None:
     )
 
     root = Path(workdir).resolve()
-    key = _load_hmac_key()
+    key = load_or_create_audit_key()
     lineage_root = _lineage_root(root)
     claimed = json.loads(Path(inputs_file).read_text(encoding="utf-8"))
 

--- a/src/bernstein/cli/commands/govern_cmd.py
+++ b/src/bernstein/cli/commands/govern_cmd.py
@@ -33,17 +33,12 @@ import click
 
 from bernstein.core.govern.reconcile import propose_reconcile, snapshot_surface
 from bernstein.core.govern.reconcile_models import DesiredState, ReconcileEntry
+from bernstein.core.security.audit import load_or_create_audit_key
 
 #: The lineage run every reconcile record anchors to. Fixed so a later run can
 #: recover the previous observed state from the same run's records, the way
 #: ``governance plan`` pins ``govern-plan``.
 RECONCILE_RUN_ID = "govern-reconcile"
-
-
-def _load_hmac_key() -> bytes:
-    from bernstein.core.security.audit import load_or_create_audit_key
-
-    return load_or_create_audit_key()
 
 
 @click.command("reconcile")
@@ -95,7 +90,7 @@ def govern_reconcile_cmd(propose: bool, desired_file: str, workdir: str, full: b
     diff, decision = propose_reconcile(
         run_id=RECONCILE_RUN_ID,
         lineage_root=root / ".sdd" / "lineage",
-        hmac_key=_load_hmac_key(),
+        hmac_key=load_or_create_audit_key(),
         snapshot=snapshot,
         desired=desired,
         now=now,

--- a/src/bernstein/cli/commands/governance_cmd.py
+++ b/src/bernstein/cli/commands/governance_cmd.py
@@ -58,15 +58,10 @@ from bernstein.cli.helpers import console
 from bernstein.core.govern import collect_remediation as _collect_remediation
 from bernstein.core.govern import compute_plan as _compute_plan
 from bernstein.core.lineage.spine import LineageSpine
+from bernstein.core.security.audit import load_or_create_audit_key
 
 if TYPE_CHECKING:
     from bernstein.core.govern.plan_models import GovernPlan
-
-
-def _load_hmac_key() -> bytes:
-    from bernstein.core.security.audit import load_or_create_audit_key
-
-    return load_or_create_audit_key()
 
 
 def _lineage_root(workdir: Path) -> Path:
@@ -124,7 +119,7 @@ def governance_verify_cmd(run_id: str, bindings_file: str, ledger_file: str | No
     result = verify_governance(
         run_id=run_id,
         lineage_root=_lineage_root(root),
-        hmac_key=_load_hmac_key(),
+        hmac_key=load_or_create_audit_key(),
         bindings=bindings,
         ledger_path=ledger_path,
     )
@@ -199,7 +194,7 @@ def governance_plan_cmd(
     # Anchoring in the lineage spine
     from bernstein.core.lineage.spine import LineageSpine
 
-    hmac_key = _load_hmac_key()
+    hmac_key = load_or_create_audit_key()
     lineage_root = _lineage_root(root)
     spine = LineageSpine(lineage_root, run_id="govern-plan", hmac_key=hmac_key)
 
@@ -339,7 +334,7 @@ def governance_posture_cmd(workdir: str, as_json: bool) -> None:
     root = Path(workdir).resolve()
 
     if as_json:
-        click.echo(evidenced_posture_json(root, hmac_key=_load_hmac_key()))
+        click.echo(evidenced_posture_json(root, hmac_key=load_or_create_audit_key()))
         raise SystemExit(0)
 
     console.print()
@@ -709,7 +704,7 @@ def govern_discover_cmd(
     lineage_root = _lineage_root(root)
     lineage_root.mkdir(parents=True, exist_ok=True)
 
-    hmac_key = _load_hmac_key()
+    hmac_key = load_or_create_audit_key()
     spine = LineageSpine(lineage_root, run_id="govern-discover", hmac_key=hmac_key)
 
     artifact_path = f"govern-discover/proposal-{proposal.content_hash()[:16]}.json"
@@ -828,7 +823,7 @@ def governance_ingest_cmd(
         source_label=source_label,
         profile_name=profile_name,
         audit_dir=root / ".sdd" / "audit",
-        hmac_key=_load_hmac_key(),
+        hmac_key=load_or_create_audit_key(),
         ingest_adapter=adapter,
     ).ingest_batch(spans)
 

--- a/src/bernstein/cli/commands/lineage_replay_cmd.py
+++ b/src/bernstein/cli/commands/lineage_replay_cmd.py
@@ -17,12 +17,7 @@ from rich.table import Table
 
 from bernstein.cli.helpers import console
 from bernstein.core.lineage.spine import LineageSpine
-
-
-def _load_hmac_key() -> bytes:
-    from bernstein.core.security.audit import load_or_create_audit_key
-
-    return load_or_create_audit_key()
+from bernstein.core.security.audit import load_or_create_audit_key
 
 
 @click.command(name="replay")
@@ -45,7 +40,7 @@ def _load_hmac_key() -> bytes:
 def lineage_replay_cmd(run_id: str, workdir: str, limit: int) -> None:
     """Replay the lineage spine for *run_id* in append order."""
     lineage_root = Path(workdir).resolve() / ".sdd" / "lineage"
-    spine = LineageSpine(lineage_root, run_id=run_id, hmac_key=_load_hmac_key())
+    spine = LineageSpine(lineage_root, run_id=run_id, hmac_key=load_or_create_audit_key())
     entries = list(spine.iter_entries())
     if not entries:
         console.print(f"[yellow]NO ENTRIES[/yellow] -- no lineage spine for run={run_id}.")

--- a/src/bernstein/cli/commands/lineage_verify_cmd.py
+++ b/src/bernstein/cli/commands/lineage_verify_cmd.py
@@ -22,28 +22,8 @@ from pathlib import Path
 
 import click
 
-from bernstein.cli.helpers import console
+from bernstein.cli.helpers import console, load_verify_only_key
 from bernstein.core.lineage.spine import LineageSpine, SpineStatus
-
-
-def _load_hmac_key(key_path: Path | None = None) -> bytes:
-    """Load the audit HMAC key read-only for a verify pass.
-
-    ``verify`` only reads the chain, so it must never mint key material.
-    ``load_or_create_audit_key`` would generate a fresh key on a machine that
-    has none -- and that key cannot authenticate a chain written under the real
-    key, so every HMAC tag would fail and a plain missing-key setup error would
-    be misreported as tamper (issue #2639). Load read-only and fail closed with
-    a clear "key missing" error and a distinct exit code instead.
-    """
-    from bernstein.core.security.audit import AuditKeyMissingError, load_audit_key
-
-    try:
-        return load_audit_key(key_path)
-    except AuditKeyMissingError as exc:
-        console.print()
-        console.print(f"[yellow]CANNOT VERIFY[/yellow] -- {exc}")
-        raise SystemExit(3) from exc
 
 
 def _spine_dir(workdir: str) -> Path:
@@ -113,7 +93,7 @@ def lineage_verify_cmd(
         _verify_receipt(run_id, lineage_root, spine_path, receipt_hash, receipt_file, key_path_resolved)
 
     if spine_path.exists():
-        spine = LineageSpine(lineage_root, run_id=run_id, hmac_key=_load_hmac_key(key_path_resolved))
+        spine = LineageSpine(lineage_root, run_id=run_id, hmac_key=load_verify_only_key(key_path_resolved))
         result = spine.verify()
         console.print()
         console.print(f"[bold]Lineage spine[/bold] run={run_id} entries={result.count} head={spine.head_hash()[:16]}")
@@ -164,7 +144,7 @@ def _verify_receipt(
         console.print(f"[red]No spine for run[/red] {run_id} -- cannot resolve receipt {receipt_hash}.")
         raise SystemExit(2)
 
-    spine = LineageSpine(lineage_root, run_id=run_id, hmac_key=_load_hmac_key(key_path))
+    spine = LineageSpine(lineage_root, run_id=run_id, hmac_key=load_verify_only_key(key_path))
     content = Path(receipt_file).read_bytes() if receipt_file is not None else None
     resolution = resolve_receipt_on_spine(spine, entry_hash=receipt_hash, receipt_content=content)
 

--- a/src/bernstein/cli/commands/mandate_cmd.py
+++ b/src/bernstein/cli/commands/mandate_cmd.py
@@ -23,12 +23,7 @@ from pathlib import Path
 import click
 
 from bernstein.cli.helpers import console
-
-
-def _load_hmac_key() -> bytes:
-    from bernstein.core.security.audit import load_or_create_audit_key
-
-    return load_or_create_audit_key()
+from bernstein.core.security.audit import load_or_create_audit_key
 
 
 def _lineage_root(workdir: Path) -> Path:
@@ -95,7 +90,7 @@ def mandate_emit_cmd(intent_file: str, cart_file: str, settlement_file: str, wor
     from bernstein.core.security.audit_chain import AuditChainStore, record_mandate_consent_receipt
 
     root = Path(workdir).resolve()
-    key = _load_hmac_key()
+    key = load_or_create_audit_key()
 
     intent = IntentMandate.from_dict(_read_json(intent_file))
     cart = CartMandate.from_dict(_read_json(cart_file))
@@ -184,7 +179,7 @@ def mandate_verify_cmd(mandate_hash: str, intent_file: str, cart_file: str, work
     result = verify_consent_receipt(
         workdir=root,
         lineage_root=_lineage_root(root),
-        hmac_key=_load_hmac_key(),
+        hmac_key=load_or_create_audit_key(),
         mandate_hash=mandate_hash,
         intent=intent,
         cart=cart,
@@ -223,7 +218,7 @@ def mandate_revoke_cmd(mandate_hash: str, reason: str, workdir: str) -> None:
     from bernstein.core.security.audit_chain import AuditChainStore, record_mandate_revocation
 
     root = Path(workdir).resolve()
-    key = _load_hmac_key()
+    key = load_or_create_audit_key()
     entry = revoke_mandate(
         workdir=root,
         hmac_key=key,
@@ -279,7 +274,7 @@ def mandate_verify_settlement_cmd(receipt_hash: str, intent_file: str, workdir: 
     result = verify_spend_receipt(
         workdir=root,
         lineage_root=_lineage_root(root),
-        hmac_key=_load_hmac_key(),
+        hmac_key=load_or_create_audit_key(),
         wal_sdd_dir=root / ".sdd",
         spend_receipt_hash=receipt_hash,
         intent=intent,

--- a/src/bernstein/cli/commands/memory_cmd.py
+++ b/src/bernstein/cli/commands/memory_cmd.py
@@ -18,16 +18,11 @@ from bernstein.core.memory.chain import (
 )
 from bernstein.core.memory.cross_task_kb import CrossTaskKB, Scope, redact_value
 from bernstein.core.memory.sqlite_store import MemoryType, SQLiteMemoryStore
+from bernstein.core.security.audit import load_or_create_audit_key
 
 _MEMORY_DB_PATH = ".sdd/memory/memory.db"
 
 console = Console()
-
-
-def _load_hmac_key() -> bytes:
-    from bernstein.core.security.audit import load_or_create_audit_key
-
-    return load_or_create_audit_key()
 
 
 def _chain_root(workdir: str) -> Path:
@@ -259,7 +254,7 @@ def verify_memory(scope: str, namespace: str, workdir: str) -> None:
 
     Exit codes: 0 = OK, 1 = no entries / bad input, 2 = tamper detected.
     """
-    chain = MemoryChain(_chain_root(workdir), hmac_key=_load_hmac_key())
+    chain = MemoryChain(_chain_root(workdir), hmac_key=load_or_create_audit_key())
     result = chain.verify(MemoryScope(scope), namespace, spine_root=_spine_root(workdir))
     console.print()
     console.print(f"[bold]Memory chain[/bold] scope={scope} namespace={namespace} entries={result.count}")
@@ -298,7 +293,7 @@ def why_memory(fact: str, scope: str, namespace: str, workdir: str) -> None:
 
     Exit codes: 0 = found, 1 = unknown fact / unresolved provenance.
     """
-    chain = MemoryChain(_chain_root(workdir), hmac_key=_load_hmac_key())
+    chain = MemoryChain(_chain_root(workdir), hmac_key=load_or_create_audit_key())
     origin = chain.why(
         fact,
         scope=MemoryScope(scope),
@@ -343,7 +338,7 @@ def forget_memory(entry_hash: str, scope: str, namespace: str, actor: str, workd
 
     Exit codes: 0 = tombstoned, 1 = target entry not found.
     """
-    chain = MemoryChain(_chain_root(workdir), hmac_key=_load_hmac_key())
+    chain = MemoryChain(_chain_root(workdir), hmac_key=load_or_create_audit_key())
     target = None
     for entry in chain.iter_entries(MemoryScope(scope), namespace):
         if entry.entry_hash == entry_hash:
@@ -398,7 +393,7 @@ def show_memory(scope: str, namespace: str, workdir: str, as_json: bool) -> None
     Exit codes: 0 = live claims printed, 1 = nothing live in this
     scope/namespace.
     """
-    chain = MemoryChain(_chain_root(workdir), hmac_key=_load_hmac_key())
+    chain = MemoryChain(_chain_root(workdir), hmac_key=load_or_create_audit_key())
     memory_scope = MemoryScope(scope)
     entries = chain.fold(memory_scope, namespace)
 

--- a/src/bernstein/cli/commands/review_receipt_cmd.py
+++ b/src/bernstein/cli/commands/review_receipt_cmd.py
@@ -28,12 +28,7 @@ from pathlib import Path
 import click
 
 from bernstein.cli.helpers import console
-
-
-def _load_hmac_key() -> bytes:
-    from bernstein.core.security.audit import load_or_create_audit_key
-
-    return load_or_create_audit_key()
+from bernstein.core.security.audit import load_or_create_audit_key
 
 
 def _lineage_root(workdir: Path) -> Path:
@@ -103,7 +98,7 @@ def review_receipt_emit_cmd(
     from bernstein.core.security.audit_chain import AuditChainStore, record_review_receipt
 
     root = Path(workdir).resolve()
-    key = _load_hmac_key()
+    key = load_or_create_audit_key()
     private_pem, public_pem = load_or_create_review_identity(_identity_dir(root))
 
     issue_body = Path(issue_file).read_text(encoding="utf-8")
@@ -205,7 +200,7 @@ def review_receipt_verify_cmd(
     result = verify_review_receipt(
         workdir=root,
         lineage_root=_lineage_root(root),
-        hmac_key=_load_hmac_key(),
+        hmac_key=load_or_create_audit_key(),
         pr_url=pr_url,
         issue_body=issue_body,
         diff=diff,
@@ -242,7 +237,7 @@ def _verify_chain(
     result = verify_review_chain(
         workdir=root,
         lineage_root=_lineage_root(root),
-        hmac_key=_load_hmac_key(),
+        hmac_key=load_or_create_audit_key(),
         pr_url=pr_url,
         issue_body=issue_body,
         diff=diff,

--- a/src/bernstein/cli/commands/run_graph_cmd.py
+++ b/src/bernstein/cli/commands/run_graph_cmd.py
@@ -37,6 +37,7 @@ import click
 from rich.tree import Tree
 
 from bernstein.cli.helpers import console
+from bernstein.core.security.audit import load_or_create_audit_key
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -49,12 +50,6 @@ __all__ = ["parse_run_ids", "resolve_receipt_path", "run_graph_cmd"]
 RECEIPT_RELDIR = Path(".sdd") / "run-graph"
 
 _HASH_PREFIX = "sha256:"
-
-
-def _load_hmac_key() -> bytes:
-    from bernstein.core.security.audit import load_or_create_audit_key
-
-    return load_or_create_audit_key()
 
 
 def parse_run_ids(pairs: tuple[str, ...]) -> dict[str, str]:
@@ -201,7 +196,7 @@ def run_graph_cmd(
         raise click.ClickException(msg) from exc
 
     run_ids = parse_run_ids(run_id_pairs)
-    hmac_key = _load_hmac_key()
+    hmac_key = load_or_create_audit_key()
     lineage_root = root / ".sdd" / "lineage"
     graph = build_run_graph(root, run_ids=run_ids, lineage_root=lineage_root, hmac_key=hmac_key)
     rows = _branch_rows(graph, lineage_root, hmac_key)

--- a/src/bernstein/cli/commands/skill_cmd.py
+++ b/src/bernstein/cli/commands/skill_cmd.py
@@ -19,12 +19,7 @@ from pathlib import Path
 import click
 
 from bernstein.cli.helpers import console
-
-
-def _load_hmac_key() -> bytes:
-    from bernstein.core.security.audit import load_or_create_audit_key
-
-    return load_or_create_audit_key()
+from bernstein.core.security.audit import load_or_create_audit_key
 
 
 def _lineage_root(workdir: Path) -> Path:
@@ -90,7 +85,7 @@ def skill_provenance_cmd(skill: str, workdir: str) -> None:
     graph = provenance_graph(
         workdir=root,
         lineage_root=_lineage_root(root),
-        hmac_key=_load_hmac_key(),
+        hmac_key=load_or_create_audit_key(),
         skill_hash=skill_hash,
     )
 
@@ -150,7 +145,7 @@ def skill_verify_cmd(skill: str, workdir: str) -> None:
     result = verify_install(
         workdir=root,
         lineage_root=_lineage_root(root),
-        hmac_key=_load_hmac_key(),
+        hmac_key=load_or_create_audit_key(),
         skill_hash=skill_hash,
         installed_manifest_hash=manifest_hash,
     )

--- a/src/bernstein/cli/commands/skills_package_cmd.py
+++ b/src/bernstein/cli/commands/skills_package_cmd.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import click
 
 from bernstein.cli.helpers import console
+from bernstein.core.security.audit import load_or_create_audit_key
 from bernstein.core.skills.conformance import (
     DEFAULT_MIN_HOSTS,
     SubprocessTransport,
@@ -42,12 +43,6 @@ from bernstein.core.skills.packaging import (
     update_packaged_install,
     verify_packaged_install,
 )
-
-
-def _load_hmac_key() -> bytes:
-    from bernstein.core.security.audit import load_or_create_audit_key
-
-    return load_or_create_audit_key()
 
 
 def _resolve_dest(
@@ -174,7 +169,7 @@ def install_cmd(
         outcome = install_packaged_skill(
             workdir=root,
             dest=target,
-            hmac_key=_load_hmac_key(),
+            hmac_key=load_or_create_audit_key(),
             install_id=install_id,
             timestamp=int(datetime.now(tz=UTC).timestamp()),
             host=host_label,
@@ -234,7 +229,7 @@ def verify_cmd(host: str | None, scope: str, dest: str | None, workdir: str) -> 
         console.print(f"[red]No installed tree at[/red] {target}")
         raise SystemExit(1)
 
-    result = verify_packaged_install(workdir=root, dest=target, hmac_key=_load_hmac_key())
+    result = verify_packaged_install(workdir=root, dest=target, hmac_key=load_or_create_audit_key())
     console.print()
     console.print(f"[bold]Packaged install verify[/bold] dest={target}")
     if result.ok:
@@ -299,7 +294,7 @@ def update_cmd(
             workdir=root,
             dest=target,
             source=Path(source) if source is not None else None,
-            hmac_key=_load_hmac_key(),
+            hmac_key=load_or_create_audit_key(),
             install_id=install_id,
             timestamp=int(datetime.now(tz=UTC).timestamp()),
             host=host_label,
@@ -354,7 +349,7 @@ def status_cmd(as_json: bool, home: str | None, workdir: str) -> None:
     """
     root = Path(workdir).resolve()
     home_dir = Path(home).resolve() if home is not None else None
-    hmac_key = _load_hmac_key()
+    hmac_key = load_or_create_audit_key()
 
     rows: list[dict[str, object]] = []
     any_failed = False
@@ -555,7 +550,7 @@ def conformance_cmd(
             workdir=root,
             hosts=selected,
             transport=_default_transport(),
-            hmac_key=_load_hmac_key(),
+            hmac_key=load_or_create_audit_key(),
             install_id=f"conformance-{scope}",
             timestamp=int(datetime.now(tz=UTC).timestamp()),
             scope=scope,

--- a/src/bernstein/cli/commands/tournament_cmd.py
+++ b/src/bernstein/cli/commands/tournament_cmd.py
@@ -21,12 +21,7 @@ from pathlib import Path
 import click
 
 from bernstein.cli.helpers import console
-
-
-def _load_hmac_key() -> bytes:
-    from bernstein.core.security.audit import load_or_create_audit_key
-
-    return load_or_create_audit_key()
+from bernstein.core.security.audit import load_or_create_audit_key
 
 
 @click.group("tournament")
@@ -120,7 +115,7 @@ def tournament_verify_cmd(task: str, workdir: str) -> None:
     result = verify_tournament_receipt(
         workdir=root,
         lineage_root=root / ".sdd" / "lineage",
-        hmac_key=_load_hmac_key(),
+        hmac_key=load_or_create_audit_key(),
         task_id=task,
     )
     console.print()

--- a/src/bernstein/cli/commands/var_cmd.py
+++ b/src/bernstein/cli/commands/var_cmd.py
@@ -20,12 +20,7 @@ from pathlib import Path
 import click
 
 from bernstein.cli.helpers import console
-
-
-def _load_hmac_key() -> bytes:
-    from bernstein.core.security.audit import load_or_create_audit_key
-
-    return load_or_create_audit_key()
+from bernstein.core.security.audit import load_or_create_audit_key
 
 
 def _store(workdir: Path):
@@ -33,7 +28,7 @@ def _store(workdir: Path):
     from bernstein.core.security.audit_chain import AuditChainStore
 
     sdd = Path(workdir) / ".sdd"
-    chain = AuditChainStore(sdd / "audit", key=_load_hmac_key())
+    chain = AuditChainStore(sdd / "audit", key=load_or_create_audit_key())
     return FleetVariableStore(sdd / "fleet" / "variables", chain=chain)
 
 

--- a/src/bernstein/cli/commands/webhook_cmd.py
+++ b/src/bernstein/cli/commands/webhook_cmd.py
@@ -20,12 +20,7 @@ from pathlib import Path
 import click
 
 from bernstein.cli.helpers import console
-
-
-def _load_hmac_key() -> bytes:
-    from bernstein.core.security.audit import load_or_create_audit_key
-
-    return load_or_create_audit_key()
+from bernstein.core.security.audit import load_or_create_audit_key
 
 
 def _lineage_root(workdir: Path) -> Path:
@@ -63,7 +58,7 @@ def webhook_verify_cmd(event_id: str, workdir: str) -> None:
     result = verify_webhook_event(
         workdir=root,
         lineage_root=_lineage_root(root),
-        hmac_key=_load_hmac_key(),
+        hmac_key=load_or_create_audit_key(),
         event_id=event_id,
     )
 

--- a/src/bernstein/cli/helpers.py
+++ b/src/bernstein/cli/helpers.py
@@ -619,3 +619,45 @@ def print_warning(message: str) -> None:
 def print_info(message: str) -> None:
     """Print an informational message in cyan with an → prefix."""
     console.print(f"[cyan]→[/cyan] {message}")
+
+
+# ---------------------------------------------------------------------------
+# Audit key loading for read-only commands (issue #5095)
+# ---------------------------------------------------------------------------
+
+
+def load_verify_only_key(key_path: Path | None = None) -> bytes:
+    """Load the audit HMAC key read-only, for a command that only verifies.
+
+    The named alternative to importing
+    :func:`bernstein.core.security.audit.load_or_create_audit_key` directly,
+    which every writing command does. A ``verify`` pass only reads the chain,
+    so it must never mint key material: ``load_or_create_audit_key`` would
+    generate a fresh key on a machine that has none, that key cannot
+    authenticate a chain written under the real key, every HMAC tag would fail,
+    and a plain missing-key setup error would be reported as tamper
+    (issue #2639).
+
+    It lives here rather than inside one command module so the next read-only
+    ``verify`` shares the fail-closed behaviour instead of copying it -- which
+    is how twenty copies of the *writing* loader accumulated (issue #5095).
+
+    Args:
+        key_path: Optional explicit key location, forwarded unchanged.
+
+    Returns:
+        The raw key bytes suitable for ``hmac.new``.
+
+    Raises:
+        SystemExit: Exit code 3 when no key exists, after printing a distinct
+            ``CANNOT VERIFY`` line so the operator sees a setup problem rather
+            than an integrity failure.
+    """
+    from bernstein.core.security.audit import AuditKeyMissingError, load_audit_key
+
+    try:
+        return load_audit_key(key_path)
+    except AuditKeyMissingError as exc:
+        console.print()
+        console.print(f"[yellow]CANNOT VERIFY[/yellow] -- {exc}")
+        raise SystemExit(3) from exc

--- a/tests/unit/test_load_hmac_key_single_source.py
+++ b/tests/unit/test_load_hmac_key_single_source.py
@@ -1,0 +1,90 @@
+"""Regression test for issue #5095: one audit-key loader, not twenty.
+
+``def _load_hmac_key`` was defined twenty times under ``src/bernstein/cli``.
+Nineteen were byte-identical two-line wrappers around
+:func:`bernstein.core.security.audit.load_or_create_audit_key`; the twentieth,
+in ``lineage_verify_cmd``, differed on purpose because a ``verify`` pass must
+never mint key material (issue #2639).
+
+Nineteen copies of a two-line wrapper is nineteen places a later edit -- a
+key-rotation check, a different error message -- has to land correctly, and it
+usually will not. This test locks the post-fix invariant: no module defines its
+own private loader, so the one deliberate divergence stays visible as a named
+helper rather than hiding as wrapper number fourteen.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from bernstein.cli.helpers import load_verify_only_key
+from bernstein.core.security.audit import load_audit_key, load_or_create_audit_key
+
+SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "bernstein"
+
+
+def _private_loader_definitions() -> list[str]:
+    """Every ``def _load_hmac_key`` under ``src/bernstein``, as ``path:line``.
+
+    Walked as an AST rather than grepped so a name inside a string or a comment
+    cannot fail the test, and so a nested or method definition is still caught.
+    """
+    found: list[str] = []
+    for path in sorted(SRC_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and node.name == "_load_hmac_key":
+                found.append(f"{path.relative_to(SRC_ROOT)}:{node.lineno}")
+    return found
+
+
+def test_no_duplicate_load_hmac_key_definitions() -> None:
+    """No module defines a private ``_load_hmac_key``.
+
+    Writing commands import ``load_or_create_audit_key`` directly; the one
+    read-only caller uses the named ``load_verify_only_key`` helper.
+    """
+    definitions = _private_loader_definitions()
+    assert definitions == [], (
+        "private _load_hmac_key wrappers are back (issue #5095) -- import "
+        "load_or_create_audit_key directly, or load_verify_only_key for a "
+        f"read-only verify: {definitions}"
+    )
+
+
+def test_writing_commands_import_the_canonical_loader() -> None:
+    """The command modules that had a wrapper now bind the canonical function."""
+    from importlib import import_module
+
+    for name in ("evidence_cmd", "governance_cmd", "gate_cmd", "mandate_cmd", "skill_cmd"):
+        module = import_module(f"bernstein.cli.commands.{name}")
+        assert module.load_or_create_audit_key is load_or_create_audit_key, (
+            f"{name} no longer resolves to the canonical audit-key loader"
+        )
+
+
+def test_lineage_verify_uses_read_only_key_loader() -> None:
+    """The verify path never reaches the key-creating loader.
+
+    A verifier that minted its own key would fail every HMAC check against a
+    chain written under the real key and report that as tampering, turning a
+    missing-key operator error into a false integrity alarm (issue #2639).
+    """
+    from bernstein.cli.commands import lineage_verify_cmd
+
+    assert lineage_verify_cmd.load_verify_only_key is load_verify_only_key
+    assert not hasattr(lineage_verify_cmd, "load_or_create_audit_key")
+
+    source = (SRC_ROOT / "cli" / "commands" / "lineage_verify_cmd.py").read_text(encoding="utf-8")
+    assert "load_or_create_audit_key" not in source
+
+
+def test_verify_only_loader_is_the_read_only_one() -> None:
+    """``load_verify_only_key`` delegates to ``load_audit_key``, not its creating sibling."""
+    import inspect
+
+    body = inspect.getsource(load_verify_only_key)
+    assert "load_audit_key(key_path)" in body
+    assert "load_or_create_audit_key(" not in body
+    assert load_audit_key is not load_or_create_audit_key


### PR DESCRIPTION
Closes #5095.

## What changed

`def _load_hmac_key` was defined **20 times** under `src/bernstein/cli`. Nineteen were byte-identical two-line wrappers around `load_or_create_audit_key`; the twentieth, in `lineage_verify_cmd.py`, differed on purpose because a `verify` pass must never mint key material (#2639).

- The nineteen wrappers are deleted. Their 47 call sites now import `load_or_create_audit_key` from `bernstein.core.security.audit` directly.
- The read-only variant becomes `bernstein.cli.helpers.load_verify_only_key` — a named, documented alternative rather than a twentieth copy — and `lineage_verify_cmd` uses it.
- `tests/unit/test_load_hmac_key_single_source.py` AST-walks `src/bernstein` and fails on any `def _load_hmac_key`. It finds 20 on `main` and 0 here.

## The open decision the issue left to the implementer

> whether `lineage_verify_cmd.py`'s read-only call becomes a plain direct import of `load_audit_key` (simplest), or whether it is worth a tiny `_load_verify_only_key` helper

**The shared helper**, in `cli/helpers.py`. A plain `load_audit_key` import at the call site would drop the part that matters: the `AuditKeyMissingError` handler that prints `CANNOT VERIFY` and exits **3**, so a missing-key setup error is not reported as tamper. That behaviour is CLI presentation, so it does not belong in `core/security/audit.py` next to the loaders — and it belongs even less inside one command module, where the next read-only `verify` command copies it and the count starts climbing again. `cli/helpers.py` is where the rest of the shared CLI behaviour already lives.

## Verification

```
uv run pytest tests/unit/test_load_hmac_key_single_source.py -x -q   # 4 passed
uv run ruff check src/bernstein                                      # All checks passed
uv run ruff format --check src/bernstein/cli                         # 291 files already formatted
```

Net: **-158 / +58** across 20 command modules.

## Out of scope

No change to what `load_or_create_audit_key` or `load_audit_key` do, to key file locations or formats, or to canonical-bytes signing (#5094).

🤖 Generated with [Claude Code](https://claude.com/claude-code)