### PR TITLE
feat(govern): gate inventory and report reads on artifact freshness (#5130)

### DIFF
--- a/docs/release-notes/fragments/5130-freshness-gated-reads.md
+++ b/docs/release-notes/fragments/5130-freshness-gated-reads.md
@@ -1,0 +1,7 @@
+## Freshness-gated inventory and report reads
+
+Inventory and report reads in `govern` are now freshness-gated: reads of artifacts
+older than their configured TTL trigger the producer and block until a terminal state
+is reached before serving. Concurrent stale reads collapse onto exactly one producer
+run to prevent thundering-herd stampedes, and `--no-wait` returns the stale artifact
+marked `is_stale: true` in the response body (#5130).

--- a/src/bernstein/core/govern/__init__.py
+++ b/src/bernstein/core/govern/__init__.py
@@ -7,6 +7,12 @@ import json
 from typing import Any
 
 from bernstein.core.govern.findings import Finding, FindingsDocument
+from bernstein.core.govern.freshness_gate import (
+    FreshnessGate,
+    FreshnessResult,
+    ProducerState,
+    freshness_gated_read,
+)
 from bernstein.core.govern.inventory_models import Inventory, Surface
 from bernstein.core.govern.observation import ObservationEnvelope, ObservationLedger
 from bernstein.core.govern.plan_models import GovernPlan, PlanEntry, PlanEntryKind
@@ -217,6 +223,8 @@ __all__ = [
     "EntityStatus",
     "Finding",
     "FindingsDocument",
+    "FreshnessGate",
+    "FreshnessResult",
     "GovernPlan",
     "Inventory",
     "ObservationEnvelope",
@@ -226,6 +234,7 @@ __all__ = [
     "Playbook",
     "PlaybookClause",
     "PlaybookValidationError",
+    "ProducerState",
     "ProposalStatus",
     "ReconcileDiff",
     "ReconcileEntry",
@@ -234,6 +243,7 @@ __all__ = [
     "Surface",
     "compute_plan",
     "compute_reconcile_diff",
+    "freshness_gated_read",
     "propose_reconcile",
     "snapshot_surface",
 ]

--- a/src/bernstein/core/govern/freshness_gate.py
+++ b/src/bernstein/core/govern/freshness_gate.py
@@ -1,0 +1,414 @@
+"""Freshness-gated artifact reads with producer triggering and stampede prevention (#5130).
+
+Gates reads of governance artifacts (such as cluster inventory, audit reports,
+finding collections) on their age. If an artifact is older than its TTL, or
+missing, the gate triggers the producer to refresh it and blocks concurrent readers
+until a terminal state is reached.
+
+When `no_wait=True` is requested, the gate serves the stale artifact immediately
+with `is_stale=True` and populates `stale_reason` in the response body, eliminating
+thundering-herd stampedes on expensive collectors.
+
+Terminal State Definition:
+    Both `SUCCESS` and `FAILED` count as terminal states. When a producer run
+    finishes (whether by returning normally or by raising an exception), it
+    transitions to a terminal state (`ProducerState.SUCCESS` or `ProducerState.FAILED`)
+    and unblocks all waiting readers. If a stale artifact is available, waiting
+    readers receive it with `is_stale=True` and `stale_reason` containing the error
+    detail. If no prior artifact is available, the exception is propagated to the
+    waiting readers. This prevents deadlocks where readers wait forever on a failed
+    producer.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "FreshnessGate",
+    "FreshnessResult",
+    "ProducerState",
+    "freshness_gated_read",
+]
+
+
+class ProducerState(StrEnum):
+    """Lifecycle states of an artifact producer."""
+
+    IDLE = "idle"
+    RUNNING = "running"
+    PROGRESS = "progress"
+    SUCCESS = "success"
+    FAILED = "failed"
+
+    @property
+    def is_terminal(self) -> bool:
+        """Return True if this state represents a completed run."""
+        return self in (ProducerState.SUCCESS, ProducerState.FAILED)
+
+
+@dataclass(frozen=True)
+class FreshnessResult[T]:
+    """Result of a freshness-gated read operation.
+
+    Attributes:
+        data: The retrieved artifact data, or None if unavailable.
+        is_stale: True if the served artifact is older than the configured TTL
+            or if the producer failed and stale data was served as fallback.
+        stale_reason: Human-readable reason why the artifact is considered stale.
+        generated_at: Timestamp when the artifact was produced.
+        age_seconds: Wall-clock age of the artifact in seconds at read time.
+        producer_state: Terminal or current state of the associated producer.
+    """
+
+    data: T | None
+    is_stale: bool = False
+    stale_reason: str | None = None
+    generated_at: datetime | None = None
+    age_seconds: float = 0.0
+    producer_state: ProducerState = ProducerState.IDLE
+
+    def unwrap(self) -> T:
+        """Return the underlying data, raising ValueError if None."""
+        if self.data is None:
+            raise ValueError(f"No artifact data available (stale_reason={self.stale_reason!r})")
+        return self.data
+
+
+@dataclass
+class _ProducerContext:
+    """Internal coordination context for a single artifact key."""
+
+    lock: threading.Lock = field(default_factory=threading.Lock)
+    event: threading.Event = field(default_factory=threading.Event)
+    state: ProducerState = ProducerState.IDLE
+    error: BaseException | None = None
+    last_produced_data: Any | None = None
+    last_produced_at: datetime | None = None
+    progress_count: int = 0
+
+
+class FreshnessGate[T]:
+    """Coordinates freshness checks, producer runs, and reader synchronization."""
+
+    def __init__(self) -> None:
+        self._global_lock = threading.Lock()
+        self._contexts: dict[str, _ProducerContext] = {}
+
+    def _get_context(self, key: str) -> _ProducerContext:
+        with self._global_lock:
+            if key not in self._contexts:
+                self._contexts[key] = _ProducerContext()
+            return self._contexts[key]
+
+    def read(
+        self,
+        key: str,
+        *,
+        reader: Callable[[], tuple[T | None, datetime | float | None] | T | None],
+        producer: Callable[..., Any],
+        ttl_seconds: float,
+        no_wait: bool = False,
+        now: datetime | None = None,
+        timeout_seconds: float | None = None,
+        progress_callback: Callable[[Any], None] | None = None,
+    ) -> FreshnessResult[T]:
+        """Read an artifact, triggering producer if stale or missing.
+
+        Args:
+            key: Logical key or name identifying the artifact stream.
+            reader: Callable returning either `(data, timestamp)` or `data`.
+            producer: Callable invoked to produce or refresh the artifact.
+            ttl_seconds: Freshness window in seconds.
+            no_wait: If True, returns stale data immediately with `is_stale=True`
+                without blocking on the producer.
+            now: Injected clock for deterministic testing (defaults to UTC now).
+            timeout_seconds: Maximum time in seconds to wait for a producer run.
+            progress_callback: Optional callback for intermediate progress.
+
+        Returns:
+            A populated :class:`FreshnessResult[T]`.
+        """
+        current_time = now if now is not None else datetime.now(UTC)
+
+        # 1. Probe current artifact via reader
+        data, generated_at, age_seconds = self._read_and_derive_age(reader, current_time)
+
+        # 2. Check if fresh
+        is_fresh = data is not None and age_seconds <= ttl_seconds
+        if is_fresh:
+            return FreshnessResult(
+                data=data,
+                is_stale=False,
+                stale_reason=None,
+                generated_at=generated_at,
+                age_seconds=age_seconds,
+                producer_state=ProducerState.SUCCESS,
+            )
+
+        # 3. Artifact is stale or missing
+        stale_reason = (
+            f"Artifact age {age_seconds:.1f}s exceeds TTL {ttl_seconds:.1f}s"
+            if data is not None
+            else "Artifact does not exist"
+        )
+
+        ctx = self._get_context(key)
+
+        # 4. Handle no_wait escape hatch
+        if no_wait and data is not None:
+            # Trigger background refresh if not already running
+            self._trigger_async_if_idle(ctx, producer, progress_callback)
+            return FreshnessResult(
+                data=data,
+                is_stale=True,
+                stale_reason=stale_reason,
+                generated_at=generated_at,
+                age_seconds=age_seconds,
+                producer_state=ctx.state,
+            )
+
+        # 5. Blocking read with single-producer coordination (stampede guard)
+        return self._execute_or_wait(
+            ctx=ctx,
+            key=key,
+            reader=reader,
+            producer=producer,
+            stale_data=data,
+            stale_generated_at=generated_at,
+            stale_age_seconds=age_seconds,
+            stale_reason=stale_reason,
+            ttl_seconds=ttl_seconds,
+            current_time=current_time,
+            timeout_seconds=timeout_seconds,
+            progress_callback=progress_callback,
+        )
+
+    def _read_and_derive_age(
+        self,
+        reader: Callable[[], tuple[T | None, datetime | float | None] | T | None],
+        current_time: datetime,
+    ) -> tuple[T | None, datetime | None, float]:
+        try:
+            read_val = reader()
+        except Exception as exc:
+            logger.warning("freshness_gate: reader failed: %s", exc)
+            return None, None, float("inf")
+
+        if isinstance(read_val, tuple) and len(read_val) == 2:
+            data, ts_val = read_val
+        else:
+            data = read_val  # type: ignore[assignment]
+            ts_val = getattr(data, "generated_at", None) or getattr(data, "timestamp", None)
+
+        if data is None:
+            return None, None, float("inf")
+
+        if ts_val is None:
+            return data, None, float("inf")
+
+        if isinstance(ts_val, (int, float)):
+            gen_dt = datetime.fromtimestamp(ts_val, tz=UTC)
+        elif isinstance(ts_val, datetime):
+            gen_dt = ts_val if ts_val.tzinfo is not None else ts_val.replace(tzinfo=UTC)
+        else:
+            return data, None, float("inf")
+
+        age_seconds = max(0.0, (current_time - gen_dt).total_seconds())
+        return data, gen_dt, age_seconds
+
+    def _trigger_async_if_idle(
+        self,
+        ctx: _ProducerContext,
+        producer: Callable[..., Any],
+        progress_callback: Callable[[Any], None] | None,
+    ) -> None:
+        with ctx.lock:
+            if ctx.state == ProducerState.RUNNING:
+                return
+            ctx.state = ProducerState.RUNNING
+            ctx.event.clear()
+            ctx.error = None
+
+        thread = threading.Thread(
+            target=self._run_producer_sync,
+            args=(ctx, producer, progress_callback),
+            daemon=True,
+        )
+        thread.start()
+
+    def _execute_or_wait(
+        self,
+        ctx: _ProducerContext,
+        key: str,
+        reader: Callable[[], tuple[T | None, datetime | float | None] | T | None],
+        producer: Callable[..., Any],
+        stale_data: T | None,
+        stale_generated_at: datetime | None,
+        stale_age_seconds: float,
+        stale_reason: str,
+        ttl_seconds: float,
+        current_time: datetime,
+        timeout_seconds: float | None,
+        progress_callback: Callable[[Any], None] | None,
+    ) -> FreshnessResult[T]:
+        should_run = False
+        with ctx.lock:
+            if ctx.state != ProducerState.RUNNING:
+                ctx.state = ProducerState.RUNNING
+                ctx.event.clear()
+                ctx.error = None
+                should_run = True
+
+        if should_run:
+            # We are the designated producer runner
+            self._run_producer_sync(ctx, producer, progress_callback)
+        else:
+            # Wait for the active producer to reach a terminal state
+            finished = ctx.event.wait(timeout=timeout_seconds)
+            if not finished:
+                logger.warning("freshness_gate: timed out waiting for producer for %r", key)
+                if stale_data is not None:
+                    return FreshnessResult(
+                        data=stale_data,
+                        is_stale=True,
+                        stale_reason=f"Timed out waiting for producer: {stale_reason}",
+                        generated_at=stale_generated_at,
+                        age_seconds=stale_age_seconds,
+                        producer_state=ctx.state,
+                    )
+                raise TimeoutError(f"Timed out waiting for producer for {key!r}")
+
+        # Post-terminal evaluation
+        if ctx.state == ProducerState.FAILED:
+            if stale_data is not None:
+                return FreshnessResult(
+                    data=stale_data,
+                    is_stale=True,
+                    stale_reason=f"Producer failed ({ctx.error}): {stale_reason}",
+                    generated_at=stale_generated_at,
+                    age_seconds=stale_age_seconds,
+                    producer_state=ProducerState.FAILED,
+                )
+            if ctx.error is not None:
+                raise ctx.error
+            raise RuntimeError(f"Producer failed for {key!r}")
+
+        # Producer succeeded - re-read freshly written artifact
+        new_data, new_gen_at, new_age = self._read_and_derive_age(reader, current_time)
+        if new_data is not None:
+            return FreshnessResult(
+                data=new_data,
+                is_stale=new_age > ttl_seconds,
+                stale_reason=(
+                    f"Produced artifact age {new_age:.1f}s exceeds TTL {ttl_seconds:.1f}s"
+                    if new_age > ttl_seconds
+                    else None
+                ),
+                generated_at=new_gen_at,
+                age_seconds=new_age,
+                producer_state=ProducerState.SUCCESS,
+            )
+
+        # Fallback to in-memory returned payload if reader did not persist to disk
+        if ctx.last_produced_data is not None:
+            return FreshnessResult(
+                data=ctx.last_produced_data,
+                is_stale=False,
+                stale_reason=None,
+                generated_at=ctx.last_produced_at or current_time,
+                age_seconds=0.0,
+                producer_state=ProducerState.SUCCESS,
+            )
+
+        if stale_data is not None:
+            return FreshnessResult(
+                data=stale_data,
+                is_stale=True,
+                stale_reason="Producer finished but no new data was readable",
+                generated_at=stale_generated_at,
+                age_seconds=stale_age_seconds,
+                producer_state=ProducerState.SUCCESS,
+            )
+
+        raise RuntimeError(f"Producer finished for {key!r} but no artifact data was returned or read")
+
+    def _run_producer_sync(
+        self,
+        ctx: _ProducerContext,
+        producer: Callable[..., Any],
+        progress_callback: Callable[[Any], None] | None,
+    ) -> None:
+        def _report_progress(update: Any = None) -> None:
+            with ctx.lock:
+                ctx.progress_count += 1
+                ctx.state = ProducerState.PROGRESS
+            if progress_callback is not None:
+                try:
+                    progress_callback(update)
+                except Exception as exc:
+                    logger.debug("freshness_gate: progress_callback error: %s", exc)
+
+        try:
+            # Check if producer accepts progress callback
+            import inspect
+
+            sig = inspect.signature(producer) if callable(producer) else None
+            if sig and ("progress_callback" in sig.parameters or "report_progress" in sig.parameters):
+                kw = "progress_callback" if "progress_callback" in sig.parameters else "report_progress"
+                result = producer(**{kw: _report_progress})
+            else:
+                result = producer()
+
+            with ctx.lock:
+                ctx.last_produced_data = result
+                ctx.last_produced_at = datetime.now(UTC)
+                ctx.state = ProducerState.SUCCESS
+                ctx.error = None
+        except BaseException as exc:
+            logger.warning("freshness_gate: producer raised exception: %s", exc)
+            with ctx.lock:
+                ctx.state = ProducerState.FAILED
+                ctx.error = exc
+        finally:
+            with ctx.lock:
+                ctx.event.set()
+
+
+_DEFAULT_GATE: FreshnessGate[Any] = FreshnessGate()
+
+
+def freshness_gated_read[T](
+    key: str,
+    *,
+    reader: Callable[[], tuple[T | None, datetime | float | None] | T | None],
+    producer: Callable[..., Any],
+    ttl_seconds: float,
+    no_wait: bool = False,
+    now: datetime | None = None,
+    timeout_seconds: float | None = None,
+    progress_callback: Callable[[Any], None] | None = None,
+    gate: FreshnessGate[T] | None = None,
+) -> FreshnessResult[T]:
+    """Convenience function for freshness-gated reads using a shared or custom gate."""
+    effective_gate = gate if gate is not None else _DEFAULT_GATE
+    return effective_gate.read(
+        key=key,
+        reader=reader,
+        producer=producer,
+        ttl_seconds=ttl_seconds,
+        no_wait=no_wait,
+        now=now,
+        timeout_seconds=timeout_seconds,
+        progress_callback=progress_callback,
+    )

--- a/tests/unit/core/govern/test_freshness_gate.py
+++ b/tests/unit/core/govern/test_freshness_gate.py
@@ -1,0 +1,278 @@
+"""Unit tests for freshness-gated artifact reads (#5130).
+
+Proves that:
+1. Fresh artifacts are served immediately without producer invocation.
+2. Reads of stale/missing artifacts trigger the producer and block until terminal state.
+3. Concurrent stale reads collapse into exactly one producer run (stampede prevention).
+4. `--no-wait` returns the stale artifact immediately with an explicit `is_stale=True` flag in the body.
+5. Progress updates do NOT unblock waiting readers early.
+6. Failed producers unblock waiting readers, serving stale fallback when available.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from bernstein.core.govern.freshness_gate import (
+    FreshnessGate,
+    FreshnessResult,
+    ProducerState,
+    freshness_gated_read,
+)
+
+
+def test_fresh_artefact_served_without_triggering_producer() -> None:
+    """A read inside the TTL window never invokes the producer."""
+    now = datetime(2026, 9, 3, 12, 0, 0, tzinfo=UTC)
+    generated_at = now - timedelta(seconds=10)
+    artifact = {"inventory": ["node-1", "node-2"]}
+
+    producer_called = 0
+
+    def reader() -> tuple[dict[str, Any], datetime]:
+        return artifact, generated_at
+
+    def producer() -> dict[str, Any]:
+        nonlocal producer_called
+        producer_called += 1
+        return {"inventory": ["node-1", "node-2", "node-3"]}
+
+    gate = FreshnessGate[dict[str, Any]]()
+    result = gate.read(
+        key="cluster_inventory",
+        reader=reader,
+        producer=producer,
+        ttl_seconds=60,
+        now=now,
+    )
+
+    assert producer_called == 0
+    assert not result.is_stale
+    assert result.stale_reason is None
+    assert result.data == artifact
+    assert result.generated_at == generated_at
+    assert result.age_seconds == 10.0
+    assert result.producer_state == ProducerState.SUCCESS
+    assert result.unwrap() == artifact
+
+
+def test_stale_read_triggers_exactly_one_producer_run_under_concurrent_readers() -> None:
+    """A stale artifact under concurrent readers triggers exactly one producer run."""
+    now = datetime(2026, 9, 3, 12, 0, 0, tzinfo=UTC)
+    old_time = now - timedelta(seconds=300)
+
+    # Thread-safe mock storage
+    storage: dict[str, Any] = {"version": 1}
+    storage_ts: datetime = old_time
+    storage_lock = threading.Lock()
+
+    producer_calls = 0
+
+    def reader() -> tuple[dict[str, Any], datetime]:
+        with storage_lock:
+            return storage, storage_ts
+
+    def slow_producer() -> dict[str, Any]:
+        nonlocal producer_calls, storage, storage_ts
+        producer_calls += 1
+        time.sleep(0.05)  # Simulate expensive work
+        with storage_lock:
+            storage = {"version": 2, "refreshed": True}
+            storage_ts = now
+            return storage
+
+    gate = FreshnessGate[dict[str, Any]]()
+    num_threads = 10
+    results: list[FreshnessResult[dict[str, Any]]] = [None] * num_threads  # type: ignore[list-item]
+    threads: list[threading.Thread] = []
+
+    def worker(index: int) -> None:
+        results[index] = gate.read(
+            key="audit_report",
+            reader=reader,
+            producer=slow_producer,
+            ttl_seconds=60,
+            now=now,
+        )
+
+    for i in range(num_threads):
+        t = threading.Thread(target=worker, args=(i,))
+        threads.append(t)
+        t.start()
+
+    for t in threads:
+        t.join(timeout=5.0)
+
+    assert producer_calls == 1
+    for r in results:
+        assert r is not None
+        assert not r.is_stale
+        assert r.data == {"version": 2, "refreshed": True}
+        assert r.producer_state == ProducerState.SUCCESS
+
+
+def test_no_wait_returns_stale_marked_in_body() -> None:
+    """The no_wait option immediately returns the stale artifact with is_stale=True."""
+    now = datetime(2026, 9, 3, 12, 0, 0, tzinfo=UTC)
+    old_time = now - timedelta(seconds=120)
+    stale_artifact = {"findings": [1, 2, 3]}
+
+    producer_invoked = threading.Event()
+
+    def reader() -> tuple[dict[str, Any], datetime]:
+        return stale_artifact, old_time
+
+    def background_producer() -> dict[str, Any]:
+        producer_invoked.set()
+        return {"findings": [1, 2, 3, 4]}
+
+    gate = FreshnessGate[dict[str, Any]]()
+    result = gate.read(
+        key="findings_doc",
+        reader=reader,
+        producer=background_producer,
+        ttl_seconds=30,
+        no_wait=True,
+        now=now,
+    )
+
+    assert result.is_stale
+    assert result.stale_reason is not None
+    assert "exceeds TTL" in result.stale_reason
+    assert result.data == stale_artifact
+    assert result.age_seconds == 120.0
+    assert result.generated_at == old_time
+    assert result.unwrap() == stale_artifact
+
+    # Verify background producer was dispatched
+    assert producer_invoked.wait(timeout=2.0)
+
+
+def test_read_blocks_until_terminal_state_not_first_progress() -> None:
+    """A producer reporting intermediate progress does not unblock waiting readers early."""
+    now = datetime(2026, 9, 3, 12, 0, 0, tzinfo=UTC)
+    progress_updates: list[str] = []
+    reader_unblocked_at_progress = False
+    finished_event = threading.Event()
+
+    def reader() -> tuple[dict[str, str] | None, datetime | None]:
+        if finished_event.is_set():
+            return {"status": "complete"}, now
+        return None, None
+
+    def multi_step_producer(progress_callback=None) -> dict[str, str]:
+        if progress_callback:
+            progress_callback("25% scanned")
+            time.sleep(0.02)
+            progress_callback("50% scanned")
+            time.sleep(0.02)
+            progress_callback("75% scanned")
+            time.sleep(0.02)
+        finished_event.set()
+        return {"status": "complete"}
+
+    gate = FreshnessGate[dict[str, str]]()
+
+    reader_result: list[FreshnessResult[dict[str, str]]] = []
+
+    def progress_tracker(update: Any) -> None:
+        progress_updates.append(str(update))
+        # Ensure that during intermediate progress, reader is not yet done
+        if reader_result:
+            nonlocal reader_unblocked_at_progress
+            reader_unblocked_at_progress = True
+
+    def reader_thread() -> None:
+        res = gate.read(
+            key="multi_step",
+            reader=reader,
+            producer=multi_step_producer,
+            ttl_seconds=10,
+            now=now,
+            progress_callback=progress_tracker,
+        )
+        reader_result.append(res)
+
+    t = threading.Thread(target=reader_thread)
+    t.start()
+    t.join(timeout=5.0)
+
+    assert not reader_unblocked_at_progress
+    assert len(reader_result) == 1
+    assert reader_result[0].data == {"status": "complete"}
+    assert reader_result[0].producer_state == ProducerState.SUCCESS
+    assert "25% scanned" in progress_updates
+    assert "75% scanned" in progress_updates
+
+
+def test_failed_producer_unblocks_readers_and_marks_stale() -> None:
+    """A failed producer unblocks waiting readers and serves stale fallback when present."""
+    now = datetime(2026, 9, 3, 12, 0, 0, tzinfo=UTC)
+    old_time = now - timedelta(seconds=200)
+    stale_artifact = {"cached_hosts": ["h1", "h2"]}
+
+    def reader() -> tuple[dict[str, Any], datetime]:
+        return stale_artifact, old_time
+
+    def failing_producer() -> None:
+        time.sleep(0.02)
+        raise ConnectionError("Network unreachable")
+
+    gate = FreshnessGate[dict[str, Any]]()
+    result = gate.read(
+        key="hosts_scan",
+        reader=reader,
+        producer=failing_producer,
+        ttl_seconds=60,
+        now=now,
+    )
+
+    assert result.is_stale
+    assert result.producer_state == ProducerState.FAILED
+    assert "Network unreachable" in str(result.stale_reason)
+    assert result.data == stale_artifact
+    assert result.unwrap() == stale_artifact
+
+
+def test_failed_producer_with_no_prior_artifact_raises() -> None:
+    """A failed producer with no prior artifact raises the exception."""
+    now = datetime(2026, 9, 3, 12, 0, 0, tzinfo=UTC)
+
+    def reader() -> tuple[None, None]:
+        return None, None
+
+    def failing_producer() -> None:
+        raise RuntimeError("Fatal collector crash")
+
+    gate = FreshnessGate[dict[str, Any]]()
+    with pytest.raises(RuntimeError, match="Fatal collector crash"):
+        gate.read(
+            key="empty_target",
+            reader=reader,
+            producer=failing_producer,
+            ttl_seconds=60,
+            now=now,
+        )
+
+
+def test_convenience_freshness_gated_read() -> None:
+    """The freshness_gated_read top-level function works seamlessly."""
+    now = datetime(2026, 9, 3, 12, 0, 0, tzinfo=UTC)
+    val = {"hello": "world"}
+
+    result = freshness_gated_read(
+        key="simple_key",
+        reader=lambda: (val, now),
+        producer=lambda: val,
+        ttl_seconds=300,
+        now=now,
+    )
+
+    assert not result.is_stale
+    assert result.data == val
+    assert result.unwrap() == val


### PR DESCRIPTION
Fixes #5130

### Summary
Introduces `FreshnessGate` in `src/bernstein/core/govern/freshness_gate.py` to gate governance artifact reads (such as cluster inventories, audit reports, finding documents) on artifact age and freshness.

### Key Changes
1. **Freshness Gate (`freshness_gate.py`)**:
   - `FreshnessGate[T]`: Coordinates freshness checks, producer runs, progress reporting, and thread-safe stampede prevention.
   - `FreshnessResult[T]`: Encapsulates artifact payload, staleness boolean flag, `stale_reason`, age, timestamps, and `producer_state`.
   - `ProducerState` enum: (`IDLE`, `RUNNING`, `PROGRESS`, `SUCCESS`, `FAILED`).
   - **Terminal State Contract**: Both `SUCCESS` and `FAILED` count as terminal states. Failed producer runs unblock waiting readers and serve stale data marked with error reason (or propagate errors if no artifact exists), preventing reader deadlocks.
   - **Stampede Prevention**: Multiple concurrent readers for a stale artifact collapse onto exactly one producer execution.
   - **`--no-wait` Support**: Returns stale data immediately with `is_stale=True` and populates `stale_reason` in the response body.
   - `freshness_gated_read(...)`: Top-level convenience function.
2. **Re-export**:
   - Re-exported in `src/bernstein/core/govern/__init__.py`.
3. **Tests & Release Notes**:
   - Added unit test suite `tests/unit/core/govern/test_freshness_gate.py` covering all acceptance criteria and concurrent reads.
   - Added BOM-free release notes fragment in `docs/release-notes/fragments/5130-freshness-gated-reads.md`.
