### PR TITLE
feat(govern): declared derivation rules that name the rule behind every fact (#5121)

### DIFF
--- a/docs/release-notes/fragments/5121-derivation-rules.md
+++ b/docs/release-notes/fragments/5121-derivation-rules.md
@@ -1,0 +1,20 @@
+## Derived classification facts come from declared rules that name themselves
+
+Site, owning team, contact and per-target endpoints were facts nothing
+derived. `bernstein.core.govern.derivation` makes them data: a rule file
+declares `network prefix -> site`, `owner -> contact` and
+`site -> endpoints`, and every fact records the `rule_id` that produced
+it, so a wrong answer is debuggable by reading one field.
+
+Rules are validated at load, not at use — an unknown key, an empty field,
+an unfamiliar kind, a prefix that is not a valid network, or two rules of
+one kind claiming the same match are all refused with the reason. A
+malformed rule silently producing wrong ownership is worse than one that
+fails to load.
+
+**Ownership cannot be derived from a name pattern.** `team-*`,
+`host[0-9]`, `regex:` and friends are refused on an `owner_contact` rule:
+it is wrong the first time a host is named after the wrong team, and
+wrong silently. The most specific prefix wins, not the first declared,
+and a target no rule matches derives `unknown` — a value, so it shows up
+in a gap query (#5121).

--- a/src/bernstein/core/govern/__init__.py
+++ b/src/bernstein/core/govern/__init__.py
@@ -21,6 +21,13 @@ from bernstein.core.govern.apply import (
     apply_plan,
     verify_govern_apply_projection,
 )
+from bernstein.core.govern.derivation import (
+    DerivationRule,
+    DerivationRuleError,
+    DerivationRules,
+    DerivedFact,
+    RuleKind,
+)
 from bernstein.core.govern.duplication_audit import (
     DuplicationFinding,
     DuplicationReport,
@@ -279,6 +286,10 @@ __all__ = [
     "ChangeStatus",
     "CollectionMethod",
     "CostClass",
+    "DerivationRule",
+    "DerivationRuleError",
+    "DerivationRules",
+    "DerivedFact",
     "DesiredEntity",
     "DesiredState",
     "DiffAction",
@@ -324,6 +335,7 @@ __all__ = [
     "RestoreEntry",
     "RestorePlan",
     "RestoreRefusal",
+    "RuleKind",
     "Snapshot",
     "SnapshotEntity",
     "Surface",

--- a/src/bernstein/core/govern/derivation.py
+++ b/src/bernstein/core/govern/derivation.py
@@ -1,0 +1,293 @@
+"""Declared derivation rules, and the facts they produce (issue #5121).
+
+Site, owning team, contact and per-target endpoints are facts nothing derived.
+This module makes them data: a rule file states ``network prefix -> site``,
+``owner -> contact`` and ``site -> endpoints``, and every fact a rule produces
+records which rule produced it.
+
+Three properties, and each exists because of a specific way this goes wrong.
+
+**Rules are validated at load, not at use.** A malformed rule silently producing
+wrong ownership is worse than one that fails to load: the first is discovered
+three weeks later by whoever was paged instead of the real owner. So an unknown
+key is rejected rather than dropped, and an empty field is rejected rather than
+carried as ``""``. Same posture :class:`~bernstein.core.govern.playbook_models.Playbook`
+takes to its clauses, applied here at load time as well.
+
+**No rule derives ownership from a NAME PATTERN.** It is the one derivation
+shortcut that looks convenient and is wrong the first time a host is named after
+the wrong team -- and it is wrong silently, because a plausible answer is
+indistinguishable from a correct one. A rule that tries is refused at load with
+the reason, not accepted and then trusted.
+
+**A target no rule matches is ``unknown``, not absent.** A missing fact and a
+fact nobody could derive read alike if the row simply is not there, and only one
+of them is a gap somebody should close. ``unknown`` is a value, so it shows up in
+a gap query.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+#: The value a fact takes when no declared rule matched the target. A value, not
+#: an absence: a gap query can only find what is written down.
+UNKNOWN = "unknown"
+
+
+class RuleKind(StrEnum):
+    """The derivations this module knows how to declare.
+
+    A closed set. A rule naming anything else is a typo, not a looser schema --
+    and a typo that loads is a derivation that silently never fires.
+    """
+
+    #: A network prefix (CIDR) to the site the addresses in it belong to.
+    PREFIX_SITE = "prefix_site"
+    #: An owning team to the contact for it.
+    OWNER_CONTACT = "owner_contact"
+    #: A site to the endpoints reachable for targets at it.
+    SITE_ENDPOINTS = "site_endpoints"
+
+
+#: Keys a rule dict may carry. Declared once, so `from_dict` can tell a key the
+#: schema does not know from one it merely left unset.
+_RULE_KEYS = frozenset({"kind", "match", "value", "rule_id"})
+
+#: Substrings that betray a name-pattern ownership rule. Matched on the MATCH
+#: side of an owner rule, which is the only place the shortcut can hide: a
+#: prefix rule matching on an address is exact by construction.
+_GLOB_MARKERS = ("*", "?", "[", "regex:", "glob:")
+
+
+class DerivationRuleError(ValueError):
+    """Raised when a rule file cannot be loaded as declared rules.
+
+    A distinct type so a caller can tell "your rules are wrong" from every other
+    ``ValueError`` a load might raise, and report it at startup as the
+    configuration error it is.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class DerivationRule:
+    """One declared derivation.
+
+    Attributes:
+        kind: Which derivation this rule performs.
+        match: The left-hand side -- a CIDR for ``prefix_site``, an owning team
+            for ``owner_contact``, a site for ``site_endpoints``.
+        value: The fact the rule produces.
+        rule_id: Stable identifier, carried onto every fact this rule derives so
+            an explain names its source. Defaults to ``<kind>:<match>``, which is
+            unique because two rules of one kind cannot share a match.
+    """
+
+    kind: RuleKind
+    match: str
+    value: str
+    rule_id: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical serialization."""
+        return {
+            "kind": self.kind.value,
+            "match": self.match,
+            "value": self.value,
+            "rule_id": self.rule_id,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> DerivationRule:
+        """Rebuild a rule from a serialized dict, or refuse it.
+
+        Raises:
+            DerivationRuleError: The record carries an unknown key, omits or
+                empties a required field, names a kind outside
+                :class:`RuleKind`, declares a network prefix that is not a valid
+                CIDR, or tries to match an owner by name pattern.
+        """
+        unknown = set(raw) - _RULE_KEYS
+        if unknown:
+            raise DerivationRuleError(f"derivation rule has unknown key(s): {sorted(unknown)}")
+        for name in ("kind", "match", "value"):
+            if not str(raw.get(name, "")).strip():
+                raise DerivationRuleError(f"derivation rule is missing required field {name!r}")
+
+        raw_kind = str(raw["kind"])
+        try:
+            kind = RuleKind(raw_kind)
+        except ValueError as exc:
+            known = ", ".join(sorted(member.value for member in RuleKind))
+            raise DerivationRuleError(f"derivation rule has unknown kind {raw_kind!r}; known: {known}") from exc
+
+        match = str(raw["match"]).strip()
+        _reject_name_pattern_ownership(kind, match)
+        if RuleKind.PREFIX_SITE is kind:
+            _require_cidr(match)
+
+        rule_id = str(raw.get("rule_id", "")).strip() or f"{kind.value}:{match}"
+        return cls(kind=kind, match=match, value=str(raw["value"]).strip(), rule_id=rule_id)
+
+
+def _reject_name_pattern_ownership(kind: RuleKind, match: str) -> None:
+    """Refuse an ownership rule that matches on a name pattern.
+
+    Wrong the first time a host is named after the wrong team, and wrong
+    SILENTLY -- a plausible owner is indistinguishable from a correct one to
+    everybody except the person who gets paged.
+    """
+    if RuleKind.OWNER_CONTACT is not kind:
+        return
+    for marker in _GLOB_MARKERS:
+        if marker in match:
+            raise DerivationRuleError(
+                f"ownership rule matches on a name pattern ({match!r}); ownership must be declared "
+                "per owner, not inferred from a name -- a host named after the wrong team would be "
+                "attributed to it silently"
+            )
+
+
+def _require_cidr(match: str) -> None:
+    """Refuse a prefix rule whose match is not a network.
+
+    A prefix that does not parse can never match anything, so accepting it
+    declares a derivation that is guaranteed never to fire -- the failure this
+    validation exists to make loud.
+    """
+    try:
+        ipaddress.ip_network(match, strict=False)
+    except ValueError as exc:
+        raise DerivationRuleError(f"prefix rule match {match!r} is not a valid network: {exc}") from exc
+
+
+@dataclass(frozen=True, slots=True)
+class DerivedFact:
+    """One fact, and the rule that produced it.
+
+    Attributes:
+        value: The derived value, or :data:`UNKNOWN`.
+        rule_id: The rule that fired, or ``""`` when none did. Reading one field
+            answers "why is this the answer", instead of re-deriving by hand to
+            guess which rule matched.
+    """
+
+    value: str
+    rule_id: str = ""
+
+    @property
+    def is_known(self) -> bool:
+        """Whether a rule actually produced this value."""
+        return self.value != UNKNOWN
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical serialization."""
+        return {"value": self.value, "rule_id": self.rule_id}
+
+
+#: The fact a target gets when nothing matched. One shared instance: it carries
+#: no per-target state, and an identical object makes "nothing derived this"
+#: comparable by value.
+NO_FACT = DerivedFact(value=UNKNOWN, rule_id="")
+
+
+@dataclass(frozen=True, slots=True)
+class DerivationRules:
+    """A validated, ordered set of declared rules.
+
+    Attributes:
+        rules: The rules, in declared order. Order is the tie-break for prefix
+            matching only -- see :meth:`site_for_address`.
+    """
+
+    rules: tuple[DerivationRule, ...]
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> DerivationRules:
+        """Load and validate rules from a serialized document.
+
+        Raises:
+            DerivationRuleError: Any rule is malformed, or two rules of the same
+                kind declare the same match -- which is not a merge, it is two
+                answers to one question with nothing to choose between them.
+        """
+        unknown = set(raw) - {"rules"}
+        if unknown:
+            raise DerivationRuleError(f"derivation rules document has unknown key(s): {sorted(unknown)}")
+        entries = raw.get("rules", [])
+        if not isinstance(entries, list):
+            raise DerivationRuleError("derivation rules document's 'rules' must be a list")
+        rules = tuple(DerivationRule.from_dict(entry) for entry in entries)
+
+        seen: set[tuple[str, str]] = set()
+        for rule in rules:
+            key = (rule.kind.value, rule.match)
+            if key in seen:
+                raise DerivationRuleError(
+                    f"two {rule.kind.value} rules declare the same match {rule.match!r}; "
+                    "one question cannot have two declared answers"
+                )
+            seen.add(key)
+        return cls(rules=rules)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical serialization."""
+        return {"rules": [rule.to_dict() for rule in self.rules]}
+
+    def _of_kind(self, kind: RuleKind) -> tuple[DerivationRule, ...]:
+        return tuple(rule for rule in self.rules if rule.kind is kind)
+
+    def site_for_address(self, address: str) -> DerivedFact:
+        """The site an address belongs to, by declared prefix.
+
+        The MOST SPECIFIC prefix wins, not the first declared. A site declared
+        for ``10.0.0.0/8`` and a different one for ``10.1.2.0/24`` are not in
+        conflict -- the narrower one is the more precise statement, and picking
+        by declaration order would make the answer depend on file layout.
+
+        An address that does not parse derives :data:`UNKNOWN` rather than
+        raising: this is a query about a target, and one unreadable target must
+        not take the report down.
+        """
+        try:
+            parsed = ipaddress.ip_address(address.strip())
+        except ValueError:
+            return NO_FACT
+        best: DerivationRule | None = None
+        best_bits = -1
+        for rule in self._of_kind(RuleKind.PREFIX_SITE):
+            network = ipaddress.ip_network(rule.match, strict=False)
+            if parsed.version != network.version or parsed not in network:
+                continue
+            if network.prefixlen > best_bits:
+                best, best_bits = rule, network.prefixlen
+        return NO_FACT if best is None else DerivedFact(value=best.value, rule_id=best.rule_id)
+
+    def contact_for_owner(self, owner: str) -> DerivedFact:
+        """The contact declared for an owning team. Exact match, by construction."""
+        return self._exact(RuleKind.OWNER_CONTACT, owner)
+
+    def endpoints_for_site(self, site: str) -> DerivedFact:
+        """The endpoints declared for a site. Exact match."""
+        return self._exact(RuleKind.SITE_ENDPOINTS, site)
+
+    def _exact(self, kind: RuleKind, match: str) -> DerivedFact:
+        wanted = match.strip()
+        for rule in self._of_kind(kind):
+            if rule.match == wanted:
+                return DerivedFact(value=rule.value, rule_id=rule.rule_id)
+        return NO_FACT
+
+
+__all__ = [
+    "NO_FACT",
+    "UNKNOWN",
+    "DerivationRule",
+    "DerivationRuleError",
+    "DerivationRules",
+    "DerivedFact",
+    "RuleKind",
+]

--- a/tests/unit/core/govern/test_derivation_rules.py
+++ b/tests/unit/core/govern/test_derivation_rules.py
@@ -1,0 +1,205 @@
+"""Issue #5121: derived classification facts are declared, validated, and attributed.
+
+Site, owning team, contact and per-target endpoints were facts nothing derived.
+The nearest precedent, ``Playbook.from_dict``, loads typed rules from data but
+validates nothing beyond `str()` casts -- and a malformed derivation rule
+silently producing wrong ownership is worse than one that fails to load: the
+first is discovered three weeks later by whoever was paged instead of the real
+owner.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.govern.derivation import (
+    UNKNOWN,
+    DerivationRuleError,
+    DerivationRules,
+    RuleKind,
+)
+
+RULES = {
+    "rules": [
+        {"kind": "prefix_site", "match": "10.0.0.0/8", "value": "dc-main"},
+        {"kind": "prefix_site", "match": "10.1.2.0/24", "value": "dc-lab"},
+        {"kind": "owner_contact", "match": "platform", "value": "platform@example.test"},
+        {"kind": "site_endpoints", "match": "dc-lab", "value": "https://lab.example.test"},
+    ]
+}
+
+
+def _rules() -> DerivationRules:
+    return DerivationRules.from_dict(RULES)
+
+
+# ---------------------------------------------------------------------------
+# Load-time validation
+# ---------------------------------------------------------------------------
+
+
+def test_a_well_formed_document_loads() -> None:
+    assert len(_rules().rules) == 4
+
+
+def test_an_unknown_key_is_rejected_not_dropped() -> None:
+    """Silently dropping it would load a rule that is not the one written."""
+    with pytest.raises(DerivationRuleError, match="unknown key"):
+        DerivationRules.from_dict(
+            {"rules": [{"kind": "owner_contact", "match": "a", "value": "b", "contct": "typo"}]}
+        )
+
+
+def test_an_unknown_key_on_the_document_is_rejected() -> None:
+    with pytest.raises(DerivationRuleError, match="unknown key"):
+        DerivationRules.from_dict({"rules": [], "rulez": []})
+
+
+@pytest.mark.parametrize("missing", ["kind", "match", "value"])
+def test_a_missing_or_empty_field_is_rejected(missing: str) -> None:
+    rule = {"kind": "owner_contact", "match": "a", "value": "b"}
+    rule[missing] = "   "
+    with pytest.raises(DerivationRuleError, match=missing):
+        DerivationRules.from_dict({"rules": [rule]})
+
+
+def test_an_unknown_kind_is_rejected_and_names_the_known_ones() -> None:
+    """A kind that loads is a derivation that silently never fires."""
+    with pytest.raises(DerivationRuleError, match="unknown kind") as excinfo:
+        DerivationRules.from_dict({"rules": [{"kind": "hostname_owner", "match": "a", "value": "b"}]})
+    for kind in RuleKind:
+        assert kind.value in str(excinfo.value)
+
+
+def test_a_prefix_that_is_not_a_network_is_rejected() -> None:
+    """It could never match, so accepting it declares a rule guaranteed not to fire."""
+    with pytest.raises(DerivationRuleError, match="not a valid network"):
+        DerivationRules.from_dict({"rules": [{"kind": "prefix_site", "match": "10.0.0.*", "value": "x"}]})
+
+
+def test_two_rules_of_one_kind_cannot_claim_the_same_match() -> None:
+    """Not a merge -- two answers to one question with nothing to choose between."""
+    with pytest.raises(DerivationRuleError, match="same match"):
+        DerivationRules.from_dict(
+            {
+                "rules": [
+                    {"kind": "owner_contact", "match": "platform", "value": "a@x"},
+                    {"kind": "owner_contact", "match": "platform", "value": "b@x"},
+                ]
+            }
+        )
+
+
+def test_the_same_match_under_different_kinds_is_fine() -> None:
+    """They are different questions; a site and an owner may share a name."""
+    rules = DerivationRules.from_dict(
+        {
+            "rules": [
+                {"kind": "owner_contact", "match": "lab", "value": "lab@x"},
+                {"kind": "site_endpoints", "match": "lab", "value": "https://lab"},
+            ]
+        }
+    )
+    assert len(rules.rules) == 2
+
+
+def test_a_rules_list_that_is_not_a_list_is_rejected() -> None:
+    with pytest.raises(DerivationRuleError, match="must be a list"):
+        DerivationRules.from_dict({"rules": {"kind": "owner_contact"}})
+
+
+# ---------------------------------------------------------------------------
+# No ownership from a name pattern
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("pattern", ["team-*", "web-?", "host[0-9]", "regex:^svc-", "glob:svc-*"])
+def test_ownership_by_name_pattern_is_refused(pattern: str) -> None:
+    """Wrong the first time a host is named after the wrong team, and wrong SILENTLY."""
+    with pytest.raises(DerivationRuleError, match="name pattern"):
+        DerivationRules.from_dict({"rules": [{"kind": "owner_contact", "match": pattern, "value": "x@y"}]})
+
+
+def test_the_refusal_says_why() -> None:
+    with pytest.raises(DerivationRuleError) as excinfo:
+        DerivationRules.from_dict({"rules": [{"kind": "owner_contact", "match": "svc-*", "value": "x@y"}]})
+    assert "declared per owner" in str(excinfo.value)
+
+
+def test_a_literal_owner_name_is_still_accepted() -> None:
+    """The control: the refusal must not swallow ordinary team names."""
+    rules = DerivationRules.from_dict(
+        {"rules": [{"kind": "owner_contact", "match": "platform-infra", "value": "x@y"}]}
+    )
+    assert rules.contact_for_owner("platform-infra").value == "x@y"
+
+
+# ---------------------------------------------------------------------------
+# Derivation, and provenance
+# ---------------------------------------------------------------------------
+
+
+def test_the_most_specific_prefix_wins_not_the_first_declared() -> None:
+    """Picking by declaration order would make the answer depend on file layout."""
+    rules = _rules()
+    assert rules.site_for_address("10.1.2.7").value == "dc-lab"
+    assert rules.site_for_address("10.9.9.9").value == "dc-main"
+
+
+def test_every_derived_fact_names_the_rule_that_produced_it() -> None:
+    """Reading one field answers "why is this the answer"."""
+    rules = _rules()
+    assert rules.site_for_address("10.1.2.7").rule_id == "prefix_site:10.1.2.0/24"
+    assert rules.contact_for_owner("platform").rule_id == "owner_contact:platform"
+    assert rules.endpoints_for_site("dc-lab").rule_id == "site_endpoints:dc-lab"
+
+
+def test_a_declared_rule_id_is_carried_instead_of_the_derived_one() -> None:
+    rules = DerivationRules.from_dict(
+        {"rules": [{"kind": "owner_contact", "match": "a", "value": "b", "rule_id": "OWN-7"}]}
+    )
+    assert rules.contact_for_owner("a").rule_id == "OWN-7"
+
+
+# ---------------------------------------------------------------------------
+# Unknown is a value
+# ---------------------------------------------------------------------------
+
+
+def test_an_unmatched_target_is_unknown_rather_than_absent() -> None:
+    """A missing fact and one nobody could derive read alike if the row is not there."""
+    rules = _rules()
+    fact = rules.site_for_address("192.0.2.1")
+    assert fact.value == UNKNOWN
+    assert fact.rule_id == ""
+    assert fact.is_known is False
+
+
+def test_an_unparseable_address_is_unknown_rather_than_an_exception() -> None:
+    """One unreadable target must not take the whole report down."""
+    assert _rules().site_for_address("not-an-address").value == UNKNOWN
+
+
+def test_an_ipv6_address_does_not_match_an_ipv4_prefix() -> None:
+    """Comparing across versions raises inside ipaddress; it must read as no match."""
+    assert _rules().site_for_address("2001:db8::1").value == UNKNOWN
+
+
+def test_a_known_fact_reports_itself_as_known() -> None:
+    assert _rules().contact_for_owner("platform").is_known is True
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+
+def test_rules_round_trip() -> None:
+    rules = _rules()
+    assert DerivationRules.from_dict(rules.to_dict()) == rules
+
+
+def test_a_round_trip_preserves_the_derived_rule_ids() -> None:
+    """The provenance has to survive a save, or an explain loses its source."""
+    reloaded = DerivationRules.from_dict(_rules().to_dict())
+    assert reloaded.site_for_address("10.1.2.7").rule_id == "prefix_site:10.1.2.0/24"

--- a/tests/unit/core/govern/test_derivation_rules.py
+++ b/tests/unit/core/govern/test_derivation_rules.py
@@ -43,9 +43,14 @@ def test_a_well_formed_document_loads() -> None:
 
 
 def test_an_unknown_key_is_rejected_not_dropped() -> None:
-    """Silently dropping it would load a rule that is not the one written."""
+    """Silently dropping it would load a rule that is not the one written.
+
+    The stray key is a near-miss of a real one -- ``contacts`` for ``contact`` --
+    because that is the realistic mistake, and the one whose silent acceptance
+    would leave a rule that looks right and derives nothing.
+    """
     with pytest.raises(DerivationRuleError, match="unknown key"):
-        DerivationRules.from_dict({"rules": [{"kind": "owner_contact", "match": "a", "value": "b", "contct": "typo"}]})
+        DerivationRules.from_dict({"rules": [{"kind": "owner_contact", "match": "a", "value": "b", "contacts": "x@y"}]})
 
 
 def test_an_unknown_key_on_the_document_is_rejected() -> None:

--- a/tests/unit/core/govern/test_derivation_rules.py
+++ b/tests/unit/core/govern/test_derivation_rules.py
@@ -45,9 +45,7 @@ def test_a_well_formed_document_loads() -> None:
 def test_an_unknown_key_is_rejected_not_dropped() -> None:
     """Silently dropping it would load a rule that is not the one written."""
     with pytest.raises(DerivationRuleError, match="unknown key"):
-        DerivationRules.from_dict(
-            {"rules": [{"kind": "owner_contact", "match": "a", "value": "b", "contct": "typo"}]}
-        )
+        DerivationRules.from_dict({"rules": [{"kind": "owner_contact", "match": "a", "value": "b", "contct": "typo"}]})
 
 
 def test_an_unknown_key_on_the_document_is_rejected() -> None:
@@ -128,9 +126,7 @@ def test_the_refusal_says_why() -> None:
 
 def test_a_literal_owner_name_is_still_accepted() -> None:
     """The control: the refusal must not swallow ordinary team names."""
-    rules = DerivationRules.from_dict(
-        {"rules": [{"kind": "owner_contact", "match": "platform-infra", "value": "x@y"}]}
-    )
+    rules = DerivationRules.from_dict({"rules": [{"kind": "owner_contact", "match": "platform-infra", "value": "x@y"}]})
     assert rules.contact_for_owner("platform-infra").value == "x@y"
 
 


### PR DESCRIPTION
Closes #5121 — slices 1 and 2.

Site, owning team, contact and per-target endpoints were facts nothing derived. The nearest precedent, `Playbook.from_dict`, loads typed rules from data but validates nothing beyond `str()` casts — and as the issue says, these rules *"need to do better than that, not just copy it"*.

## Validated at load, not at use

A malformed rule silently producing wrong ownership is worse than one that fails to load: the first is discovered three weeks later by whoever was paged instead of the real owner.

| refused at load | why |
|---|---|
| unknown key on a rule or the document | dropping it loads a rule that is not the one written |
| a missing or whitespace-only `kind`/`match`/`value` | carried as `""` it is a rule that cannot fire |
| a kind outside `RuleKind` | a kind that loads is a derivation that silently never fires — the error names the known set |
| a `prefix_site` match that is not a network | it could never match, so accepting it declares a rule guaranteed not to fire |
| two rules of one kind claiming the same match | not a merge; two answers to one question with nothing to choose between them |

The same match under two **different kinds** is fine — a site and an owner may share a name, and they are different questions.

## No ownership from a name pattern

It is the one derivation shortcut that looks convenient and is wrong the first time a host is named after the wrong team — and wrong **silently**, because a plausible owner is indistinguishable from a correct one to everybody except the person who gets paged. `team-*`, `web-?`, `host[0-9]`, `regex:`, `glob:` are all refused at load with the reason. A literal `platform-infra` still loads (the control).

## Two more decisions

**The most specific prefix wins**, not the first declared. `10.0.0.0/8` and `10.1.2.0/24` are not in conflict: the narrower one is the more precise statement, and picking by declaration order would make the answer depend on file layout.

**`unknown` is a value, not an absence.** A missing fact and a fact nobody could derive read alike if the row simply is not there, and only one is a gap somebody should close — so it shows up in a gap query. An address that does not parse, and an IPv6 address against IPv4 prefixes, both derive `unknown` rather than raising: this is a query about a target, and one unreadable target must not take the report down.

## Provenance

Every `DerivedFact` carries the `rule_id` that produced it, defaulting to `<kind>:<match>` (unique, since two rules of one kind cannot share a match) and overridable per rule. A wrong answer is debuggable by reading one field instead of re-deriving by hand to guess which rule fired — and the id survives a round trip, or an explain would lose its source on the first save.

## Verification

```
uv run pytest tests/unit/core/govern/ -q          # 227 passed (27 new)
uv run mypy --config-file mypy.gate.ini           # Success, 98 files
uv run ruff check / ruff format --check           # clean
```

## Not in this PR

Attaching these facts to the entity records from #5082/#5129, and plugging `unknown` into #5116/#5118's gap query — both need those to land first. This is the rule format and the derivation, which the issue says is worth taking alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)