### PR TITLE
fix(skills): one broken source is quarantined, not fatal to every skill (#5108)

### DIFF
--- a/docs/release-notes/fragments/5108-skill-loader-quarantine.md
+++ b/docs/release-notes/fragments/5108-skill-loader-quarantine.md
@@ -1,0 +1,18 @@
+## One broken skill source no longer takes every other skill with it
+
+`SkillLoader` re-scanned every source with no exception handling, and its
+constructor calls that scan directly — so a source whose `iter_skills()`
+threw raised out of `SkillLoader(...)` and the caller got no loader at
+all. A single duplicate skill name did the same through
+`DuplicateSkillError`.
+
+Failures are now isolated per source and per artifact, and recorded as
+`QuarantinedSkill`: which source, which skill (or `None` when a source
+threw before naming one), the exception text, its type, and when. The
+rest of the set loads.
+
+A name conflict is still never silent — the first origin still wins, so
+precedence follows source order exactly as before — it is reported
+instead of fatal. `SkillLoader(..., on_quarantine=...)` is called once per
+entry as it happens, for a caller that wants to journal a governance
+event; a hook that raises is itself caught (#5108).

--- a/src/bernstein/core/skills/__init__.py
+++ b/src/bernstein/core/skills/__init__.py
@@ -29,6 +29,7 @@ from bernstein.core.skills.load_skill_tool import load_skill
 from bernstein.core.skills.loader import (
     DuplicateSkillError,
     LoadedSkill,
+    QuarantinedSkill,
     SkillLoader,
     SkillNotFoundError,
 )
@@ -39,6 +40,7 @@ __all__ = [
     "DuplicateSkillError",
     "LazySkillSource",
     "LoadedSkill",
+    "QuarantinedSkill",
     "SkillLoader",
     "SkillManifest",
     "SkillManifestError",

--- a/src/bernstein/core/skills/loader.py
+++ b/src/bernstein/core/skills/loader.py
@@ -1,8 +1,19 @@
 """Orchestrates :class:`~bernstein.core.skills.source.SkillSource` instances.
 
 The loader merges every registered source into a single lookup table and
-fails fast when two sources publish a skill with the same name. This is
-the central piece that makes progressive disclosure safe:
+QUARANTINES anything it cannot index, rather than failing the whole load.
+One broken source used to take every other skill with it: ``_reload`` had
+no exception handling, and ``__init__`` calls it directly, so a source
+whose ``iter_skills()`` threw -- or a single duplicate name -- left the
+caller with no ``SkillLoader`` at all (issue #5108). A conflict is still
+never silent; it is now recorded and reportable instead of fatal.
+
+Distinct from ``source_resolutions``, which reports what each declared
+ENTRY POINT resolved to at import time. This is the next stage: a source
+that imported fine and then threw while enumerating, or produced an
+artifact the index refused.
+
+This is the central piece that makes progressive disclosure safe:
 
 - ``role_resolver`` asks the loader for a skill matching a role; if one
   exists, its body is NOT injected into the prompt - only the index is.
@@ -18,6 +29,8 @@ eagerly. Re-registering a source requires a new :class:`SkillLoader`.
 
 from __future__ import annotations
 
+import logging
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
@@ -38,6 +51,8 @@ if TYPE_CHECKING:
 # checker into skipping the runtime string-validation in :func:`_call_reader`.
 _ReaderFn = Callable[[str, str], object]
 
+logger = logging.getLogger(__name__)
+
 
 class DuplicateSkillError(RuntimeError):
     """Raised at startup when two sources define a skill with the same name.
@@ -55,6 +70,36 @@ class DuplicateSkillError(RuntimeError):
 
 class SkillNotFoundError(KeyError):
     """Raised when a caller asks for a skill that no source provides."""
+
+
+@dataclass(frozen=True)
+class QuarantinedSkill:
+    """A source or artifact the loader refused to index, and why.
+
+    A failure that vanishes into a log line is the same as no failure at all
+    to the operator reading ``status``. This is the record that makes it
+    visible and bounded: everything else loaded, and this names exactly what
+    did not and what stopped it.
+
+    Attributes:
+        source_name: Label of the :class:`SkillSource` involved.
+        origin:      The artifact's origin, or the source label when the whole
+                     source failed before producing any artifact.
+        skill_name:  The skill that failed, or ``None`` for a whole-source
+                     failure -- a source that throws in ``iter_skills`` has not
+                     said which skill it was building.
+        reason:      The exception text.
+        error_type:  The exception class name, so a caller can group by cause
+                     without parsing prose.
+        at:          Unix timestamp of the failure.
+    """
+
+    source_name: str
+    origin: str
+    skill_name: str | None
+    reason: str
+    error_type: str
+    at: float
 
 
 @dataclass(frozen=True)
@@ -101,11 +146,28 @@ class SkillLoader:
         sources: list[SkillSource],
         *,
         source_resolutions: Sequence[SkillSourceResolution] = (),
+        on_quarantine: Callable[[QuarantinedSkill], None] | None = None,
     ) -> None:
+        """Index every source, quarantining whatever cannot be indexed.
+
+        Args:
+            sources: Sources to merge, in precedence order.
+            source_resolutions: What each declared entry point resolved to at
+                import time. A different stage from the quarantine below.
+            on_quarantine: Called once per quarantined entry, as it happens.
+                The hook exists because the loader is deliberately stateless
+                and has no audit key: journaling a governance event is the
+                caller's to do, and it needs the record at the moment of
+                failure rather than a list to diff afterwards. A hook that
+                raises is itself caught -- a broken reporter must not become
+                the thing that stops the load.
+        """
         self._sources: list[SkillSource] = sources.copy()
         self._source_resolutions: tuple[SkillSourceResolution, ...] = tuple(source_resolutions)
         self._skills: dict[str, LoadedSkill] = {}
         self._source_by_skill: dict[str, SkillSource] = {}
+        self._quarantined: list[QuarantinedSkill] = []
+        self._on_quarantine = on_quarantine
         self._reload()
 
     @property
@@ -123,15 +185,78 @@ class SkillLoader:
         """
         return self._source_resolutions
 
+    @property
+    def quarantined(self) -> tuple[QuarantinedSkill, ...]:
+        """Every source or artifact this load refused to index, in failure order."""
+        return tuple(self._quarantined)
+
+    def _quarantine(
+        self,
+        *,
+        source_name: str,
+        origin: str,
+        skill_name: str | None,
+        exc: Exception,
+    ) -> None:
+        """Record one failure and report it, without letting either fail the load."""
+        record = QuarantinedSkill(
+            source_name=source_name,
+            origin=origin,
+            skill_name=skill_name,
+            reason=str(exc),
+            error_type=type(exc).__name__,
+            at=time.time(),
+        )
+        self._quarantined.append(record)
+        logger.error(
+            "Quarantined skill %s from source %r (%s): %s",
+            skill_name or "<whole source>",
+            source_name,
+            record.error_type,
+            record.reason,
+        )
+        if self._on_quarantine is None:
+            return
+        try:
+            self._on_quarantine(record)
+        except Exception:
+            # The reporter is not the subject. An audit sink that is down must
+            # not do what the broken skill could not.
+            logger.exception("on_quarantine hook raised for %s", skill_name or source_name)
+
     def _reload(self) -> None:
-        """Re-scan every source. Separate method so tests can force a refresh."""
+        """Re-scan every source. Separate method so tests can force a refresh.
+
+        Per-source AND per-artifact isolation, because they are different
+        failures: a source that throws in ``iter_skills`` never named a skill,
+        while a duplicate name is one artifact out of many.
+        """
         self._skills.clear()
         self._source_by_skill.clear()
+        self._quarantined.clear()
 
         for source in self._sources:
-            artifacts = source.iter_skills()
+            source_name = _source_label(source)
+            try:
+                artifacts = source.iter_skills()
+            except Exception as exc:
+                self._quarantine(
+                    source_name=source_name,
+                    origin=source_name,
+                    skill_name=None,
+                    exc=exc,
+                )
+                continue
             for artifact in artifacts:
-                self._register(source, artifact)
+                try:
+                    self._register(source, artifact)
+                except Exception as exc:
+                    self._quarantine(
+                        source_name=source_name,
+                        origin=_artifact_origin(artifact),
+                        skill_name=_artifact_name(artifact),
+                        exc=exc,
+                    )
 
     def _register(self, source: SkillSource, artifact: SkillArtifact) -> None:
         """Add a single artifact to the index, raising on name conflicts.
@@ -290,6 +415,29 @@ def default_loader_from_templates(
         resolutions = scan.resolutions
 
     return SkillLoader(sources=sources, source_resolutions=resolutions)
+
+
+def _source_label(source: SkillSource) -> str:
+    """A source's name, for a source whose own ``name`` may be the broken part."""
+    try:
+        return source.name
+    except Exception:  # pragma: no cover - a source this broken is hypothetical
+        return repr(source)
+
+
+def _artifact_name(artifact: SkillArtifact) -> str | None:
+    """The artifact's skill name, or None when reading it is itself the failure."""
+    try:
+        return artifact.manifest.name
+    except Exception:  # pragma: no cover - defensive, same reason as above
+        return None
+
+
+def _artifact_origin(artifact: SkillArtifact) -> str:
+    try:
+        return artifact.origin
+    except Exception:  # pragma: no cover - defensive, same reason as above
+        return "<unreadable artifact>"
 
 
 def _resolve_reader(source: SkillSource, attr: str) -> _ReaderFn:

--- a/tests/unit/skills/test_loader.py
+++ b/tests/unit/skills/test_loader.py
@@ -52,17 +52,28 @@ def test_loader_indexes_sources_in_order(sample_skills_root: Path) -> None:
     assert loader.has("does-not-exist") is False
 
 
-def test_loader_raises_on_duplicate_name() -> None:
+def test_loader_quarantines_a_duplicate_name() -> None:
+    """A conflict is recorded, not fatal (#5108).
+
+    This used to raise out of ``__init__``, which meant one duplicate name took
+    every OTHER skill down with it. Detection is what mattered -- two plugins
+    must never silently shadow each other -- and the quarantine record keeps
+    that while leaving the rest of the set loaded. The first origin wins,
+    deterministically, so precedence still follows source order.
+    """
     first = _InMemorySource("first", [_artifact("conflict", "from-first")])
-    second = _InMemorySource("second", [_artifact("conflict", "from-second")])
+    second = _InMemorySource("second", [_artifact("conflict", "from-second"), _artifact("fine", "from-second")])
 
-    with pytest.raises(DuplicateSkillError) as excinfo:
-        SkillLoader([first, second])
+    loader = SkillLoader([first, second])
 
-    err = excinfo.value
-    assert err.skill_name == "conflict"
-    assert err.first_origin == "from-first"
-    assert err.second_origin == "from-second"
+    assert loader.get("conflict").origin == "from-first"
+    assert loader.has("fine") is True, "the duplicate must not cost the source's other skills"
+
+    (quarantined,) = loader.quarantined
+    assert quarantined.error_type == DuplicateSkillError.__name__
+    assert quarantined.skill_name == "conflict"
+    assert quarantined.origin == "from-second"
+    assert "from-first" in quarantined.reason and "from-second" in quarantined.reason
 
 
 def test_loader_get_raises_skill_not_found_error() -> None:

--- a/tests/unit/skills/test_loader_quarantine.py
+++ b/tests/unit/skills/test_loader_quarantine.py
@@ -1,0 +1,187 @@
+"""Issue #5108: one broken skill source must not take every other skill with it.
+
+``SkillLoader._reload`` had no exception handling, and ``__init__`` calls it
+directly. A source whose ``iter_skills()`` threw therefore raised out of the
+constructor: the caller got no ``SkillLoader`` at all, and every skill from
+every OTHER source failed to load because of one bad entry.
+
+A failure that vanishes into a log line is the same as no failure at all to the
+operator reading ``status``, so the loader records what it refused to index and
+why, and the rest of the set loads.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from bernstein.core.skills.loader import (
+    DuplicateSkillError,
+    QuarantinedSkill,
+    SkillLoader,
+)
+from bernstein.core.skills.manifest import SkillManifest
+from bernstein.core.skills.source import SkillArtifact, SkillSource
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class _InMemorySource(SkillSource):
+    """A source that yields a fixed artifact list. Idiom from ``test_loader.py``."""
+
+    def __init__(self, label: str, artifacts: list[SkillArtifact]) -> None:
+        self._label = label
+        self._artifacts = artifacts
+
+    @property
+    def name(self) -> str:
+        return self._label
+
+    def iter_skills(self) -> list[SkillArtifact]:
+        return self._artifacts.copy()
+
+
+class _ThrowingSource(SkillSource):
+    """A source that cannot enumerate at all -- an unreadable dir, a bad plugin."""
+
+    def __init__(self, label: str, error: Exception) -> None:
+        self._label = label
+        self._error = error
+
+    @property
+    def name(self) -> str:
+        return self._label
+
+    def iter_skills(self) -> list[SkillArtifact]:
+        raise self._error
+
+
+def _artifact(name: str, origin: str) -> SkillArtifact:
+    return SkillArtifact(
+        manifest=SkillManifest(
+            name=name,
+            description="A stub description exceeding twenty characters easily.",
+        ),
+        body=f"# body for {name}",
+        origin=origin,
+    )
+
+
+def test_one_throwing_source_quarantines_and_others_load() -> None:
+    """The load-bearing case. On main the constructor raises and there is no loader."""
+    broken = _ThrowingSource("broken-plugin", RuntimeError("entry point blew up"))
+    healthy = _InMemorySource("healthy", [_artifact("alpha", "from-healthy")])
+
+    loader = SkillLoader([broken, healthy])
+
+    assert [s.name for s in loader.list_all()] == ["alpha"]
+
+    (quarantined,) = loader.quarantined
+    assert quarantined.source_name == "broken-plugin"
+    assert quarantined.error_type == "RuntimeError"
+    assert quarantined.reason == "entry point blew up"
+    # A source that threw while enumerating never said WHICH skill it was
+    # building, and claiming one would be an invention.
+    assert quarantined.skill_name is None
+
+
+def test_a_source_after_a_broken_one_still_loads() -> None:
+    """Ordering: the isolation is per source, not "stop at the first failure"."""
+    loader = SkillLoader(
+        [
+            _InMemorySource("first", [_artifact("alpha", "a")]),
+            _ThrowingSource("broken", OSError("permission denied")),
+            _InMemorySource("last", [_artifact("beta", "b")]),
+        ]
+    )
+
+    assert [s.name for s in loader.list_all()] == ["alpha", "beta"]
+    assert len(loader.quarantined) == 1
+
+
+def test_duplicate_skill_name_quarantines_the_second_one() -> None:
+    """A conflict is still never silent -- it is recorded rather than fatal."""
+    first = _InMemorySource("first", [_artifact("conflict", "from-first")])
+    second = _InMemorySource("second", [_artifact("conflict", "from-second")])
+
+    loader = SkillLoader([first, second])
+
+    assert loader.get("conflict").origin == "from-first"
+    (quarantined,) = loader.quarantined
+    assert quarantined.error_type == DuplicateSkillError.__name__
+    assert quarantined.skill_name == "conflict"
+
+
+def test_the_record_carries_a_reason_and_a_timestamp() -> None:
+    """What the operator needs to act: which, why, and when."""
+    before = time.time()
+    loader = SkillLoader([_ThrowingSource("broken", ValueError("bad manifest"))])
+    after = time.time()
+
+    (quarantined,) = loader.quarantined
+    assert isinstance(quarantined, QuarantinedSkill)
+    assert quarantined.reason == "bad manifest"
+    assert quarantined.error_type == "ValueError"
+    assert before <= quarantined.at <= after
+
+
+def test_the_hook_is_called_once_per_quarantine_as_it_happens() -> None:
+    """The seam a caller journals a governance event through.
+
+    The loader is deliberately stateless and holds no audit key, so it reports
+    rather than writes -- and it reports at the moment of failure rather than
+    handing back a list to diff afterwards.
+    """
+    seen: list[QuarantinedSkill] = []
+    SkillLoader(
+        [
+            _ThrowingSource("broken-a", RuntimeError("a")),
+            _ThrowingSource("broken-b", RuntimeError("b")),
+            _InMemorySource("healthy", [_artifact("alpha", "x")]),
+        ],
+        on_quarantine=seen.append,
+    )
+
+    assert [record.reason for record in seen] == ["a", "b"]
+
+
+def test_a_throwing_hook_does_not_break_the_load() -> None:
+    """The reporter is not the subject.
+
+    An audit sink that is down must not do what the broken skill could not.
+    """
+
+    def _explode(_record: QuarantinedSkill) -> None:
+        raise RuntimeError("audit sink unavailable")
+
+    loader = SkillLoader(
+        [
+            _ThrowingSource("broken", RuntimeError("boom")),
+            _InMemorySource("healthy", [_artifact("alpha", "x")]),
+        ],
+        on_quarantine=_explode,
+    )
+
+    assert [s.name for s in loader.list_all()] == ["alpha"]
+    assert len(loader.quarantined) == 1
+
+
+def test_a_healthy_load_quarantines_nothing() -> None:
+    """The control: the record is empty when nothing failed."""
+    loader = SkillLoader([_InMemorySource("healthy", [_artifact("alpha", "x")])])
+    assert loader.quarantined == ()
+
+
+def test_a_reload_clears_the_previous_quarantine(sample_skills_root: Path) -> None:
+    """Quarantine describes THIS load, not every load the object has ever done."""
+    from bernstein.core.skills.sources import LocalDirSkillSource
+
+    loader = SkillLoader([_ThrowingSource("broken", RuntimeError("boom"))])
+    assert len(loader.quarantined) == 1
+
+    loader._sources = [LocalDirSkillSource(sample_skills_root)]
+    loader._reload()
+
+    assert loader.quarantined == ()
+    assert [s.name for s in loader.list_all()] == ["alpha", "beta", "gamma"]


### PR DESCRIPTION
#5108 — the skills-loader slice, which carries the issue's load-bearing test.

## The bug

`SkillLoader._reload` had no exception handling, and `__init__` calls it directly. A source whose `iter_skills()` threw therefore **raised out of the constructor**: the caller got no `SkillLoader` at all, and every skill from every *other* source failed to load because of one bad entry. A duplicate name did the same thing through `DuplicateSkillError`.

## The fix

Isolation is **per source and per artifact**, because they are different failures: a source that throws while enumerating never named a skill, while a duplicate name is one artifact out of many.

`QuarantinedSkill` carries what an operator needs in order to act — which source, which skill (`None` for a whole-source failure, since claiming one would be an invention), the exception text, its type so a caller can group by cause without parsing prose, and when.

**A conflict is still never silent.** Detection is what mattered — two plugins must not silently shadow each other — and the record keeps that while leaving the rest of the set loaded. The first origin still wins, so precedence follows source order exactly as before.

## `on_quarantine`, and the open decision

The issue asks for a journaled governance event. The loader is deliberately stateless and holds **no audit key**, so it reports rather than writes: `on_quarantine` is called once per entry *at the moment of failure*, rather than handing back a list for the caller to diff afterwards. A hook that raises is itself caught — an audit sink that is down must not do what the broken skill could not.

That also answers the issue's open decision (*"one store keyed by declaration kind, or four separate stores"*) in the only way this slice can: **neither yet**. There is no common base type across `skills/loader.py`, `trackers/registry.py`, `plugins_core/` and `orchestration/trigger_manager.py` to key a shared store on, and inventing one from a single call site would be a guess. The hook gives whoever builds the store a stable seam to attach to without this module having to know which shape won.

## One existing test changed, deliberately

`test_loader_raises_on_duplicate_name` → `test_loader_quarantines_a_duplicate_name`. The behaviour it pinned is the one this issue exists to change. It now also asserts the duplicate does not cost the second source its *other* skills, which is the actual regression.

## Tests — `tests/unit/skills/test_loader_quarantine.py` (8)

- **`test_one_throwing_source_quarantines_and_others_load`** — fails on `main`: the constructor raises and no loader is produced.
- a source *after* a broken one still loads (isolation is per source, not "stop at the first failure")
- a duplicate quarantines the second and the first still wins
- the record carries reason, error type and a timestamp within the call window
- the hook fires once per quarantine, in failure order
- a throwing hook does not break the load
- a healthy load quarantines nothing (the control)
- a reload clears the previous quarantine — the record describes *this* load

```
uv run pytest tests/unit/skills/ -q      # 372 passed
uv run ruff check / ruff format          # clean
```

## Not in this PR

`doctor` / `govern audit` findings, the `status` count, and the explicit re-enable command — those need the store the open decision is about, and this PR is the seam it would attach to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)