### PR TITLE
fix(cli): drop duplicate bernstein run registration (#5101)

### DIFF
--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -1116,7 +1116,6 @@ cli.add_command(trackers_group, "trackers")
 cli.add_command(run, "run")  # visible: `bernstein run [plan.yaml]`
 cli.add_command(cook, "cook")
 cli.add_command(init)
-cli.add_command(run, "run")
 cli.add_command(start)
 cli.add_command(serve)  # foreground task server for containers / central node (#2803)
 cli.add_command(demo)

--- a/tests/unit/test_cli_command_registration.py
+++ b/tests/unit/test_cli_command_registration.py
@@ -23,6 +23,29 @@ from click.testing import CliRunner
 
 from bernstein.cli.main import cli
 
+_MAIN_PY = Path(__file__).resolve().parents[2] / "src" / "bernstein" / "cli" / "main.py"
+# Explicit name form only: ``receiver.add_command(obj, "name")``. Derived-name
+# calls like ``cli.add_command(cancel)`` are out of scope (#5101).
+_EXPLICIT_ADD_COMMAND = re.compile(
+    r"""(?P<receiver>\w+)\.add_command\(\s*[^,\n]+,\s*['"](?P<name>[^'"]+)['"]"""
+)
+
+
+def _explicit_add_command_pairs() -> list[tuple[str, str]]:
+    """``(receiver, name)`` for every explicitly-named ``add_command`` in main.py."""
+    return [(m.group("receiver"), m.group("name")) for m in _EXPLICIT_ADD_COMMAND.finditer(_MAIN_PY.read_text(encoding="utf-8"))]
+
+
+def test_no_command_registered_twice_on_the_same_group() -> None:
+    """No explicit name may be registered twice on the same Click group.
+
+    Parses ``main.py`` source rather than the live ``cli`` object: Click keeps
+    only the last registration, so a live-dict check is blind to overwrites.
+    """
+    pairs = _explicit_add_command_pairs()
+    duplicates = sorted({pair for pair in pairs if pairs.count(pair) > 1})
+    assert duplicates == [], f"add_command registered the same (receiver, name) more than once: {duplicates}"
+
 
 def _command_names() -> list[str]:
     return sorted(cli.commands)

--- a/tests/unit/test_cli_command_registration.py
+++ b/tests/unit/test_cli_command_registration.py
@@ -27,13 +27,15 @@ _MAIN_PY = Path(__file__).resolve().parents[2] / "src" / "bernstein" / "cli" / "
 # Explicit name form only: ``receiver.add_command(obj, "name")``. Derived-name
 # calls like ``cli.add_command(cancel)`` are out of scope (#5101).
 _EXPLICIT_ADD_COMMAND = re.compile(
-    r"""(?P<receiver>\w+)\.add_command\(\s*[^,\n]+,\s*['"](?P<name>[^'"]+)['"]"""
+    r"""^\s*(?P<receiver>\w+)\.add_command\(\s*[^,\n]+,\s*['"](?P<name>[^'"]+)['"]""",
+    re.MULTILINE,
 )
 
 
 def _explicit_add_command_pairs() -> list[tuple[str, str]]:
     """``(receiver, name)`` for every explicitly-named ``add_command`` in main.py."""
-    return [(m.group("receiver"), m.group("name")) for m in _EXPLICIT_ADD_COMMAND.finditer(_MAIN_PY.read_text(encoding="utf-8"))]
+    source = _MAIN_PY.read_text(encoding="utf-8")
+    return [(m.group("receiver"), m.group("name")) for m in _EXPLICIT_ADD_COMMAND.finditer(source)]
 
 
 def test_no_command_registered_twice_on_the_same_group() -> None:
@@ -42,8 +44,10 @@ def test_no_command_registered_twice_on_the_same_group() -> None:
     Parses ``main.py`` source rather than the live ``cli`` object: Click keeps
     only the last registration, so a live-dict check is blind to overwrites.
     """
-    pairs = _explicit_add_command_pairs()
-    duplicates = sorted({pair for pair in pairs if pairs.count(pair) > 1})
+    counts: dict[tuple[str, str], int] = {}
+    for pair in _explicit_add_command_pairs():
+        counts[pair] = counts.get(pair, 0) + 1
+    duplicates = sorted(pair for pair, n in counts.items() if n > 1)
     assert duplicates == [], f"add_command registered the same (receiver, name) more than once: {duplicates}"
 
 


### PR DESCRIPTION
## Summary
- Delete the second `cli.add_command(run, "run")` in `cli/main.py` (was silently overwriting the first).
- Add `test_no_command_registered_twice_on_the_same_group`: parses `main.py` for explicitly-named `receiver.add_command(..., "name")` pairs and fails on duplicates.

## Design choice
**Static source parse of explicitly-named registrations only** (all receivers, not just `cli`). Click keeps only the last registration, so a live `cli.commands` check cannot see overwrites. Derived-name calls like `cli.add_command(cancel)` are out of scope — covering them would reintroduce live-object resolution. Confirmed red on main (`("cli", "run")`), then green after the one-line deletion.

## Test plan
- [x] `test_no_command_registered_twice_on_the_same_group` failed on main with `("cli", "run")`
- [x] Same test passes after deleting the duplicate
- [ ] `uv run pytest tests/unit/test_cli_command_registration.py -x -q`

Closes #5101