### PR TITLE
test(cli): no two commands share a body, and `completions` stops being two (#5102)

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -1245,7 +1245,7 @@ receipt that no longer recomputes fails exactly like a tampered chain entry.
 | `bernstein self` | Provenance-verified update lifecycle (group). | `cli/commands/self_update_cmd.py:self_group` |
 | `bernstein self-update` | Compatibility alias for `bernstein self`. | `cli/commands/self_update_cmd.py:self_update_cmd` |
 | `bernstein man-pages` | Man-page generator. | `cli/man_page.py:man_pages_cmd` |
-| `bernstein completions` | Shell completion script. | `cli/commands/advanced_cmd.py:1076` |
+| `bernstein completions` | Shell completion script. | `cli/commands/completions_cmd.py:14` |
 | `bernstein config-path` | Show config path. | `cli/config_path_cmd.py:54` |
 | `bernstein config` | Config mgmt (group). | `cli/workspace_cmd.py:180` |
 | `bernstein workspace` | Workspace mgmt (group). | `cli/workspace_cmd.py:30` |

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -5,7 +5,7 @@ This module contains advanced/specialized commands (excluding eval/benchmark whi
   github_group (setup, test-webhook)
   mcp_server
   quarantine_group (list, clear)
-  completions, live, dashboard
+  live, dashboard
   install_hooks, plugins_cmd, doctor, recap, help_all, retro
 
 All commands and groups are registered with the main CLI group in main.py.
@@ -2738,50 +2738,6 @@ def _github_setup() -> None:  # type: ignore[reportUnusedFunction]
 def _github_test_webhook() -> None:  # type: ignore[reportUnusedFunction]
     """Test GitHub webhook configuration."""
     console.print("[green]Webhook configured.[/green]")
-
-
-# ---------------------------------------------------------------------------
-# completions
-# ---------------------------------------------------------------------------
-
-
-@click.command("completions")
-@click.option(
-    "--shell",
-    type=click.Choice(["bash", "zsh", "fish"]),
-    default="bash",
-    show_default=True,
-    help="Shell type.",
-)
-@click.pass_context
-def completions(ctx: click.Context, shell: str) -> None:
-    """Generate shell completion scripts.
-
-    \b
-    For bash, add to ~/.bashrc:
-      eval "$(bernstein completions --shell bash)"
-
-    \b
-    For zsh, add to ~/.zshrc:
-      eval "$(bernstein completions --shell zsh)"
-
-    \b
-    For fish, add to ~/.config/fish/completions/bernstein.fish:
-      bernstein completions --shell fish | source
-    """
-    from click.shell_completion import BashComplete, FishComplete, ZshComplete
-
-    _complete_var = "_BERNSTEIN_COMPLETE"
-    _prog_name = "bernstein"
-
-    shell_cls = {"bash": BashComplete, "zsh": ZshComplete, "fish": FishComplete}[shell]
-    # Walk up to the root CLI group so completions cover all subcommands.
-    root_ctx = ctx
-    while root_ctx.parent is not None:
-        root_ctx = root_ctx.parent
-
-    completer = shell_cls(root_ctx.command, {}, _prog_name, _complete_var)
-    click.echo(completer.source())
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -28,7 +28,6 @@ from bernstein.cli.adapter_cmd import adapters_group, test_adapter
 
 # Import commands from decomposed modules (NEW)
 from bernstein.cli.advanced_cmd import (
-    completions,
     dashboard,
     doctor,
     github_group,
@@ -61,6 +60,7 @@ from bernstein.cli.commands.bom_cmd import bom_group
 from bernstein.cli.commands.bundle_cmd import bundle_group
 from bernstein.cli.commands.citation_cmd import quality_group as citation_quality_group
 from bernstein.cli.commands.compaction_cmd import compaction_group
+from bernstein.cli.commands.completions_cmd import completions_cmd
 from bernstein.cli.commands.criterion_profile_cmd import criterion_profile_group
 from bernstein.cli.commands.datasource_cmd import datasource_group
 from bernstein.cli.commands.decisions_cmd import decisions_group
@@ -202,7 +202,7 @@ __all__ = [
     "checkpoint_cmd",
     "cleanup_cmd",
     "cloud_group",
-    "completions",
+    "completions_cmd",
     # Groups and commands from workspace_cmd
     "config_group",
     "console",
@@ -1028,7 +1028,7 @@ cli.add_command(mcp_server, "mcp")
 from bernstein.cli.commands.mcp_catalog_cmd import catalog_group as _catalog_group  # noqa: E402
 
 mcp_server.add_command(_catalog_group, "catalog")
-cli.add_command(completions)
+cli.add_command(completions_cmd)
 cli.add_command(quarantine_group)
 cli.add_command(install_hooks, "install-hooks")
 cli.add_command(plugins_cmd, "plugins")

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -60,7 +60,11 @@ from bernstein.cli.commands.bom_cmd import bom_group
 from bernstein.cli.commands.bundle_cmd import bundle_group
 from bernstein.cli.commands.citation_cmd import quality_group as citation_quality_group
 from bernstein.cli.commands.compaction_cmd import compaction_group
-from bernstein.cli.commands.completions_cmd import completions_cmd
+
+# Aliased to `completions` so `from bernstein.cli.main import completions` keeps
+# working: the name is part of main's backward-compatible surface, and only the
+# implementation behind it moved to the module the docs already named (#5102).
+from bernstein.cli.commands.completions_cmd import completions_cmd as completions
 from bernstein.cli.commands.criterion_profile_cmd import criterion_profile_group
 from bernstein.cli.commands.datasource_cmd import datasource_group
 from bernstein.cli.commands.decisions_cmd import decisions_group
@@ -202,7 +206,7 @@ __all__ = [
     "checkpoint_cmd",
     "cleanup_cmd",
     "cloud_group",
-    "completions_cmd",
+    "completions",
     # Groups and commands from workspace_cmd
     "config_group",
     "console",
@@ -1028,7 +1032,7 @@ cli.add_command(mcp_server, "mcp")
 from bernstein.cli.commands.mcp_catalog_cmd import catalog_group as _catalog_group  # noqa: E402
 
 mcp_server.add_command(_catalog_group, "catalog")
-cli.add_command(completions_cmd)
+cli.add_command(completions)
 cli.add_command(quarantine_group)
 cli.add_command(install_hooks, "install-hooks")
 cli.add_command(plugins_cmd, "plugins")

--- a/tests/unit/test_cli_decomposition.py
+++ b/tests/unit/test_cli_decomposition.py
@@ -37,7 +37,6 @@ def test_advanced_cmd_imports() -> None:
     assert hasattr(advanced_cmd, "github_group")
     assert hasattr(advanced_cmd, "mcp_server")
     assert hasattr(advanced_cmd, "quarantine_group")
-    assert hasattr(advanced_cmd, "completions")
     assert hasattr(advanced_cmd, "live")
     assert hasattr(advanced_cmd, "dashboard")
     assert hasattr(advanced_cmd, "install_hooks")
@@ -46,6 +45,27 @@ def test_advanced_cmd_imports() -> None:
     assert hasattr(advanced_cmd, "recap")
     assert hasattr(advanced_cmd, "help_all")
     assert hasattr(advanced_cmd, "retro")
+    # `completions` is deliberately NOT here. It was defined twice with
+    # byte-identical bodies -- once here and once in the dedicated
+    # `commands/completions_cmd.py` that docs/operations/shell-completions.md
+    # names as the source -- and only this copy was registered, so an edit to
+    # the documented module had no runtime effect (#5102). The copy is gone;
+    # see test_completions_cmd_is_the_documented_home below.
+    assert not hasattr(advanced_cmd, "completions")
+
+
+def test_completions_cmd_is_the_documented_home() -> None:
+    """`completions` lives in its own module, which is the one the docs name.
+
+    `bernstein.cli.main.completions` still resolves -- it is aliased to the
+    surviving implementation, so the backward-compatible import surface pinned
+    by ``test_backward_compat_main_imports`` is unchanged.
+    """
+    from bernstein.cli.commands.completions_cmd import completions_cmd
+    from bernstein.cli.main import completions
+
+    assert completions is completions_cmd
+    assert completions_cmd.name == "completions"
 
 
 def test_eval_benchmark_cmd_imports() -> None:

--- a/tests/unit/test_collapse_duplicate_commands.py
+++ b/tests/unit/test_collapse_duplicate_commands.py
@@ -9,6 +9,8 @@ what comes back on each stream.
 
 from __future__ import annotations
 
+import ast
+import hashlib
 import json
 from pathlib import Path
 
@@ -377,3 +379,101 @@ def test_deprecated_debug_bundle_alias_names_the_flags_that_do_not_carry_over() 
     assert "WARNING: 'bernstein debug-bundle' is deprecated" in result.stderr
     for flag in sorted(dropped):
         assert flag.replace("_", "-") in result.stderr, f"warning does not mention --{flag}"
+
+
+# ---------------------------------------------------------------------------
+# No two commands share a body (#5102)
+# ---------------------------------------------------------------------------
+#
+# The tests above pin the collapses that were already made. This one catches the
+# NEXT accidental copy, which is how the collapsed cases got there: a command was
+# reimplemented in a second module, both spellings kept working, and the two
+# copies then drifted apart with nobody watching. Comparing AST bodies rather
+# than text means a reformat, a renamed local or a different docstring cannot
+# hide a duplicate -- and cannot invent one either.
+
+
+def _command_name(decorator: ast.expr) -> str | None:
+    """The name a ``@click.command("x")`` / ``@group.command("x")`` decorator registers."""
+    if not isinstance(decorator, ast.Call):
+        return None
+    func = decorator.func
+    if not (isinstance(func, ast.Attribute) and func.attr in {"command", "group"}):
+        return None
+    if not decorator.args:
+        return None
+    first = decorator.args[0]
+    return first.value if isinstance(first, ast.Constant) and isinstance(first.value, str) else None
+
+
+def _body_digest(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str | None:
+    """A hash of the function body, with the docstring dropped. ``None`` for an empty body.
+
+    The docstring is excluded on purpose: two copies whose help text was reworded
+    are still two copies, and a group whose entire body IS its docstring (the
+    common Click idiom) has no implementation to duplicate.
+    """
+    body = node.body
+    if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant):
+        body = body[1:]
+    if not body:
+        return None
+    dumped = ast.dump(ast.Module(body=body, type_ignores=[]))
+    return hashlib.sha256(dumped.encode("utf-8")).hexdigest()
+
+
+def _commands_by_body() -> dict[tuple[str, str], list[str]]:
+    """Every registered CLI command, grouped by ``(command name, body digest)``."""
+    root = Path(__file__).resolve().parents[2] / "src" / "bernstein" / "cli"
+    grouped: dict[tuple[str, str], list[str]] = {}
+    for path in sorted(root.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            names = [n for n in (_command_name(d) for d in node.decorator_list) if n is not None]
+            digest = _body_digest(node)
+            if not names or digest is None:
+                continue
+            where = f"{path.relative_to(root)}:{node.lineno} ({node.name})"
+            grouped.setdefault((names[0], digest), []).append(where)
+    return grouped
+
+
+def test_no_two_commands_named_verify_share_a_body() -> None:
+    """``verify`` is the name most copied, and the one an operator most needs to be single."""
+    duplicates = {
+        name: where for (name, _digest), where in _commands_by_body().items() if name == "verify" and len(where) > 1
+    }
+    assert duplicates == {}, (
+        "two `verify` commands have the same implementation -- collapse them to one "
+        f"and make the other a warn-and-delegate shim (#5102): {duplicates}"
+    )
+
+
+def test_no_two_commands_of_any_name_share_a_body() -> None:
+    """The general form: a second copy of any command is a second place to fix a bug.
+
+    `bernstein completions` was implemented twice with byte-identical bodies --
+    once in ``commands/advanced_cmd.py`` and once in the dedicated
+    ``commands/completions_cmd.py`` the operations docs name as the source. Only
+    the first was registered, so an edit to the documented module would have had
+    no runtime effect at all.
+    """
+    duplicates = {
+        f"{name}:{digest[:8]}": where for (name, digest), where in _commands_by_body().items() if len(where) > 1
+    }
+    assert duplicates == {}, (
+        "a CLI command is implemented more than once with the same body -- register one and "
+        f"delete the copy, or make it delegate (#5102): {duplicates}"
+    )
+
+
+def test_completions_is_the_module_the_docs_name() -> None:
+    """The registered `completions` must be the one ``docs/operations/shell-completions.md`` points at."""
+    from bernstein.cli.commands.completions_cmd import completions_cmd
+
+    registered = cli.commands["completions"]
+    assert registered is completions_cmd
+    assert completions_cmd.callback is not None
+    assert completions_cmd.callback.__module__ == "bernstein.cli.commands.completions_cmd"


### PR DESCRIPTION
Slice 1 of #5102 — the guard test, which the issue says is *"worth taking alone — it is a real regression guard even before any shim is written, and catches a fifth accidental `receipt` group appearing tomorrow."*

## The guard

`_commands_by_body()` AST-walks `src/bernstein/cli`, hashes each registered command's body with the docstring dropped, and fails when two commands of the same name share a digest.

- **AST, not text** — a reformat, a renamed local or a reworded docstring can neither hide a duplicate nor invent one.
- **Docstring excluded on purpose** — two copies whose help text was reworded are still two copies, and a Click group whose whole body *is* its docstring has no implementation to duplicate.
- Both the `verify`-specific assertion the issue asks for and the general-name form, which is strictly stronger and costs the same walk. 655 commands scanned.

## It found one, and it is exactly the shape the issue describes

`bernstein completions` is implemented **twice with byte-identical bodies**:

| where | registered? | documented? |
|---|---|---|
| `cli/commands/advanced_cmd.py:2748` | ✅ `main.py:1031` | ❌ |
| `cli/commands/completions_cmd.py:23` | ❌ | ✅ `docs/operations/shell-completions.md` names it as *the* source |

So an edit to the documented module — a new shell, a fix — would have had **no runtime effect at all**, and `tests/unit/test_completions_cmd.py` drives through `cli`, meaning it was testing the undocumented copy.

`main.py` now registers `completions_cmd` and the copy in `advanced_cmd` is deleted. **The CLI surface is unchanged**: both carried `@click.command("completions")`, so it is the same command with the same options, and all six existing tests pass against it untouched. `test_completions_is_the_module_the_docs_name` pins it.

## ⚠️ Slice 2 as written would break three working commands

Flagging before anyone picks it up. The issue assumes the four `receipt … verify` commands are duplicate implementations *"backed by (at least) four of the eight `verify_receipt` implementations #5096 is consolidating"*. They are not — they verify **four different artefact types**:

| command | verifies |
|---|---|
| `receipt verify` | a result-receipt **bundle** — DSSE envelope, worker key, `--prev-digest` chain continuity, `--expected-manifest-digest` |
| `audit receipt verify` | an **audit receipt** — shells to `tools/verify_audit_receipt.py` for COSE / in-toto / transparency formats |
| `sandbox receipt verify` | a **fork-race selection receipt** — signature plus a re-hash of every snapshot blob in CAS, with five distinct exit codes |
| `benchmark receipt verify` | a **benchmark receipt** |

Making three of them `ctx.invoke` shims onto the top-level group would mean `bernstein sandbox receipt verify <selection-receipt>` is answered by a result-bundle verifier that cannot read that file. The guard test agrees: none of the four share a body.

The operator problem in the issue is real — *"which of four namespaces produced this receipt"* — but the fix is dispatch or cross-referencing help, not deprecation. Happy to take that as a follow-up if you agree with the reading.

## Verification

```
uv run pytest tests/unit/test_collapse_duplicate_commands.py \
              tests/unit/test_completions_cmd.py \
              tests/unit/test_cli_command_registration.py -q
# 752 passed, 1 skipped
uv run ruff check / ruff format --check   # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)