### PR TITLE
fix(spawner): apply the host-isolation declaration to the run-level adapter

### DIFF
--- a/docs/release-notes/fragments/5341-run-level-adapter-host-isolation.md
+++ b/docs/release-notes/fragments/5341-run-level-adapter-host-isolation.md
@@ -1,0 +1,4 @@
+## Host-isolation declaration now reaches the run-level adapter
+
+The host-isolation declaration is now applied to the run-level adapter as well, so a
+declared container tier drops the Codex vendor sandbox on every spawn path (#5341, #5314).

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -1648,14 +1648,21 @@ class AgentSpawner:
         self._default_model = default_model
         self._resource_limits = resource_limits
         self._adapter_cache: dict[str, CLIAdapter] = {}
+        self._templates_dir = templates_dir
+        self._workdir = workdir
+        # The run-level adapter is seeded into the cache below without ever
+        # going through _get_adapter_by_name's cache-miss path, so it has to
+        # receive the host-isolation declaration here too -- otherwise the
+        # later cache hit in _get_adapter_by_name skips applying it, and a
+        # declared container tier never reaches this adapter (#5341, #5314).
+        if getattr(adapter, "consumes_host_isolation", False):
+            self._apply_host_isolation(adapter.name(), adapter)
         if enable_caching:
             from bernstein.adapters.caching_adapter import CachingAdapter
 
             adapter = CachingAdapter(adapter, workdir)
         self._adapter = adapter
         self._adapter_cache[self._adapter.name()] = self._adapter
-        self._templates_dir = templates_dir
-        self._workdir = workdir
         self._registry = agent_registry or get_registry(
             definitions_dir=workdir / ".sdd" / "agents" / "definitions",
             auto_reload=True,

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -1655,7 +1655,10 @@ class AgentSpawner:
         # receive the host-isolation declaration here too -- otherwise the
         # later cache hit in _get_adapter_by_name skips applying it, and a
         # declared container tier never reaches this adapter (#5341, #5314).
-        if getattr(adapter, "consumes_host_isolation", False):
+        # `is True`, not truthiness: test doubles built on MagicMock answer
+        # every attribute with a truthy mock and would record a declaration
+        # for an adapter that owns no vendor sandbox.
+        if getattr(adapter, "consumes_host_isolation", False) is True:
             self._apply_host_isolation(adapter.name(), adapter)
         if enable_caching:
             from bernstein.adapters.caching_adapter import CachingAdapter

--- a/tests/unit/test_spawner_host_isolation.py
+++ b/tests/unit/test_spawner_host_isolation.py
@@ -108,6 +108,61 @@ def test_adapter_without_the_marker_is_untouched(tmp_path: Path) -> None:
     assert _events(tmp_path) == []
 
 
+def _codex_spawner(tmp_path: Path) -> AgentSpawner:
+    """Spawner constructed the way the orchestrator/worker command does:
+
+    a real, un-cached, run-level ``CodexAdapter`` passed straight into
+    ``__init__`` rather than resolved later through ``_get_adapter_by_name``.
+    """
+    templates_dir = tmp_path / "templates" / "roles"
+    templates_dir.mkdir(parents=True)
+    return AgentSpawner(CodexAdapter(), templates_dir, tmp_path, use_worktrees=False, default_model="mock-model")
+
+
+def test_run_level_adapter_receives_host_isolation_declaration(tmp_path: Path) -> None:
+    """The adapter passed into __init__ must get the declaration too (#5341, #5314).
+
+    It is seeded into the adapter cache directly, without ever going through
+    _get_adapter_by_name's cache-miss path -- so if __init__ itself does not
+    apply the declaration, nothing else ever will for this instance, and a
+    declared container tier never drops the Codex vendor sandbox.
+    """
+    spawner = _codex_spawner(tmp_path)
+
+    adapter = spawner._adapter  # type: ignore[reportPrivateUsage]
+    assert str(adapter.host_isolation) == "container"
+    assert adapter._sandbox_args() == ("--dangerously-bypass-approvals-and-sandbox",)  # type: ignore[reportPrivateUsage]
+
+
+def test_run_level_adapter_without_declaration_keeps_vendor_sandbox(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("BERNSTEIN_HOST_ISOLATION_TIER", raising=False)
+    monkeypatch.delenv("BERNSTEIN_HOST_ISOLATION_EVIDENCE", raising=False)
+    spawner = _codex_spawner(tmp_path)
+
+    adapter = spawner._adapter  # type: ignore[reportPrivateUsage]
+    assert adapter._sandbox_args() == ("--sandbox", "workspace-write")  # type: ignore[reportPrivateUsage]
+
+
+def test_run_level_adapter_declaration_is_not_reapplied_on_cache_hit(tmp_path: Path) -> None:
+    """__init__ applies the declaration once; a later same-name lookup is a cache hit.
+
+    ``_get_adapter_by_name`` caches the run-level adapter under
+    ``adapter.name()`` (seeded by __init__), so looking it up again by that
+    same name must return the identical, already-declared instance rather
+    than re-resolving and re-recording it.
+    """
+    spawner = _codex_spawner(tmp_path)
+    stored = spawner._adapter  # type: ignore[reportPrivateUsage]
+    assert len(_events(tmp_path)) == 1
+
+    resolved = spawner._get_adapter_by_name(stored.name())  # type: ignore[reportPrivateUsage]
+
+    assert resolved is stored
+    assert len(_events(tmp_path)) == 1
+
+
 def test_a_broken_declaration_does_not_wedge_the_spawn(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:


### PR DESCRIPTION
## What

`AgentSpawner.__init__` seeds the adapter cache with the run-level adapter without applying the operator's host-isolation declaration. `_get_adapter_by_name` applies it only on a cache miss, so the adapter that actually spawns every agent in a run never receives it. A declared `host_isolation_tier: container` (config key or `BERNSTEIN_HOST_ISOLATION_TIER`) therefore never reached `CodexAdapter._sandbox_args()`, and every spawn kept `--sandbox workspace-write`. Inside a capability-dropped container that sandbox cannot start bubblewrap: each shell call the model issues fails while `codex exec` still exits 0 with an empty diff.

## Change

- `__init__` now applies the declaration to the passed-in adapter (guarded by `consumes_host_isolation`) before the `CachingAdapter` wrap and before the cache is seeded, the same way the cache-miss path does.
- Tests: the run-level adapter receives a declared container tier and yields the bypass argv; no declaration keeps the vendor sandbox; the declaration is recorded once and not re-applied on a later cache hit.
- Release-notes fragment.

Refs #5341, #5314.