### PR TITLE
feat(runs): report the runs that succeeded only after retrying (#5106)

### DIFF
--- a/docs/release-notes/fragments/5106-masked-failure-report.md
+++ b/docs/release-notes/fragments/5106-masked-failure-report.md
@@ -1,0 +1,16 @@
+## Runs that succeeded only after retrying are reported
+
+A retry that eventually succeeds is invisible in any report that reads
+only the final state: a run that failed twice and closed on the third
+attempt looked identical to one that closed on its first —
+`outcome=pr-opened`, with nothing saying it took three goes.
+`FinishedRun.attempt_count` already carried the number and nothing read
+it as a signal.
+
+`masked_failures(runs)` reports every run that reached a SUCCESSFUL
+outcome with more than one attempt, grouped by the host that ran it, with
+every finished run in the window as the denominator. A run that retried
+and still failed is not masked — it is already visible in every report,
+which is the point. `MaskedFailureReport.exceeds(threshold)` is the gate
+a CI check reads; an empty window is a zero share, so a quiet day does
+not fire it (#5106).

--- a/src/bernstein/core/persistence/runs_report.py
+++ b/src/bernstein/core/persistence/runs_report.py
@@ -66,6 +66,7 @@ from bernstein.core.persistence.work_ledger import (
 from bernstein.core.security.path_containment import PathContainmentError
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
     from bernstein.core.persistence.work_ledger import LedgerEntry
@@ -628,3 +629,175 @@ __all__ = [
     "list_finished_runs",
     "list_non_terminal_runs",
 ]
+
+
+# ---------------------------------------------------------------------------
+# Masked failures: retries that succeeded (#5106)
+# ---------------------------------------------------------------------------
+#
+# A retry that eventually succeeds is invisible in every dashboard reading only
+# the final state. `flaky_detector.py` closed exactly this blind spot for TESTS
+# by keeping per-execution history; a run that failed twice and closed on the
+# third attempt reports identically to one that closed on its first --
+# `outcome=pr-opened`, and nothing anywhere says it took three goes.
+#
+# `FinishedRun.attempt_count` already carries the number, from the run's own
+# `task.started` transitions. Nothing read it as a signal.
+
+
+#: An attempt count at or below this is a run that did not need retrying.
+#: One `task.started` is the run happening; the second is the first retry.
+FIRST_RETRY_ATTEMPT = 2
+
+#: Outcomes that mean the run got where it was going. A retry only MASKS
+#: something when the ending it reached was a success -- a run that retried and
+#: still failed is already visible in every report, which is the point.
+_SUCCESS_OUTCOMES = frozenset({RunOutcome.PR_OPENED, RunOutcome.NO_CHANGES})
+
+
+@dataclass(frozen=True)
+class MaskedFailure:
+    """A run that failed at least one attempt and then succeeded anyway.
+
+    Attributes:
+        run_id: The run.
+        branch: Branch it published, when it published one.
+        outcome: The successful outcome it reported, unchanged -- this record
+            adds to the report, it does not reclassify the run.
+        attempt_count: Total attempts, from ``FinishedRun.attempt_count``.
+        retries: ``attempt_count - 1``. The number an operator asks for.
+        owner: Attribution for grouping -- see :func:`masked_failures`.
+        started_at: Unix instant the run started, for the window it falls in.
+    """
+
+    run_id: str
+    branch: str
+    outcome: RunOutcome
+    attempt_count: int
+    retries: int
+    owner: str
+    started_at: float
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the stable JSON row shape, mirroring :meth:`FinishedRun.to_dict`."""
+        return {
+            "run_id": self.run_id,
+            "branch": self.branch,
+            "outcome": self.outcome.value,
+            "attempt_count": self.attempt_count,
+            "retries": self.retries,
+            "owner": self.owner,
+            "started_at": self.started_at,
+        }
+
+
+@dataclass(frozen=True)
+class MaskedFailureReport:
+    """Masked failures over one window, grouped by owner.
+
+    Attributes:
+        rows: Every masked failure, in the order :func:`list_finished_runs`
+            produced -- newest-started first, ties broken by run id, so two
+            reports over the same journal are byte-identical.
+        finished: How many finished runs the window held, masked or not. The
+            denominator; without it a count of 3 says nothing.
+        by_owner: ``owner -> (masked, finished)``, so a share can be computed
+            per owner as well as overall.
+    """
+
+    rows: tuple[MaskedFailure, ...]
+    finished: int
+    by_owner: Mapping[str, tuple[int, int]]
+
+    @property
+    def masked(self) -> int:
+        """How many finished runs in this window needed a retry to succeed."""
+        return len(self.rows)
+
+    @property
+    def share(self) -> float:
+        """Masked runs as a fraction of finished ones. ``0.0`` for an empty window.
+
+        An empty window is not a clean bill of health, and it is not a failure
+        either -- there is nothing to divide. Zero keeps a threshold gate from
+        firing on a quiet day, which is the only sane reading of "no data".
+        """
+        return 0.0 if self.finished == 0 else len(self.rows) / self.finished
+
+    def exceeds(self, threshold: float) -> bool:
+        """Whether :attr:`share` is over *threshold*, for a CI gate to exit on.
+
+        Strictly greater: a threshold of ``0.4`` admits exactly 40% and refuses
+        anything above it, so an operator setting a limit gets the limit rather
+        than one masked run less than it.
+        """
+        return self.share > threshold
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the stable JSON document shape."""
+        return {
+            "finished": self.finished,
+            "masked": self.masked,
+            "share": self.share,
+            "by_owner": {
+                owner: {"masked": masked, "finished": finished, "share": 0.0 if finished == 0 else masked / finished}
+                for owner, (masked, finished) in sorted(self.by_owner.items())
+            },
+            "rows": [row.to_dict() for row in self.rows],
+        }
+
+
+def _run_owner(run: FinishedRun) -> str:
+    """Attribution for one run.
+
+    The HOST, because it is the attribution runs actually carry today. Grouping
+    by the owning capability or adapter is what the issue ultimately wants, and
+    it needs runs to record that first (#5107); this reports the real number
+    against the real key rather than inventing a bucket.
+
+    A run whose entries never recorded a host groups under ``unattributed``,
+    named rather than dropped: a run with no host is still a run that retried,
+    and silently omitting it would understate the very number being reported.
+    """
+    return run.host if run.host else "unattributed"
+
+
+def masked_failures(runs: list[FinishedRun]) -> MaskedFailureReport:
+    """Report the runs that succeeded only after retrying.
+
+    Args:
+        runs: Finished runs, typically from :func:`list_finished_runs`, whose
+            ordering is inherited unchanged so the report is byte-identical for
+            the same window on the same journal.
+
+    Returns:
+        A :class:`MaskedFailureReport` over exactly the runs given. The window
+        is the caller's to choose -- pass ``list_finished_runs(sdd, since=...)``.
+    """
+    rows: list[MaskedFailure] = []
+    counts: dict[str, list[int]] = {}
+    for run in runs:
+        owner = _run_owner(run)
+        tally = counts.setdefault(owner, [0, 0])
+        tally[1] += 1
+        if run.outcome not in _SUCCESS_OUTCOMES:
+            continue
+        if run.attempt_count < FIRST_RETRY_ATTEMPT:
+            continue
+        tally[0] += 1
+        rows.append(
+            MaskedFailure(
+                run_id=run.run_id,
+                branch=run.branch,
+                outcome=run.outcome,
+                attempt_count=run.attempt_count,
+                retries=run.attempt_count - 1,
+                owner=owner,
+                started_at=run.started_at,
+            )
+        )
+    return MaskedFailureReport(
+        rows=tuple(rows),
+        finished=len(runs),
+        by_owner={owner: (masked, finished) for owner, (masked, finished) in counts.items()},
+    )

--- a/tests/unit/test_masked_failure_report.py
+++ b/tests/unit/test_masked_failure_report.py
@@ -1,0 +1,185 @@
+"""Issue #5106: a retry that succeeded is invisible in every final-state report.
+
+`flaky_detector.py` closed exactly this blind spot for TESTS by keeping
+per-execution history. At the run level a run that failed twice and closed on
+the third attempt reports identically to one that closed on its first --
+``outcome=pr-opened``, and nothing anywhere says it took three goes.
+
+``FinishedRun.attempt_count`` already carried the number, from the run's own
+``task.started`` transitions. Nothing read it as a signal.
+"""
+
+from __future__ import annotations
+
+import json
+
+from bernstein.core.persistence.runs_report import (
+    FIRST_RETRY_ATTEMPT,
+    FinishedRun,
+    RunOutcome,
+    masked_failures,
+)
+
+
+def _run(
+    run_id: str,
+    outcome: RunOutcome = RunOutcome.PR_OPENED,
+    *,
+    attempts: int = 1,
+    host: str = "builder-1",
+    started_at: float = 1000.0,
+) -> FinishedRun:
+    return FinishedRun(
+        run_id,
+        f"fix/{run_id}",
+        outcome,
+        "evidence",
+        started_at,
+        attempt_count=attempts,
+        host=host,
+    )
+
+
+# ---------------------------------------------------------------------------
+# What counts as masked
+# ---------------------------------------------------------------------------
+
+
+def test_a_run_that_succeeded_first_time_is_not_masked() -> None:
+    report = masked_failures([_run("r1", attempts=1)])
+    assert report.masked == 0
+    assert report.finished == 1
+
+
+def test_a_success_that_needed_a_retry_is_masked() -> None:
+    report = masked_failures([_run("r1", attempts=3)])
+
+    (row,) = report.rows
+    assert row.run_id == "r1"
+    assert row.attempt_count == 3
+    assert row.retries == 2, "an operator asks for retries, not attempts"
+    # The run's own classification is untouched: this report adds to it.
+    assert row.outcome is RunOutcome.PR_OPENED
+
+
+def test_the_second_attempt_is_the_first_retry() -> None:
+    """One `task.started` is the run happening; the second is the retry."""
+    assert FIRST_RETRY_ATTEMPT == 2
+    assert masked_failures([_run("r1", attempts=1)]).masked == 0
+    assert masked_failures([_run("r1", attempts=2)]).masked == 1
+
+
+def test_a_run_that_retried_and_still_failed_is_not_masked() -> None:
+    """It is already visible in every report -- which is the point.
+
+    A retry only MASKS something when the ending it reached was a success.
+    """
+    report = masked_failures([_run("r1", RunOutcome.GATE_FAILED, attempts=4)])
+    assert report.masked == 0
+    assert report.finished == 1
+
+
+def test_a_no_changes_run_counts_as_a_success() -> None:
+    """It got where it was going; the retries are still hidden by the outcome."""
+    assert masked_failures([_run("r1", RunOutcome.NO_CHANGES, attempts=2)]).masked == 1
+
+
+def test_infra_error_and_wedged_are_not_successes() -> None:
+    for outcome in (RunOutcome.INFRA_ERROR, RunOutcome.WEDGED):
+        assert masked_failures([_run("r1", outcome, attempts=5)]).masked == 0
+
+
+# ---------------------------------------------------------------------------
+# The share, and the gate that reads it
+# ---------------------------------------------------------------------------
+
+
+def test_the_share_has_every_finished_run_as_its_denominator() -> None:
+    """A count of 3 says nothing without the number it is out of."""
+    report = masked_failures(
+        [
+            _run("r1", attempts=3),
+            _run("r2", attempts=1),
+            _run("r3", RunOutcome.GATE_FAILED, attempts=2),
+            _run("r4", attempts=1),
+        ]
+    )
+    assert report.masked == 1
+    assert report.finished == 4
+    assert report.share == 0.25
+
+
+def test_an_empty_window_is_a_zero_share_not_a_division() -> None:
+    """No data is not a clean bill of health, and it is not a failure either."""
+    report = masked_failures([])
+    assert report.share == 0.0
+    assert report.exceeds(0.0) is False
+
+
+def test_the_gate_admits_exactly_the_threshold() -> None:
+    """Strictly greater, so a limit of 0.5 permits 50% rather than 50% minus one run."""
+    report = masked_failures([_run("r1", attempts=2), _run("r2", attempts=1)])
+    assert report.share == 0.5
+    assert report.exceeds(0.5) is False
+    assert report.exceeds(0.49) is True
+
+
+# ---------------------------------------------------------------------------
+# Grouping
+# ---------------------------------------------------------------------------
+
+
+def test_rows_are_grouped_by_the_attribution_runs_actually_carry() -> None:
+    report = masked_failures(
+        [
+            _run("r1", attempts=3, host="builder-1"),
+            _run("r2", attempts=1, host="builder-1"),
+            _run("r3", attempts=2, host="builder-2"),
+        ]
+    )
+    assert report.by_owner["builder-1"] == (1, 2)
+    assert report.by_owner["builder-2"] == (1, 1)
+
+
+def test_a_run_with_no_host_is_named_not_dropped() -> None:
+    """Silently omitting it would understate the very number being reported."""
+    report = masked_failures([_run("r1", attempts=2, host="")])
+    assert report.rows[0].owner == "unattributed"
+    assert report.by_owner["unattributed"] == (1, 1)
+
+
+# ---------------------------------------------------------------------------
+# Determinism and the JSON contract
+# ---------------------------------------------------------------------------
+
+
+def test_the_report_is_byte_identical_for_the_same_input() -> None:
+    """The ordering `list_finished_runs` established is inherited unchanged."""
+    runs = [
+        _run("r3", attempts=2, started_at=1020.0),
+        _run("r1", attempts=4, started_at=1000.0),
+        _run("r2", attempts=1, started_at=1010.0),
+    ]
+    first = json.dumps(masked_failures(runs).to_dict(), sort_keys=True)
+    second = json.dumps(masked_failures(runs).to_dict(), sort_keys=True)
+    assert first == second
+    assert [row.run_id for row in masked_failures(runs).rows] == ["r3", "r1"]
+
+
+def test_the_json_shape_mirrors_a_finished_run_row() -> None:
+    document = masked_failures([_run("r1", attempts=3)]).to_dict()
+
+    assert set(document) == {"finished", "masked", "share", "by_owner", "rows"}
+    assert set(document["rows"][0]) == {
+        "run_id",
+        "branch",
+        "outcome",
+        "attempt_count",
+        "retries",
+        "owner",
+        "started_at",
+    }
+    # Enums as their string values, the same contract FinishedRun.to_dict has.
+    assert document["rows"][0]["outcome"] == "pr-opened"
+    assert document["by_owner"]["builder-1"] == {"masked": 1, "finished": 1, "share": 1.0}
+    json.dumps(document)  # serialises without a custom encoder


### PR DESCRIPTION
#5106, **slices 1 and 3**. Slice 2's grouping key does not exist yet — see below.

## What was missing

`FinishedRun.attempt_count` already carried the number, from the run's own `task.started` transitions. **Nothing read it as a signal.** A run that failed twice and closed on the third attempt reported identically to one that closed on its first: `outcome=pr-opened`, and nothing anywhere said it took three goes — the same blind spot `flaky_detector.py` already closed for tests.

So this extends `runs_report.py` rather than duplicating it, as the issue asks.

## Decisions worth reviewing

- **A retry only masks something when the ending was a success.** A run that retried and still failed is already visible in every report — which is the point. `gate-failed` / `infra-error` / `wedged` count in the denominator and never in the rows. `no-changes` counts as a success: it got where it was going, and the retries are still hidden by the outcome.
- **The denominator is every finished run in the window.** A count of 3 says nothing without the number it is out of.
- **An empty window is a `0.0` share, not a division.** No data is not a clean bill of health and it is not a failure either; zero is the only reading that keeps a threshold gate from firing on a quiet day.
- **`exceeds` is strictly greater.** A limit of `0.5` permits 50%, rather than 50% minus one run.
- **`FIRST_RETRY_ATTEMPT = 2`**, named and tested — one `task.started` is the run happening; the second is the first retry.

## Grouping: host, not capability, and why

The issue wants grouping by owning capability or adapter. Runs do not record that today — the issue says so itself, and slice 2 depends on #5107 landing it. `host` is the attribution runs *do* carry, and *"this host needed a retry on 40% of its runs this week"* is a number an operator can act on now. When #5107 lands, `_run_owner` is the one function that changes.

A run whose entries recorded no host groups under `unattributed`, **named rather than dropped** — silently omitting it would understate the very number being reported.

## Determinism and the JSON contract

Ordering is inherited from `list_finished_runs` unchanged (`-started_at`, then `run_id`), so two reports over the same window on the same journal are byte-identical — pinned by a test that serialises twice and compares. `to_dict` mirrors `FinishedRun.to_dict` field-for-field, enums as string values, and serialises without a custom encoder.

`MaskedFailureReport.exceeds(threshold)` is the gate a `--fail-over` flag calls; wiring it to a CLI flag is a one-liner once you say which command it belongs under (`runs report`, presumably) — I left it out rather than guess at the surface.

## Verification

```
uv run pytest tests/unit/test_masked_failure_report.py -q   # 13 passed
uv run pytest tests/unit/test_runs_report.py -q             # 28 passed, unchanged
uv run ruff check / ruff format --check                     # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)