### PR TITLE
feat(govern): reconciliation lanes are data, and bootstrap is create-if-absent (#5120)

### DIFF
--- a/docs/release-notes/fragments/5120-reconciliation-lanes.md
+++ b/docs/release-notes/fragments/5120-reconciliation-lanes.md
@@ -1,0 +1,20 @@
+## Reconciliation lanes are data, and bootstrap is create-if-absent
+
+`bernstein.core.govern.lanes` adds the lane record that did not exist: a
+`name`, a `selector`, a `schedule`, a `timeout_seconds`, a
+`log_destination`, and a `barrier` of `per-step` or `free`. An operator
+changes how reconciliation is grouped by editing a file, and that edit is
+hashed and reviewable rather than a code change to a scheduler.
+
+The barrier is why a lane is one mechanism instead of two: a canary lane
+that must serialize its steps and a bulk lane where one stuck target must
+not block the rest are the same runner with one flag flipped.
+
+`lane_hash` is computed from the content, never accepted from the caller,
+and a hash present in a loaded document is verified rather than trusted —
+an edited lane cannot keep the identity of the one that was reviewed.
+`reconcile_lanes` makes the same three-way decision `pool register`
+already makes, over a whole set, so a second bootstrap against an
+unchanged lane set changes nothing and says so. A lane absent from the
+file is not retired: that is a decision an operator makes deliberately,
+not one a bootstrap infers from an omission (#5120).

--- a/src/bernstein/core/govern/__init__.py
+++ b/src/bernstein/core/govern/__init__.py
@@ -14,6 +14,14 @@ from bernstein.core.govern.freshness_gate import (
     freshness_gated_read,
 )
 from bernstein.core.govern.inventory_models import Inventory, Surface
+from bernstein.core.govern.lanes import (
+    Barrier,
+    LaneAction,
+    LaneError,
+    LaneManifest,
+    load_lane_set,
+    reconcile_lanes,
+)
 from bernstein.core.govern.observation import ObservationEnvelope, ObservationLedger
 from bernstein.core.govern.observation_store import (
     ObservationRecord,
@@ -234,6 +242,7 @@ def _compare_values(observed: str, ceiling: str) -> int:
 
 
 __all__ = [
+    "Barrier",
     "DesiredEntity",
     "DesiredState",
     "DiffAction",
@@ -247,6 +256,9 @@ __all__ = [
     "FreshnessResult",
     "GovernPlan",
     "Inventory",
+    "LaneAction",
+    "LaneError",
+    "LaneManifest",
     "ObservationEnvelope",
     "ObservationLedger",
     "ObservationRecord",
@@ -277,7 +289,9 @@ __all__ = [
     "compute_plan",
     "compute_reconcile_diff",
     "freshness_gated_read",
+    "load_lane_set",
     "observation_store_root",
     "propose_reconcile",
+    "reconcile_lanes",
     "snapshot_surface",
 ]

--- a/src/bernstein/core/govern/lanes.py
+++ b/src/bernstein/core/govern/lanes.py
@@ -1,0 +1,306 @@
+"""Reconciliation lanes as data (issue #5120).
+
+A lane groups targets for reconciliation and says how to run them: which
+targets, on what schedule, with what timeout, where the log goes, and whether
+steps serialize. Making that a record rather than a scheduler script means an
+operator changes how reconciliation is grouped by editing a file, and that edit
+is itself reviewable, hashed and projectable -- not a code change.
+
+The shape is deliberately the one
+:class:`~bernstein.core.sandbox.pool.PoolManifest` already established: a named
+record whose identity is a SHA-256 over the canonical JSON of every other field,
+so re-registering an unchanged lane is a no-op that says so. Lanes are the
+missing half of that pattern; the fields differ, the discipline does not.
+
+The barrier is the reason a lane is one mechanism instead of two. A canary lane
+that must serialize its steps and a bulk lane where one stuck target must not
+block the rest are the same runner with one flag flipped, and keeping them as
+two pieces of code is keeping two things in sync forever.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+#: Wire-format version, carried so a lane document written today is readable
+#: after the shape changes.
+LANE_MANIFEST_SCHEMA_VERSION = 1
+
+
+class Barrier(StrEnum):
+    """How a lane's steps are ordered against each other."""
+
+    #: One target at a time; a step waits for its predecessor. What a canary
+    #: lane needs, because the point of a canary is to learn before proceeding.
+    PER_STEP = "per-step"
+    #: Targets proceed independently. What a bulk lane needs, because one slow
+    #: target blocking the rest turns a wide sweep into a serial queue.
+    FREE = "free"
+
+
+class LaneError(ValueError):
+    """Raised when a lane record is not a valid lane.
+
+    A distinct type so a caller can report a bad lane file at startup as the
+    configuration error it is, rather than as an unattributed ``ValueError``.
+    """
+
+
+class LaneAction(StrEnum):
+    """What reconciling a declared lane against the existing set did."""
+
+    REGISTERED = "registered"
+    UPDATED = "updated"
+    UNCHANGED = "unchanged"
+
+
+#: Keys a lane dict may carry. Declared once so `from_dict` can tell a key the
+#: schema does not know from one it merely left unset.
+_LANE_KEYS = frozenset(
+    {
+        "name",
+        "selector",
+        "schedule",
+        "timeout_seconds",
+        "log_destination",
+        "barrier",
+        "schema_version",
+        "lane_hash",
+    }
+)
+
+
+def _canonical_json(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+@dataclass(frozen=True)
+class LaneManifest:
+    """One reconciliation lane.
+
+    Attributes:
+        name: Operator-facing lane name. The identity an existing set is keyed
+            on, so renaming a lane registers a new one rather than mutating it.
+        selector: Which targets the lane covers, in the selector grammar.
+        schedule: When it runs, as a cron expression.
+        timeout_seconds: Per-run ceiling. ``0`` means no ceiling, matching the
+            convention ``PoolManifest.max_concurrency`` already uses for
+            unbounded.
+        log_destination: Where the run's dated log artefact is written.
+        barrier: :class:`Barrier`.
+        schema_version: Wire-format version.
+        lane_hash: SHA-256 over the canonical payload of every other field --
+            the lane's identity, and what makes re-registering it a no-op.
+    """
+
+    name: str
+    selector: str
+    schedule: str
+    log_destination: str
+    timeout_seconds: int = 0
+    barrier: Barrier = Barrier.FREE
+    schema_version: int = LANE_MANIFEST_SCHEMA_VERSION
+    lane_hash: str = ""
+
+    def __post_init__(self) -> None:
+        for field_name in ("name", "selector", "schedule", "log_destination"):
+            if not str(getattr(self, field_name)).strip():
+                raise LaneError(f"lane {field_name} must be non-empty")
+        if self.timeout_seconds < 0:
+            raise LaneError(f"lane timeout_seconds must not be negative, got {self.timeout_seconds}")
+        if not isinstance(self.barrier, Barrier):
+            raise LaneError(f"lane barrier {self.barrier!r} is not one of {[b.value for b in Barrier]}")
+        # Computed here rather than asked of the caller: a hash somebody can
+        # pass in is a hash somebody can pass in wrong, and the whole no-op
+        # decision downstream rests on it being the hash of the content.
+        object.__setattr__(self, "lane_hash", hashlib.sha256(_canonical_json(self.payload())).hexdigest())
+
+    def payload(self) -> dict[str, Any]:
+        """The canonical content the hash is taken over -- everything but the hash."""
+        return {
+            "name": self.name,
+            "selector": self.selector,
+            "schedule": self.schedule,
+            "log_destination": self.log_destination,
+            "timeout_seconds": self.timeout_seconds,
+            "barrier": self.barrier.value,
+            "schema_version": self.schema_version,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical serialization, hash included."""
+        return {**self.payload(), "lane_hash": self.lane_hash}
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> LaneManifest:
+        """Rebuild a lane from a serialized dict, or refuse it.
+
+        A ``lane_hash`` in the document is VERIFIED, not trusted: it is
+        recomputed from the content, and a mismatch means the record was edited
+        after it was hashed. Trusting it would let an edited lane keep the
+        identity of the one that was reviewed.
+
+        Raises:
+            LaneError: An unknown key, a missing or empty required field, a
+                barrier outside :class:`Barrier`, a non-integer timeout, or a
+                ``lane_hash`` the content does not produce.
+        """
+        unknown = set(raw) - _LANE_KEYS
+        if unknown:
+            raise LaneError(f"lane has unknown key(s): {sorted(unknown)}")
+        raw_barrier = str(raw.get("barrier", Barrier.FREE.value))
+        try:
+            barrier = Barrier(raw_barrier)
+        except ValueError as exc:
+            known = ", ".join(b.value for b in Barrier)
+            raise LaneError(f"lane barrier {raw_barrier!r} is not one of: {known}") from exc
+        try:
+            timeout = int(raw.get("timeout_seconds", 0))
+        except (TypeError, ValueError) as exc:
+            raise LaneError(f"lane timeout_seconds {raw.get('timeout_seconds')!r} is not an integer") from exc
+
+        lane = cls(
+            name=str(raw.get("name", "")),
+            selector=str(raw.get("selector", "")),
+            schedule=str(raw.get("schedule", "")),
+            log_destination=str(raw.get("log_destination", "")),
+            timeout_seconds=timeout,
+            barrier=barrier,
+            schema_version=int(raw.get("schema_version", LANE_MANIFEST_SCHEMA_VERSION)),
+        )
+        declared_hash = str(raw.get("lane_hash", "")).strip()
+        if declared_hash and declared_hash != lane.lane_hash:
+            raise LaneError(
+                f"lane {lane.name!r} carries lane_hash {declared_hash[:16]}... but its content "
+                f"hashes to {lane.lane_hash[:16]}...; the record was edited after it was hashed"
+            )
+        return lane
+
+
+@dataclass(frozen=True)
+class LaneReconcileEntry:
+    """What reconciling one declared lane did, and against what.
+
+    Attributes:
+        lane: The declared lane.
+        action: Whether it was new, changed, or already exactly this.
+        prev_hash: The hash it replaced, or ``""`` when it is new.
+    """
+
+    lane: LaneManifest
+    action: LaneAction
+    prev_hash: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON row shape, mirroring ``pool register --json``."""
+        return {"action": self.action.value, "prev_hash": self.prev_hash, **self.lane.to_dict()}
+
+
+@dataclass(frozen=True)
+class LaneReconcileResult:
+    """One bootstrap pass over a declared lane set.
+
+    Attributes:
+        entries: One per declared lane, in declared order.
+    """
+
+    entries: tuple[LaneReconcileEntry, ...]
+
+    @property
+    def changed(self) -> tuple[LaneReconcileEntry, ...]:
+        """The entries that were not already exactly as declared."""
+        return tuple(e for e in self.entries if LaneAction.UNCHANGED is not e.action)
+
+    @property
+    def is_noop(self) -> bool:
+        """Whether this pass changed nothing.
+
+        The property bootstrap needs: starting the scheduler against an existing
+        lane set must change nothing AND say so, rather than being silent about
+        having done nothing.
+        """
+        return len(self.changed) == 0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the stable JSON document shape."""
+        return {
+            "noop": self.is_noop,
+            "changed": len(self.changed),
+            "lanes": [entry.to_dict() for entry in self.entries],
+        }
+
+
+def reconcile_lanes(
+    declared: list[LaneManifest],
+    existing: dict[str, str] | None = None,
+) -> LaneReconcileResult:
+    """Compare a declared lane set against the hashes already registered.
+
+    Create-if-absent, and a no-op on match -- the same three-way decision
+    ``pool register`` makes, over a whole set rather than one record.
+
+    Args:
+        declared: The lanes the operator's file declares, in file order. Order
+            is preserved so a report reads the way the file does.
+        existing: ``lane name -> lane_hash`` already registered, typically
+            projected from the chain. ``None`` is a first bootstrap.
+
+    Returns:
+        One entry per declared lane. Nothing is removed here: a lane absent from
+        the file is a retirement, which is a decision an operator makes
+        deliberately rather than one a bootstrap infers from an omission.
+
+    Raises:
+        LaneError: Two declared lanes share a name -- the set is keyed on it, so
+            the second would silently shadow the first.
+    """
+    seen: set[str] = set()
+    for lane in declared:
+        if lane.name in seen:
+            raise LaneError(f"two declared lanes are named {lane.name!r}; a lane set is keyed on the name")
+        seen.add(lane.name)
+
+    known = existing or {}
+    entries: list[LaneReconcileEntry] = []
+    for lane in declared:
+        prev = known.get(lane.name, "")
+        if not prev:
+            entries.append(LaneReconcileEntry(lane=lane, action=LaneAction.REGISTERED))
+        elif prev == lane.lane_hash:
+            entries.append(LaneReconcileEntry(lane=lane, action=LaneAction.UNCHANGED, prev_hash=prev))
+        else:
+            entries.append(LaneReconcileEntry(lane=lane, action=LaneAction.UPDATED, prev_hash=prev))
+    return LaneReconcileResult(entries=tuple(entries))
+
+
+def load_lane_set(raw: dict[str, Any]) -> tuple[LaneManifest, ...]:
+    """Load a lane-set document.
+
+    Raises:
+        LaneError: The document carries an unknown key, ``lanes`` is not a list,
+            or any lane is invalid.
+    """
+    unknown = set(raw) - {"lanes"}
+    if unknown:
+        raise LaneError(f"lane set document has unknown key(s): {sorted(unknown)}")
+    lanes = raw.get("lanes", [])
+    if not isinstance(lanes, list):
+        raise LaneError("lane set document's 'lanes' must be a list")
+    return tuple(LaneManifest.from_dict(entry) for entry in lanes)
+
+
+__all__ = [
+    "LANE_MANIFEST_SCHEMA_VERSION",
+    "Barrier",
+    "LaneAction",
+    "LaneError",
+    "LaneManifest",
+    "LaneReconcileEntry",
+    "LaneReconcileResult",
+    "load_lane_set",
+    "reconcile_lanes",
+]

--- a/tests/unit/core/govern/test_reconciliation_lanes.py
+++ b/tests/unit/core/govern/test_reconciliation_lanes.py
@@ -1,0 +1,239 @@
+"""Issue #5120: reconciliation lanes are data, and bootstrap is create-if-absent.
+
+There was no "lane" concept anywhere. The pattern this needs -- a named,
+content-hashed record where re-registering an unchanged one is a no-op --
+already existed for sandbox pools (``pool register``'s
+``action = "unchanged"``), and lanes are the missing half of it.
+
+The barrier is why a lane is one mechanism rather than two: a canary lane that
+must serialize its steps and a bulk lane where one stuck target must not block
+the rest are the same runner with one flag flipped.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.govern.lanes import (
+    Barrier,
+    LaneAction,
+    LaneError,
+    LaneManifest,
+    load_lane_set,
+    reconcile_lanes,
+)
+
+
+def _lane(name: str = "canary", **over: object) -> LaneManifest:
+    fields: dict[str, object] = {
+        "name": name,
+        "selector": "env=prod,tier=1",
+        "schedule": "0 * * * *",
+        "log_destination": f".sdd/logs/{name}",
+    }
+    fields.update(over)
+    return LaneManifest(**fields)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# The record
+# ---------------------------------------------------------------------------
+
+
+def test_a_lane_carries_every_field_the_issue_names() -> None:
+    lane = _lane(timeout_seconds=900, barrier=Barrier.PER_STEP)
+    assert lane.name == "canary"
+    assert lane.selector == "env=prod,tier=1"
+    assert lane.schedule == "0 * * * *"
+    assert lane.timeout_seconds == 900
+    assert lane.log_destination == ".sdd/logs/canary"
+    assert lane.barrier is Barrier.PER_STEP
+
+
+def test_the_barrier_defaults_to_free() -> None:
+    """The bulk case is the common one; a canary opts in to serializing."""
+    assert _lane().barrier is Barrier.FREE
+
+
+def test_the_hash_is_the_identity_and_moves_with_any_field() -> None:
+    base = _lane()
+    for changed in (
+        {"selector": "env=staging"},
+        {"schedule": "0 3 * * *"},
+        {"timeout_seconds": 60},
+        {"log_destination": ".sdd/logs/other"},
+        {"barrier": Barrier.PER_STEP},
+    ):
+        assert _lane(**changed).lane_hash != base.lane_hash, changed
+
+
+def test_two_lanes_declared_identically_hash_identically() -> None:
+    assert _lane().lane_hash == _lane().lane_hash
+
+
+def test_the_hash_is_computed_not_accepted() -> None:
+    """A hash somebody can pass in is a hash somebody can pass in wrong."""
+    lane = LaneManifest(
+        name="canary",
+        selector="env=prod",
+        schedule="0 * * * *",
+        log_destination=".sdd/logs/canary",
+        lane_hash="deadbeef",
+    )
+    assert lane.lane_hash != "deadbeef"
+
+
+@pytest.mark.parametrize("field_name", ["name", "selector", "schedule", "log_destination"])
+def test_an_empty_required_field_is_refused(field_name: str) -> None:
+    with pytest.raises(LaneError, match=field_name):
+        _lane(**{field_name: "   "})
+
+
+def test_a_negative_timeout_is_refused() -> None:
+    with pytest.raises(LaneError, match="timeout_seconds"):
+        _lane(timeout_seconds=-1)
+
+
+def test_a_zero_timeout_means_no_ceiling() -> None:
+    """Matching the convention PoolManifest.max_concurrency already uses."""
+    assert _lane(timeout_seconds=0).timeout_seconds == 0
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+
+def test_a_lane_round_trips() -> None:
+    lane = _lane(barrier=Barrier.PER_STEP, timeout_seconds=30)
+    assert LaneManifest.from_dict(lane.to_dict()) == lane
+
+
+def test_a_declared_hash_is_verified_not_trusted() -> None:
+    """Trusting it would let an edited lane keep the identity that was reviewed."""
+    document = _lane().to_dict()
+    document["selector"] = "env=everything"
+
+    with pytest.raises(LaneError, match="edited after it was hashed"):
+        LaneManifest.from_dict(document)
+
+
+def test_a_document_with_no_hash_is_accepted_and_hashed() -> None:
+    document = _lane().to_dict()
+    del document["lane_hash"]
+    assert LaneManifest.from_dict(document).lane_hash == _lane().lane_hash
+
+
+def test_an_unknown_key_is_refused() -> None:
+    with pytest.raises(LaneError, match="unknown key"):
+        LaneManifest.from_dict({**_lane().to_dict(), "barier": "free"})
+
+
+def test_an_unknown_barrier_is_refused_and_names_the_known_ones() -> None:
+    document = _lane().to_dict()
+    document["barrier"] = "sequential"
+    del document["lane_hash"]
+    with pytest.raises(LaneError, match="not one of") as excinfo:
+        LaneManifest.from_dict(document)
+    assert "per-step" in str(excinfo.value)
+    assert "free" in str(excinfo.value)
+
+
+def test_a_non_integer_timeout_is_refused() -> None:
+    document = _lane().to_dict()
+    document["timeout_seconds"] = "soon"
+    del document["lane_hash"]
+    with pytest.raises(LaneError, match="not an integer"):
+        LaneManifest.from_dict(document)
+
+
+def test_a_lane_set_document_loads() -> None:
+    lanes = load_lane_set({"lanes": [_lane("canary").to_dict(), _lane("bulk").to_dict()]})
+    assert [lane.name for lane in lanes] == ["canary", "bulk"]
+
+
+def test_a_lane_set_with_an_unknown_key_is_refused() -> None:
+    with pytest.raises(LaneError, match="unknown key"):
+        load_lane_set({"lanes": [], "lanez": []})
+
+
+def test_a_lane_set_whose_lanes_are_not_a_list_is_refused() -> None:
+    with pytest.raises(LaneError, match="must be a list"):
+        load_lane_set({"lanes": {"name": "canary"}})
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap
+# ---------------------------------------------------------------------------
+
+
+def test_a_first_bootstrap_registers_everything() -> None:
+    result = reconcile_lanes([_lane("canary"), _lane("bulk")])
+
+    assert [e.action for e in result.entries] == [LaneAction.REGISTERED, LaneAction.REGISTERED]
+    assert result.is_noop is False
+
+
+def test_running_it_twice_against_an_unchanged_set_is_a_no_op() -> None:
+    """The issue's named test. Bootstrap must change nothing AND say so."""
+    lanes = [_lane("canary"), _lane("bulk")]
+    first = reconcile_lanes(lanes)
+    existing = {e.lane.name: e.lane.lane_hash for e in first.entries}
+
+    second = reconcile_lanes(lanes, existing)
+
+    assert [e.action for e in second.entries] == [LaneAction.UNCHANGED, LaneAction.UNCHANGED]
+    assert second.is_noop is True
+    assert second.changed == ()
+
+
+def test_only_the_lane_that_moved_is_updated() -> None:
+    existing = {
+        "canary": _lane("canary").lane_hash,
+        "bulk": _lane("bulk").lane_hash,
+    }
+
+    result = reconcile_lanes([_lane("canary"), _lane("bulk", schedule="0 3 * * *")], existing)
+
+    assert [e.action for e in result.entries] == [LaneAction.UNCHANGED, LaneAction.UPDATED]
+    assert result.is_noop is False
+    assert [e.lane.name for e in result.changed] == ["bulk"]
+
+
+def test_an_updated_lane_reports_the_hash_it_replaced() -> None:
+    previous = _lane("bulk").lane_hash
+    result = reconcile_lanes([_lane("bulk", timeout_seconds=60)], {"bulk": previous})
+    assert result.entries[0].prev_hash == previous
+
+
+def test_declared_order_is_preserved_so_a_report_reads_like_the_file() -> None:
+    names = ["zulu", "alpha", "mike"]
+    result = reconcile_lanes([_lane(name) for name in names])
+    assert [e.lane.name for e in result.entries] == names
+
+
+def test_a_lane_missing_from_the_file_is_not_retired_here() -> None:
+    """A retirement is a deliberate decision, not one inferred from an omission."""
+    existing = {"canary": _lane("canary").lane_hash, "retired": "abc"}
+    result = reconcile_lanes([_lane("canary")], existing)
+
+    assert len(result.entries) == 1
+    assert result.is_noop is True
+
+
+def test_two_declared_lanes_cannot_share_a_name() -> None:
+    """The set is keyed on it, so the second would silently shadow the first."""
+    with pytest.raises(LaneError, match="two declared lanes"):
+        reconcile_lanes([_lane("canary"), _lane("canary", schedule="0 3 * * *")])
+
+
+def test_the_json_shape_mirrors_pool_register() -> None:
+    document = reconcile_lanes([_lane("canary")]).to_dict()
+
+    assert document["noop"] is False
+    assert document["changed"] == 1
+    row = document["lanes"][0]
+    assert row["action"] == "registered"
+    assert row["name"] == "canary"
+    assert row["barrier"] == "free"
+    assert len(row["lane_hash"]) == 64


### PR DESCRIPTION
#5120 — the record and the bootstrap decision. There was no "lane" concept anywhere in the codebase, so this is what everything else in the issue attaches to.

## Shape

Deliberately `PoolManifest`'s, since the issue identifies it as the closest existing analog: a named record whose identity is a SHA-256 over the canonical JSON of every other field, so re-registering an unchanged one is a no-op that says so. The fields differ (`selector`, `schedule`, `timeout_seconds`, `log_destination`, `barrier`); the discipline does not.

## The barrier is why a lane is one mechanism, not two

A canary lane that must serialize its steps and a bulk lane where one stuck target must not block the rest are the same runner with one flag flipped. Keeping them as two pieces of code is keeping two things in sync forever. It defaults to `free` — the bulk case is the common one, and a canary opts in to serializing.

## Two decisions about the hash

- **Computed, never accepted.** `lane_hash` is set in `__post_init__`. A hash somebody can pass in is a hash somebody can pass in wrong, and the whole no-op decision downstream rests on it being the hash of the content. Passing `lane_hash="deadbeef"` gets you the real hash.
- **Verified on load, not trusted.** A `lane_hash` present in a document is recomputed and compared; a mismatch is refused with *"the record was edited after it was hashed"*. Trusting it would let an edited lane keep the identity of the one that was reviewed.

## Bootstrap

`reconcile_lanes(declared, existing)` makes the same three-way decision `pool register` already makes — `registered` / `updated` / `unchanged` — over a whole set rather than one record. `LaneReconcileResult.is_noop` is the property the issue's requirement 3 asks for: starting the scheduler against an existing lane set changes nothing **and says so**.

**Nothing is retired here.** A lane absent from the file is a retirement, and that is a decision an operator makes deliberately rather than one a bootstrap infers from an omission — inferring it would make a typo in a filename delete a lane set.

Two declared lanes sharing a name are refused: the set is keyed on it, so the second would silently shadow the first.

## Tests — 28, including the issue's named one

`test_running_it_twice_against_an_unchanged_set_is_a_no_op` — *"run a lane twice against an unchanged fixture; the second run is a journaled no-op"*.

Plus: every field moves the hash and identical declarations match; each required field refused empty; a negative timeout refused and zero meaning no ceiling; round-trip; **tamper detection**; unknown key, unknown barrier (naming the known set), non-integer timeout; declared order preserved; only the lane that moved marked updated, with the hash it replaced; a lane absent from the file left alone; and the `--json` row shape mirroring `pool register`.

```
uv run pytest tests/unit/core/govern/ -q      # 228 passed
uv run mypy --config-file mypy.gate.ini       # Success, 98 files
uv run ruff check / ruff format --check       # clean
```

## Not in this PR

The chain projection, the dated log artefact per run, and the CLI. Those attach to this record; the record is what did not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)