### PR TITLE
feat(worktrees): capture executed agent helpers as run artefacts (#5322)

### DIFF
--- a/docs/reference/FEATURE_MATRIX.md
+++ b/docs/reference/FEATURE_MATRIX.md
@@ -132,6 +132,7 @@ test, and a row naming a command the CLI no longer registers fails it too.
 | [Stall escalation receipts](../operations/stall-escalation.md) | Full | 3 | A stalled worker produces a signed escalation receipt embedding the last audit entries and a deterministic recommended action (`supervisor escalate`) |
 | C2PA content credentials | Full | 3 | Artifact lineage projected into signed C2PA credentials (`credential emit/verify`) |
 | Skill install receipts | Full | 3 | Install and usage links recomputable via `skill verify` / `skill provenance` |
+| Run-helper artefacts | Brief | 2 | Executed agent-created files are classified from journal `file_create`/`file_execute` events and content-addressed into `.sdd/cas` with an origin step before worktree reap (`core/worktrees/run_helpers.py`, #5322 PR1) |
 | Adapter security-floor receipts | Full | 3 | A below-floor adapter spawn is refused with a content-addressed, chain-anchored refusal receipt (`adapters/security_floor.py`) |
 | Endpoint certification | Full | 3 | Local-model workers are conformance-tested and issued a signed certification (`core/endpoints/certification.py`) |
 | SLA violation receipts | Full | 3 | Per-goal SLA contracts evaluated read-only each tick; a breach becomes a signed, offline-verifiable violation receipt (`core/planning/sla_store.py`) |

--- a/docs/release-notes/fragments/5322-run-helper-capture.md
+++ b/docs/release-notes/fragments/5322-run-helper-capture.md
@@ -1,0 +1,19 @@
+## Helper scripts an agent wrote and ran survive the worktree that held them
+
+An agent that solved a task by writing a throwaway script and executing it left
+no trace of it once the worktree was collected. The run receipt recorded that
+something ran; the file itself went away with the directory, so a later reader
+could see the effect and never the instrument. `bernstein worktrees gc` now
+content-addresses those files into the store before it destroys anything.
+
+Which files count is decided from the run journal alone: a helper is a file the
+run both created and executed, classified by `classify_run_helpers` from
+`file_create` and `file_execute` events, so the set is derived rather than
+guessed and two readers of the same journal agree. Paths are resolved inside the
+worktree and one that escapes it is dropped rather than followed. Each captured
+file appends a `run_helper_captured` row naming it in the run receipt.
+
+Capture happens after the reap event is recorded and before the directory is
+removed, and it is best-effort: a failure to capture never blocks collection, so
+a full disk or an unreadable file costs the artefact rather than the sweep. A
+dry run captures nothing and reports what it would have taken.

--- a/src/bernstein/cli/commands/worktrees_cmd.py
+++ b/src/bernstein/cli/commands/worktrees_cmd.py
@@ -37,6 +37,7 @@ from bernstein.core.worktrees.classifier import (
     reap_worktree,
     worktree_fingerprint,
 )
+from bernstein.core.worktrees.run_helpers import capture_helpers_before_reap
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -508,6 +509,14 @@ def run_gc(
             # 1-2: fingerprint then record BEFORE any destruction. A raised
             # exception here aborts the sweep with the worktree intact.
             _append_reap_event(log, row, dry_run=dry_run, reaped=True, forced=force_unsaved)
+            # 2b: content-address executed agent helpers while the directory
+            # still exists (#5322 PR1). Best-effort — never blocks reap.
+            capture_helpers_before_reap(
+                repo_root,
+                row.path,
+                row.session_id,
+                dry_run=dry_run,
+            )
             # 3: only now is it safe to destroy.
             removed = reap_worktree(repo_root, row, dry_run=dry_run)
             if on_progress is not None:

--- a/src/bernstein/core/worktrees/__init__.py
+++ b/src/bernstein/core/worktrees/__init__.py
@@ -20,13 +20,21 @@ from bernstein.core.worktrees.classifier import (
     reap_worktree,
     worktrees_root,
 )
+from bernstein.core.worktrees.run_helpers import (
+    RunHelper,
+    capture_run_helpers,
+    classify_run_helpers,
+)
 
 __all__ = [
     "GC_LOCK_RELPATH",
     "STALE_TRACE_AGE_S",
     "WORKTREE_GC_LIFECYCLE_EVENT",
     "ClassifiedWorktree",
+    "RunHelper",
     "WorktreeState",
+    "capture_run_helpers",
+    "classify_run_helpers",
     "classify_worktrees",
     "format_size",
     "iter_worktree_dirs",

--- a/src/bernstein/core/worktrees/run_helpers.py
+++ b/src/bernstein/core/worktrees/run_helpers.py
@@ -16,12 +16,14 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from bernstein.core.persistence.cas_store import CASStore
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from pathlib import Path
 
 logger = logging.getLogger(__name__)
 

--- a/src/bernstein/core/worktrees/run_helpers.py
+++ b/src/bernstein/core/worktrees/run_helpers.py
@@ -1,0 +1,299 @@
+"""Capture agent-authored helpers as content-addressed run artefacts (#5322).
+
+PR1 is capture and classification only. An agent-created file that was
+executed during the run becomes a ``run_helper``: classified from journal
+``file_create`` / ``file_execute`` events (read-only, deterministic), then
+content-addressed into the CAS store with its origin step before the
+worktree is reaped. Promotion / skill provenance is a follow-up PR.
+
+Decision (stated for reviewers): a file that executed with a non-zero exit
+code still counts as a helper. Reproduction harnesses are *supposed* to
+fail; exit codes are recorded on the artefact so later promotion policy
+can filter, but classification itself is ``created ∧ executed``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
+
+from bernstein.core.persistence.cas_store import CASStore
+
+logger = logging.getLogger(__name__)
+
+JOURNAL_EVENT_FILE_CREATE = "file_create"
+JOURNAL_EVENT_FILE_EXECUTE = "file_execute"
+JOURNAL_EVENT_RUN_HELPER_CAPTURED = "run_helper_captured"
+
+TRUST_CLASS_AGENT_AUTHORED = "agent_authored"
+
+
+@dataclass(frozen=True, slots=True)
+class RunHelper:
+    """One executed, agent-created file classified from the run journal.
+
+    Attributes:
+        path: Worktree-relative POSIX path.
+        origin_step: Journal ``index`` of the first ``file_create`` for
+            this path (the origin step named on the run receipt).
+        content_hash: CAS SHA-256 hex digest after capture; ``None`` from
+            classify alone.
+        execution_count: Number of matching ``file_execute`` events.
+        exit_codes: Exit codes from those executes, in journal order.
+        trust_class: Provenance class; agent-authored until promoted.
+    """
+
+    path: str
+    origin_step: int
+    content_hash: str | None
+    execution_count: int
+    exit_codes: tuple[int, ...]
+    trust_class: str = TRUST_CLASS_AGENT_AUTHORED
+
+
+def _normalize_relpath(raw: object) -> str | None:
+    """Return a worktree-relative POSIX path, or ``None`` if unusable."""
+
+    if not isinstance(raw, str):
+        return None
+    cleaned = raw.strip().replace("\\", "/")
+    if not cleaned or cleaned.startswith("/") or cleaned.startswith("~"):
+        return None
+    parts = [p for p in cleaned.split("/") if p and p != "."]
+    if not parts or any(p == ".." for p in parts):
+        return None
+    return "/".join(parts)
+
+
+def classify_run_helpers(journal_events: Sequence[Mapping[str, Any]]) -> list[RunHelper]:
+    """Classify run helpers from journal events alone.
+
+    A helper is a path that has at least one ``file_create`` and at least
+    one later ``file_execute``. Classification never probes the filesystem;
+    exit codes (including non-zero) are recorded but do not exclude a path.
+
+    Args:
+        journal_events: Ordered journal rows (each with ``event`` and
+            usually ``index`` / ``path`` / ``exit_code``).
+
+    Returns:
+        Deterministic list of :class:`RunHelper` sorted by ``origin_step``,
+        then path. ``content_hash`` is always ``None`` here.
+    """
+
+    created: dict[str, int] = {}
+    executions: dict[str, list[int]] = {}
+
+    for position, row in enumerate(journal_events):
+        event = row.get("event")
+        path = _normalize_relpath(row.get("path"))
+        if path is None:
+            continue
+        raw_index = row.get("index", position)
+        try:
+            index = int(raw_index)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            index = position
+
+        if event == JOURNAL_EVENT_FILE_CREATE:
+            created.setdefault(path, index)
+            continue
+        if event != JOURNAL_EVENT_FILE_EXECUTE:
+            continue
+        if path not in created:
+            # Execute without a prior create in this journal is not an
+            # agent-authored helper for this run (e.g. pre-existing tool).
+            continue
+        raw_exit = row.get("exit_code", 0)
+        try:
+            exit_code = int(raw_exit)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            exit_code = 0
+        executions.setdefault(path, []).append(exit_code)
+
+    helpers: list[RunHelper] = []
+    for path, exit_codes in executions.items():
+        helpers.append(
+            RunHelper(
+                path=path,
+                origin_step=created[path],
+                content_hash=None,
+                execution_count=len(exit_codes),
+                exit_codes=tuple(exit_codes),
+            )
+        )
+    helpers.sort(key=lambda h: (h.origin_step, h.path))
+    return helpers
+
+
+def _resolve_helper_file(worktree_path: Path, relpath: str) -> Path | None:
+    """Resolve ``relpath`` under ``worktree_path`` without escaping it."""
+
+    candidate = (worktree_path / relpath).resolve()
+    try:
+        candidate.relative_to(worktree_path.resolve())
+    except ValueError:
+        return None
+    if not candidate.is_file():
+        return None
+    return candidate
+
+
+def capture_run_helpers(
+    worktree_path: Path,
+    helpers: Sequence[RunHelper],
+    cas: CASStore,
+    *,
+    journal: Any | None = None,
+) -> list[RunHelper]:
+    """Content-address helper file bytes into ``cas`` while the worktree exists.
+
+    Args:
+        worktree_path: Absolute worktree root (still present).
+        helpers: Output of :func:`classify_run_helpers`.
+        cas: Content-addressed store (typically ``.sdd/cas``).
+        journal: Optional :class:`~bernstein.core.replay.journal.EventJournal`
+            to append ``run_helper_captured`` naming rows for the run receipt.
+
+    Returns:
+        Helpers with ``content_hash`` filled. Missing files are skipped
+        (logged) so GC is never wedged by a vanished path.
+    """
+
+    captured: list[RunHelper] = []
+    for helper in helpers:
+        file_path = _resolve_helper_file(worktree_path, helper.path)
+        if file_path is None:
+            logger.warning(
+                "run_helper: skipping missing or escaped path %s under %s",
+                helper.path,
+                worktree_path,
+            )
+            continue
+        try:
+            data = file_path.read_bytes()
+        except OSError as exc:
+            logger.warning("run_helper: failed to read %s: %s", file_path, exc)
+            continue
+        digest = cas.put(
+            data,
+            content_type="application/octet-stream",
+            metadata={
+                "kind": "run_helper",
+                "path": helper.path,
+                "origin_step": helper.origin_step,
+                "execution_count": helper.execution_count,
+                "exit_codes": list(helper.exit_codes),
+                "trust_class": helper.trust_class,
+            },
+        )
+        filled = replace(helper, content_hash=digest)
+        captured.append(filled)
+        if journal is not None:
+            try:
+                journal.record(
+                    JOURNAL_EVENT_RUN_HELPER_CAPTURED,
+                    path=filled.path,
+                    origin_step=filled.origin_step,
+                    content_hash=digest,
+                    execution_count=filled.execution_count,
+                    exit_codes=list(filled.exit_codes),
+                    trust_class=filled.trust_class,
+                )
+            except Exception as exc:  # boundary: never block reap on journal
+                logger.warning(
+                    "run_helper: failed to name helper on journal for %s: %s",
+                    filled.path,
+                    exc,
+                )
+    return captured
+
+
+def resolve_run_id_from_pid_record(repo_root: Path, session_id: str) -> str | None:
+    """Return ``run_id`` from the session PID record, if present."""
+
+    pid_file = repo_root / ".sdd" / "runtime" / "pids" / f"{session_id}.json"
+    if not pid_file.is_file():
+        return None
+    try:
+        data = json.loads(pid_file.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    run_id = data.get("run_id")
+    if isinstance(run_id, str) and run_id.strip():
+        return run_id.strip()
+    return None
+
+
+def load_journal_events_for_run(sdd_dir: Path, run_id: str) -> list[dict[str, Any]]:
+    """Load journal events for ``run_id``, or ``[]`` when absent/unreadable."""
+
+    from bernstein.core.replay.journal import JournalPathError, load_events, run_journal_path
+
+    try:
+        path = run_journal_path(sdd_dir, run_id)
+    except JournalPathError:
+        return []
+    try:
+        return list(load_events(path).events)
+    except OSError as exc:
+        logger.warning("run_helper: failed to load journal for run %s: %s", run_id, exc)
+        return []
+
+
+def capture_helpers_before_reap(
+    repo_root: Path,
+    worktree_path: Path,
+    session_id: str,
+    *,
+    dry_run: bool = False,
+) -> list[RunHelper]:
+    """Classify + CAS-capture helpers for one worktree before it is deleted.
+
+    Best-effort: any failure logs and returns what was captured so GC never
+    wedges. Skipped entirely on ``dry_run``.
+    """
+
+    if dry_run:
+        return []
+    sdd_dir = repo_root / ".sdd"
+    run_id = resolve_run_id_from_pid_record(repo_root, session_id)
+    if run_id is None:
+        return []
+    events = load_journal_events_for_run(sdd_dir, run_id)
+    helpers = classify_run_helpers(events)
+    if not helpers:
+        return []
+    cas = CASStore(sdd_dir / "cas")
+    journal = None
+    try:
+        from bernstein.core.replay.journal import EventJournal
+
+        journal = EventJournal.resume(run_id, sdd_dir)
+    except Exception as exc:  # boundary
+        logger.debug("run_helper: no journal to name helpers for run %s: %s", run_id, exc)
+    try:
+        return capture_run_helpers(worktree_path, helpers, cas, journal=journal)
+    except Exception as exc:  # boundary
+        logger.warning("run_helper: capture failed for %s: %s", worktree_path, exc)
+        return []
+
+
+__all__ = [
+    "JOURNAL_EVENT_FILE_CREATE",
+    "JOURNAL_EVENT_FILE_EXECUTE",
+    "JOURNAL_EVENT_RUN_HELPER_CAPTURED",
+    "TRUST_CLASS_AGENT_AUTHORED",
+    "RunHelper",
+    "capture_helpers_before_reap",
+    "capture_run_helpers",
+    "classify_run_helpers",
+    "load_journal_events_for_run",
+    "resolve_run_id_from_pid_record",
+]

--- a/tests/unit/test_run_helpers.py
+++ b/tests/unit/test_run_helpers.py
@@ -1,0 +1,92 @@
+"""Run-helper classification and CAS capture (#5322 PR1)."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from bernstein.core.persistence.cas_store import CASStore
+from bernstein.core.replay.journal import EventJournal, load_events
+from bernstein.core.worktrees.run_helpers import (
+    JOURNAL_EVENT_RUN_HELPER_CAPTURED,
+    RunHelper,
+    capture_run_helpers,
+    classify_run_helpers,
+)
+
+
+def test_unexecuted_scaffolding_is_not_a_helper() -> None:
+    """Created-but-never-executed files are scaffolding, not helpers."""
+
+    events = [
+        {"index": 0, "event": "file_create", "path": "scratch/setup.py"},
+        {"index": 1, "event": "file_create", "path": "notes.md"},
+        # no file_execute for either path
+    ]
+    assert classify_run_helpers(events) == []
+
+
+def test_executed_helper_gets_origin_step_and_hash(tmp_path: Path) -> None:
+    """An executed agent-created file gets origin_step + CAS content hash."""
+
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    body = b"raise SystemExit(1)\n"
+    (worktree / "repro.py").write_bytes(body)
+
+    events = [
+        {"index": 3, "event": "file_create", "path": "repro.py"},
+        {"index": 7, "event": "file_execute", "path": "repro.py", "exit_code": 1},
+        {"index": 8, "event": "file_execute", "path": "repro.py", "exit_code": 1},
+    ]
+    helpers = classify_run_helpers(events)
+    assert len(helpers) == 1
+    helper = helpers[0]
+    assert helper.path == "repro.py"
+    assert helper.origin_step == 3
+    assert helper.execution_count == 2
+    assert helper.exit_codes == (1, 1)
+    assert helper.content_hash is None
+
+    cas = CASStore(tmp_path / "cas")
+    sdd = tmp_path / ".sdd"
+    journal = EventJournal(run_id="run-helper-1", sdd_dir=sdd)
+    captured = capture_run_helpers(worktree, helpers, cas, journal=journal)
+    assert len(captured) == 1
+    assert captured[0].origin_step == 3
+    expected = hashlib.sha256(body).hexdigest()
+    assert captured[0].content_hash == expected
+    assert cas.has(expected)
+
+    rows = load_events(journal.path).events
+    naming = [r for r in rows if r.get("event") == JOURNAL_EVENT_RUN_HELPER_CAPTURED]
+    assert len(naming) == 1
+    assert naming[0]["path"] == "repro.py"
+    assert naming[0]["origin_step"] == 3
+    assert naming[0]["content_hash"] == expected
+
+
+def test_nonzero_exit_still_counts_as_helper() -> None:
+    """Non-zero exit codes are recorded but do not exclude the helper."""
+
+    events = [
+        {"index": 1, "event": "file_create", "path": "harness.py"},
+        {"index": 2, "event": "file_execute", "path": "harness.py", "exit_code": 2},
+    ]
+    helpers = classify_run_helpers(events)
+    assert helpers == [
+        RunHelper(
+            path="harness.py",
+            origin_step=1,
+            content_hash=None,
+            execution_count=1,
+            exit_codes=(2,),
+        )
+    ]
+
+
+def test_execute_without_create_is_not_a_helper() -> None:
+    events = [
+        {"index": 0, "event": "file_execute", "path": "vendor/bin", "exit_code": 0},
+    ]
+    assert classify_run_helpers(events) == []


### PR DESCRIPTION
## Summary

Partial implementation of #5322 (PR1: capture and classification only).

- Add `core/worktrees/run_helpers.py`: deterministic `classify_run_helpers` from journal `file_create` / `file_execute` events; `capture_run_helpers` content-addresses file bytes into `.sdd/cas` and appends `run_helper_captured` naming rows for the run receipt.
- Hook capture into `worktrees gc` immediately before `reap_worktree` (best-effort; never blocks reap).
- FEATURE_MATRIX Brief row for the new surface.

## Decision

**Non-zero exit still counts as a helper.** Classification is `created ∧ executed`; exit codes (including ≠0) are recorded on the artefact so later promotion policy can filter. Counting keeps reproduction harnesses that are *supposed* to fail — the case excluding them would lose.

## Out of scope (PR2)

- `skill promote`, N-runs / M-goals thresholds
- Anything touching `provenance.py` hashing/verification (reuse as-is)
- Registry-sourced packs (#2899), loaded-set reconciliation (#4986)
- Review-view deliverable/scaffolding separation
- Live adapter emitters for `file_create` / `file_execute` (contract + tests land first)

## Test plan

- [x] `pytest tests/unit/test_run_helpers.py -q` → 4 passed
- [x] `test_unexecuted_scaffolding_is_not_a_helper`
- [x] `test_executed_helper_gets_origin_step_and_hash`
- [x] `test_nonzero_exit_still_counts_as_helper`