### PR TITLE
fix(orchestrator): honor max_agent_runtime_s floor

### DIFF
--- a/docs/operations/CONFIG.md
+++ b/docs/operations/CONFIG.md
@@ -272,7 +272,7 @@ tuning:
     drain_timeout_s: 120.0
     stale_claim_timeout_s: 1800.0
     stalled_manager_threshold_s: 300.0
-    max_agent_runtime_s: 3600.0
+    max_agent_runtime_s: 5400.0
   spawn:
     spawn_backoff_base_s: 60.0
   agent:
@@ -317,12 +317,15 @@ now tunable, with defaults unchanged so nothing breaks for existing users:
   `IncidentManager`'s auto-pause. A negative override is clamped to `0`
   rather than being allowed to suppress the SLO-target-derived budget.
 - **`max_agent_runtime_s`** (`OrchestratorDefaults.max_agent_runtime_s`,
-  default `1800`) - the starting wall-clock kill deadline for a spawned
-  agent, now sourced through `OrchestratorConfig` via the same
-  `tuning.orchestrator.*` mechanism as `stale_claim_timeout_s`. This is
-  only the *starting* value - the agent lifecycle reaper already
-  self-extends it by 600s per cycle up to a 5400s hard cap while the agent
-  keeps heartbeating.
+  default `1800`) - an upward-only floor for the scope-based starting
+  wall-clock deadline. At the default (or any lower value), the existing
+  buckets remain small=`900`, medium=`1800`, large=`3600`, XL=`7200` seconds.
+  Raising the value above `1800` lifts only shorter buckets: for example,
+  `max_agent_runtime_s: 5400` makes small/medium/large start at `5400` while
+  XL remains `7200`. Lower values do **not** provide an early-kill override.
+  The lifecycle reaper can still self-extend a heartbeating agent by 600s per
+  cycle up to its 5400s extension ceiling; that ceiling does not shorten an
+  already-longer initial scope/XL deadline or configured floor.
 
 See `defaults.py` for the full list of parameters and their default values.
 

--- a/docs/release-notes/fragments/5379-max-agent-runtime-floor.md
+++ b/docs/release-notes/fragments/5379-max-agent-runtime-floor.md
@@ -1,0 +1,3 @@
+## Honour raised max_agent_runtime_s as an agent deadline floor
+
+`tuning.orchestrator.max_agent_runtime_s` once again reaches the spawned-agent watchdog when raised above its shipped 1800-second default. Raised values act as a floor under the existing scope/XL deadline buckets, while default or lower values leave the current 900/1800/3600/7200-second buckets unchanged and never shorten a longer bucket (#5379).

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -28,6 +28,7 @@ from bernstein.adapters.registry import adapter_name_for_provider, get_adapter
 from bernstein.adapters.skills_injector import inject_skills
 from bernstein.agents.registry import AgentRegistry, get_registry
 from bernstein.bridges.base import AgentState, AgentStatus, BridgeError, RuntimeBridge, SpawnRequest
+from bernstein.core import defaults as _defaults
 from bernstein.core.agents import project_context as _project_context
 from bernstein.core.agents.adapter_health import AdapterHealthMonitor
 from bernstein.core.agents.attachment_dispatch import (
@@ -1653,6 +1654,10 @@ class AgentSpawner:
         # understands - see ``_coerce_model_for_non_claude_adapter``.
         self._default_model = default_model
         self._resource_limits = resource_limits
+        # Bare spawners (for example worker-only entry points) start from the
+        # current tuning-backed orchestrator value. Orchestrator owners wire
+        # their concrete config after construction via set_max_agent_runtime_s.
+        self._max_agent_runtime_s = int(_defaults.ORCHESTRATOR.max_agent_runtime_s)
         self._adapter_cache: dict[str, CLIAdapter] = {}
         self._templates_dir = templates_dir
         self._workdir = workdir
@@ -2095,6 +2100,10 @@ class AgentSpawner:
     def set_quality_gate_config(self, config: Any) -> None:
         """Wire in the orchestrator's :class:`QualityGatesConfig` (#4393)."""
         self._quality_gate_config = config
+
+    def set_max_agent_runtime_s(self, max_agent_runtime_s: int) -> None:
+        """Wire in the orchestrator's upward-only runtime floor."""
+        self._max_agent_runtime_s = int(max_agent_runtime_s)
 
     def set_run_id(self, run_id: str) -> None:
         """Wire in the orchestrator's run id.
@@ -3348,7 +3357,7 @@ class AgentSpawner:
                     command=[],
                     prompt=prompt,
                     workdir=str(spawn_cwd),
-                    timeout_seconds=session.timeout_s or 1800,
+                    timeout_seconds=session.timeout_s or DEFAULT_TIMEOUT_SECONDS,
                     log_path=str(preferred_log_path),
                     role=session.role,
                     model=model_config.model,
@@ -3424,8 +3433,7 @@ class AgentSpawner:
                 else:
                     os.environ[_k] = _prev
 
-    @staticmethod
-    def _resolve_spawn_timeout(tasks: list[Task]) -> int:
+    def _resolve_spawn_timeout(self, tasks: list[Task]) -> int:
         """Resolve the wall-clock timeout bucket for a task batch (#4571).
 
         Delegates to ``_batch_timeout_seconds`` so the value armed on the
@@ -3434,7 +3442,7 @@ class AgentSpawner:
         """
         from bernstein.core.tasks.task_lifecycle import _batch_timeout_seconds
 
-        return _batch_timeout_seconds(tasks)
+        return _batch_timeout_seconds(tasks, self._max_agent_runtime_s)
 
     def _apply_provider_availability(
         self,
@@ -5101,6 +5109,7 @@ class AgentSpawner:
                                 model_config=model_config,
                                 session_id=session_id,
                                 mcp_config=attempt_mcp,
+                                timeout_seconds=session.timeout_s or DEFAULT_TIMEOUT_SECONDS,
                             )
                             result = SpawnResult(pid=fake_pid, log_path=actual_log_path)
                         elif self._sandbox_session_routing_active():
@@ -5706,6 +5715,7 @@ class AgentSpawner:
             task_ids=[t.id for t in tasks],
             model_config=model_config,
             status="starting",
+            timeout_s=self._resolve_spawn_timeout(tasks),
             context_receipt=receipt.to_dict()["entries"],
             # Endpoint identity fields (issue #4908) - resume resolves the
             # same way the primary spawn path does: role policy overrides
@@ -5946,6 +5956,7 @@ class AgentSpawner:
                 model_config=model_config,
                 session_id=session_id,
                 mcp_config=mcp_config,
+                timeout_seconds=session.timeout_s or DEFAULT_TIMEOUT_SECONDS,
                 task_scope=task_scope,
                 system_addendum=system_addendum,
             )
@@ -6066,6 +6077,7 @@ class AgentSpawner:
                 model_config=model_config,
                 session_id=session_id,
                 mcp_config=mcp_config,
+                timeout_seconds=session.timeout_s or DEFAULT_TIMEOUT_SECONDS,
                 task_scope=task_scope,
                 system_addendum=system_addendum,
             )
@@ -6190,6 +6202,7 @@ class AgentSpawner:
                     model_config=model_config,
                     session_id=session_id,
                     mcp_config=mcp_config,
+                    timeout_seconds=session.timeout_s or DEFAULT_TIMEOUT_SECONDS,
                     system_addendum=system_addendum,
                 )
             owned = True

--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -160,10 +160,12 @@ class OrchestratorDefaults:
     # logic and its relationship to ``AGENT.idle_log_age_threshold_s``.
     stalled_manager_threshold_s: float = 170.0
 
-    # Starting wall-clock kill deadline for a spawned agent (OrchestratorConfig.
-    # max_agent_runtime_s). Self-extends +600s/tick up to a 5400s hard cap while
-    # the agent is heartbeating (see core/agents/agent_lifecycle.py); this is
-    # only the initial value before any extension. Tunable via
+    # Upward-only floor for spawned-agent scope/XL wall-clock buckets. Values
+    # above the shipped 1800s default raise shorter starting deadlines; values
+    # at or below the default never shorten the 900/1800/3600/7200s buckets.
+    # Heartbeat self-extension remains +600s/tick up to its 5400s ceiling (see
+    # core/agents/agent_lifecycle.py); that extension ceiling does not clamp a
+    # longer initial scope/XL deadline. Tunable via
     # ``tuning.orchestrator.max_agent_runtime_s``.
     max_agent_runtime_s: int = 1800  # 30 min
 

--- a/src/bernstein/core/orchestration/multi_cell.py
+++ b/src/bernstein/core/orchestration/multi_cell.py
@@ -180,6 +180,8 @@ class MultiCellOrchestrator:
     ) -> None:
         self._config = config
         self._spawner = spawner
+        if hasattr(self._spawner, "set_max_agent_runtime_s"):
+            self._spawner.set_max_agent_runtime_s(config.max_agent_runtime_s)
         self._workdir = workdir
         self._bulletin = bulletin or BulletinBoard()
         self._client = client or httpx.Client(timeout=10.0)

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -882,6 +882,8 @@ class Orchestrator:
             self._spawner.set_quality_gate_config(self._quality_gate_config)
         if hasattr(self._spawner, "set_run_id"):
             self._spawner.set_run_id(self._run_id)
+        if hasattr(self._spawner, "set_max_agent_runtime_s"):
+            self._spawner.set_max_agent_runtime_s(config.max_agent_runtime_s)
 
         # Convergence guard: blocks spawn waves when merge queue, active
         # agent count, error rate, or spawn rate exceed safe thresholds.

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -54,7 +54,7 @@ def _default_planning_window_s() -> float:
 
 
 def _default_max_agent_runtime_s() -> int:
-    """Return the current canonical agent wall-clock kill starting value.
+    """Return the current canonical agent runtime floor value.
 
     Reads from :mod:`bernstein.core.defaults` each call (same pattern as
     :func:`_default_poll_interval_s`) so that ``tuning.orchestrator.
@@ -1631,11 +1631,11 @@ class OrchestratorConfig:
     # #3012). Overridable via ``tuning.agent.heartbeat_starting_timeout_s``.
     heartbeat_starting_timeout_s: int = field(default_factory=lambda: int(AGENT.heartbeat_starting_timeout_s))
     heartbeat_enabled: bool = True
-    # Derived from ORCHESTRATOR.max_agent_runtime_s (canonical) so
-    # ``tuning.orchestrator.max_agent_runtime_s`` overrides the starting
-    # wall-clock kill deadline (agents need time for complex tasks; this
-    # self-extends up to a 5400s hard cap while heartbeating, see
-    # core/agents/agent_lifecycle.py - this is only the starting value).
+    # Derived from ORCHESTRATOR.max_agent_runtime_s (canonical). Values above
+    # the shipped 1800s default raise shorter scope/XL starting deadlines;
+    # values at or below the default never shorten those buckets. Heartbeat
+    # self-extension still tops out at 5400s, but does not clamp a longer
+    # initial deadline (see core/agents/agent_lifecycle.py).
     max_agent_runtime_s: int = field(default_factory=_default_max_agent_runtime_s)
     # Derived from ORCHESTRATOR.stalled_manager_threshold_s (canonical) so
     # ``tuning.orchestrator.stalled_manager_threshold_s`` overrides actually

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -29,7 +29,7 @@ from bernstein.core.cross_model_verifier import (
     CrossModelVerifierConfig,
     run_cross_model_verification_sync,
 )
-from bernstein.core.defaults import TASK
+from bernstein.core.defaults import TASK, OrchestratorDefaults
 from bernstein.core.effectiveness import EffectivenessScorer
 from bernstein.core.evidence.completion_gate import seal_evidence_on_completion
 from bernstein.core.fast_path import (
@@ -84,6 +84,7 @@ else:
 logger = logging.getLogger(__name__)
 
 _XL_ROLES = frozenset({"architect", "security", "manager"})
+_SHIPPED_MAX_AGENT_RUNTIME_S = OrchestratorDefaults().max_agent_runtime_s
 
 # Bug 1 (2026-07-02, fix/claim-conflict-churn): bounds for the claim-conflict
 # recovery loop in ``_claim_task_with_conflict_retry`` / ``claim_and_spawn_batches``.
@@ -338,12 +339,14 @@ def _speculative_warm_pool_candidates(orch: Any, task_graph: Any, tasks: list[Ta
     return candidates
 
 
-def _batch_timeout_seconds(batch: list[Task]) -> int:
+def _batch_timeout_seconds(batch: list[Task], configured_max_agent_runtime_s: int | None = None) -> int:
     """Return the spawn timeout bucket for a task batch.
 
     The timeout contract is intentionally coarse-grained so operators can reason
-    about behavior without reconstructing adaptive multipliers:
-    small=15m, medium=30m, large=60m, xl=120m.
+    about behavior without reconstructing adaptive multipliers: small=15m,
+    medium=30m, large=60m, xl=120m. ``max_agent_runtime_s`` is an upward-only
+    floor when configured above its shipped default; lower values never shorten
+    a scope or XL bucket.
     """
     bucket_seconds = max(TASK.scope_timeout_s.get(task.scope.value, 30 * 60) for task in batch)
     xl_batch = any(task.role in _XL_ROLES for task in batch) or any(
@@ -353,7 +356,10 @@ def _batch_timeout_seconds(batch: list[Task]) -> int:
     # every configured bucket is a whole second count and every downstream
     # consumer (AgentSession.timeout_s) is int - convert explicitly rather than
     # widen the return type and push the float onward.
-    return int(TASK.xl_timeout_s) if xl_batch else int(bucket_seconds)
+    resolved = int(TASK.xl_timeout_s) if xl_batch else int(bucket_seconds)
+    if configured_max_agent_runtime_s is not None and configured_max_agent_runtime_s > _SHIPPED_MAX_AGENT_RUNTIME_S:
+        return max(resolved, int(configured_max_agent_runtime_s))
+    return resolved
 
 
 # ---------------------------------------------------------------------------
@@ -2786,7 +2792,7 @@ def claim_and_spawn_batches(
                         _route.refused_reason,
                     )
 
-        batch_timeout_s = _batch_timeout_seconds(batch)
+        batch_timeout_s = _batch_timeout_seconds(batch, orch._config.max_agent_runtime_s)
         _shadow_bandit_decision: Any | None = None
         _routing_bandit: Any = getattr(orch, "_bandit_router", None)
         _bandit_mode = str(getattr(orch, "_bandit_routing_mode", "static"))

--- a/tests/unit/adapters/test_issue_4571_timeout_extension.py
+++ b/tests/unit/adapters/test_issue_4571_timeout_extension.py
@@ -19,12 +19,16 @@ not a mocked clock: the bug lives in the arming / re-arming.
 from __future__ import annotations
 
 import time
+from pathlib import Path
+from threading import Event
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
-from bernstein.core.models import AgentSession, Complexity, Scope, Task
+from bernstein.core.models import AgentBackend, AgentSession, Complexity, ModelConfig, Scope, Task
 
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult
 from bernstein.core.agents.spawner_core import AgentSpawner
 from bernstein.core.defaults import TASK
 
@@ -33,6 +37,39 @@ def _make_popen_mock(pid: int) -> MagicMock:
     m = MagicMock()
     m.pid = pid
     return m
+
+
+class _WatchdogAdapter(CLIAdapter):
+    """Minimal adapter that arms the real base-class timeout watchdog."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.received_timeout: int | None = None
+        self.timer = None
+        self.spawned = Event()
+
+    def name(self) -> str:
+        return "watchdog-test"
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+        multimodal_context: Any | None = None,
+    ) -> SpawnResult:
+        del prompt, model_config, mcp_config, task_scope, budget_multiplier, system_addendum, multimodal_context
+        self.received_timeout = timeout_seconds
+        self.timer = self._start_timeout_watchdog(pid=9004, timeout_seconds=timeout_seconds, session_id=session_id)
+        self.spawned.set()
+        return SpawnResult(pid=9004, log_path=workdir / "watchdog.log", timeout_timer=self.timer)
 
 
 def test_extending_a_session_moves_the_process_deadline() -> None:
@@ -94,7 +131,7 @@ def test_non_extended_agent_still_killed_at_deadline() -> None:
     timer.cancel()
 
 
-def test_timeout_fallback_follows_scope_bucket_not_literal_default() -> None:
+def test_timeout_fallback_follows_scope_bucket_not_literal_default(tmp_path: Path) -> None:
     """The resolved spawn timeout follows the scope/XL bucket rather than a
     hard-coded 1800s literal. A large+high task resolves to the XL bucket;
     a small task resolves to the small bucket (both distinct from 1800 to
@@ -116,12 +153,105 @@ def test_timeout_fallback_follows_scope_bucket_not_literal_default() -> None:
         complexity=Complexity.HIGH,
     )
 
-    small_timeout = AgentSpawner._resolve_spawn_timeout([small])
-    xl_timeout = AgentSpawner._resolve_spawn_timeout([xl])
+    adapter = _WatchdogAdapter()
+    templates_dir = tmp_path / "templates" / "roles"
+    templates_dir.mkdir(parents=True)
+    spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, default_model="mock-model")
+
+    small_timeout = spawner._resolve_spawn_timeout([small])
+    xl_timeout = spawner._resolve_spawn_timeout([xl])
 
     assert small_timeout == int(TASK.scope_timeout_s["small"])
     assert xl_timeout == int(TASK.xl_timeout_s)
     assert small_timeout != xl_timeout, "scope and XL buckets collapsed"
+
+
+def test_raised_runtime_floor_reaches_real_spawn_watchdog(tmp_path: Path) -> None:
+    task = Task(
+        id="T-floor",
+        title="t",
+        description="d",
+        role="backend",
+        scope=Scope.SMALL,
+    )
+    adapter = _WatchdogAdapter()
+    templates_dir = tmp_path / "templates" / "roles"
+    templates_dir.mkdir(parents=True)
+    spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, default_model="mock-model")
+    spawner.set_max_agent_runtime_s(5400)
+
+    session = spawner.spawn_for_tasks([task])
+    try:
+        assert session.timeout_s == 5400
+        assert adapter.received_timeout == 5400
+        assert session.timeout_timer is adapter.timer
+        assert session.timeout_timer is not None
+        assert session.timeout_timer.interval == 5400
+    finally:
+        if adapter.timer is not None:
+            adapter.timer.cancel()
+
+
+def test_resume_spawn_arms_same_resolved_runtime_floor(tmp_path: Path) -> None:
+    task = Task(
+        id="T-resume-floor",
+        title="t",
+        description="d",
+        role="backend",
+        scope=Scope.SMALL,
+    )
+    adapter = _WatchdogAdapter()
+    templates_dir = tmp_path / "templates" / "roles"
+    templates_dir.mkdir(parents=True)
+    spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, default_model="mock-model")
+    spawner.set_max_agent_runtime_s(5400)
+
+    session = spawner.spawn_for_resume([task], worktree_path=tmp_path, changed_files=[])
+    try:
+        assert session.timeout_s == 5400
+        assert adapter.received_timeout == 5400
+        assert session.timeout_timer is adapter.timer
+        assert session.timeout_timer is not None
+        assert session.timeout_timer.interval == 5400
+    finally:
+        if adapter.timer is not None:
+            adapter.timer.cancel()
+
+
+def test_in_process_spawn_arms_resolved_runtime_floor(tmp_path: Path) -> None:
+    task = Task(
+        id="T-in-process-floor",
+        title="t",
+        description="d",
+        role="backend",
+        scope=Scope.SMALL,
+    )
+    adapter = _WatchdogAdapter()
+    templates_dir = tmp_path / "templates" / "roles"
+    templates_dir.mkdir(parents=True)
+    spawner = AgentSpawner(
+        adapter,
+        templates_dir,
+        tmp_path,
+        use_worktrees=False,
+        default_model="mock-model",
+        backend=AgentBackend.IN_PROCESS,
+    )
+    spawner.set_max_agent_runtime_s(5400)
+
+    session = spawner.spawn_for_tasks([task])
+    try:
+        assert session.timeout_s == 5400
+        assert adapter.spawned.wait(2), "in-process adapter was not invoked"
+        assert adapter.received_timeout == 5400
+        assert adapter.timer is not None
+        assert adapter.timer.interval == 5400
+    finally:
+        if adapter.timer is not None:
+            adapter.timer.cancel()
+        if spawner._in_process is not None:  # pyright: ignore[reportPrivateUsage]
+            spawner._in_process.wait(session.id, timeout=1.0)  # pyright: ignore[reportPrivateUsage]
+            spawner._in_process.cleanup(session.id)  # pyright: ignore[reportPrivateUsage]
 
 
 def test_rearm_uses_remaining_budget_not_absolute_budget() -> None:

--- a/tests/unit/tasks/test_lifecycle_helpers.py
+++ b/tests/unit/tasks/test_lifecycle_helpers.py
@@ -275,6 +275,21 @@ def test_batch_timeout_large_low_complexity_stays_large_bucket() -> None:
     assert _batch_timeout_seconds(batch) == 3600
 
 
+def test_batch_timeout_raised_runtime_floor_lifts_only_shorter_buckets() -> None:
+    assert _batch_timeout_seconds([_task(scope=Scope.SMALL)], 5400) == 5400
+    assert _batch_timeout_seconds([_task(scope=Scope.MEDIUM)], 5400) == 5400
+    assert _batch_timeout_seconds([_task(scope=Scope.LARGE, complexity=Complexity.LOW)], 5400) == 5400
+    assert _batch_timeout_seconds([_task(scope=Scope.LARGE, complexity=Complexity.HIGH)], 5400) == 7200
+
+
+def test_batch_timeout_default_or_lower_runtime_never_shortens_buckets() -> None:
+    for configured in (1800, 600):
+        assert _batch_timeout_seconds([_task(scope=Scope.SMALL)], configured) == 900
+        assert _batch_timeout_seconds([_task(scope=Scope.MEDIUM)], configured) == 1800
+        assert _batch_timeout_seconds([_task(scope=Scope.LARGE, complexity=Complexity.LOW)], configured) == 3600
+        assert _batch_timeout_seconds([_task(scope=Scope.LARGE, complexity=Complexity.HIGH)], configured) == 7200
+
+
 # ---------------------------------------------------------------------------
 # infer_affected_paths
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_multi_cell.py
+++ b/tests/unit/test_multi_cell.py
@@ -140,6 +140,14 @@ class TestRegisterRemoveCell:
         orch.register_cell(cell)
         assert "alpha" in orch.cells
 
+    def test_runtime_floor_is_wired_to_shared_spawner(self, tmp_path: Path) -> None:
+        mock_spawner = MagicMock(spec=AgentSpawner)
+        config = OrchestratorConfig(max_agent_runtime_s=5400, server_url="http://localhost:9999")
+
+        MultiCellOrchestrator(config=config, spawner=mock_spawner, workdir=tmp_path)
+
+        mock_spawner.set_max_agent_runtime_s.assert_called_once_with(5400)
+
     def test_remove_cell(self, tmp_path: Path) -> None:
         orch = self._make_orchestrator(tmp_path)
         cell = _make_cell(id="alpha")

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -4100,6 +4100,37 @@ def test_per_task_timeout_medium_bucket(tmp_path: Path) -> None:
     assert session.timeout_s == 1800
 
 
+def test_raised_max_agent_runtime_floor_reaches_spawn_timeout(tmp_path: Path) -> None:
+    """A raised runtime floor is applied before the adapter watchdog is armed."""
+    task = _make_task(id="T-floor", scope="small", complexity="low")
+    task_dict = _task_as_dict(task)
+    transport = _mock_transport(
+        {
+            "GET /tasks?status=open": httpx.Response(200, json=[task_dict]),
+            "GET /tasks?status=done": httpx.Response(200, json=[]),
+            "GET /tasks?status=failed": httpx.Response(200, json=[]),
+            "GET /status": httpx.Response(200, json={"open": 1, "done": 0}),
+            f"POST /tasks/{task.id}/claim": httpx.Response(200, json={}),
+        }
+    )
+    cfg = OrchestratorConfig(
+        max_agents=6,
+        poll_interval_s=1,
+        max_agent_runtime_s=5400,
+        max_tasks_per_agent=1,
+        server_url="http://testserver",
+    )
+    adapter = _mock_adapter()
+    orch = _build_orchestrator(tmp_path, transport, adapter=adapter, config=cfg)
+
+    orch.tick()
+
+    sessions = list(orch._agents.values())
+    assert sessions
+    assert sessions[0].timeout_s == 5400
+    assert adapter.spawn.call_args.kwargs["timeout_seconds"] == 5400
+
+
 def test_reap_uses_per_session_timeout(tmp_path: Path) -> None:
     """_reap_dead_agents uses session.timeout_s when set, not config.max_agent_runtime_s."""
     cfg = OrchestratorConfig(

--- a/tests/unit/test_spawner_explicit_container_runtime.py
+++ b/tests/unit/test_spawner_explicit_container_runtime.py
@@ -58,6 +58,7 @@ class FakeAdapter(CLIAdapter):
         self._name = adapter_name
         self.spawn_calls: list[tuple[str, Path]] = []
         self.spawn_system_addenda: list[str] = []
+        self.spawn_timeouts: list[int] = []
 
     def name(self) -> str:
         return self._name
@@ -75,9 +76,10 @@ class FakeAdapter(CLIAdapter):
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
     ) -> SpawnResult:
-        del model_config, session_id, mcp_config, timeout_seconds, task_scope, budget_multiplier
+        del model_config, session_id, mcp_config, task_scope, budget_multiplier
         self.spawn_calls.append((prompt, workdir))
         self.spawn_system_addenda.append(system_addendum)
+        self.spawn_timeouts.append(timeout_seconds)
         return SpawnResult(pid=42, log_path=workdir / ".sdd" / "logs" / "fallback.log")
 
     def is_alive(self, pid: int) -> bool:  # pragma: no cover - not exercised
@@ -334,7 +336,7 @@ def test_legacy_container_degrade_to_none_is_surfaced_and_audited(
 
     adapter = FakeAdapter("claude")
     spawner = _spawner_with_failing_container_manager(tmp_path, adapter, error="Cannot connect to the Docker daemon.")
-    session = AgentSession(id="S-legacy", role="backend")
+    session = AgentSession(id="S-legacy", role="backend", timeout_s=5400)
 
     result = spawner._spawn_in_container(  # pyright: ignore[reportPrivateUsage]
         session_id="S-legacy",
@@ -349,6 +351,7 @@ def test_legacy_container_degrade_to_none_is_surfaced_and_audited(
     # Behaviour preserved: the run continues on the host.
     assert result.pid == 42
     assert session.isolation == IsolationMode.NONE.value
+    assert adapter.spawn_timeouts == [5400]
 
     # 1) Surfaced on the spawner so the run summary can render it.
     downgrades = spawner.isolation_downgrades

--- a/tests/unit/test_spawner_openclaw_bridge.py
+++ b/tests/unit/test_spawner_openclaw_bridge.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, cast
 from unittest.mock import MagicMock
 
 import pytest
-from bernstein.core.models import AgentSession
+from bernstein.core.models import AgentSession, Scope
 from bernstein.core.spawner import AgentSpawner
 
 from bernstein.adapters.plugin_sdk import SamplingParamsRefusal
@@ -117,6 +117,22 @@ def test_bridge_is_preferred_over_local_adapter(
     assert session.bridge_session_key == "agent:ops:bernstein-backend-1"
     adapter.spawn.assert_not_called()
     assert bridge.spawn_calls
+
+
+def test_bridge_request_uses_resolved_runtime_floor(
+    tmp_path: Path,
+    make_task: Callable[..., Task],
+    mock_adapter_factory: Callable[..., CLIAdapter],
+) -> None:
+    adapter = cast("MagicMock", mock_adapter_factory(pid=42))
+    bridge = _FakeBridge()
+    spawner = _make_spawner(tmp_path, adapter, bridge)
+    spawner.set_max_agent_runtime_s(5400)
+
+    session = spawner.spawn_for_tasks([make_task(scope=Scope.SMALL)])
+
+    assert session.timeout_s == 5400
+    assert bridge.spawn_calls[0].timeout_seconds == 5400
 
 
 def test_bridge_pre_accept_failure_falls_back_to_local(

--- a/tests/unit/test_spawner_sandbox.py
+++ b/tests/unit/test_spawner_sandbox.py
@@ -22,6 +22,7 @@ class FakeAdapter(CLIAdapter):
         self._name = adapter_name
         self.spawn_calls: list[tuple[str, Path]] = []
         self.spawn_system_addenda: list[str] = []
+        self.spawn_timeouts: list[int] = []
 
     def name(self) -> str:
         return self._name
@@ -39,9 +40,10 @@ class FakeAdapter(CLIAdapter):
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
     ) -> SpawnResult:
-        del model_config, session_id, mcp_config, timeout_seconds, task_scope, budget_multiplier
+        del model_config, session_id, mcp_config, task_scope, budget_multiplier
         self.spawn_calls.append((prompt, workdir))
         self.spawn_system_addenda.append(system_addendum)
+        self.spawn_timeouts.append(timeout_seconds)
         return SpawnResult(pid=42, log_path=workdir / ".sdd" / "logs" / "fallback.log")
 
     def is_alive(self, pid: int) -> bool:  # pragma: no cover - not used here
@@ -99,7 +101,7 @@ def test_spawn_in_sandbox_falls_back_to_adapter_on_runtime_failure(
     monkeypatch.delenv("BERNSTEIN_SANDBOX_RUNTIME", raising=False)
     adapter = FakeAdapter("codex")
     sandbox = DockerSandbox(enabled=True)
-    session = AgentSession(id="S-2", role="backend")
+    session = AgentSession(id="S-2", role="backend", timeout_s=5400)
 
     with (
         patch("bernstein.core.agents.spawner_core.get_registry", return_value=MagicMock()),
@@ -124,6 +126,7 @@ def test_spawn_in_sandbox_falls_back_to_adapter_on_runtime_failure(
 
     assert result.pid == 42
     assert adapter.spawn_calls == [("fallback", tmp_path)]
+    assert adapter.spawn_timeouts == [5400]
     assert session.container_id is None
     assert session.isolation == "worktree"
 

--- a/tests/unit/test_spawner_sandbox_session.py
+++ b/tests/unit/test_spawner_sandbox_session.py
@@ -39,6 +39,7 @@ class _FakeAdapter(CLIAdapter):
         self._name = adapter_name
         self.spawn_calls: list[tuple[str, Path]] = []
         self.spawn_system_addenda: list[str] = []
+        self.spawn_timeouts: list[int] = []
 
     def name(self) -> str:
         return self._name
@@ -56,10 +57,11 @@ class _FakeAdapter(CLIAdapter):
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
     ) -> SpawnResult:
-        del model_config, session_id, mcp_config, timeout_seconds
+        del model_config, session_id, mcp_config
         del task_scope, budget_multiplier
         self.spawn_calls.append((prompt, workdir))
         self.spawn_system_addenda.append(system_addendum)
+        self.spawn_timeouts.append(timeout_seconds)
         return SpawnResult(pid=99, log_path=workdir / ".sdd" / "logs" / "direct.log")
 
     def is_alive(self, pid: int) -> bool:  # pragma: no cover - not used
@@ -409,7 +411,7 @@ def test_provisioning_failure_falls_back_to_direct_spawn(tmp_path: Path) -> None
     backend = _BrokenBackend(tmp_path)
     spawner, adapter = _build_spawner_with_backend(tmp_path, backend=backend)
 
-    agent_session = AgentSession(id="S-25", role="backend")
+    agent_session = AgentSession(id="S-25", role="backend", timeout_s=5400)
     result = spawner._spawn_via_sandbox_session(  # pyright: ignore[reportPrivateUsage]
         session_id="S-25",
         prompt="fallback",
@@ -421,6 +423,7 @@ def test_provisioning_failure_falls_back_to_direct_spawn(tmp_path: Path) -> None
     )
     assert result.pid == 99
     assert adapter.spawn_calls == [("fallback", tmp_path)]
+    assert adapter.spawn_timeouts == [5400]
     assert "S-25" not in spawner._sandbox_owned_sessions  # pyright: ignore[reportPrivateUsage]
 
 


### PR DESCRIPTION
## What

- Treat raised `tuning.orchestrator.max_agent_runtime_s` values as an upward-only floor beneath the existing scope/XL spawn deadlines.
- Propagate the resolved deadline consistently through fresh direct, in-process, resume, runtime-bridge, container fallback, sandbox fallback, sandbox-session fallback, and multi-cell spawning.
- Preserve the existing default/lower-value buckets and document the floor semantics in CONFIG.md and the release notes.

## Why

`max_agent_runtime_s` was still loaded into `OrchestratorConfig`, but scope-based spawn resolution meant the value no longer reliably reached every process watchdog. Raising the documented setting now affects the actual starting deadline without changing default behavior or turning lower values into an early-kill control.

Fixes #5379

## How

The shared batch timeout resolver applies `max_agent_runtime_s` only when it is above the shipped 1800-second default, using `max(bucket, configured)` so longer XL deadlines are never shortened. `AgentSpawner` receives the active orchestrator value after construction, resolves the session timeout once, and forwards that same value to direct, in-process, resume, bridge, and supported isolation-fallback spawn paths; the runtime bridge also uses `DEFAULT_TIMEOUT_SECONDS` instead of a duplicated literal fallback.

Focused timeout and isolation-fallback regressions pass, including real watchdog arming for the raised in-process deadline. The previously observed repository-wide Pyright diagnostics and unrelated narrow-TTY startup-banner full-suite failure remain independent of this change.

## Checklist

- [x] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` passes
- [ ] `uv run python scripts/run_tests.py -x` passes
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [ ] User-visible README section updated (or N/A if internal-only)
- [x] `docs/operations/<area>.md` updated (or N/A)
- [x] `docs/api/` schema regenerated if a public surface changed (N/A — no public API schema changed)
- [x] `uv run bernstein agents-md sync` run so AGENTS.md, CLAUDE.md, `.goosehints`, `CONVENTIONS.md`, and `.cursor/rules/*.mdc` reflect any new module (N/A — no module was added)
- [x] Tests cover the documented behaviour