### PR TITLE
chore: remove stray REVIEW-VERDICT.md from the repository root

### DIFF
--- a/REVIEW-VERDICT.md
+++ b/REVIEW-VERDICT.md
@@ -1,3 +1,0 @@
-FIXED: 1 of 1 blocking findings
-
-F1 — Missing release notes fragment: NO CHANGE NEEDED — The file `docs/release-notes/fragments/2899-skill-catalog-lint-gate.md` already exists in the PR head (git diff shows 3 lines added). The reviewer's finding was based on an earlier state; the fragment was added in commit c7341ae8 which is part of this branch.


### PR DESCRIPTION
Removes a working note that was committed by mistake in 04e499ae1. Nothing in the package, docs, or tests reads it.