### PR TITLE
fix(quality): constrain fast_path ruff execution to workdir (#5390)

### DIFF
--- a/docs/release-notes/fragments/5390-fast-path-workdir-containment.md
+++ b/docs/release-notes/fragments/5390-fast-path-workdir-containment.md
@@ -1,0 +1,7 @@
+## Constrain fast_path ruff execution to workdir and guard against system tempdir
+
+Fast-path deterministic L0 executors (`_run_ruff_format`, `_run_ruff_fix`, `_run_sort_imports`)
+now validate that target `owned_files` are contained within the task's `workdir` and refuse
+unbounded project-wide execution (`targets=["."]`) when `workdir` is a filesystem root or
+system temporary directory (/tmp, /var/tmp, tempfile.gettempdir()). This prevents tests or
+unbounded runs from mutating external repositories (#5390).

--- a/src/bernstein/core/quality/fast_path.py
+++ b/src/bernstein/core/quality/fast_path.py
@@ -22,7 +22,8 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, cast
+from pathlib import Path
+from typing import cast
 
 import httpx
 
@@ -30,9 +31,6 @@ from bernstein.core.agents.spawn_errors import ModelNotConfiguredError
 from bernstein.core.metrics import get_collector
 from bernstein.core.models import Complexity, ModelConfig, Scope, Task
 from bernstein.core.security.path_containment import PathContainmentError, contained_subpath
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -202,10 +200,60 @@ def classify_task(task: Task) -> ClassificationResult:
 # ---------------------------------------------------------------------------
 
 
+def _is_system_or_root_directory(path: Path) -> bool:
+    """Check if a path is a filesystem root or system temporary directory."""
+    import tempfile
+
+    try:
+        resolved = path.resolve()
+    except (OSError, RuntimeError):
+        return True
+    if resolved == resolved.parent:
+        return True
+    system_temps = {
+        Path("/tmp").resolve(),
+        Path("/var/tmp").resolve(),
+        Path("/private/tmp").resolve(),
+        Path(tempfile.gettempdir()).resolve(),
+    }
+    return resolved in system_temps
+
+
+def _resolve_ruff_targets(workdir: Path, owned_files: list[str]) -> tuple[list[str] | None, str | None]:
+    """Validate targets and workdir containment for ruff commands.
+
+    Returns (targets, None) on success, or (None, error_message) on refusal.
+    """
+    if not owned_files:
+        if _is_system_or_root_directory(workdir):
+            return None, f"refusing to run ruff on root or system temp directory: {workdir}"
+        return ["."], None
+
+    safe_targets: list[str] = []
+    for rel_path in owned_files:
+        try:
+            full_path = contained_subpath(workdir, rel_path)
+            rel = full_path.relative_to(workdir.resolve())
+            safe_targets.append(str(rel))
+        except (PathContainmentError, ValueError):
+            logger.warning("fast_path: path %r outside workdir %s - skipping", rel_path, workdir)
+
+    if not safe_targets:
+        return None, f"all owned_files were outside workdir {workdir}"
+    return safe_targets, None
+
+
 def _run_ruff_format(workdir: Path, owned_files: list[str]) -> FastPathResult:
     """Run ruff format on owned files or entire project."""
     start = time.monotonic()
-    targets = owned_files or ["."]
+    targets, err = _resolve_ruff_targets(workdir, owned_files)
+    if targets is None or err is not None:
+        return FastPathResult(
+            success=False,
+            action=FastPathAction.RUFF_FORMAT,
+            duration_s=time.monotonic() - start,
+            error=err or "no valid targets within workdir",
+        )
 
     try:
         proc = subprocess.run(
@@ -247,7 +295,14 @@ def _run_ruff_format(workdir: Path, owned_files: list[str]) -> FastPathResult:
 def _run_ruff_fix(workdir: Path, owned_files: list[str]) -> FastPathResult:
     """Run ruff check --fix on owned files or entire project."""
     start = time.monotonic()
-    targets = owned_files or ["."]
+    targets, err = _resolve_ruff_targets(workdir, owned_files)
+    if targets is None or err is not None:
+        return FastPathResult(
+            success=False,
+            action=FastPathAction.RUFF_FIX,
+            duration_s=time.monotonic() - start,
+            error=err or "no valid targets within workdir",
+        )
 
     try:
         proc = subprocess.run(
@@ -282,7 +337,14 @@ def _run_ruff_fix(workdir: Path, owned_files: list[str]) -> FastPathResult:
 def _run_sort_imports(workdir: Path, owned_files: list[str]) -> FastPathResult:
     """Run ruff check --select I --fix to sort imports."""
     start = time.monotonic()
-    targets = owned_files or ["."]
+    targets, err = _resolve_ruff_targets(workdir, owned_files)
+    if targets is None or err is not None:
+        return FastPathResult(
+            success=False,
+            action=FastPathAction.SORT_IMPORTS,
+            duration_s=time.monotonic() - start,
+            error=err or "no valid targets within workdir",
+        )
 
     try:
         proc = subprocess.run(

--- a/tests/unit/test_fast_path.py
+++ b/tests/unit/test_fast_path.py
@@ -362,26 +362,26 @@ class TestExecuteFastPath:
         assert "get_cwd" in good.read_text(encoding="utf-8")
         assert outside.read_bytes() == original
 
-    def test_rename_no_task_fails(self) -> None:
+    def test_rename_no_task_fails(self, tmp_path: Path) -> None:
         result = execute_fast_path(
             FastPathAction.RENAME_SYMBOL,
-            Path("/tmp"),
+            tmp_path,
             ["some.py"],
             task=None,
         )
         assert result.success is False
 
-    def test_rename_unparseable_pattern_fails(self) -> None:
+    def test_rename_unparseable_pattern_fails(self, tmp_path: Path) -> None:
         task = _make_task(title="Do something weird", complexity=Complexity.LOW)
         result = execute_fast_path(
             FastPathAction.RENAME_SYMBOL,
-            Path("/tmp"),
+            tmp_path,
             ["some.py"],
             task=task,
         )
         assert result.success is False
 
-    def test_rename_no_owned_files_fails(self) -> None:
+    def test_rename_no_owned_files_fails(self, tmp_path: Path) -> None:
         task = _make_task(
             title="Rename foo to bar",
             complexity=Complexity.LOW,
@@ -389,13 +389,115 @@ class TestExecuteFastPath:
         )
         result = execute_fast_path(
             FastPathAction.RENAME_SYMBOL,
-            Path("/tmp"),
+            tmp_path,
             [],
             task=task,
         )
         assert result.success is False
 
-    def test_unknown_action_fails(self) -> None:
+    def test_ruff_format_refuses_system_temp_or_root_workdir(self) -> None:
+        """Running ruff format with unbounded targets on /tmp or root is refused."""
+        result = execute_fast_path(
+            FastPathAction.RUFF_FORMAT,
+            Path("/tmp"),
+            [],
+        )
+        assert result.success is False
+        assert "refusing to run ruff on root or system temp directory" in (result.error or "")
+
+    def test_ruff_fix_refuses_system_temp_or_root_workdir(self) -> None:
+        """Running ruff fix with unbounded targets on /tmp or root is refused."""
+        result = execute_fast_path(
+            FastPathAction.RUFF_FIX,
+            Path("/tmp"),
+            [],
+        )
+        assert result.success is False
+        assert "refusing to run ruff on root or system temp directory" in (result.error or "")
+
+    def test_sort_imports_refuses_system_temp_or_root_workdir(self) -> None:
+        """Running sort imports with unbounded targets on /tmp or root is refused."""
+        result = execute_fast_path(
+            FastPathAction.SORT_IMPORTS,
+            Path("/tmp"),
+            [],
+        )
+        assert result.success is False
+        assert "refusing to run ruff on root or system temp directory" in (result.error or "")
+
+    @patch("bernstein.core.quality.fast_path.subprocess.run")
+    def test_ruff_format_ignores_outside_owned_files(self, mock_run: MagicMock, tmp_path: Path) -> None:
+        """Outside files in owned_files are filtered before invoking ruff."""
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = "reformatted 1 file"
+        mock_proc.stderr = ""
+        mock_run.return_value = mock_proc
+
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        (workdir / "inside.py").write_text("x = 1\n", encoding="utf-8")
+
+        result = execute_fast_path(
+            FastPathAction.RUFF_FORMAT,
+            workdir,
+            ["../outside.py", "inside.py"],
+        )
+        assert result.success is True
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "inside.py" in cmd
+        assert "../outside.py" not in cmd
+
+    @patch("bernstein.core.quality.fast_path.subprocess.run")
+    def test_ruff_fix_ignores_outside_owned_files(self, mock_run: MagicMock, tmp_path: Path) -> None:
+        """Outside files in owned_files are filtered before invoking ruff fix."""
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = "Fixed 1 issue"
+        mock_proc.stderr = ""
+        mock_run.return_value = mock_proc
+
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        (workdir / "inside.py").write_text("x = 1\n", encoding="utf-8")
+
+        result = execute_fast_path(
+            FastPathAction.RUFF_FIX,
+            workdir,
+            ["/outside/path.py", "inside.py"],
+        )
+        assert result.success is True
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "inside.py" in cmd
+        assert "/outside/path.py" not in cmd
+
+    @patch("bernstein.core.quality.fast_path.subprocess.run")
+    def test_sort_imports_ignores_outside_owned_files(self, mock_run: MagicMock, tmp_path: Path) -> None:
+        """Outside files in owned_files are filtered before invoking sort imports."""
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = "Fixed 1 issue"
+        mock_proc.stderr = ""
+        mock_run.return_value = mock_proc
+
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        (workdir / "inside.py").write_text("x = 1\n", encoding="utf-8")
+
+        result = execute_fast_path(
+            FastPathAction.SORT_IMPORTS,
+            workdir,
+            ["/outside/path.py", "inside.py"],
+        )
+        assert result.success is True
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "inside.py" in cmd
+        assert "/outside/path.py" not in cmd
+
+    def test_unknown_action_fails(self, tmp_path: Path) -> None:
         # Reach the "no executor" branch by creating a mock action value
         # We can't easily add a new enum, so test the execute_fast_path
         # function handles missing executors gracefully by verifying
@@ -403,7 +505,7 @@ class TestExecuteFastPath:
         for action in FastPathAction:
             result = execute_fast_path(
                 action,
-                Path("/tmp"),
+                tmp_path,
                 [],
                 task=_make_task(title="Rename foo to bar", complexity=Complexity.LOW),
             )
@@ -531,7 +633,7 @@ class TestL1ModelConfig:
 class TestTryFastPathBatch:
     """Tests for the orchestrator integration function."""
 
-    def test_multi_task_batch_skipped(self) -> None:
+    def test_multi_task_batch_skipped(self, tmp_path: Path) -> None:
         """Batches with >1 task are never fast-pathed."""
         tasks = [
             _make_task(title="Format code", complexity=Complexity.LOW),
@@ -540,20 +642,20 @@ class TestTryFastPathBatch:
         stats = FastPathStats()
         result = try_fast_path_batch(
             tasks,
-            Path("/tmp"),
+            tmp_path,
             MagicMock(),
             "http://localhost:8052",
             stats,
         )
         assert result is False
 
-    def test_l2_task_skipped(self) -> None:
+    def test_l2_task_skipped(self, tmp_path: Path) -> None:
         """L2 tasks are not handled by fast-path."""
         tasks = [_make_task(title="Implement WebSocket support")]
         stats = FastPathStats()
         result = try_fast_path_batch(
             tasks,
-            Path("/tmp"),
+            tmp_path,
             MagicMock(),
             "http://localhost:8052",
             stats,
@@ -562,7 +664,7 @@ class TestTryFastPathBatch:
 
     @patch("bernstein.core.quality.fast_path.execute_fast_path")
     @patch("bernstein.core.quality.fast_path.get_collector")
-    def test_l0_task_handled(self, mock_collector: MagicMock, mock_exec: MagicMock) -> None:
+    def test_l0_task_handled(self, mock_collector: MagicMock, mock_exec: MagicMock, tmp_path: Path) -> None:
         """L0 formatting task is handled and marked complete."""
         mock_exec.return_value = FastPathResult(
             success=True,
@@ -580,7 +682,7 @@ class TestTryFastPathBatch:
         stats = FastPathStats()
         result = try_fast_path_batch(
             [task],
-            Path("/tmp"),
+            tmp_path,
             mock_client,
             "http://localhost:8052",
             stats,


### PR DESCRIPTION
Closes #5390

### Summary of Changes
- **Containment checks for ruff execution in fast-path**:
  - Refuse execution of unbounded targets (`targets=["."]`) if `workdir` is a filesystem root or system temp directory (`/tmp`, `/var/tmp`, `/private/tmp`, `tempfile.gettempdir()`).
  - Validate and filter `owned_files` using `contained_subpath(workdir, rel_path)` to drop references attempting path traversal outside `workdir`.
- **Unit test fixtures**:
  - Replaced unmocked `Path("/tmp")` invocations in `tests/unit/test_fast_path.py` with `tmp_path` fixture to prevent mutating system checkouts during test runs.
  - Added unit tests for temporary directory / root directory refusal and outside path filtering.
- **Release notes**: Added release notes fragment `docs/release-notes/fragments/5390-fast-path-workdir-containment.md`.
