### PR TITLE
fix(adapters): resolve adapter contract by registry id during admission preflight (#5348)

### DIFF
--- a/docs/release-notes/fragments/5348-admission-contract-registry-id.md
+++ b/docs/release-notes/fragments/5348-admission-contract-registry-id.md
@@ -1,0 +1,6 @@
+## Admission preflight resolves adapter contract by registry ID
+
+When spawning with a model whose provider prefix is not in the adapter registry (such as a
+custom gateway proxy), admission preflight and contract verification now resolve against the
+canonical adapter registry ID rather than the human display name, preventing erroneous
+`no_contract` refusal receipts (#5348).

--- a/src/bernstein/adapters/_contract.py
+++ b/src/bernstein/adapters/_contract.py
@@ -115,10 +115,16 @@ class ContractSpec:
     @classmethod
     def load(cls, name: str, contracts_dir: Path | None = None) -> ContractSpec:
         """Load a contract by adapter name."""
+        from bernstein.adapters.registry import canonical_adapter_name
+
         base = contracts_dir if contracts_dir is not None else CONTRACTS_DIR
-        path = base / f"{name}.yaml"
+        canonical = canonical_adapter_name(name) or name
+        path = base / f"{canonical}.yaml"
+        if not path.exists() and (base / f"{name}.yaml").exists():
+            path = base / f"{name}.yaml"
+            canonical = name
         if not path.exists():
-            raise FileNotFoundError(f"No contract found for adapter {name!r} at {path}")
+            raise FileNotFoundError(f"No contract found for adapter {canonical!r} at {path}")
         with path.open("r", encoding="utf-8") as fh:
             data: dict[str, Any] = yaml.safe_load(fh) or {}
 

--- a/src/bernstein/adapters/admission.py
+++ b/src/bernstein/adapters/admission.py
@@ -1305,7 +1305,12 @@ def preflight_admission(
         AdapterAdmissionRefusal: Under :data:`POLICY_ENFORCE`, when admission
             cannot be proved.
     """
-    if policy == POLICY_OFF or adapter in ADMISSION_EXEMPT:
+    from bernstein.adapters.registry import canonical_adapter_name
+
+    canonical_adapter = canonical_adapter_name(adapter) if isinstance(adapter, str) else None
+    effective_adapter = canonical_adapter or adapter
+
+    if policy == POLICY_OFF or adapter in ADMISSION_EXEMPT or effective_adapter in ADMISSION_EXEMPT:
         return None
 
     # Every field of the receipt is serialised into the audit chain, so a
@@ -1322,7 +1327,7 @@ def preflight_admission(
     stamp = generated_at if generated_at is not None else clock.isoformat()
 
     evidence = gather_admission_evidence(
-        adapter,
+        effective_adapter,
         contracts_dir=contracts_dir,
         golden_dir=golden_dir,
         last_green_path=last_green_path,
@@ -1330,7 +1335,7 @@ def preflight_admission(
         version_probe=version_probe,
         canary_verdict=canary_verdict,
     )
-    stored, problem = load_admission_receipt(receipts_dir, adapter)
+    stored, problem = load_admission_receipt(receipts_dir, effective_adapter)
     decision = gate_decision(
         evidence,
         stored,

--- a/src/bernstein/adapters/registry.py
+++ b/src/bernstein/adapters/registry.py
@@ -342,6 +342,76 @@ def registry_name_for(adapter: CLIAdapter) -> str | None:
     return None
 
 
+_DISPLAY_NAME_TO_REGISTRY: dict[str, str] = {}
+
+
+def canonical_adapter_name(name: str) -> str | None:
+    """Resolve an adapter registry name or display name to its canonical registry id.
+
+    Examples:
+        >>> canonical_adapter_name("qwen")
+        'qwen'
+        >>> canonical_adapter_name("Qwen CLI")
+        'qwen'
+        >>> canonical_adapter_name("OpenCode")
+        'opencode'
+        >>> canonical_adapter_name("Claude Code")
+        'claude'
+
+    Args:
+        name: Registry name or display name.
+
+    Returns:
+        The canonical registry key, or None if not recognized.
+    """
+    if not isinstance(name, str) or not name:
+        return None
+    clean = name.strip()
+    if not clean:
+        return None
+    lower = clean.lower()
+
+    _load_entrypoint_adapters()
+    if lower in _ADAPTERS:
+        return lower
+
+    if not _DISPLAY_NAME_TO_REGISTRY:
+        for reg_id, entry in _ADAPTERS.items():
+            _DISPLAY_NAME_TO_REGISTRY[reg_id.lower()] = reg_id
+            disp = None
+            if isinstance(entry, CLIAdapter):
+                disp = entry.name()
+            elif inspect.isclass(entry) and issubclass(entry, CLIAdapter):
+                disp = getattr(entry, "display_name", None)
+                if not disp:
+                    try:
+                        disp = entry().name()
+                    except Exception:
+                        disp = None
+            if disp:
+                _DISPLAY_NAME_TO_REGISTRY[disp.strip().lower()] = reg_id
+
+    resolved = _DISPLAY_NAME_TO_REGISTRY.get(lower)
+    if resolved is not None:
+        return resolved
+
+    # Handle common suffixes / formatting
+    no_cli = lower.removesuffix(" cli").strip()
+    if no_cli in _ADAPTERS:
+        return no_cli
+    no_code = lower.removesuffix(" code").strip()
+    if no_code in _ADAPTERS:
+        return no_code
+    underscored = lower.replace(" ", "_").replace("-", "_")
+    if underscored in _ADAPTERS:
+        return underscored
+    hyphenated = lower.replace(" ", "-").replace("_", "-")
+    if hyphenated in _ADAPTERS:
+        return hyphenated
+
+    return None
+
+
 def register_adapter(name: str, adapter: type[CLIAdapter] | CLIAdapter) -> None:
     """Register a custom adapter by name.
 

--- a/src/bernstein/adapters/report.py
+++ b/src/bernstein/adapters/report.py
@@ -178,12 +178,15 @@ def _binary_for_adapter(name: str) -> str:
     hand-maintained override table, where a second copy of the same fact
     could drift from the adapter it describes.
     """
-    override = _BINARY_OVERRIDES.get(name)
+    from bernstein.adapters.registry import canonical_adapter_name
+
+    canonical = canonical_adapter_name(name) or name
+    override = _BINARY_OVERRIDES.get(canonical) or _BINARY_OVERRIDES.get(name)
     if override is not None:
         return override
     from bernstein.adapters.capability_profile import profile_binary_for
 
-    return profile_binary_for(name) or name
+    return profile_binary_for(canonical) or profile_binary_for(name) or canonical
 
 
 def _resolve_module_path(adapter: type[CLIAdapter] | CLIAdapter) -> str:
@@ -220,8 +223,13 @@ def _module_mtime_utc(adapter: type[CLIAdapter] | CLIAdapter) -> str:
 
 def _contract_hash(name: str, contracts_dir: Path | None = None) -> str:
     """Return ``sha256`` of the contract YAML, or ``""`` when absent."""
+    from bernstein.adapters.registry import canonical_adapter_name
+
     base = contracts_dir if contracts_dir is not None else CONTRACTS_DIR
-    path = base / f"{name}.yaml"
+    canonical = canonical_adapter_name(name) or name
+    path = base / f"{canonical}.yaml"
+    if not path.exists() and (base / f"{name}.yaml").exists():
+        path = base / f"{name}.yaml"
     try:
         data = path.read_bytes()
     except OSError:
@@ -313,8 +321,14 @@ def check_adapter_in_process(
     Returns:
         A populated :class:`ConformanceVerdictPayload`.
     """
+    from bernstein.adapters.registry import canonical_adapter_name
+
     base = contracts_dir if contracts_dir is not None else CONTRACTS_DIR
-    contract_path = base / f"{name}.yaml"
+    canonical = canonical_adapter_name(name) or name
+    contract_path = base / f"{canonical}.yaml"
+    if not contract_path.exists() and (base / f"{name}.yaml").exists():
+        contract_path = base / f"{name}.yaml"
+        canonical = name
     if not contract_path.exists():
         return ConformanceVerdictPayload(
             verdict=CONFORMANCE_SKIP,
@@ -323,7 +337,7 @@ def check_adapter_in_process(
         )
 
     try:
-        spec = ContractSpec.load(name, contracts_dir=base)
+        spec = ContractSpec.load(canonical, contracts_dir=base)
     except (FileNotFoundError, OSError, ValueError) as exc:
         return ConformanceVerdictPayload(
             verdict=CONFORMANCE_SKIP,

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -1671,6 +1671,11 @@ class AgentSpawner:
 
             adapter = CachingAdapter(adapter, workdir)
         self._adapter = adapter
+        from bernstein.adapters.registry import registry_name_for
+
+        reg_name = registry_name_for(self._adapter)
+        if reg_name:
+            self._adapter_cache[reg_name] = self._adapter
         self._adapter_cache[self._adapter.name()] = self._adapter
         self._registry = agent_registry or get_registry(
             definitions_dir=workdir / ".sdd" / "agents" / "definitions",
@@ -2814,11 +2819,14 @@ class AgentSpawner:
         is used. Model-name inference applies only when nothing is pinned
         anywhere.
         """
+        from bernstein.adapters.registry import registry_name_for
+
+        active_id = registry_name_for(self._adapter) or self._adapter.name()
         logger.debug(
             "_infer_adapter_name_for_provider: provider_name=%r model=%r current_adapter=%r adapter_pinned=%r",
             provider_name,
             model,
-            self._adapter.name(),
+            active_id,
             self._adapter_pinned,
         )
         if self._adapter_pinned:
@@ -2829,18 +2837,17 @@ class AgentSpawner:
                     "(overrides run-level pin %r)",
                     provider_name,
                     resolved,
-                    self._adapter.name(),
+                    active_id,
                 )
                 return resolved
-            pinned = self._adapter.name()
             logger.info(
                 "_infer_adapter_name_for_provider: run-level adapter pin %r wins; "
                 "model-name inference skipped for provider_name=%r model=%r",
-                pinned,
+                active_id,
                 provider_name,
                 model,
             )
-            return pinned
+            return active_id
         resolved = adapter_name_for_provider(provider_name, model)
         if resolved is not None:
             logger.info(
@@ -2850,15 +2857,14 @@ class AgentSpawner:
                 resolved,
             )
             return resolved
-        fallback = self._adapter.name()
         logger.info(
             "_infer_adapter_name_for_provider: no registry match for provider_name=%r model=%r; "
             "falling back to current adapter %r",
             provider_name,
             model,
-            fallback,
+            active_id,
         )
-        return fallback
+        return active_id
 
     def _get_adapter_by_name(self, adapter_name: str, *, role: str | None = None) -> CLIAdapter:
         """Return cached adapter instance, creating one when needed.
@@ -2877,6 +2883,9 @@ class AgentSpawner:
                 primary task's ``role`` field). Optional so legacy
                 call sites that have no role still work.
         """
+        from bernstein.adapters.registry import canonical_adapter_name
+
+        canonical = canonical_adapter_name(adapter_name) or adapter_name
         if role is not None:
             from bernstein.core.security.audit import AuditLog as _AuditLog
             from bernstein.core.security.role_adapter_policy import enforce as _enforce_role_adapter
@@ -2886,19 +2895,20 @@ class AgentSpawner:
                 audit_log = _AuditLog(audit_dir=self._workdir / ".sdd" / "audit")
             except Exception as exc:
                 logger.debug("role_adapter_policy: audit ctor failed (%s); deny will not be logged", exc)
-            _enforce_role_adapter(role, adapter_name, audit_log=audit_log)
+            _enforce_role_adapter(role, canonical, audit_log=audit_log)
 
-        cached = self._adapter_cache.get(adapter_name)
+        cached = self._adapter_cache.get(canonical) or self._adapter_cache.get(adapter_name)
         if cached is not None:
             return cached
 
-        adapter = get_adapter(adapter_name)
+        adapter = get_adapter(canonical)
         if getattr(adapter, "consumes_host_isolation", False):
-            self._apply_host_isolation(adapter_name, adapter)
+            self._apply_host_isolation(canonical, adapter)
         if self._enable_caching:
             from bernstein.adapters.caching_adapter import CachingAdapter
 
             adapter = CachingAdapter(adapter, self._workdir)
+        self._adapter_cache[canonical] = adapter
         self._adapter_cache[adapter_name] = adapter
         return adapter
 

--- a/tests/unit/test_adapter_admission_registry_id.py
+++ b/tests/unit/test_adapter_admission_registry_id.py
@@ -1,0 +1,150 @@
+"""Unit tests verifying adapter admission uses registry IDs for contract lookup (#5348).
+
+When a model's provider prefix is not a registered adapter (e.g. `--model myproxy/coder`
+with `--cli qwen`), the spawner's preflight must use the registry ID (`qwen`) rather
+than the display name (`Qwen CLI`) so contract lookup (`qwen.yaml`) succeeds and does
+not issue a `no_contract` refusal.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from bernstein.adapters._contract import ContractSpec
+from bernstein.adapters.admission import (
+    AdmissionGate,
+    preflight_admission,
+)
+from bernstein.adapters.opencode import OpenCodeAdapter
+from bernstein.adapters.qwen import QwenAdapter
+from bernstein.adapters.registry import (
+    canonical_adapter_name,
+)
+from bernstein.adapters.report import _contract_hash, check_adapter_in_process
+from bernstein.core.agents.spawner_core import AgentSpawner
+
+
+def _spawner(tmp_path: Path, adapter: MagicMock | None = None) -> AgentSpawner:
+    templates_dir = tmp_path / "templates" / "roles"
+    templates_dir.mkdir(parents=True, exist_ok=True)
+    active_adapter = adapter or QwenAdapter()
+    return AgentSpawner(
+        active_adapter,
+        templates_dir,
+        tmp_path,
+        use_worktrees=False,
+        default_model="mock-model",
+    )
+
+
+def test_canonical_adapter_name_resolutions() -> None:
+    """Canonical adapter name resolves display names, aliases, and registry keys."""
+    assert canonical_adapter_name("qwen") == "qwen"
+    assert canonical_adapter_name("Qwen CLI") == "qwen"
+    assert canonical_adapter_name("qwen cli") == "qwen"
+    assert canonical_adapter_name("opencode") == "opencode"
+    assert canonical_adapter_name("OpenCode") == "opencode"
+    assert canonical_adapter_name("claude") == "claude"
+    assert canonical_adapter_name("Claude Code") == "claude"
+    assert canonical_adapter_name("codex") == "codex"
+    assert canonical_adapter_name("Codex CLI") == "codex"
+    assert canonical_adapter_name("gemini") == "gemini"
+    assert canonical_adapter_name("Gemini CLI") == "gemini"
+    assert canonical_adapter_name("") is None
+    assert canonical_adapter_name("unknown-adapter-xyz") is None
+
+
+def test_infer_adapter_name_for_provider_uses_registry_id_for_unmatched_provider(tmp_path: Path) -> None:
+    """Spawner fallback with an unmatched provider prefix returns registry ID, not display name."""
+    spawner_qwen = _spawner(tmp_path, QwenAdapter())
+    inferred = spawner_qwen._infer_adapter_name_for_provider("myproxy", "myproxy/coder")
+    assert inferred == "qwen"
+    assert inferred != "Qwen CLI"
+
+    spawner_opencode = _spawner(tmp_path, OpenCodeAdapter())
+    inferred_oc = spawner_opencode._infer_adapter_name_for_provider("customgateway", "customgateway/deepseek")
+    assert inferred_oc == "opencode"
+
+
+def test_contract_lookup_finds_qwen_for_display_name() -> None:
+    """_contract_hash and ContractSpec.load find qwen.yaml for both display name and registry ID."""
+    hash_reg = _contract_hash("qwen")
+    hash_disp = _contract_hash("Qwen CLI")
+    assert hash_reg
+    assert hash_reg == hash_disp
+
+    spec_reg = ContractSpec.load("qwen")
+    spec_disp = ContractSpec.load("Qwen CLI")
+    assert spec_reg.adapter == "qwen"
+    assert spec_disp.adapter == "qwen"
+
+    # Also test check_adapter_in_process with display name
+    payload_reg = check_adapter_in_process("qwen", binary_resolved=None)
+    payload_disp = check_adapter_in_process("Qwen CLI", binary_resolved=None)
+    assert payload_disp.detail != "no contract"
+    assert payload_disp.capabilities == payload_reg.capabilities
+
+
+def test_contract_lookup_finds_opencode_for_display_name() -> None:
+    """_contract_hash and ContractSpec.load find opencode.yaml for OpenCode."""
+    hash_reg = _contract_hash("opencode")
+    hash_disp = _contract_hash("OpenCode")
+    assert hash_reg
+    assert hash_reg == hash_disp
+
+    spec_reg = ContractSpec.load("opencode")
+    spec_disp = ContractSpec.load("OpenCode")
+    assert spec_reg.adapter == "opencode"
+    assert spec_disp.adapter == "opencode"
+
+
+def test_admission_gate_admit_display_name_resolves_to_contract_and_receipt_stem(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AdmissionGate.admit('Qwen CLI') evaluates against qwen contract and writes qwen receipts."""
+    monkeypatch.setenv("BERNSTEIN_ADAPTER_ADMISSION_POLICY", "warn")
+    receipts_dir = tmp_path / "receipts"
+    decisions_dir = tmp_path / "decisions"
+    receipts_dir.mkdir(parents=True, exist_ok=True)
+    decisions_dir.mkdir(parents=True, exist_ok=True)
+
+    gate = AdmissionGate(
+        receipts_dir=receipts_dir,
+        decisions_dir=decisions_dir,
+        policy="warn",
+    )
+    decision = gate.admit("Qwen CLI")
+    assert decision is not None
+    assert decision.evidence.adapter == "qwen"
+    # Verify contract was found (reason is not NO_CONTRACT)
+    assert decision.reason != "no_contract"
+
+    # Decisions file is written with qwen stem
+    written = list(decisions_dir.glob("qwen-*.json"))
+    assert len(written) == 1
+    assert not list(decisions_dir.glob("Qwen CLI-*.json"))
+
+
+def test_refusal_message_names_registry_id_contract_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When a genuinely missing contract is refused, remediation path uses registry ID without space."""
+    decision = preflight_admission(
+        adapter="Qwen CLI",
+        receipts_dir=tmp_path / "receipts",
+        policy="warn",
+        contracts_dir=tmp_path / "empty_contracts",
+    )
+    assert decision is not None
+    assert decision.evidence.adapter == "qwen"
+    assert decision.reason == "no_contract"
+    from bernstein.adapters.admission import REMEDIATION
+
+    remediation = REMEDIATION["no_contract"].format(adapter=decision.evidence.adapter)
+    assert "tests/contract/contracts/qwen.yaml" in remediation
+    assert "Qwen CLI" not in remediation


### PR DESCRIPTION
Fixes #5348

### Summary
When spawning an adapter with a custom gateway proxy model (e.g. `--cli qwen --model myproxy/coder`), `_infer_adapter_name_for_provider` in `spawner_core.py` previously fell back to `self._adapter.name()` (the human display name, e.g. `Qwen CLI` or `OpenCode`). The admission preflight checks contract by file stem (`ContractSpec.load("Qwen CLI")`), which failed with a `no_contract` refusal because contracts are named by registry ID (`qwen.yaml`, `opencode.yaml`).

### Key Changes
1. **Spawner Core**:
   - In `_infer_adapter_name_for_provider`, return `registry_name_for(self._adapter) or self._adapter.name()` on fallback / run-level pin paths.
   - Seed both canonical registry name and display name in `self._adapter_cache` during `AgentSpawner.__init__`.
   - In `_get_adapter_by_name`, normalize adapter name via `canonical_adapter_name`.
2. **Adapter Registry & Contract**:
   - Introduced `canonical_adapter_name(name: str) -> str | None` in `src/bernstein/adapters/registry.py` resolving display names, common suffixes, and aliases to registry IDs.
   - Updated `ContractSpec.load`, `_contract_hash`, `_binary_for_adapter`, and `check_adapter_in_process` to use `canonical_adapter_name`.
3. **Admission Gate**:
   - Updated `preflight_admission` to normalize candidate adapter names, ensuring receipt stems and evidence derivations match registry IDs.
4. **Testing & Release Notes**:
   - Added unit tests in `tests/unit/test_adapter_admission_registry_id.py` verifying all acceptance criteria.
   - Added BOM-free release notes fragment in `docs/release-notes/fragments/5348-admission-contract-registry-id.md`.
