### PR TITLE
fix(ci): an empty affected set names the commits it compared (#5111)

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -683,18 +683,62 @@ def run_parallel(
     return 1 if failed else 0
 
 
-def _report_empty_selection(shard: tuple[int, int] | None, context: str) -> None:
+def _describe_rev(rev: str) -> str:
+    """``<rev> (<short sha>)``, or bare ``<rev>`` when git cannot resolve it.
+
+    Best-effort by design: this only ever decorates a message, so a detached
+    checkout, a missing ref or no git at all costs the sha and nothing else.
+    """
+    try:
+        sha = subprocess.run(
+            ["git", "rev-parse", "--short", rev],
+            cwd=Path(__file__).parent.parent,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return rev
+    return f"{rev} ({sha})" if sha else rev
+
+
+def _compared_range(base: str) -> str:
+    """The comparison an affected-set run actually performed, in words.
+
+    ``--affected HEAD`` compares the WORKING TREE against HEAD, which is not a
+    commit range and must not be printed as one.
+    """
+    if base == "HEAD":
+        return f"working tree vs {_describe_rev('HEAD')}"
+    return f"{_describe_rev(base)}...{_describe_rev('HEAD')}"
+
+
+def _report_empty_selection(shard: tuple[int, int] | None, context: str, base: str | None = None) -> None:
     """Print a clear message when the selected file set is empty.
 
     An empty shard (N greater than the file count, or a small affected set
     split across many shards) is a legitimate no-op that must exit 0 - not a
     discovery failure. The message disambiguates the two for CI log readers.
+
+    ``base`` names the commits that were compared to reach an empty affected
+    set, because a run that tested nothing and a run that tested everything
+    look identical in the Actions UI: both are a green check (#5111). Without
+    the range, "nothing was affected" is unfalsifiable from the outside - the
+    reader cannot tell a correct no-op from a diff computed against the wrong
+    base. On GitHub Actions the same sentence is also emitted as a ``notice``
+    annotation, so it surfaces on the run summary rather than only inside a
+    step's log.
     """
     if shard is not None:
-        print(f"No {context}test files in shard {shard[0]}/{shard[1]} - nothing to run (empty shard)")
+        message = f"No {context}test files in shard {shard[0]}/{shard[1]} - nothing to run (empty shard)"
     else:
         suffix = "affected tests found" if context else "test files found"
-        print(f"No {suffix} - nothing to run")
+        message = f"No {suffix} - nothing to run"
+    if base is not None:
+        message += f"; compared {_compared_range(base)}"
+    print(message)
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        print(f"::notice title=Nothing to run::{message}")
 
 
 def discover_affected_files(base: str) -> list[Path]:
@@ -898,11 +942,14 @@ def main() -> None:
                 changed_files = discover_changed_files(args.affected)
                 deleted_files = discover_changed_files(args.affected, diff_filter="D")
                 if changed_files_require_tests(changed_files, deleted_files):
-                    print("No affected tests found for code or workflow changes; failing closed.")
+                    print(
+                        "No affected tests found for code or workflow changes; failing closed. "
+                        f"Compared {_compared_range(args.affected)}."
+                    )
                     for changed_file in changed_files:
                         print(f"  {changed_file}")
                     sys.exit(1)
-            _report_empty_selection(shard, context="affected ")
+            _report_empty_selection(shard, context="affected ", base=args.affected)
             sys.exit(0)
         shard_label = f" [shard {shard[0]}/{shard[1]}]" if shard else ""
         print(f"Running {len(files)} affected test files{shard_label} (each in its own process)")

--- a/tests/unit/scripts/test_run_tests_empty_affected_report.py
+++ b/tests/unit/scripts/test_run_tests_empty_affected_report.py
@@ -1,0 +1,118 @@
+"""Issue #5111: an empty affected set says which commits it compared.
+
+A green run and a run that tested nothing look identical in the GitHub Actions
+UI -- both are a checkmark. The empty-selection message did not name the base or
+head being compared, which makes "nothing was affected" unfalsifiable from the
+outside: a reader cannot tell a correct no-op from a diff computed against the
+wrong base, without opening the log and reconstructing the invocation.
+
+These tests pin the sentence, the annotation that surfaces it on the run
+summary, and the one comparison that must not be printed as a commit range.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from collections.abc import Generator
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "run_tests.py"
+
+
+@pytest.fixture
+def run_tests_module() -> Generator[ModuleType, None, None]:
+    """Load scripts/run_tests.py as an importable module."""
+    spec = importlib.util.spec_from_file_location("run_tests_empty_report_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    yield module
+    sys.modules.pop(spec.name, None)
+
+
+def test_the_empty_affected_message_names_the_compared_commits(
+    run_tests_module: ModuleType, capsys: pytest.CaptureFixture[str]
+) -> None:
+    run_tests_module._report_empty_selection(None, "affected ", base="origin/main")
+    out = capsys.readouterr().out
+    assert "No affected tests found - nothing to run" in out
+    assert "compared origin/main" in out
+    assert "..." in out, "the two ends of the comparison must both appear"
+
+
+def test_a_working_tree_comparison_is_not_printed_as_a_commit_range(run_tests_module: ModuleType) -> None:
+    """``--affected HEAD`` compares the working tree against HEAD, not two commits.
+
+    Printing ``HEAD...HEAD`` would be a range that is empty by definition, and
+    would read as a bug in the runner rather than as the local-diff mode it is.
+    """
+    described = run_tests_module._compared_range("HEAD")
+    assert described.startswith("working tree vs HEAD")
+    assert "..." not in described
+
+
+def test_a_resolvable_rev_carries_its_short_sha(run_tests_module: ModuleType) -> None:
+    head = subprocess.run(
+        ["git", "rev-parse", "--short", "HEAD"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert run_tests_module._describe_rev("HEAD") == f"HEAD ({head})"
+
+
+def test_an_unresolvable_rev_degrades_to_its_name(run_tests_module: ModuleType) -> None:
+    """Best-effort: a missing ref costs the sha and nothing else."""
+    assert run_tests_module._describe_rev("no-such-ref-5111") == "no-such-ref-5111"
+
+
+def test_the_message_is_annotated_on_github_actions(
+    run_tests_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The annotation is what puts it on the run summary instead of inside a log."""
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    run_tests_module._report_empty_selection(None, "affected ", base="origin/main")
+    out = capsys.readouterr().out
+    assert "::notice title=Nothing to run::" in out
+    assert "compared origin/main" in out.split("::notice title=Nothing to run::", 1)[1]
+
+
+def test_no_annotation_off_github_actions(
+    run_tests_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    run_tests_module._report_empty_selection(None, "affected ", base="origin/main")
+    assert "::notice" not in capsys.readouterr().out
+
+
+def test_an_empty_shard_still_says_it_is_an_empty_shard(
+    run_tests_module: ModuleType, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The legitimate no-op keeps its own wording; the range is added, not swapped in."""
+    run_tests_module._report_empty_selection((7, 8), "affected ", base="origin/main")
+    out = capsys.readouterr().out
+    assert "shard 7/8" in out
+    assert "empty shard" in out
+    assert "compared origin/main" in out
+
+
+def test_a_full_discovery_run_reports_no_range(
+    run_tests_module: ModuleType, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Without ``--affected`` nothing was compared, so nothing is claimed."""
+    run_tests_module._report_empty_selection(None, "")
+    out = capsys.readouterr().out
+    assert "No test files found - nothing to run" in out
+    assert "compared" not in out

--- a/tests/unit/test_test_impact_alias_edges.py
+++ b/tests/unit/test_test_impact_alias_edges.py
@@ -277,3 +277,99 @@ def test_every_live_redirect_edge_is_discovered() -> None:
         f"selector, so a change to the module behind them would not select the suites that "
         f"import them under the legacy name: {missing[:10]}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Re-exports (#5111 slice 4)
+# ---------------------------------------------------------------------------
+#
+# The alias tests above cover a name the import SYSTEM redirects. A re-export is
+# the ordinary-Python cousin: module A binds a name defined in module B, a test
+# imports only A, and a change confined to B still has to select that test.
+#
+# It does today -- the edge is carried by A's own import of B, so the transitive
+# walk reaches it. That is worth pinning rather than assuming: the shape is
+# indistinguishable from the alias case to a reader of the test file, the whole
+# selection is invisible when it is wrong (a green required lane that ran
+# nothing), and nothing else asserts it explicitly.
+
+
+def _reexport_fixture(tmp_path: Path, facade_body: str, test_body: str) -> tuple[Path, Path]:
+    """A project where the test imports a facade and never names the definition."""
+    src = tmp_path / "src"
+    tests = tmp_path / "tests" / "unit"
+    _write(src / "proj" / "__init__.py", "")
+    _write(src / "proj" / "engine.py", "def compute() -> int:\n    return 1\n")
+    _write(src / "proj" / "facade.py", facade_body)
+    _write(tests / "test_via_facade.py", test_body)
+    return src, tests
+
+
+def _selected_for(tmp_path: Path, src: Path, tests: Path, changed: str) -> set[str]:
+    dep_map = build_compat_dep_map(tmp_path, src, [tests], {"proj"})
+    return {
+        p.relative_to(tmp_path).as_posix()
+        for p in compat_get_affected_tests([changed], dep_map, root=tmp_path, src_root=src)
+    }
+
+
+def test_a_named_reexport_makes_its_importers_affected(tmp_path: Path) -> None:
+    src, tests = _reexport_fixture(
+        tmp_path,
+        facade_body="from proj.engine import compute\n\n__all__ = ['compute']\n",
+        test_body="from proj.facade import compute\n\n\ndef test_it() -> None:\n    assert compute() == 1\n",
+    )
+    selected = _selected_for(tmp_path, src, tests, "src/proj/engine.py")
+    assert "tests/unit/test_via_facade.py" in selected, (
+        "a change to the module that DEFINES a re-exported name must select the suite that "
+        "imports it through the facade; the test never names proj.engine"
+    )
+
+
+def test_a_star_reexport_makes_its_importers_affected(tmp_path: Path) -> None:
+    """``from x import *`` binds no name statically, so it is the shape most likely to be lost."""
+    src, tests = _reexport_fixture(
+        tmp_path,
+        facade_body="from proj.engine import *  # noqa: F403\n",
+        test_body="from proj.facade import compute\n\n\ndef test_it() -> None:\n    assert compute() == 1\n",
+    )
+    assert "tests/unit/test_via_facade.py" in _selected_for(tmp_path, src, tests, "src/proj/engine.py")
+
+
+def test_a_package_init_reexport_makes_its_importers_affected(tmp_path: Path) -> None:
+    """The commonest form in this codebase: ``from pkg import name``."""
+    src = tmp_path / "src"
+    tests = tmp_path / "tests" / "unit"
+    _write(src / "proj" / "__init__.py", "from proj.engine import compute\n")
+    _write(src / "proj" / "engine.py", "def compute() -> int:\n    return 1\n")
+    _write(
+        tests / "test_via_facade.py",
+        "from proj import compute\n\n\ndef test_it() -> None:\n    assert compute() == 1\n",
+    )
+    assert "tests/unit/test_via_facade.py" in _selected_for(tmp_path, src, tests, "src/proj/engine.py")
+
+
+def test_a_two_hop_reexport_chain_still_reaches_the_test(tmp_path: Path) -> None:
+    """Definition -> middle -> facade -> test. One missing hop selects nothing."""
+    src = tmp_path / "src"
+    tests = tmp_path / "tests" / "unit"
+    _write(src / "proj" / "__init__.py", "")
+    _write(src / "proj" / "engine.py", "def compute() -> int:\n    return 1\n")
+    _write(src / "proj" / "mid.py", "from proj.engine import compute\n")
+    _write(src / "proj" / "facade.py", "from proj.mid import compute\n")
+    _write(
+        tests / "test_via_facade.py",
+        "from proj.facade import compute\n\n\ndef test_it() -> None:\n    assert compute() == 1\n",
+    )
+    assert "tests/unit/test_via_facade.py" in _selected_for(tmp_path, src, tests, "src/proj/engine.py")
+
+
+def test_an_unrelated_module_does_not_select_the_facade_test(tmp_path: Path) -> None:
+    """The control. Without it every assertion above passes on a selector that returns everything."""
+    src, tests = _reexport_fixture(
+        tmp_path,
+        facade_body="from proj.engine import compute\n",
+        test_body="from proj.facade import compute\n\n\ndef test_it() -> None:\n    assert compute() == 1\n",
+    )
+    _write(src / "proj" / "unrelated.py", "VALUE = 2\n")
+    assert _selected_for(tmp_path, src, tests, "src/proj/unrelated.py") == set()


### PR DESCRIPTION
#5111, slices **2** and **4**.

## Slice 2 — the empty affected set is no longer unfalsifiable

A green run and a run that tested nothing look identical in the Actions UI. The empty-selection message named neither the base nor the head, so *"nothing was affected"* could not be checked from the outside: a reader cannot tell a correct no-op from a diff computed against the wrong base without opening the log and reconstructing the invocation.

Before / after:

```
No affected tests found - nothing to run
No affected tests found - nothing to run; compared origin/main (a1b2c3d)...HEAD (e4f5a6b)
```

- `_report_empty_selection(shard, context, base=None)` appends the comparison it actually performed.
- On GitHub Actions the same sentence is emitted as a `::notice title=Nothing to run::` annotation, so it lands **on the run summary** rather than inside a step's log — which is the "operator can tell them apart without opening logs" property the issue asks for, without restructuring the workflow.
- The **fail-closed** branch names the range too. That message is read by whoever has to decide whether the gate is right.
- `--affected HEAD` compares the **working tree** against HEAD, so it is described that way rather than as `HEAD...HEAD` — a range that is empty by definition and reads as a bug in the runner.
- `_describe_rev` is best-effort: a detached checkout, a missing ref, or no git at all costs the sha and nothing else, since this only ever decorates a message.

## Slice 4 — re-export regression tests

Added next to the alias-edge tests they are the ordinary-Python cousin of. **The property holds today** — the edge is carried by the facade's own import of the definition, so the transitive walk reaches it — across all four shapes I could construct:

| shape | selects the test |
|---|---|
| `from proj.engine import compute` in a facade | ✅ |
| `from proj.engine import *` | ✅ |
| package `__init__` re-export | ✅ |
| two-hop chain (engine → mid → facade) | ✅ |

So this is a lock, not a fix, and I'd rather say so than imply I repaired something. It earns its place: the shape is indistinguishable from the alias case to a reader of the test file, the failure is invisible when it happens (a green required lane that ran nothing), and nothing else asserted it explicitly. A **control case** — an unrelated module selecting nothing — fails if the selector ever starts returning everything, which would otherwise make all four pass for the wrong reason.

## Not in this PR

Slices 1 and 3 — hoisting the affected-set computation into `determine-changes` and emitting it as a matrix for `test`/`test-macos`/the strict-zone lanes. That is a real `ci.yml` restructuring and belongs in its own reviewable change; slice 2's output is what makes its result legible once it lands.

## Verification

```
uv run pytest tests/unit/scripts/test_run_tests_empty_affected_report.py -q   # 8 passed
uv run pytest tests/unit/test_test_impact_alias_edges.py -q                   # 16 passed
uv run pytest tests/unit/scripts/test_run_tests_affected_gate.py \
              tests/unit/scripts/test_run_tests_sharding.py \
              tests/unit/scripts/test_run_tests_zero_test_outcomes.py -q      # 86 passed
uv run ruff check / ruff format                                               # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)