### PR TITLE
fix(worktrees): gc is a dry run unless you ask it to delete (#5112)

### DIFF
--- a/docs/operations/worktrees.md
+++ b/docs/operations/worktrees.md
@@ -63,7 +63,7 @@ only ever blocks deletion, it never deletes more.
 
 ```text
 bernstein worktrees list   [--workdir DIR] [--json]
-bernstein worktrees gc     [--workdir DIR] [--yes] [--dry] [--force-unsaved]
+bernstein worktrees gc     [--workdir DIR] [--apply] [--yes] [--dry] [--force-unsaved]
 bernstein worktrees unlock [--workdir DIR] [--force] [--json]
 ```
 
@@ -180,17 +180,27 @@ Inspect what's on disk:
 bernstein worktrees list
 ```
 
-Preview reap plan without touching disk:
+Preview reap plan without touching disk — this is the default, so no flag is
+needed:
 
 ```bash
-bernstein worktrees gc --dry
+bernstein worktrees gc
 ```
 
-Reap non-interactively (CI / cron):
+Reap, with a confirmation prompt:
+
+```bash
+bernstein worktrees gc --apply
+```
+
+Reap non-interactively (CI / cron). `--yes` implies `--apply`, so an existing
+script keeps working unchanged:
 
 ```bash
 bernstein worktrees gc --yes
 ```
+
+`--dry` forces a dry run and outranks both, so `gc --yes --dry` still previews.
 
 JSON dump for piping into `jq`:
 

--- a/docs/release-notes/fragments/5112-worktrees-gc-dry-run-default.md
+++ b/docs/release-notes/fragments/5112-worktrees-gc-dry-run-default.md
@@ -1,0 +1,14 @@
+## `bernstein worktrees gc` is a dry run unless you ask it to delete
+
+An unqualified `bernstein worktrees gc` now prints the reap plan and
+stops, instead of going straight to a confirmation prompt for a
+destructive sweep. Deleting is opt-in through the new `--apply`.
+
+`--yes` still deletes, so an existing `gc --yes` in a cron job or a
+script keeps working unchanged: it has always meant "do it without asking
+me", and reading it as a dry run would leave those runs reporting success
+while cleaning nothing up. `--dry` still forces a dry run and outranks
+both, so `gc --yes --dry` means what it always meant.
+
+A dry run no longer prompts — there is nothing to authorise — and says
+after the plan that nothing was deleted and what to pass instead (#5112).

--- a/src/bernstein/cli/commands/worktrees_cmd.py
+++ b/src/bernstein/cli/commands/worktrees_cmd.py
@@ -3,7 +3,7 @@
 Two subcommands::
 
     bernstein worktrees list           # tabular dump of every worktree
-    bernstein worktrees gc [--yes] [--dry]
+    bernstein worktrees gc [--apply] [--yes]
 
 The classifier in :mod:`bernstein.core.worktrees.classifier` is the
 source of truth for state. This module only handles I/O: rendering the
@@ -318,7 +318,8 @@ def list_cmd(workdir: Path, as_json: bool) -> None:
     reapable = sum(1 for r in rows if r.is_reapable)
     if reapable:
         console.print(
-            f"[yellow]{reapable} worktree(s) reapable - run [bold]bernstein worktrees gc[/bold] to clean up.[/yellow]"
+            f"[yellow]{reapable} worktree(s) reapable - run [bold]bernstein worktrees gc[/bold] to preview, "
+            f"then [bold]--apply[/bold] to clean up.[/yellow]"
         )
 
 
@@ -330,13 +331,20 @@ def list_cmd(workdir: Path, as_json: bool) -> None:
     show_default=True,
     help="Project root containing .sdd/.",
 )
-@click.option("--yes", is_flag=True, default=False, help="Skip the confirmation prompt.")
+@click.option("--yes", is_flag=True, default=False, help="Skip the confirmation prompt. Implies --apply.")
 @click.option(
-    "--dry",
-    "dry_run",
+    "--apply",
+    "apply_changes",
     is_flag=True,
     default=False,
-    help="Print what would be deleted without touching disk.",
+    help="Actually delete. Without it (and without --yes) this is a dry run.",
+)
+@click.option(
+    "--dry",
+    "dry",
+    is_flag=True,
+    default=False,
+    help="Force a dry run. Now the default, so only meaningful alongside --apply or --yes.",
 )
 @click.option(
     "--force-unsaved",
@@ -348,8 +356,19 @@ def list_cmd(workdir: Path, as_json: bool) -> None:
         "destroys the only copy of that work. Requires an extra confirmation."
     ),
 )
-def gc_cmd(workdir: Path, yes: bool, dry_run: bool, force_unsaved: bool) -> None:
-    """Delete orphan, stale, and corrupt worktrees.
+def gc_cmd(workdir: Path, yes: bool, apply_changes: bool, dry: bool, force_unsaved: bool) -> None:
+    """Delete orphan, stale, and corrupt worktrees. Dry run unless --apply.
+
+    An unqualified ``gc`` never touches disk: it prints what it would reap and
+    stops (issue #5112). Deleting is opt-in through ``--apply``.
+
+    ``--yes`` still deletes. It has always meant "do it without asking me", so
+    reading it as a dry run would leave every existing ``gc --yes`` in a cron
+    job or a script reporting success while cleaning nothing up - a silent
+    change in the one direction an operator cannot notice.
+
+    ``--dry`` keeps forcing a dry run and OUTRANKS both, so ``gc --yes --dry``
+    means today what it meant before. It is now redundant on its own.
 
     Worktrees that still hold unsaved work (uncommitted changes or unmerged
     commits) are preserved and reported as safety-skips unless
@@ -357,6 +376,10 @@ def gc_cmd(workdir: Path, yes: bool, dry_run: bool, force_unsaved: bool) -> None
     recorded in the HMAC-chained audit log either way, so a skip is never
     silent.
     """
+    # `--dry` outranks the opt-ins: between "delete" and "do not", the flag that
+    # asks for less is the one to honour, and `gc --yes --dry` is an existing
+    # spelling that has always meant a dry run.
+    dry_run = dry or not (apply_changes or yes)
     repo_root = workdir.resolve()
     rows = classify_worktrees(repo_root)
     reapable = [r for r in rows if r.is_reapable]
@@ -417,6 +440,14 @@ def gc_cmd(workdir: Path, yes: bool, dry_run: bool, force_unsaved: bool) -> None
     except GcLockError as exc:
         console.print(f"[red]{exc}[/red]")
         raise SystemExit(2) from exc
+
+    if dry_run:
+        # Said after the plan, not before it: the reader has just seen a list of
+        # paths and needs to know nothing happened to them.
+        console.print(
+            f"[cyan]Dry run - nothing was deleted. Re-run with [bold]--apply[/bold] to reap "
+            f"{len(targets)} worktree(s).[/cyan]"
+        )
 
 
 def _report_safety_skips(console: Console, skipped: list[ClassifiedWorktree]) -> None:

--- a/tests/unit/test_worktrees_cmd.py
+++ b/tests/unit/test_worktrees_cmd.py
@@ -945,3 +945,77 @@ def worktrees_group_ref():  # small helper so the import lives next to use
     from bernstein.cli.commands.worktrees_cmd import worktrees_group
 
     return worktrees_group
+
+
+# ---------------------------------------------------------------------------
+# Dry run is the default (#5112)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_gc_without_flags_deletes_nothing(repo_root: Path) -> None:
+    """An unqualified ``gc`` prints the plan and never touches disk."""
+    wt = _make_worktree_dir(repo_root, "gc-default")
+    runner = CliRunner()
+
+    result = runner.invoke(worktrees_group, ["gc", "--workdir", str(repo_root)])
+
+    assert result.exit_code == 0, result.output
+    assert wt.exists(), "an unqualified gc must not delete"
+    # And it says so, after the plan, so the reader knows what happened to the
+    # paths they were just shown.
+    assert "--apply" in result.output
+
+
+def test_cli_gc_apply_deletes(repo_root: Path) -> None:
+    """``--apply --yes`` is the opt-in, and it reaps."""
+    wt = _make_worktree_dir(repo_root, "gc-apply")
+    runner = CliRunner()
+
+    result = runner.invoke(worktrees_group, ["gc", "--workdir", str(repo_root), "--apply", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert not wt.exists()
+
+
+def test_cli_gc_yes_alone_still_deletes(repo_root: Path) -> None:
+    """The compatibility rule.
+
+    ``--yes`` has always meant "do it without asking me". Reading it as a dry
+    run would leave every existing ``gc --yes`` in a cron job reporting success
+    while cleaning nothing up - a change in the one direction an operator
+    cannot notice.
+    """
+    wt = _make_worktree_dir(repo_root, "gc-yes-only")
+    runner = CliRunner()
+
+    result = runner.invoke(worktrees_group, ["gc", "--workdir", str(repo_root), "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert not wt.exists()
+
+
+def test_cli_gc_dry_outranks_apply(repo_root: Path) -> None:
+    """Between "delete" and "do not", the flag asking for less wins."""
+    wt = _make_worktree_dir(repo_root, "gc-dry-wins")
+    runner = CliRunner()
+
+    result = runner.invoke(worktrees_group, ["gc", "--workdir", str(repo_root), "--apply", "--yes", "--dry"])
+
+    assert result.exit_code == 0, result.output
+    assert wt.exists()
+
+
+def test_cli_gc_dry_run_does_not_prompt(repo_root: Path) -> None:
+    """Nothing is being destroyed, so there is nothing to confirm.
+
+    Answering the prompt is what an operator does to authorise deletion; asking
+    for it when no deletion can follow trains them to answer without reading.
+    """
+    _make_worktree_dir(repo_root, "gc-no-prompt")
+    runner = CliRunner()
+
+    # No stdin at all: a prompt would abort here rather than pass.
+    result = runner.invoke(worktrees_group, ["gc", "--workdir", str(repo_root)], input="")
+
+    assert result.exit_code == 0, result.output
+    assert "Reap" not in result.output or "worktree(s)?" not in result.output


### PR DESCRIPTION
#5112, **slice 2** — *"Make dry-run the default everywhere: flip `worktrees gc`'s `--dry` default … so an unqualified invocation never deletes."*

## What changed

`--dry` defaulted to `False`, so the unqualified `bernstein worktrees gc` — the exact spelling `worktrees list` suggests when it finds reapable trees — went straight to a confirmation prompt for a destructive sweep.

An unqualified `gc` now prints the plan and stops. Deleting is opt-in through `--apply`.

## The compatibility rule, and why it is what it is

| invocation | before | after |
|---|---|---|
| `gc` | prompt, then delete | **dry run** |
| `gc --apply` | *(new)* | prompt, then delete |
| `gc --yes` | delete | **delete** — unchanged |
| `gc --dry` | dry run | dry run |
| `gc --yes --dry` | dry run | dry run |
| `gc --apply --yes --dry` | *(new)* | dry run |

**`--yes` still deletes.** It has always meant *"do it without asking me"*, so reading it as a dry run would leave every existing `gc --yes` in a cron job or a script reporting success while cleaning nothing up. That is a silent change in the one direction an operator cannot notice — the same class of failure this issue is about, pointed the other way.

**`--dry` outranks both.** Between "delete" and "do not", the flag that asks for less is the one to honour, and `gc --yes --dry` is an existing spelling with an existing meaning.

All **47 existing tests pass untouched**, including the two that pin `gc --yes --dry` and `gc --yes`.

## A dry run does not prompt

Answering the prompt is what an operator does to authorise deletion. Asking for it when no deletion can follow trains them to answer without reading. Instead the run says — **after** the plan rather than before it — that nothing was deleted and what to pass:

```
Dry run - nothing was deleted. Re-run with --apply to reap 3 worktree(s).
```

After, because the reader has just been shown a list of paths and needs to know what happened to *those*.

## Also

`worktrees list`'s own hint (`run bernstein worktrees gc to clean up`) and `docs/operations/worktrees.md` now say the same thing, so nothing in the surface still points at a `gc` that reaps on sight.

## Verification

```
uv run pytest tests/unit/test_worktrees_cmd.py -q   # 52 passed (47 existing + 5 new)
uv run ruff check / ruff format                      # clean
```

The 5 new tests cover: unqualified `gc` deletes nothing and names `--apply`; `--apply --yes` reaps; `--yes` alone still reaps; `--dry` outranks `--apply --yes`; and a dry run completes with **no stdin at all**, which a surviving prompt would fail.

## Not in this PR

Slices 1 and 3 — the sandbox-side sweep keyed on the task record's terminal status, and the aged-leak `doctor` finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)