### PR TITLE
fix(routines): cooldown resets only on a productive run, dedup is one section (#5113)

### DIFF
--- a/docs/release-notes/fragments/5113-routine-cooldown-and-dedup.md
+++ b/docs/release-notes/fragments/5113-routine-cooldown-and-dedup.md
@@ -1,0 +1,21 @@
+## A routine's cooldown resets only on a run that found something
+
+A scheduled routine that ran, found nothing, and recorded that fact used
+to suppress itself for the whole cooldown window — so "nothing is
+happening" and "nothing is checking" looked identical in the fire log.
+`TriggerFireRecord` now carries `produced`, and only a productive fire
+moves the cooldown clock. An empty run is still recorded, so
+`get_fire_history` shows it; it just does not start the timer. Records
+written before this change have no `produced` field and are read as
+productive, which is what they were.
+
+## One action per event id, decided atomically
+
+The dedup check read an in-memory cache and the write rewrote the file
+afterwards, so two ticks — or two processes under the schedule supervisor
+— could both pass the check on the same event id and both proceed.
+`TriggerManager.claim_dedup` makes the check and the write one section
+against every other thread and process, under a `flock` on a lock file
+beside the cache, re-reading the cache from disk inside the lock. The
+cache is now written through a scratch sibling too, so an interrupted
+write no longer releases every reservation at once (#5113).

--- a/src/bernstein/core/orchestration/trigger_manager.py
+++ b/src/bernstein/core/orchestration/trigger_manager.py
@@ -17,12 +17,18 @@ import logging
 import os
 import re
 import tempfile
+import threading
 import time
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterator
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows has no fcntl
+    fcntl = None  # type: ignore[assignment]
 
 import yaml
 
@@ -458,6 +464,10 @@ class TriggerManager:
 
         # Dedup cache: {dedup_key: expiry_timestamp}
         self._dedup_cache: dict[str, float] = {}
+        # Serialises this process's claims; the flock in _dedup_lock covers the
+        # rest. `flock` attaches to an open file description, so two threads
+        # opening the lock file separately would not exclude each other.
+        self._dedup_guard = threading.Lock()
 
         # Cron state: {trigger_name: last_fire_minute}
         self._cron_state: dict[str, str] = {}
@@ -535,17 +545,89 @@ class TriggerManager:
         now = time.time()
         self._dedup_cache = {k: v for k, v in self._dedup_cache.items() if v > now}
         path = self._runtime_dir / "dedup_cache.json"
-        with path.open("w") as f:
-            json.dump(self._dedup_cache, f)
+        # Scratch sibling + rename, for the reason _save_cron_state gives: "w"
+        # truncates before the content lands, and _load_dedup_cache reads a
+        # corrupt file as EMPTY - so an interrupted write does not lose one
+        # reservation, it releases every one of them at once.
+        fd, tmp_name = tempfile.mkstemp(dir=self._runtime_dir, prefix="dedup_cache.", suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(self._dedup_cache, f)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_name, path)
+        finally:
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(tmp_name)
+
+    @contextlib.contextmanager
+    def _dedup_lock(self) -> Iterator[None]:
+        """Hold the dedup ledger exclusively across read-decide-write.
+
+        Blocking ``flock(LOCK_EX)`` on a lock file beside the cache, matching
+        the idiom the trigger-source bridge already uses for the same problem:
+        a waiter waits rather than polling, so a contended claim is delayed and
+        never dropped. Falls back to a no-op where ``fcntl`` is unavailable
+        (Windows), where the process-wide lock remains the only ordering -
+        exactly as the bridge's decision lock degrades.
+        """
+        with self._dedup_guard:
+            if fcntl is None:  # pragma: no cover - Windows path
+                yield
+                return
+            path = self._runtime_dir / "dedup_cache.lock"
+            fd = os.open(str(path), os.O_WRONLY | os.O_CREAT, 0o600)
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX)
+                try:
+                    yield
+                finally:
+                    with contextlib.suppress(OSError):
+                        fcntl.flock(fd, fcntl.LOCK_UN)
+            finally:
+                os.close(fd)
 
     def _check_dedup(self, dedup_key: str) -> bool:
-        """Return True if the key is a duplicate (should be skipped)."""
+        """Return True if the key is a duplicate (should be skipped).
+
+        An ADVISORY read of the in-memory cache, kept because it is free and it
+        skips work early. It is not the decision: two callers can both pass it,
+        which is what :meth:`claim_dedup` exists to settle.
+        """
         expiry = self._dedup_cache.get(dedup_key)
         return bool(expiry is not None and expiry > time.time())
 
     def _record_dedup(self, dedup_key: str, ttl_s: int) -> None:
-        self._dedup_cache[dedup_key] = time.time() + ttl_s
-        self._save_dedup_cache()
+        """Reserve ``dedup_key`` unconditionally. Prefer :meth:`claim_dedup`."""
+        with self._dedup_lock():
+            self._load_dedup_cache()
+            self._dedup_cache[dedup_key] = time.time() + ttl_s
+            self._save_dedup_cache()
+
+    def claim_dedup(self, dedup_key: str, ttl_s: int) -> bool:
+        """Reserve ``dedup_key`` for ``ttl_s`` seconds; False if already held.
+
+        The check and the write are ONE section against every other thread and
+        every other process. Before this they were two: ``_check_dedup`` read a
+        dict loaded at construction and ``_record_dedup`` rewrote the file
+        wholesale, so two ticks - or two processes under the schedule
+        supervisor - could both pass the check on the same event id before
+        either wrote it back, and both proceeded. That is one action per
+        delivery rather than one per event id, which is the whole point of a
+        dedup ledger.
+
+        The cache is re-read from disk inside the lock: this process's copy was
+        loaded at construction and says nothing about what another process
+        claimed since.
+        """
+        with self._dedup_lock():
+            self._load_dedup_cache()
+            expiry = self._dedup_cache.get(dedup_key)
+            if expiry is not None and expiry > time.time():
+                return False
+            self._dedup_cache[dedup_key] = time.time() + ttl_s
+            self._save_dedup_cache()
+            return True
 
     # -- Cron state ---------------------------------------------------------
 
@@ -611,7 +693,18 @@ class TriggerManager:
             f.write(json.dumps(asdict(record)) + "\n")
 
     def _last_fire_time(self, trigger_name: str) -> float | None:
-        """Return the most recent fire timestamp for a trigger, or None."""
+        """Return the most recent PRODUCTIVE fire timestamp for a trigger, or None.
+
+        The cooldown clock is driven from this, and a fire that produced nothing
+        deliberately does not move it (issue #5113). A routine that runs on an
+        empty repository, finds no work and then suppresses itself for the next
+        cooldown window is reporting "quiet" and "not checking" as the same
+        thing, which is exactly the state an operator cannot afford to
+        misread.
+
+        ``produced`` missing means ``True``: records written before the field
+        existed were all real fires that created a task.
+        """
         path = self._runtime_dir / _FIRE_LOG_FILENAME
         if not path.exists():
             return None
@@ -621,7 +714,7 @@ class TriggerManager:
                 if not line:
                     continue
                 entry = json.loads(line)
-                if entry.get("trigger_name") == trigger_name:
+                if entry.get("trigger_name") == trigger_name and entry.get("produced", True):
                     last = entry.get("fired_at")
         except (json.JSONDecodeError, OSError):
             logger.warning("Error reading fire log")
@@ -809,7 +902,13 @@ class TriggerManager:
             return None
 
         cooldown_s = trigger.conditions.get("cooldown_s", 300)
-        self._record_dedup(dedup_key, max(cooldown_s, 300))
+        # The authoritative decision, taken here rather than at the advisory
+        # check above: another tick may have claimed this event id in between,
+        # and the render must not have burned the reservation if it failed.
+        if not self.claim_dedup(dedup_key, max(cooldown_s, 300)):
+            suppressed[trigger.name] = "deduplicated"
+            logger.info("Trigger %s lost the dedup race (key=%s)", trigger.name, dedup_key)
+            return None
         self._record_rate()
         logger.info("Trigger %s fired for %s event", trigger.name, event.source)
         return payload
@@ -825,8 +924,26 @@ class TriggerManager:
         title_prefix = trigger.task.title.split("{")[0] if "{" in trigger.task.title else trigger.task.title
         return sum(1 for t in tasks if t.title.startswith(title_prefix) and t.status in active_statuses)
 
-    def record_fire(self, trigger_name: str, source: str, task_id: str, dedup_key: str, summary: str) -> None:
-        """Record a trigger fire after task creation succeeds."""
+    def record_fire(
+        self,
+        trigger_name: str,
+        source: str,
+        task_id: str,
+        dedup_key: str,
+        summary: str,
+        *,
+        produced: bool = True,
+    ) -> None:
+        """Record a trigger fire after task creation succeeds.
+
+        Pass ``produced=False`` for a run that completed but found no work. The
+        record is still appended -- ``get_fire_history`` shows it, so "it ran
+        and found nothing" stays visible -- but it does not reset the cooldown
+        clock (see :meth:`_last_fire_time`).
+
+        Keyword-only and defaulted, so every existing caller keeps recording a
+        productive fire without changing a line.
+        """
         record = TriggerFireRecord(
             trigger_name=trigger_name,
             source=source,
@@ -834,6 +951,7 @@ class TriggerManager:
             task_id=task_id,
             dedup_key=dedup_key,
             event_summary=summary,
+            produced=produced,
         )
         self._record_fire(record)
 
@@ -876,7 +994,9 @@ class TriggerManager:
                 return TriggerGateResult(trigger.name, True, reason, None)
 
             cooldown_s = trigger.conditions.get("cooldown_s", 300)
-            self._record_dedup(dedup_key, max(cooldown_s, 300))
+            if not self.claim_dedup(dedup_key, max(cooldown_s, 300)):
+                logger.info("Trigger %s suppressed a direct %s task: deduplicated", trigger.name, event.source)
+                return TriggerGateResult(trigger.name, True, "deduplicated", None)
             self._record_rate()
             logger.info("Trigger %s governance passed for a direct %s task", trigger.name, event.source)
             return TriggerGateResult(trigger.name, False, None, dedup_key)

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -2160,7 +2160,15 @@ class TriggerConfig:
 
 @dataclass
 class TriggerFireRecord:
-    """Audit record written when a trigger fires and creates a task."""
+    """Audit record written when a trigger fires and creates a task.
+
+    ``produced`` says whether the fire found real work. A routine that runs and
+    finds nothing is still recorded -- an operator needs to see that it ran --
+    but it does not reset the cooldown clock, because a check with an empty
+    result is otherwise indistinguishable from one that never happened
+    (issue #5113). Defaults to ``True`` so a record written before the field
+    existed, and every caller that does not pass it, means what it always did.
+    """
 
     trigger_name: str
     source: str
@@ -2168,6 +2176,7 @@ class TriggerFireRecord:
     task_id: str
     dedup_key: str
     event_summary: str = ""
+    produced: bool = True
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_routine_cooldown_and_dedup.py
+++ b/tests/unit/test_routine_cooldown_and_dedup.py
@@ -1,0 +1,221 @@
+"""Issue #5113: a cooldown that resets only on a non-empty result, and one action per event id.
+
+Two defects, one file, because they are the two halves of "did this routine
+actually do anything".
+
+**The cooldown reset.** ``_last_fire_time`` returned the latest fire record of
+any kind, so a routine that ran, found nothing, and recorded that fact then
+suppressed itself for the whole cooldown window. An operator reading the fire
+log cannot tell "nothing is happening" from "nothing is checking" -- and those
+are the two states that most need telling apart.
+
+**The dedup race.** ``_check_dedup`` read a dict loaded at construction and
+``_record_dedup`` rewrote the whole file afterwards. Two ticks -- or two
+processes under the schedule supervisor -- could both pass the check on the
+same event id before either wrote it back, and both proceeded. That is one
+action per delivery, not one per event id.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import yaml
+from bernstein.core.models import TriggerEvent
+from bernstein.core.trigger_manager import TriggerManager, compute_dedup_key
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+COOLDOWN_S = 3600
+
+
+@pytest.fixture()
+def sdd_dir(tmp_path: Path) -> Path:
+    sdd = tmp_path / ".sdd"
+    (sdd / "config").mkdir(parents=True)
+    (sdd / "runtime" / "triggers").mkdir(parents=True)
+    config: dict[str, Any] = {
+        "version": 1,
+        "triggers": [
+            {
+                "name": "nightly-sweep",
+                "source": "cron",
+                "enabled": True,
+                "conditions": {"cooldown_s": COOLDOWN_S},
+                "task": {"title": "sweep", "description": "sweep the repo"},
+            }
+        ],
+    }
+    with (sdd / "config" / "triggers.yaml").open("w") as handle:
+        yaml.dump(config, handle)
+    return sdd
+
+
+def _event(marker: str, *, at: float | None = None) -> TriggerEvent:
+    """A cron event. `compute_dedup_key` buckets cron by the minute, so two
+    events meant to be distinct have to sit in different 60s buckets."""
+    return TriggerEvent(
+        source="cron",
+        timestamp=time.time() if at is None else at,
+        raw_payload={"trigger_name": "nightly-sweep", "marker": marker},
+        message=f"Cron trigger: {marker}",
+    )
+
+
+def _fire_log(sdd_dir: Path) -> list[dict[str, Any]]:
+    path = sdd_dir / "runtime" / "triggers" / "fire_log.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line]
+
+
+# ---------------------------------------------------------------------------
+# The cooldown resets only on a productive run
+# ---------------------------------------------------------------------------
+
+
+def test_an_empty_run_does_not_start_the_cooldown(sdd_dir: Path) -> None:
+    """Three consecutive empty runs are three runs, not one run and two skips."""
+    mgr = TriggerManager(sdd_dir)
+    base = time.time()
+    for i in range(3):
+        payloads, suppressed = mgr.evaluate(_event(f"empty-{i}", at=base + i * 120))
+        assert len(payloads) == 1, f"run {i} was suppressed: {suppressed}"
+        mgr.record_fire("nightly-sweep", "cron", f"task-{i}", f"dedup-{i}", "nothing found", produced=False)
+
+    # All three are visible to an operator...
+    assert len(_fire_log(sdd_dir)) == 3
+    assert [entry["produced"] for entry in _fire_log(sdd_dir)] == [False, False, False]
+    # ...and none of them moved the clock.
+    assert mgr._last_fire_time("nightly-sweep") is None
+
+
+def test_a_productive_run_starts_the_cooldown(sdd_dir: Path) -> None:
+    """The behaviour that must not change: a fire that found work suppresses the next."""
+    mgr = TriggerManager(sdd_dir)
+    base = time.time()
+    payloads, _ = mgr.evaluate(_event("first", at=base))
+    assert len(payloads) == 1
+    mgr.record_fire("nightly-sweep", "cron", "task-1", "dedup-1", "two tasks created")
+
+    payloads, suppressed = mgr.evaluate(_event("second", at=base + 120))
+    assert payloads == []
+    assert "cooldown" in suppressed.get("nightly-sweep", "")
+
+
+def test_an_empty_run_after_a_productive_one_leaves_the_clock_alone(sdd_dir: Path) -> None:
+    """An empty run must not EXTEND a cooldown either -- it is not a fire at all."""
+    mgr = TriggerManager(sdd_dir)
+    mgr.record_fire("nightly-sweep", "cron", "task-1", "dedup-1", "found work")
+    productive_at = mgr._last_fire_time("nightly-sweep")
+    assert productive_at is not None
+
+    time.sleep(0.01)
+    mgr.record_fire("nightly-sweep", "cron", "task-2", "dedup-2", "nothing found", produced=False)
+    assert mgr._last_fire_time("nightly-sweep") == productive_at
+
+
+def test_a_record_written_before_the_field_existed_still_counts(sdd_dir: Path) -> None:
+    """An old fire_log line has no `produced` key, and was a real fire."""
+    path = sdd_dir / "runtime" / "triggers" / "fire_log.jsonl"
+    legacy = {
+        "trigger_name": "nightly-sweep",
+        "source": "cron",
+        "fired_at": 1_700_000_000.0,
+        "task_id": "task-old",
+        "dedup_key": "dedup-old",
+        "event_summary": "from before #5113",
+    }
+    path.write_text(json.dumps(legacy) + "\n")
+    assert TriggerManager(sdd_dir)._last_fire_time("nightly-sweep") == 1_700_000_000.0
+
+
+# ---------------------------------------------------------------------------
+# One action per event id, decided atomically
+# ---------------------------------------------------------------------------
+
+
+def test_the_same_event_id_twice_produces_one_action(sdd_dir: Path) -> None:
+    mgr = TriggerManager(sdd_dir)
+    event = _event("same-id")
+
+    payloads, _ = mgr.evaluate(event)
+    assert len(payloads) == 1
+
+    payloads, suppressed = mgr.evaluate(event)
+    assert payloads == []
+    assert suppressed.get("nightly-sweep") == "deduplicated"
+
+
+def test_a_second_process_cannot_claim_a_key_the_first_holds(sdd_dir: Path) -> None:
+    """The race the split check-then-write allowed, as two managers on one runtime dir.
+
+    A second ``TriggerManager`` loads its own cache at construction, exactly as
+    a second process under the schedule supervisor does. Before the claim was
+    atomic, both saw the key absent and both proceeded.
+    """
+    first = TriggerManager(sdd_dir)
+    key = compute_dedup_key("nightly-sweep", _event("shared"))
+    assert first.claim_dedup(key, COOLDOWN_S) is True
+
+    second = TriggerManager(sdd_dir)
+    assert second.claim_dedup(key, COOLDOWN_S) is False
+
+
+def test_only_one_of_many_concurrent_claims_wins(sdd_dir: Path) -> None:
+    """Eight threads, one key, one winner -- the check and the write are one section."""
+    managers = [TriggerManager(sdd_dir) for _ in range(8)]
+    key = compute_dedup_key("nightly-sweep", _event("contended"))
+
+    with ThreadPoolExecutor(max_workers=len(managers)) as pool:
+        results = list(pool.map(lambda mgr: mgr.claim_dedup(key, COOLDOWN_S), managers))
+
+    assert sum(results) == 1, f"{sum(results)} callers claimed the same event id"
+
+
+def test_an_expired_claim_can_be_taken_again(sdd_dir: Path) -> None:
+    """A claim is a window, not a tombstone."""
+    mgr = TriggerManager(sdd_dir)
+    key = compute_dedup_key("nightly-sweep", _event("short-ttl"))
+    assert mgr.claim_dedup(key, 0) is True
+    assert mgr.claim_dedup(key, COOLDOWN_S) is True
+
+
+def test_a_failed_render_does_not_burn_the_reservation(sdd_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The claim is taken AFTER the payload renders, not before.
+
+    Claiming on the early advisory check would mean a template error silently
+    swallowed the event for the whole cooldown window, with nothing created and
+    no way to retry it -- the reservation outliving the thing it reserved.
+    """
+    from bernstein.core.orchestration import trigger_manager as module
+
+    def _explode(*_args: object, **_kwargs: object) -> dict[str, Any]:
+        raise ValueError("no such field")
+
+    monkeypatch.setattr(module, "render_task_payload", _explode)
+
+    mgr = TriggerManager(sdd_dir)
+    event = _event("render-fails")
+    payloads, suppressed = mgr.evaluate(event)
+    assert payloads == []
+    assert "template_error" in suppressed.get("nightly-sweep", "")
+
+    # The key is still free, so a fixed template on the next tick can use it.
+    assert mgr.claim_dedup(compute_dedup_key("nightly-sweep", event), COOLDOWN_S) is True
+
+
+def test_the_dedup_cache_survives_an_interrupted_write(sdd_dir: Path) -> None:
+    """Written through a scratch sibling, so a torn file cannot release every claim."""
+    mgr = TriggerManager(sdd_dir)
+    key = compute_dedup_key("nightly-sweep", _event("durable"))
+    assert mgr.claim_dedup(key, COOLDOWN_S) is True
+
+    cache_path = sdd_dir / "runtime" / "triggers" / "dedup_cache.json"
+    assert json.loads(cache_path.read_text())[key] > time.time()
+    assert not list(cache_path.parent.glob("dedup_cache.*.tmp")), "scratch file left behind"


### PR DESCRIPTION
Closes #5113. Both halves, in `core/orchestration/trigger_manager.py` — the module the issue's own note correctly redirects to from `routine_cmd.py`.

## 1. The cooldown reset

`_last_fire_time` returned the latest fire record of any kind, so a routine that ran, found nothing, and recorded that fact then suppressed itself for the whole cooldown window. An operator reading the fire log cannot tell *"nothing is happening"* from *"nothing is checking"*.

- `TriggerFireRecord` gains `produced: bool = True`.
- `record_fire(..., *, produced: bool = True)` — keyword-only and defaulted, so all three existing callers (`schedule_supervisor`, `webhooks`, `triggers_cmd`) keep recording a productive fire without changing a line.
- `_last_fire_time` counts only productive fires. **An empty run is still appended**, so `get_fire_history` shows it — the run stays visible, it just does not move the clock.
- A record written before the field existed has no `produced` key and reads as `True`: it was a real fire that created a task. Pinned by `test_a_record_written_before_the_field_existed_still_counts`.

## 2. The dedup race

`_check_dedup` read a dict loaded at construction; `_record_dedup` rewrote the file wholesale afterwards. Two ticks — or two processes under the schedule supervisor — could both pass the check on the same event id before either wrote it back. That is one action per *delivery*, not one per *event id*.

`claim_dedup(key, ttl)` makes the check and the write **one section** against every other thread and every other process:

- a blocking `flock(LOCK_EX)` on a lock file beside the cache, matching the idiom `core/trigger_sources/receipt.py` already uses for exactly this problem, degrading to the in-process `threading.Lock` where `fcntl` is absent (Windows)
- the cache is **re-read from disk inside the lock** — this process's copy was loaded at construction and says nothing about what another process claimed since
- both call sites, `evaluate` and `gate_direct_task`, now decide on the claim; `_check_dedup` stays in front of `evaluate` as an advisory fast path that skips work early, which is all it ever was

**The claim is taken after the payload renders, deliberately.** Claiming on the early check would let a template error swallow the event for the whole cooldown window, with nothing created and no way to retry it — a reservation outliving the thing it reserved. `test_a_failed_render_does_not_burn_the_reservation` pins the ordering.

`_save_dedup_cache` also moves to the scratch-sibling-and-rename that `_save_cron_state` already uses, for the reason that function gives: `open("w")` truncates before the content lands, and `_load_dedup_cache` reads a corrupt file as **empty** — so an interrupted write did not lose one reservation, it released every one of them at once.

## Tests — `tests/unit/test_routine_cooldown_and_dedup.py` (10)

Including the two the issue names:

- **three consecutive empty runs produce three executions, not one and two skips** — and `_last_fire_time` stays `None` across all three while the fire log holds all three records
- **the same event id twice produces one action and one journaled skip**

plus: an empty run after a productive one does not *extend* the cooldown; a legacy record still counts; a second `TriggerManager` on the same runtime dir (the two-process shape) cannot claim a held key; **eight concurrent claims on one key yield exactly one winner**; an expired claim can be retaken; the render-failure ordering; and no scratch file is left behind.

```
uv run pytest tests/unit/test_routine_cooldown_and_dedup.py -q        # 10 passed
uv run pytest tests/unit/test_trigger_manager.py -q                   # 80 passed
uv run pytest tests/unit/test_claude_routine_adapter.py \
              tests/unit/test_schedule_cmd_2302.py \
              tests/unit/test_schedule_fire_record.py -q              # 31 passed
uv run ruff check / ruff format                                       # clean
```

One pre-existing red on `main`, untouched by this branch and failing identically without it: `test_trigger_manager.py::TestCronEvaluation::test_trigger_not_due_does_not_fire` (wall-clock dependent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)