### PR TITLE
feat(persistence): a per-item batch ledger, and a daily cap derived from it (#5126)

### DIFF
--- a/docs/release-notes/fragments/5126-batch-item-ledger.md
+++ b/docs/release-notes/fragments/5126-batch-item-ledger.md
@@ -1,0 +1,22 @@
+## A per-item batch ledger, and a daily cap derived from it
+
+`bernstein.core.persistence.batch_ledger.BatchLedger` records each item a
+flat batch completes, so a resumed run skips what is already done and a
+crash costs the item in flight and nothing before it. `WorkLedger`
+resumes a task graph by replaying a chain; a batch asks two different
+questions — "have I already done this one" and "how many have I done
+today" — and nothing mapped an entity id to its last success.
+
+The daily cap is derived from the ledger's own entries rather than a
+counter in memory, so it survives a restart — which is exactly when an
+operator most wants it to hold. `record(..., cap=N)` raises
+`DailyCapReached` rather than returning false: the cap holding is not a
+failure of the item. The check and the append are one section, so two
+callers cannot both take the last slot.
+
+Entries are hash-chained with the same `compute_entry_hash` the work
+ledger uses and appended with `O_APPEND` + `fsync`, so an item treated as
+done is on disk. A torn final line from a killed process is dropped
+rather than failing the load; a break anywhere else is reported.
+`compact()` applies a retention window, re-deriving the chain over the
+survivors and writing through a scratch sibling (#5126).

--- a/src/bernstein/core/persistence/batch_ledger.py
+++ b/src/bernstein/core/persistence/batch_ledger.py
@@ -1,0 +1,404 @@
+"""Per-item checkpoint ledger for a flat batch run (issue #5126).
+
+:class:`~bernstein.core.persistence.work_ledger.WorkLedger` resumes a task
+GRAPH by replaying a hash chain. A batch is a different shape: a flat list of
+entities processed one at a time, where the only questions are "have I already
+done this one" and "how many have I done today". Replaying a graph answers
+neither, and nothing else in the tree maps an entity id to its last success.
+
+Two properties, and they are the same property:
+
+**Resume.** An item recorded as done is skipped on the next pass, so a crash
+costs the item in flight and nothing before it.
+
+**The cap.** The daily cap is derived from the ledger's own entries, never from
+a counter in memory. An in-memory count resets to zero on restart -- which is
+exactly the moment an operator most wants the cap to hold, because a process
+that keeps dying and retrying is the one that would blow through it. Reading
+the count back from the log means "what happened today" has one source of truth
+rather than a counter that can drift from the record describing it.
+
+Append-only JSONL, hash-chained with the same
+:func:`~bernstein.core.persistence.work_ledger.compute_entry_hash` primitive the
+work ledger uses, so an entry cannot be edited or reordered without breaking
+every hash after it. Reads tolerate a torn final line: a process killed
+mid-append leaves a partial record, and refusing to load the whole ledger over
+its last byte would turn a crash into an outage.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import threading
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.persistence.work_ledger import compute_entry_hash
+from bernstein.core.security.path_containment import contained_path
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: The chain's anchor. Matches the work ledger's genesis convention.
+GENESIS_HASH = "0" * 64
+
+#: Entry kind, so a reader can tell these apart from anything else appended
+#: alongside them later.
+ENTRY_KIND = "batch.item"
+
+_LEDGER_FILENAME = "batch-items.jsonl"
+
+
+class BatchLedgerError(RuntimeError):
+    """Raised for unrecoverable batch-ledger read/write errors."""
+
+
+class DailyCapReached(RuntimeError):
+    """Raised when today's entries already meet the cap.
+
+    A distinct type rather than a boolean return, because "the cap held" is not
+    a failure of the item -- a caller that treats it as one would retry forever.
+
+    Attributes:
+        cap: The cap that held.
+        done_today: Entries already recorded for today.
+    """
+
+    def __init__(self, cap: int, done_today: int) -> None:
+        super().__init__(f"daily cap reached: {done_today} of {cap} recorded today")
+        self.cap = cap
+        self.done_today = done_today
+
+
+@dataclass(frozen=True)
+class BatchItemRecord:
+    """One successfully processed item.
+
+    Attributes:
+        entity_id: The item's identity, as the caller names it.
+        at:        Unix timestamp of the success.
+        day:       ``YYYY-MM-DD`` in UTC, the bucket the daily cap counts.
+        entry_hash: This entry's hash, chaining to its predecessor.
+        prev_hash:  The predecessor's hash, or :data:`GENESIS_HASH` for the first.
+        detail:    Caller-supplied payload, carried verbatim.
+    """
+
+    entity_id: str
+    at: float
+    day: str
+    entry_hash: str
+    prev_hash: str
+    detail: dict[str, Any]
+
+
+def _utc_day(at: float) -> str:
+    """The UTC calendar day an instant falls in.
+
+    UTC, not local time: a batch resumed in a different timezone -- or across a
+    DST boundary -- must not get a second day's worth of budget for the same
+    afternoon.
+    """
+    return datetime.fromtimestamp(at, tz=UTC).strftime("%Y-%m-%d")
+
+
+class BatchLedger:
+    """An append-only, hash-chained record of the items a batch has completed.
+
+    One instance per process; the append is guarded in-process by a lock and is
+    a single ``O_APPEND`` write, which is atomic on POSIX for a line under
+    ``PIPE_BUF``.
+    """
+
+    def __init__(self, ledger_dir: Path, *, filename: str = _LEDGER_FILENAME) -> None:
+        """Open (or create on first write) a ledger under *ledger_dir*.
+
+        Args:
+            ledger_dir: Directory holding the ledger file.
+            filename: Ledger basename. Containment-checked against
+                *ledger_dir*, so a symlinked ledger file cannot redirect an
+                append outside it -- the same barrier the work ledger applies
+                to its bucket.
+        """
+        self._dir = ledger_dir
+        self._path = contained_path(ledger_dir, filename, label="batch ledger")
+        self._lock = threading.Lock()
+
+    @property
+    def path(self) -> Path:
+        """The ledger file. It need not exist yet."""
+        return self._path
+
+    # -- reading ------------------------------------------------------------
+
+    def entries(self) -> list[BatchItemRecord]:
+        """Every recorded item, in append order. Empty when the ledger is absent."""
+        return list(self._iter_entries())
+
+    def _iter_entries(self) -> Iterator[BatchItemRecord]:
+        try:
+            raw = self._path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            raise BatchLedgerError(f"cannot read batch ledger {self._path}: {exc}") from exc
+
+        lines = raw.splitlines()
+        for index, line in enumerate(lines):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                # Only the LAST line may be torn: a process killed mid-append
+                # leaves a partial record, and refusing to load the ledger over
+                # its final byte would turn a crash into an outage. A break in
+                # the middle is corruption and is reported.
+                if index == len(lines) - 1:
+                    logger.warning("Dropping torn final line of %s", self._path)
+                    return
+                raise BatchLedgerError(f"corrupt entry at line {index + 1} of {self._path}") from None
+            if not isinstance(row, dict):
+                raise BatchLedgerError(f"entry at line {index + 1} of {self._path} is not an object")
+            yield BatchItemRecord(
+                entity_id=str(row.get("entity_id", "")),
+                at=float(row.get("at", 0.0)),
+                day=str(row.get("day", "")),
+                entry_hash=str(row.get("entry_hash", "")),
+                prev_hash=str(row.get("prev_hash", GENESIS_HASH)),
+                detail=row.get("detail") if isinstance(row.get("detail"), dict) else {},
+            )
+
+    def done_ids(self) -> set[str]:
+        """Entity ids already recorded. The resume set."""
+        return {entry.entity_id for entry in self._iter_entries()}
+
+    def last_success(self, entity_id: str) -> float | None:
+        """The most recent success instant for one entity, or None.
+
+        The LAST occurrence wins: an entity re-processed after a policy change
+        has two entries, and the question a caller asks is when it last
+        succeeded, not when it first did.
+        """
+        found: float | None = None
+        for entry in self._iter_entries():
+            if entry.entity_id == entity_id:
+                found = entry.at
+        return found
+
+    def pending(self, entity_ids: list[str]) -> list[str]:
+        """The subset of *entity_ids* not yet recorded, in the order given.
+
+        Order is preserved because a batch's order is often deliberate -- a
+        priority queue, or a dependency-respecting sequence -- and returning a
+        set would quietly discard it.
+        """
+        done = self.done_ids()
+        return [entity_id for entity_id in entity_ids if entity_id not in done]
+
+    def done_today(self, *, now: float | None = None) -> int:
+        """How many entries fall in the current UTC day.
+
+        Read from the ledger every time, never cached: the count has to survive
+        a restart, and a cached one is the thing being replaced.
+        """
+        today = _utc_day(datetime.now(tz=UTC).timestamp() if now is None else now)
+        return sum(1 for entry in self._iter_entries() if entry.day == today)
+
+    def remaining_today(self, cap: int, *, now: float | None = None) -> int:
+        """How many more items today's cap allows. Never negative.
+
+        A cap lowered below what a previous run already did leaves this at 0
+        rather than a negative budget: the cap is a ceiling on new work, and
+        work already recorded cannot be un-done by changing the number.
+        """
+        if cap <= 0:
+            return 0
+        return max(0, cap - self.done_today(now=now))
+
+    def head_hash(self) -> str:
+        """The last entry's hash, or :data:`GENESIS_HASH` for an empty ledger."""
+        head = GENESIS_HASH
+        for entry in self._iter_entries():
+            head = entry.entry_hash
+        return head
+
+    def verify(self) -> None:
+        """Recompute the chain and raise on the first entry that does not match.
+
+        Raises:
+            BatchLedgerError: An entry's recorded hash is not the hash of its
+                content and predecessor -- the ledger was edited or reordered.
+        """
+        prev = GENESIS_HASH
+        for index, entry in enumerate(self._iter_entries(), start=1):
+            expected = self._entry_hash(entry.entity_id, entry.at, entry.day, entry.detail, prev)
+            if entry.prev_hash != prev:
+                raise BatchLedgerError(f"entry {index} of {self._path} does not chain to its predecessor")
+            if entry.entry_hash != expected:
+                raise BatchLedgerError(f"entry {index} of {self._path} has a hash its content does not produce")
+            prev = entry.entry_hash
+
+    # -- writing ------------------------------------------------------------
+
+    @staticmethod
+    def _entry_hash(
+        entity_id: str,
+        at: float,
+        day: str,
+        detail: dict[str, Any],
+        prev_hash: str,
+    ) -> str:
+        return compute_entry_hash(
+            prev_hash=prev_hash,
+            kind=ENTRY_KIND,
+            task_id=entity_id,
+            payload={"at": at, "day": day, "detail": detail},
+        )
+
+    def record(
+        self,
+        entity_id: str,
+        *,
+        at: float | None = None,
+        detail: dict[str, Any] | None = None,
+        cap: int = 0,
+    ) -> BatchItemRecord:
+        """Record one item as done, and return the entry written.
+
+        Args:
+            entity_id: The item's identity.
+            at: Success instant; defaults to now.
+            detail: Payload carried verbatim into the entry.
+            cap: When positive, the daily cap this record must not exceed. The
+                check and the append are under one lock, so two threads cannot
+                both read ``cap - 1`` and both write.
+
+        Raises:
+            DailyCapReached: Today's entries already meet *cap*.
+            BatchLedgerError: The ledger could not be appended to.
+        """
+        moment = datetime.now(tz=UTC).timestamp() if at is None else at
+        day = _utc_day(moment)
+        payload = dict(detail or {})
+
+        with self._lock:
+            if cap > 0:
+                done = self.done_today(now=moment)
+                if done >= cap:
+                    raise DailyCapReached(cap=cap, done_today=done)
+            prev = self.head_hash()
+            entry = BatchItemRecord(
+                entity_id=entity_id,
+                at=moment,
+                day=day,
+                entry_hash=self._entry_hash(entity_id, moment, day, payload, prev),
+                prev_hash=prev,
+                detail=payload,
+            )
+            self._append(entry)
+        return entry
+
+    def _append(self, entry: BatchItemRecord) -> None:
+        line = json.dumps(
+            {
+                "kind": ENTRY_KIND,
+                "entity_id": entry.entity_id,
+                "at": entry.at,
+                "day": entry.day,
+                "prev_hash": entry.prev_hash,
+                "entry_hash": entry.entry_hash,
+                "detail": entry.detail,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        try:
+            self._dir.mkdir(parents=True, exist_ok=True)
+            # O_APPEND, and fsync before returning: the caller is about to treat
+            # this item as done, and a record still in the page cache when the
+            # box dies would have it processed twice -- the one thing the ledger
+            # exists to prevent.
+            with self._path.open("a", encoding="utf-8") as handle:
+                handle.write(line + "\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+        except OSError as exc:
+            raise BatchLedgerError(f"cannot append to batch ledger {self._path}: {exc}") from exc
+
+
+def compact(ledger: BatchLedger, *, keep_days: int, now: float | None = None) -> int:
+    """Drop entries older than *keep_days* whole days, rewriting the chain.
+
+    Returns the number of entries removed. The chain is RE-DERIVED from the
+    surviving entries rather than carried over, because a chain with a hole in
+    it verifies as tampered -- which is the correct reading of a file somebody
+    edited, and the wrong one for a retention policy the operator asked for.
+
+    A no-op when nothing is old enough, so a scheduled compaction on a fresh
+    ledger does not rewrite a file for no reason.
+    """
+    if keep_days < 0:
+        raise ValueError("keep_days must not be negative")
+    moment = datetime.now(tz=UTC).timestamp() if now is None else now
+    cutoff = moment - keep_days * 86400.0
+    entries = ledger.entries()
+    kept = [entry for entry in entries if entry.at >= cutoff]
+    if len(kept) == len(entries):
+        return 0
+
+    prev = GENESIS_HASH
+    lines: list[str] = []
+    for entry in kept:
+        entry_hash = BatchLedger._entry_hash(entry.entity_id, entry.at, entry.day, entry.detail, prev)
+        lines.append(
+            json.dumps(
+                {
+                    "kind": ENTRY_KIND,
+                    "entity_id": entry.entity_id,
+                    "at": entry.at,
+                    "day": entry.day,
+                    "prev_hash": prev,
+                    "entry_hash": entry_hash,
+                    "detail": entry.detail,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+        )
+        prev = entry_hash
+
+    body = "".join(f"{line}\n" for line in lines)
+    # Scratch sibling and rename: truncating the real file would, if the process
+    # died mid-write, lose every resume point at once -- turning a retention
+    # sweep into a full reprocess.
+    fd, tmp_name = tempfile.mkstemp(dir=ledger.path.parent, prefix=f"{ledger.path.name}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(body)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, ledger.path)
+    except OSError as exc:
+        raise BatchLedgerError(f"cannot compact batch ledger {ledger.path}: {exc}") from exc
+    finally:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+    return len(entries) - len(kept)
+
+
+__all__ = [
+    "ENTRY_KIND",
+    "GENESIS_HASH",
+    "BatchItemRecord",
+    "BatchLedger",
+    "BatchLedgerError",
+    "DailyCapReached",
+    "compact",
+]

--- a/src/bernstein/core/persistence/batch_ledger.py
+++ b/src/bernstein/core/persistence/batch_ledger.py
@@ -166,13 +166,15 @@ class BatchLedger:
                 raise BatchLedgerError(f"corrupt entry at line {index + 1} of {self._path}") from None
             if not isinstance(row, dict):
                 raise BatchLedgerError(f"entry at line {index + 1} of {self._path} is not an object")
+            raw_detail = row.get("detail")
+            detail: dict[str, Any] = raw_detail if isinstance(raw_detail, dict) else {}
             yield BatchItemRecord(
                 entity_id=str(row.get("entity_id", "")),
                 at=float(row.get("at", 0.0)),
                 day=str(row.get("day", "")),
                 entry_hash=str(row.get("entry_hash", "")),
                 prev_hash=str(row.get("prev_hash", GENESIS_HASH)),
-                detail=row.get("detail") if isinstance(row.get("detail"), dict) else {},
+                detail=detail,
             )
 
     def done_ids(self) -> set[str]:

--- a/tests/unit/test_batch_ledger.py
+++ b/tests/unit/test_batch_ledger.py
@@ -1,0 +1,318 @@
+"""Issue #5126: a batch's resume point and its daily cap come from one record.
+
+Two properties that are really one. An item recorded as done is skipped on the
+next pass, so a crash costs the item in flight and nothing before it. And the
+daily cap is derived from the ledger's own entries rather than a counter in
+memory -- because an in-memory count resets to zero on restart, which is exactly
+the moment an operator most wants the cap to hold: a process that keeps dying
+and retrying is the one that would blow through it.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.persistence.batch_ledger import (
+    GENESIS_HASH,
+    BatchLedger,
+    BatchLedgerError,
+    DailyCapReached,
+    compact,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+DAY = 86400.0
+
+
+def _at(day: str, hour: int = 12) -> float:
+    """A deterministic instant inside a named UTC day."""
+    return datetime.fromisoformat(f"{day}T{hour:02d}:00:00+00:00").timestamp()
+
+
+# ---------------------------------------------------------------------------
+# Resume
+# ---------------------------------------------------------------------------
+
+
+def test_an_absent_ledger_has_nothing_done(tmp_path: Path) -> None:
+    """First run: everything is pending, and no file is created by reading."""
+    ledger = BatchLedger(tmp_path)
+    assert ledger.entries() == []
+    assert ledger.pending(["a", "b"]) == ["a", "b"]
+    assert ledger.head_hash() == GENESIS_HASH
+    assert not ledger.path.exists()
+
+
+def test_a_recorded_item_is_skipped_on_resume(tmp_path: Path) -> None:
+    ledger = BatchLedger(tmp_path)
+    ledger.record("a")
+    ledger.record("c")
+
+    assert ledger.pending(["a", "b", "c", "d"]) == ["b", "d"]
+
+
+def test_pending_preserves_the_order_it_was_given(tmp_path: Path) -> None:
+    """A batch's order is often deliberate; returning a set would discard it."""
+    ledger = BatchLedger(tmp_path)
+    ledger.record("m")
+
+    assert ledger.pending(["z", "m", "a", "q"]) == ["z", "a", "q"]
+
+
+def test_a_second_process_sees_the_first_ones_work(tmp_path: Path) -> None:
+    """The resume path: a new instance reads the record, it does not inherit state."""
+    BatchLedger(tmp_path).record("a")
+
+    restarted = BatchLedger(tmp_path)
+    assert restarted.pending(["a", "b"]) == ["b"]
+
+
+def test_last_success_reports_the_most_recent_occurrence(tmp_path: Path) -> None:
+    """An item re-processed after a policy change has two entries."""
+    ledger = BatchLedger(tmp_path)
+    ledger.record("a", at=100.0)
+    ledger.record("a", at=200.0)
+
+    assert ledger.last_success("a") == 200.0
+    assert ledger.last_success("never-seen") is None
+
+
+# ---------------------------------------------------------------------------
+# The daily cap, derived from the ledger
+# ---------------------------------------------------------------------------
+
+
+def test_the_cap_survives_a_restart(tmp_path: Path) -> None:
+    """The load-bearing case.
+
+    A cap enforced from in-memory state resets to zero on every restart. Here
+    the second process reads the first one's entries and refuses.
+    """
+    now = _at("2026-09-03")
+    first = BatchLedger(tmp_path)
+    for i in range(3):
+        first.record(f"item-{i}", at=now, cap=3)
+
+    restarted = BatchLedger(tmp_path)
+    assert restarted.done_today(now=now) == 3
+    with pytest.raises(DailyCapReached) as excinfo:
+        restarted.record("item-3", at=now, cap=3)
+
+    assert excinfo.value.cap == 3
+    assert excinfo.value.done_today == 3
+    # And nothing was written: a refused item is still pending.
+    assert restarted.pending(["item-3"]) == ["item-3"]
+
+
+def test_yesterdays_entries_do_not_count_against_today(tmp_path: Path) -> None:
+    ledger = BatchLedger(tmp_path)
+    yesterday = _at("2026-09-02")
+    today = _at("2026-09-03")
+    for i in range(5):
+        ledger.record(f"old-{i}", at=yesterday)
+
+    assert ledger.done_today(now=today) == 0
+    assert ledger.remaining_today(3, now=today) == 3
+    ledger.record("new", at=today, cap=3)
+    assert ledger.done_today(now=today) == 1
+
+
+def test_the_day_boundary_is_utc(tmp_path: Path) -> None:
+    """A batch resumed in another timezone must not get a second day's budget."""
+    ledger = BatchLedger(tmp_path)
+    ledger.record("late", at=_at("2026-09-03", hour=23))
+    ledger.record("early", at=_at("2026-09-03", hour=0))
+
+    assert ledger.done_today(now=_at("2026-09-03", hour=6)) == 2
+
+
+def test_a_lowered_cap_leaves_no_negative_budget(tmp_path: Path) -> None:
+    """Work already recorded cannot be un-done by changing the number."""
+    now = _at("2026-09-03")
+    ledger = BatchLedger(tmp_path)
+    for i in range(5):
+        ledger.record(f"item-{i}", at=now)
+
+    assert ledger.remaining_today(2, now=now) == 0
+    with pytest.raises(DailyCapReached):
+        ledger.record("item-5", at=now, cap=2)
+
+
+def test_a_zero_cap_is_no_cap_on_record_and_no_budget_on_remaining(tmp_path: Path) -> None:
+    ledger = BatchLedger(tmp_path)
+    for i in range(10):
+        ledger.record(f"item-{i}", cap=0)
+    assert len(ledger.entries()) == 10
+    assert ledger.remaining_today(0) == 0
+
+
+def test_concurrent_records_cannot_both_take_the_last_slot(tmp_path: Path) -> None:
+    """The check and the append are one section.
+
+    Two threads reading ``cap - 1`` and both writing is the failure a cap
+    derived from a log is supposed to make impossible.
+    """
+    now = _at("2026-09-03")
+    ledger = BatchLedger(tmp_path)
+    ledger.record("already", at=now)
+
+    accepted: list[str] = []
+    refused: list[str] = []
+
+    def _try(entity_id: str) -> None:
+        try:
+            ledger.record(entity_id, at=now, cap=2)
+            accepted.append(entity_id)
+        except DailyCapReached:
+            refused.append(entity_id)
+
+    threads = [threading.Thread(target=_try, args=(f"item-{i}",)) for i in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(accepted) == 1, f"{len(accepted)} callers took the last slot"
+    assert len(refused) == 7
+    assert ledger.done_today(now=now) == 2
+
+
+# ---------------------------------------------------------------------------
+# The chain
+# ---------------------------------------------------------------------------
+
+
+def test_the_chain_verifies_and_links_each_entry_to_the_last(tmp_path: Path) -> None:
+    ledger = BatchLedger(tmp_path)
+    first = ledger.record("a")
+    second = ledger.record("b")
+
+    assert first.prev_hash == GENESIS_HASH
+    assert second.prev_hash == first.entry_hash
+    assert ledger.head_hash() == second.entry_hash
+    ledger.verify()
+
+
+def test_an_edited_entry_fails_verification(tmp_path: Path) -> None:
+    """The point of chaining: a record cannot be quietly rewritten."""
+    ledger = BatchLedger(tmp_path)
+    ledger.record("a", detail={"outcome": "sent"})
+    ledger.record("b")
+
+    lines = ledger.path.read_text(encoding="utf-8").splitlines()
+    row = json.loads(lines[0])
+    row["detail"] = {"outcome": "not sent"}
+    lines[0] = json.dumps(row, sort_keys=True, separators=(",", ":"))
+    ledger.path.write_text("".join(f"{line}\n" for line in lines), encoding="utf-8")
+
+    with pytest.raises(BatchLedgerError):
+        BatchLedger(tmp_path).verify()
+
+
+def test_a_reordered_ledger_fails_verification(tmp_path: Path) -> None:
+    ledger = BatchLedger(tmp_path)
+    ledger.record("a")
+    ledger.record("b")
+
+    lines = ledger.path.read_text(encoding="utf-8").splitlines()
+    ledger.path.write_text(f"{lines[1]}\n{lines[0]}\n", encoding="utf-8")
+
+    with pytest.raises(BatchLedgerError):
+        BatchLedger(tmp_path).verify()
+
+
+def test_a_torn_final_line_is_dropped_not_fatal(tmp_path: Path) -> None:
+    """A process killed mid-append leaves a partial record.
+
+    Refusing to load the ledger over its last byte would turn a crash into an
+    outage -- every completed item would be reprocessed.
+    """
+    ledger = BatchLedger(tmp_path)
+    ledger.record("a")
+    ledger.record("b")
+    with ledger.path.open("a", encoding="utf-8") as handle:
+        handle.write('{"entity_id": "c", "at": 1')
+
+    resumed = BatchLedger(tmp_path)
+    assert resumed.pending(["a", "b", "c"]) == ["c"]
+    resumed.verify()
+
+
+def test_a_break_in_the_middle_is_corruption_and_is_reported(tmp_path: Path) -> None:
+    """Only the LAST line may be torn. A hole anywhere else is not a crash."""
+    ledger = BatchLedger(tmp_path)
+    ledger.record("a")
+    ledger.record("b")
+    lines = ledger.path.read_text(encoding="utf-8").splitlines()
+    ledger.path.write_text(f"{lines[0]}\nnot json at all\n{lines[1]}\n", encoding="utf-8")
+
+    with pytest.raises(BatchLedgerError):
+        BatchLedger(tmp_path).entries()
+
+
+# ---------------------------------------------------------------------------
+# Retention
+# ---------------------------------------------------------------------------
+
+
+def test_compaction_drops_old_entries_and_re_derives_the_chain(tmp_path: Path) -> None:
+    """A chain with a hole in it verifies as tampered.
+
+    That is the right reading of a file somebody edited and the wrong one for a
+    retention policy the operator asked for, so the chain is re-derived.
+    """
+    now = time.time()
+    ledger = BatchLedger(tmp_path)
+    ledger.record("ancient", at=now - 30 * DAY)
+    ledger.record("old", at=now - 10 * DAY)
+    ledger.record("recent", at=now)
+
+    assert compact(ledger, keep_days=7, now=now) == 2
+
+    assert [entry.entity_id for entry in ledger.entries()] == ["recent"]
+    assert ledger.entries()[0].prev_hash == GENESIS_HASH
+    ledger.verify()
+
+
+def test_compaction_is_a_no_op_when_nothing_is_old_enough(tmp_path: Path) -> None:
+    now = time.time()
+    ledger = BatchLedger(tmp_path)
+    ledger.record("recent", at=now)
+    before = ledger.path.read_bytes()
+
+    assert compact(ledger, keep_days=7, now=now) == 0
+    assert ledger.path.read_bytes() == before
+
+
+def test_compaction_leaves_no_scratch_file(tmp_path: Path) -> None:
+    now = time.time()
+    ledger = BatchLedger(tmp_path)
+    ledger.record("ancient", at=now - 30 * DAY)
+    ledger.record("recent", at=now)
+
+    compact(ledger, keep_days=1, now=now)
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_compaction_rejects_a_negative_window(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="keep_days"):
+        compact(BatchLedger(tmp_path), keep_days=-1)
+
+
+# ---------------------------------------------------------------------------
+# Containment
+# ---------------------------------------------------------------------------
+
+
+def test_the_ledger_filename_cannot_escape_its_directory(tmp_path: Path) -> None:
+    """The same barrier the work ledger applies to its bucket."""
+    with pytest.raises(Exception, match="(?i)contain|escape|outside|path"):
+        BatchLedger(tmp_path, filename="../escaped.jsonl")


### PR DESCRIPTION
#5126, **slices 1 and 2**. Slice 3 (the non-interactive approval refusal) is left out deliberately — see the end.

## Why a new module rather than `WorkLedger`

`WorkLedger` resumes a task **graph** by replaying a hash chain. A batch is a flat list where the only two questions are *"have I already done this one"* and *"how many have I done today"*. Replaying a graph answers neither, and nothing in the tree mapped an entity id to its last success.

It reuses `compute_entry_hash` and `contained_path` rather than reimplementing either, so the chaining primitive and the path barrier stay single-sourced.

## The two properties are one property

**Resume.** An item recorded as done is skipped on the next pass — a crash costs the item in flight and nothing before it.

**The cap.** `done_today()` reads the ledger every time, never a cached count. An in-memory count resets to zero on restart, which is exactly the moment an operator most wants the cap to hold: a process that keeps dying and retrying is the one that would blow through it. `test_the_cap_survives_a_restart` is the load-bearing case — a second `BatchLedger` on the same directory reads the first one's entries and refuses.

## Decisions worth reviewing

- **`DailyCapReached` is an exception, not a `False`.** "The cap held" is not a failure of the *item*, and a caller that treats it as one retries forever.
- **The check and the append are one section.** Two threads reading `cap - 1` and both writing is the failure a log-derived cap exists to make impossible — eight concurrent callers, one slot, one winner.
- **UTC days.** A batch resumed in another timezone, or across a DST boundary, must not get a second day's budget for the same afternoon.
- **`remaining_today` floors at zero.** A cap lowered below what a previous run already did is a ceiling on *new* work; work already recorded cannot be un-done by changing the number.
- **`O_APPEND` + `fsync` before returning.** The caller is about to treat the item as done, and a record still in the page cache when the box dies would have it processed twice.
- **Only the FINAL line may be torn.** A process killed mid-append leaves a partial record, and refusing to load the ledger over its last byte would turn a crash into a full reprocess. A break anywhere else is corruption and is reported.
- **`compact` re-derives the chain** over the survivors instead of carrying the old hashes, because a chain with a hole verifies as *tampered* — the correct reading of a file somebody edited, and the wrong one for a retention policy the operator asked for. It writes through a scratch sibling so a death mid-sweep cannot lose every resume point at once.

## Tests — `tests/unit/test_batch_ledger.py` (21)

Resume (absent ledger, skip, order preservation, a second process, last-success wins); the cap (**survives a restart**, yesterday does not count, the UTC boundary, a lowered cap, zero means no cap, eight-thread contention); the chain (verifies, links, an edited entry fails, a reordered ledger fails, a torn final line is dropped, a mid-file break is reported); retention (drops and re-derives, a no-op leaves the bytes identical, no scratch left behind, negative window rejected); and the path-containment barrier.

```
uv run pytest tests/unit/test_batch_ledger.py -q                              # 21 passed
uv run pytest tests/unit/test_work_ledger.py \
              tests/unit/test_compliance_module_reachability.py \
              tests/unit/test_test_impact_core.py -q                          # all passed
uv run ruff check / ruff format --check                                        # clean
```

## Slice 3 is not here

The non-interactive approval gate needs a batch *loop* to sit in, and there is no caller for this ledger yet — wiring `ApprovalMode` and `record_refusal` into a loop that does not exist would be guessing at its shape. This is the substrate that slice 3 reads, which is why the issue says slice 1 is worth taking alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)