### PR TITLE
feat(evolution): declare constraint layer manifest and hash-lock all modules (#5440)

### DIFF
--- a/docs/release-notes/fragments/5440-constraint-layer-manifest.md
+++ b/docs/release-notes/fragments/5440-constraint-layer-manifest.md
@@ -1,0 +1,3 @@
+## Constraint layer declared as unified manifest with immutable hash-locks
+
+The evolution constraint layer is now defined in a single manifest covering the audit chain, identity/signing, policy/RBAC, and evolution admission/governance/invariants/gate/circuit modules. Any evolution proposal attempting to modify a module in the constraint manifest is refused at every level (L0-L3) with an audit entry. Hash-locking and CODEOWNERS drift guards verify full coverage across the constraint layer (#5440).

--- a/src/bernstein/evolution/admission.py
+++ b/src/bernstein/evolution/admission.py
@@ -133,8 +133,10 @@ def decision_key(proposal: Admissible | UpgradeProposal) -> str:
     Both halves are read through ``getattr(..., "value", ...)`` so the key is
     identical whether the field holds an enum member or a bare string.
     """
-    category = getattr(proposal.category, "value", proposal.category)
-    trigger = getattr(proposal.triggered_by, "value", proposal.triggered_by)
+    cat = getattr(proposal, "category", "general")
+    category = getattr(cat, "value", cat)
+    trig = getattr(proposal, "triggered_by", "manual")
+    trigger = getattr(trig, "value", trig)
     return f"category:{category}|trigger:{trigger}"
 
 
@@ -223,6 +225,15 @@ class AdmissionPolicy:
         agent_type = producer_identity(proposal)
         key = decision_key(proposal)
         confidence = self._query.get(agent_type, key)
+
+        target_files = getattr(proposal, "target_files", None)
+        if target_files:
+            from bernstein.evolution.invariants import check_proposal_targets
+
+            safe, violations = check_proposal_targets(target_files)
+            if not safe:
+                reason = f"Proposal targets constraint layer / locked file(s): {', '.join(sorted(violations))}"
+                return self._finalise(False, reason, agent_type, key, confidence)
 
         if confidence.insufficient_data:
             admitted = self._cold_start is ColdStartMode.FAIL_OPEN

--- a/src/bernstein/evolution/gate.py
+++ b/src/bernstein/evolution/gate.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     from bernstein.core.security.audit_chain import AuditChainStore
     from bernstein.eval.gate_receipt import VerdictReceipt
 
+from bernstein.evolution.invariants import check_proposal_targets
 from bernstein.evolution.oscillation_guard import (
     OscillationGuard,
     OscillationResult,
@@ -290,6 +291,29 @@ class ApprovalGate:
         Returns:
             ApprovalDecision describing the routing outcome.
         """
+        target_files = getattr(proposal, "target_files", []) or []
+        safe, violations = check_proposal_targets(target_files)
+        if not safe:
+            risk_level = getattr(proposal, "risk_level", None)
+            if risk_level is None or not isinstance(risk_level, RiskLevel):
+                risk_level = self._classifier.classify(target_files)
+            reason = f"Proposal targets constraint layer / locked file(s): {', '.join(sorted(violations))}"
+            decision = ApprovalDecision(
+                proposal_id=proposal.id,
+                risk_level=risk_level,
+                confidence=proposal.confidence,
+                outcome=ApprovalOutcome.BLOCKED,
+                reason=reason,
+                requires_human=True,
+            )
+            self._log_decision(decision)
+            logger.warning(
+                "Proposal %s refused by constraint manifest: %s",
+                proposal.id,
+                reason,
+            )
+            return decision
+
         risk_level = self._classifier.classify(proposal.target_files)
         outcome, reason, requires_human = self._decide(risk_level, proposal.confidence)
 

--- a/src/bernstein/evolution/invariants.py
+++ b/src/bernstein/evolution/invariants.py
@@ -19,19 +19,99 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Files that MUST NOT be modified by the evolution system.
-# These are the "immutable kernel" per the Stable Kernel Thesis.
-# Paths follow the post-decomposition layout (orchestration/, quality/, server/
-# sub-packages); legacy top-level shims are loaded via sys.meta_path and do
-# not exist on disk.
-LOCKED_FILES: tuple[str, ...] = (
+# Manifest of the constraint layer defining what the system may do.
+# These safety-critical modules and paths are hash-locked and immutable
+# against self-evolution modifications across all levels (L0-L3).
+# Do not widen the manifest without a comment naming the module's role.
+CONSTRAINT_MANIFEST: tuple[str, ...] = (
+    # Core orchestration and quality (original hard-coded kernel)
     "src/bernstein/core/quality/janitor.py",
     "src/bernstein/core/server/server_app.py",
     "src/bernstein/core/orchestration/orchestrator.py",
-    "src/bernstein/evolution/invariants.py",
+    # Evolution kernel: admission, circuit, gate, governance, invariants
+    "src/bernstein/evolution/admission.py",
     "src/bernstein/evolution/circuit.py",
     "src/bernstein/evolution/gate.py",
+    "src/bernstein/evolution/governance.py",
+    "src/bernstein/evolution/invariants.py",
+    # Core identity layer: agent registry, delegation, grants, signing, spiffe
+    "src/bernstein/core/identity/**",
+    "src/bernstein/core/security/agent_identity.py",
+    "src/bernstein/core/security/identity_spawn_anchor.py",
+    "src/bernstein/core/security/toolcall_identity.py",
+    # Core audit chain and verification
+    "src/bernstein/core/audit/**",
+    "src/bernstein/core/security/audit*.py",
+    "src/bernstein/core/security/change_receipt.py",
+    "src/bernstein/core/verifier/audit_receipt_verifier.py",
+    # Core policy and RBAC modules
+    "src/bernstein/core/security/command_policy.py",
+    "src/bernstein/core/security/external_policy_hook.py",
+    "src/bernstein/core/security/guardrail_pipeline.py",
+    "src/bernstein/core/security/guardrails.py",
+    "src/bernstein/core/security/network_policy.py",
+    "src/bernstein/core/security/permission_delegation.py",
+    "src/bernstein/core/security/permission_graph.py",
+    "src/bernstein/core/security/permission_matrix.py",
+    "src/bernstein/core/security/permission_mode.py",
+    "src/bernstein/core/security/permission_policy.py",
+    "src/bernstein/core/security/permission_rules.py",
+    "src/bernstein/core/security/permissions.py",
+    "src/bernstein/core/security/plugin_policy.py",
+    "src/bernstein/core/security/policy.py",
+    "src/bernstein/core/security/policy_engine.py",
+    "src/bernstein/core/security/policy_limits.py",
+    "src/bernstein/core/security/policy_templates.py",
+    "src/bernstein/core/security/rbac.py",
+    "src/bernstein/core/security/role_adapter_policy.py",
 )
+
+# Concrete non-glob locked files derived from CONSTRAINT_MANIFEST
+LOCKED_FILES: tuple[str, ...] = tuple(p for p in CONSTRAINT_MANIFEST if "*" not in p)
+
+
+def is_constraint_path(path: str | Path) -> bool:
+    """Check if a file path belongs to the constraint layer manifest."""
+    import fnmatch
+
+    norm = str(path).replace("\\", "/").strip().lstrip("./")
+    if norm.startswith("core/") or norm.startswith("evolution/"):
+        norm_full = f"src/bernstein/{norm}"
+    elif norm.startswith("bernstein/"):
+        norm_full = f"src/{norm}"
+    else:
+        norm_full = norm
+
+    for pattern in CONSTRAINT_MANIFEST:
+        if fnmatch.fnmatch(norm, pattern) or fnmatch.fnmatch(norm_full, pattern):
+            return True
+        if pattern.endswith("/**"):
+            prefix = pattern[:-3]
+            if (
+                norm == prefix
+                or norm.startswith(prefix + "/")
+                or norm_full == prefix
+                or norm_full.startswith(prefix + "/")
+            ):
+                return True
+        elif pattern.endswith("/*"):
+            prefix = pattern[:-2]
+            if norm.startswith(prefix + "/") or norm_full.startswith(prefix + "/"):
+                return True
+    return False
+
+
+def resolve_locked_files(repo_root: Path) -> list[str]:
+    """Derive concrete locked file paths from the constraint manifest for a given repo."""
+    locked: set[str] = set()
+    for entry in CONSTRAINT_MANIFEST:
+        if "*" in entry:
+            for p in repo_root.glob(entry):
+                if p.is_file():
+                    locked.add(p.relative_to(repo_root).as_posix())
+        else:
+            locked.add(entry)
+    return sorted(locked)
 
 
 def _sha256(path: Path) -> str:
@@ -65,7 +145,7 @@ def compute_invariants(repo_root: Path) -> dict[str, str]:
     """
     hashes: dict[str, str] = {}
     source_tree = (repo_root / "src" / "bernstein").is_dir()
-    for rel_path in LOCKED_FILES:
+    for rel_path in resolve_locked_files(repo_root):
         full_path = repo_root / rel_path
         if full_path.exists():
             hashes[rel_path] = _sha256(full_path)
@@ -144,7 +224,7 @@ def check_proposal_targets(
     Returns:
         Tuple of (safe, violations). If safe is False, proposal MUST be rejected.
     """
-    violations = [f for f in target_files if f in LOCKED_FILES]
+    violations = [f for f in target_files if is_constraint_path(f)]
     if violations:
         logger.error("Proposal targets %d locked file(s): %s", len(violations), violations)
     return len(violations) == 0, violations

--- a/tests/unit/test_constraint_manifest.py
+++ b/tests/unit/test_constraint_manifest.py
@@ -1,0 +1,192 @@
+"""Tests for constraint layer manifest, invariants hash-locking, and drift guards (#5440)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.evolution.admission import (
+    AdmissionMode,
+    AdmissionPolicy,
+    ColdStartMode,
+)
+from bernstein.evolution.gate import (
+    ApprovalGate,
+    ApprovalOutcome,
+)
+from bernstein.evolution.invariants import (
+    CONSTRAINT_MANIFEST,
+    LOCKED_FILES,
+    is_constraint_path,
+    resolve_locked_files,
+)
+from bernstein.evolution.types import RiskLevel, UpgradeProposal
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CODEOWNERS_PATH = REPO_ROOT / ".github" / "CODEOWNERS"
+
+
+def _make_proposal(
+    *,
+    id: str = "UPG-TEST",
+    risk_level: RiskLevel = RiskLevel.L0_CONFIG,
+    target_files: list[str] | None = None,
+    confidence: float = 0.99,
+) -> UpgradeProposal:
+    return UpgradeProposal(
+        id=id,
+        title="Test Proposal",
+        description="Testing constraint layer",
+        risk_level=risk_level,
+        target_files=target_files or ["src/bernstein/core/security/audit.py"],
+        diff="--- a\n+++ b",
+        rationale="Testing",
+        expected_impact="None",
+        confidence=confidence,
+    )
+
+
+class TestConstraintLayerRejection:
+    """Proposal fixture touching core/audit rejected at L0, L1, L2, L3 with the same reason."""
+
+    @pytest.mark.parametrize(
+        "level",
+        [
+            RiskLevel.L0_CONFIG,
+            RiskLevel.L1_TEMPLATE,
+            RiskLevel.L2_LOGIC,
+            RiskLevel.L3_STRUCTURAL,
+        ],
+    )
+    def test_proposal_touching_core_audit_rejected_at_all_levels_with_same_reason(
+        self,
+        tmp_path: Path,
+        level: RiskLevel,
+    ) -> None:
+        decisions_dir = tmp_path / "evolution"
+        gate = ApprovalGate(decisions_dir=decisions_dir)
+
+        # Target touching core/audit
+        proposal = _make_proposal(
+            id=f"P-{level.name}",
+            risk_level=level,
+            target_files=["src/bernstein/core/security/audit.py"],
+            confidence=0.99,
+        )
+
+        decision = gate.route(proposal)
+
+        assert decision.outcome == ApprovalOutcome.BLOCKED
+        assert decision.reason == "Proposal targets constraint layer / locked file(s): src/bernstein/core/security/audit.py"
+        assert decision.requires_human is True
+
+        # Verify audit record was written to decisions.jsonl
+        decisions_log = decisions_dir / "decisions.jsonl"
+        assert decisions_log.exists()
+        logged = [json.loads(line) for line in decisions_log.read_text(encoding="utf-8").splitlines() if line.strip()]
+        assert any(d["proposal_id"] == f"P-{level.name}" and d["outcome"] == "blocked" for d in logged)
+
+    def test_proposal_touching_shorthand_core_audit_rejected(self, tmp_path: Path) -> None:
+        gate = ApprovalGate(decisions_dir=tmp_path / "evolution")
+        proposal = _make_proposal(
+            id="P-shorthand",
+            target_files=["core/audit/audit_chain.py"],
+            confidence=0.99,
+        )
+        decision = gate.route(proposal)
+        assert decision.outcome == ApprovalOutcome.BLOCKED
+        assert "core/audit/audit_chain.py" in decision.reason
+
+    def test_admission_policy_refuses_constraint_layer_proposal(self) -> None:
+        admission = AdmissionPolicy(mode=AdmissionMode.ENFORCE, cold_start=ColdStartMode.FAIL_OPEN)
+        proposal = _make_proposal(
+            target_files=["src/bernstein/core/security/audit_chain.py"],
+        )
+        decision = admission.evaluate(proposal)
+        assert decision.admitted is False
+        assert "Proposal targets constraint layer / locked file(s)" in decision.reason
+
+
+class TestCodeownersDrift:
+    """Manifest / CODEOWNERS tests."""
+
+    def test_manifest_subset_of_codeowners(self) -> None:
+        """Every path in CONSTRAINT_MANIFEST must be covered by CODEOWNERS."""
+        assert CODEOWNERS_PATH.exists(), "CODEOWNERS file must exist"
+
+        owner_patterns: list[str] = []
+        for line in CODEOWNERS_PATH.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split()
+            pattern = parts[0].lstrip("/")
+            owner_patterns.append(pattern)
+
+        # Each entry in manifest must match at least one codeowner pattern
+        for entry in CONSTRAINT_MANIFEST:
+            norm_entry = entry.lstrip("/")
+            matched = any(
+                norm_entry.startswith(p.rstrip("*"))
+                or p == "*"
+                for p in owner_patterns
+            )
+            assert matched, f"Constraint manifest entry {entry!r} not covered by any pattern in {owner_patterns}"
+
+    def test_every_hash_locked_module_in_manifest(self) -> None:
+        """Every module returned by resolve_locked_files / compute_invariants is in the manifest."""
+        locked_files = resolve_locked_files(REPO_ROOT)
+        assert len(locked_files) > 0
+
+        for f in locked_files:
+            assert is_constraint_path(f), f"Locked file {f} is not recognized by is_constraint_path"
+
+        for f in LOCKED_FILES:
+            assert is_constraint_path(f), f"LOCKED_FILES entry {f} is not recognized by is_constraint_path"
+
+
+class TestWholeTreeConstraintGuard:
+    """Whole-tree guard asserts that all constraint subtrees are fully locked."""
+
+    def test_whole_tree_constraint_guard(self) -> None:
+        """Scan constraint directories in src/ to ensure every module is locked."""
+        subtrees = [
+            REPO_ROOT / "src" / "bernstein" / "core" / "identity",
+            REPO_ROOT / "src" / "bernstein" / "core" / "audit",
+        ]
+
+        for subtree in subtrees:
+            if not subtree.exists():
+                continue
+            for py_file in subtree.rglob("*.py"):
+                if py_file.name == "__pycache__":
+                    continue
+                rel_path = py_file.relative_to(REPO_ROOT).as_posix()
+                assert is_constraint_path(rel_path), f"Module {rel_path} under constraint subtree is not locked!"
+
+
+class TestNoBehaviorChangeOutsideManifest:
+    """Verify proposals outside the manifest retain their standard behavior."""
+
+    def test_proposals_outside_manifest_unchanged(self, tmp_path: Path) -> None:
+        gate = ApprovalGate(decisions_dir=tmp_path / "evolution")
+
+        # L0 config auto-approved
+        l0 = _make_proposal(id="L0-safe", risk_level=RiskLevel.L0_CONFIG, target_files=[".sdd/config.yaml"], confidence=0.98)
+        assert gate.route(l0).outcome == ApprovalOutcome.AUTO_APPROVED
+
+        # L1 template auto-approved
+        l1 = _make_proposal(id="L1-safe", risk_level=RiskLevel.L1_TEMPLATE, target_files=["templates/roles/backend.md"], confidence=0.98)
+        assert gate.route(l1).outcome == ApprovalOutcome.AUTO_APPROVED
+
+        # L2 logic human review
+        l2 = _make_proposal(id="L2-safe", risk_level=RiskLevel.L2_LOGIC, target_files=[".sdd/config/routing.yaml"], confidence=0.98)
+        assert gate.route(l2).outcome == ApprovalOutcome.HUMAN_REVIEW_4H
+
+        # L3 structural blocked with standard L3 message
+        l3 = _make_proposal(id="L3-safe", risk_level=RiskLevel.L3_STRUCTURAL, target_files=["src/bernstein/core/models.py"], confidence=0.98)
+        d3 = gate.route(l3)
+        assert d3.outcome == ApprovalOutcome.BLOCKED
+        assert "L3_STRUCTURAL changes require human-only review" in d3.reason


### PR DESCRIPTION
Fixes #5440

### Summary
The self-evolution loop previously only hash-locked a hard-coded set of 6 modules (janitor, server_app, orchestrator, invariants, circuit, gate). Modules defining core security constraints (audit chain, identity/signing, policy/RBAC, admission, and evolution governance) were not protected from evolution proposals.

### Changes
1. Declared CONSTRAINT_MANIFEST in src/bernstein/evolution/invariants.py with path patterns covering all constraint-layer modules (core/audit/**, core/identity/**, policy/RBAC, and evolution kernel modules).
2. Added is_constraint_path and esolve_locked_files in src/bernstein/evolution/invariants.py to derive LOCKED_FILES and invariants calculation dynamically from the manifest.
3. Updated ApprovalGate.route in src/bernstein/evolution/gate.py to refuse any proposal targeting constraint layer paths at all levels (L0-L3) with an audit entry written to decisions.jsonl.
4. Updated AdmissionPolicy.evaluate in src/bernstein/evolution/admission.py to reject proposals targeting constraint paths.
5. Added comprehensive test suite in 	ests/unit/test_constraint_manifest.py:
   - Rejection across L0, L1, L2, L3 with identical reasons and audit entries.
   - CONSTRAINT_MANIFEST ⊆ CODEOWNERS drift test.
   - Lock completeness and whole-tree guard.
   - Non-manifest proposals maintain standard routing behavior.
6. Added BOM-free release notes fragment docs/release-notes/fragments/5440-constraint-layer-manifest.md.

### Verification
- pytest tests/unit/test_constraint_manifest.py tests/unit/test_invariants.py tests/unit/test_approval_gate.py tests/unit/test_evolution_loop.py tests/unit/test_evolution_e2e.py (130 tests pass).
- scripts/check_bom.py passes with zero BOM errors.
- uff check src tests passes cleanly.