### PR TITLE
feat(eval): record cost per verdict in bundles and add budget gate (#5464)

### DIFF
--- a/docs/eval/bench.md
+++ b/docs/eval/bench.md
@@ -66,6 +66,9 @@ bernstein bench run <suite>
 ```bash
 # Run the canonical golden-v1 suite and emit a submission bundle
 bernstein bench run golden-v1 --out my-bundle.json
+
+# Run with a budget gate (halts when accumulated cost reaches limit)
+bernstein bench run golden-v1 --budget 0.50 --out my-bundle.json
 ```
 
 This executes every task in `golden-v1` via the real adapter, collects
@@ -106,7 +109,15 @@ overall     : MATCH
   ✓ doc_update_docstring                     MATCH
 ```
 
-### 3. Submit to the leaderboard
+### 3. Compare two bundles
+
+```bash
+bernstein bench compare bundle-v1.json bundle-v2.json
+```
+
+Reports pass rate, score, cost, token, and wall-time deltas side-by-side with per-task verdict transitions.
+
+### 4. Submit to the leaderboard
 
 ```bash
 bernstein bench submit my-bundle.json
@@ -173,12 +184,24 @@ Two runners on the same `suite_hash` provably ran the same task set.
 ```json
 {
   "bundle_hash": "<sha256 of everything except signature>",
+  "schema_version": 2,
   "suite_hash": "...",
   "suite_version": "golden-v1",
   "submitted_at": 1753000000.0,
   "scheduler_config": {"...": "..."},
   "overall_score": 0.95,
   "pass_rate": 1.0,
+  "total_cost_usd": 0.0450,
+  "total_tokens": 4500,
+  "total_duration_seconds": 12.5,
+  "cost_per_verdict": {
+    "passed": 0.0450,
+    "failed": 0.0
+  },
+  "tokens_per_verdict": {
+    "passed": 4500,
+    "failed": 0
+  },
   "task_results": [
     {
       "task_id": "file_io_read_write",
@@ -192,7 +215,10 @@ Two runners on the same `suite_hash` provably ran the same task set.
       "receipt_hash": "<sha256 of receipt bytes>",
       "passed": true,
       "score": 1.0,
-      "harness_output": {"...": "..."}
+      "harness_output": {"...": "..."},
+      "duration_seconds": 2.5,
+      "token_count": 900,
+      "cost_usd": 0.0090
     }
   ],
   "signature": "<Ed25519 JWS>",
@@ -214,14 +240,15 @@ from bernstein.eval.bench import (
     BenchVerifier,
     MockReplayAdapter,
     build_golden_suite_v1,
+    compare_bundles,
     Leaderboard,
     LeaderboardEntry,
 )
 
-# Build and run the golden suite (hermetic mock adapter)
+# Build and run the golden suite (hermetic mock adapter) with a budget gate
 suite = build_golden_suite_v1()
 adapter = MockReplayAdapter()
-runner = BenchRunner(suite=suite, adapter=adapter, scheduler_config={})
+runner = BenchRunner(suite=suite, adapter=adapter, scheduler_config={}, budget_usd=1.00)
 bundle = runner.run()
 
 # Verify offline
@@ -229,6 +256,10 @@ verifier = BenchVerifier(suite=suite, adapter=adapter)
 result = verifier.verify(bundle)
 print(result.report())
 # overall: MATCH
+
+# Compare two bundles
+comparison = compare_bundles(bundle_a, bundle_b)
+print(comparison.report())
 
 # Project to leaderboard
 lb = Leaderboard(suite_hash=suite.suite_hash, suite_version=suite.version)
@@ -268,14 +299,16 @@ src/bernstein/eval/bench/
 ├── suite.py             # BenchSuite, BenchTask (content-addressed)
 ├── bundle.py            # SubmissionBundle, TaskResult
 ├── runner.py            # BenchRunner, MockReplayAdapter, StochasticMockReplayAdapter
+├── compare.py           # BundleComparison, TaskComparison, compare_bundles
 ├── verifier.py          # BenchVerifier, VerificationStatus
 ├── leaderboard.py       # Leaderboard, LeaderboardEntry, Markdown render
 ├── reliability.py       # pass^k reliability floor (see reliability.md)
 └── golden_suite.py      # starter golden-v1 task suite
 
 tests/unit/eval/bench/
-├── test_bench.py        # TDD suite — all acceptance criteria
-└── test_reliability.py  # pass^k reliability floor tests
+├── test_bench.py              # TDD suite — all acceptance criteria
+├── test_bench_cost_budget.py  # Cost per verdict, budget gate, compare tests
+└── test_reliability.py        # pass^k reliability floor tests
 
 docs/eval/
 ├── bench.md                  # this document

--- a/docs/release-notes/fragments/5464-bench-cost-per-verdict-budget-gate.md
+++ b/docs/release-notes/fragments/5464-bench-cost-per-verdict-budget-gate.md
@@ -1,0 +1,8 @@
+## Benchmark cost per verdict, bundle comparison, and budget gate
+
+Submission bundles now record token count, cost in USD, and duration per task alongside
+verdict breakdowns (`cost_per_verdict` and `tokens_per_verdict`) with bundle schema version 2.
+`bernstein bench compare` enables side-by-side comparison of submission bundles across
+accuracy, cost, tokens, and wall time. `bernstein bench run` adds `--budget` to enforce a
+maximum spend limit for CI benchmark runs, halting execution and recording budget status
+when exceeded (#5464).

--- a/src/bernstein/eval/bench/__init__.py
+++ b/src/bernstein/eval/bench/__init__.py
@@ -1,6 +1,7 @@
 """bernstein-bench: runnable, reproducibility-gated evaluation harness."""
 
 from bernstein.eval.bench.bundle import SubmissionBundle, TaskResult
+from bernstein.eval.bench.compare import BundleComparison, TaskComparison, compare_bundles
 from bernstein.eval.bench.golden_suite import build_golden_suite_v1
 from bernstein.eval.bench.leaderboard import Leaderboard, LeaderboardEntry
 from bernstein.eval.bench.reliability import (
@@ -39,6 +40,7 @@ __all__ = [
     "BenchSuite",
     "BenchTask",
     "BenchVerifier",
+    "BundleComparison",
     "BundleVerificationResult",
     "InstallIdentityReliabilitySigner",
     "Leaderboard",
@@ -54,12 +56,14 @@ __all__ = [
     "StochasticMockReplayAdapter",
     "StubReliabilitySigner",
     "SubmissionBundle",
+    "TaskComparison",
     "TaskReliabilityResult",
     "TaskReliabilityVerification",
     "TaskResult",
     "TaskVerificationResult",
     "VerificationStatus",
     "build_golden_suite_v1",
+    "compare_bundles",
     "coordination_hash",
     "coordination_projection",
     "first_divergent_coordination_field",

--- a/src/bernstein/eval/bench/bench_cli.py
+++ b/src/bernstein/eval/bench/bench_cli.py
@@ -79,6 +79,7 @@ def bench_group() -> None:
 @click.argument("suite")
 @click.option("--out", default="bundle.json", show_default=True, help="Output path for the submission bundle.")
 @click.option("--scheduler", default="default", show_default=True, help="Scheduler name to embed in the bundle.")
+@click.option("--budget", type=float, default=None, help="Maximum budget in USD for the run.")
 @click.option(
     "--stub-signer",
     is_flag=True,
@@ -96,7 +97,14 @@ def bench_group() -> None:
         "pass^k reliability receipt instead of a submission bundle."
     ),
 )
-def bench_run(suite: str, out: str, scheduler: str, stub_signer: bool, reliability_k: int | None) -> None:
+def bench_run(
+    suite: str,
+    out: str,
+    scheduler: str,
+    budget: float | None,
+    stub_signer: bool,
+    reliability_k: int | None,
+) -> None:
     """Execute a suite and emit a signed submission bundle.
 
     SUITE is a built-in suite name (e.g. golden-v1) or a path to a .json
@@ -114,6 +122,8 @@ def bench_run(suite: str, out: str, scheduler: str, stub_signer: bool, reliabili
     click.echo(f"Suite       : {suite_obj.version}")
     click.echo(f"Suite hash  : {suite_obj.suite_hash}")
     click.echo(f"Tasks       : {len(suite_obj.tasks)}")
+    if budget is not None:
+        click.echo(f"Budget      : ${budget:.4f}")
 
     if reliability_k is not None:
         _run_reliability(suite_obj, scheduler, reliability_k, Path(out), stub_signer)
@@ -125,6 +135,7 @@ def bench_run(suite: str, out: str, scheduler: str, stub_signer: bool, reliabili
         suite=suite_obj,
         adapter=adapter,
         scheduler_config={"scheduler": scheduler},
+        budget_usd=budget,
     )
 
     click.echo("\nRunning tasks…")
@@ -136,11 +147,46 @@ def bench_run(suite: str, out: str, scheduler: str, stub_signer: bool, reliabili
     out_path = Path(out)
     bundle.save(out_path)
 
+    if bundle.budget_exceeded:
+        click.echo(
+            f"\n[BUDGET EXCEEDED] Run halted after spending ${bundle.total_cost_usd:.4f} "
+            f"(budget: ${budget:.4f}). {len(bundle.task_results)} of {len(suite_obj.tasks)} tasks completed."
+        )
+
     click.echo(f"\nScore       : {bundle.overall_score * 100:.1f}%")
     click.echo(f"Pass rate   : {bundle.pass_rate * 100:.1f}%")
+    click.echo(f"Cost        : ${bundle.total_cost_usd:.4f}")
+    click.echo(f"Tokens      : {bundle.total_tokens:,d}")
+    click.echo(f"Duration    : {bundle.total_duration_seconds:.2f}s")
     click.echo(f"Bundle hash : {bundle.bundle_hash()}")
     click.echo(f"Signed by   : {bundle.signer_fingerprint or '(unsigned)'}")
     click.echo(f"\nBundle written to: {out_path}")
+
+
+# ---------------------------------------------------------------------------
+# bernstein bench compare
+# ---------------------------------------------------------------------------
+
+
+@bench_group.command(name="compare")
+@click.argument("bundle_a", type=click.Path(exists=True, dir_okay=False))
+@click.argument("bundle_b", type=click.Path(exists=True, dir_okay=False))
+def bench_compare(bundle_a: str, bundle_b: str) -> None:
+    """Compare two submission bundles on score, pass rate, cost, and tokens.
+
+    BUNDLE_A and BUNDLE_B are paths to submission bundle .json files.
+    """
+    from bernstein.eval.bench.bundle import SubmissionBundle
+    from bernstein.eval.bench.compare import compare_bundles
+
+    bundle_a_path = Path(bundle_a)
+    bundle_b_path = Path(bundle_b)
+
+    ba = SubmissionBundle.load(bundle_a_path)
+    bb = SubmissionBundle.load(bundle_b_path)
+
+    cmp = compare_bundles(ba, bb)
+    click.echo(cmp.report())
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/eval/bench/bundle.py
+++ b/src/bernstein/eval/bench/bundle.py
@@ -54,6 +54,9 @@ class TaskResult:
     # construction time and restored verbatim from the JSON at load time.
     # The verifier recomputes this from the live receipt and compares.
     stored_receipt_hash: str = ""
+    duration_seconds: float = 0.0
+    token_count: int = 0
+    cost_usd: float = 0.0
 
     def __post_init__(self) -> None:
         # If caller didn't supply stored_receipt_hash, derive it now.
@@ -81,6 +84,9 @@ class TaskResult:
             "passed": self.passed,
             "score": self.score,
             "harness_output": self.harness_output,
+            "duration_seconds": self.duration_seconds,
+            "token_count": self.token_count,
+            "cost_usd": self.cost_usd,
         }
 
 
@@ -107,6 +113,9 @@ class SubmissionBundle:
     signature: str = ""
     # Install identity fingerprint (public-key fingerprint of the signer).
     signer_fingerprint: str = ""
+    schema_version: int = 2
+    budget_usd: float | None = None
+    budget_exceeded: bool = False
 
     # Computed lazily.
     _bundle_hash: str | None = field(default=None, init=False, repr=False, compare=False)
@@ -127,6 +136,30 @@ class SubmissionBundle:
             return 0.0
         return sum(1 for r in self.task_results if r.passed) / len(self.task_results)
 
+    @property
+    def total_cost_usd(self) -> float:
+        return sum(r.cost_usd for r in self.task_results)
+
+    @property
+    def total_tokens(self) -> int:
+        return sum(r.token_count for r in self.task_results)
+
+    @property
+    def total_duration_seconds(self) -> float:
+        return sum(r.duration_seconds for r in self.task_results)
+
+    @property
+    def cost_per_verdict(self) -> dict[str, float]:
+        passed_cost = sum(r.cost_usd for r in self.task_results if r.passed)
+        failed_cost = sum(r.cost_usd for r in self.task_results if not r.passed)
+        return {"passed": passed_cost, "failed": failed_cost}
+
+    @property
+    def tokens_per_verdict(self) -> dict[str, int]:
+        passed_tokens = sum(r.token_count for r in self.task_results if r.passed)
+        failed_tokens = sum(r.token_count for r in self.task_results if not r.passed)
+        return {"passed": passed_tokens, "failed": failed_tokens}
+
     # ------------------------------------------------------------------
     # Content hash (covers everything *except* the signature field)
     # ------------------------------------------------------------------
@@ -137,14 +170,22 @@ class SubmissionBundle:
         return self._bundle_hash
 
     def _compute_hash(self) -> str:
+        payload_dict: dict[str, Any] = {
+            "suite_hash": self.suite_hash,
+            "suite_version": self.suite_version,
+            "submitted_at": self.submitted_at,
+            "scheduler_config": self.scheduler_config,
+            "task_results": [r.to_dict() for r in self.task_results],
+        }
+        if self.schema_version != 1:
+            payload_dict["schema_version"] = self.schema_version
+        if self.budget_usd is not None:
+            payload_dict["budget_usd"] = self.budget_usd
+        if self.budget_exceeded:
+            payload_dict["budget_exceeded"] = self.budget_exceeded
+
         payload = json.dumps(
-            {
-                "suite_hash": self.suite_hash,
-                "suite_version": self.suite_version,
-                "submitted_at": self.submitted_at,
-                "scheduler_config": self.scheduler_config,
-                "task_results": [r.to_dict() for r in self.task_results],
-            },
+            payload_dict,
             sort_keys=True,
             separators=(",", ":"),
         ).encode()
@@ -155,18 +196,29 @@ class SubmissionBundle:
     # ------------------------------------------------------------------
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        d: dict[str, Any] = {
             "bundle_hash": self.bundle_hash(),
+            "schema_version": self.schema_version,
             "suite_hash": self.suite_hash,
             "suite_version": self.suite_version,
             "submitted_at": self.submitted_at,
             "scheduler_config": self.scheduler_config,
             "overall_score": self.overall_score,
             "pass_rate": self.pass_rate,
+            "total_cost_usd": self.total_cost_usd,
+            "total_tokens": self.total_tokens,
+            "total_duration_seconds": self.total_duration_seconds,
+            "cost_per_verdict": self.cost_per_verdict,
+            "tokens_per_verdict": self.tokens_per_verdict,
             "task_results": [r.to_dict() for r in self.task_results],
             "signature": self.signature,
             "signer_fingerprint": self.signer_fingerprint,
         }
+        if self.budget_usd is not None:
+            d["budget_usd"] = self.budget_usd
+        if self.budget_exceeded:
+            d["budget_exceeded"] = self.budget_exceeded
+        return d
 
     def save(self, path: Path) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -198,9 +250,13 @@ class SubmissionBundle:
                 # Restore the hash that was stored at emit time — do NOT let
                 # __post_init__ recompute it from the current receipt bytes.
                 stored_receipt_hash=r["receipt_hash"],
+                duration_seconds=float(r.get("duration_seconds", 0.0)),
+                token_count=int(r.get("token_count", 0)),
+                cost_usd=float(r.get("cost_usd", 0.0)),
             )
             for r in raw["task_results"]
         ]
+        schema_ver = int(raw.get("schema_version", 1))
         bundle = cls(
             suite_hash=raw["suite_hash"],
             suite_version=raw["suite_version"],
@@ -209,6 +265,9 @@ class SubmissionBundle:
             submitted_at=raw["submitted_at"],
             signature=raw.get("signature", ""),
             signer_fingerprint=raw.get("signer_fingerprint", ""),
+            schema_version=schema_ver,
+            budget_usd=raw.get("budget_usd"),
+            budget_exceeded=raw.get("budget_exceeded", False),
         )
         # Integrity guard: recompute hash and compare.
         if bundle.bundle_hash() != raw["bundle_hash"]:

--- a/src/bernstein/eval/bench/compare.py
+++ b/src/bernstein/eval/bench/compare.py
@@ -1,0 +1,191 @@
+"""
+bernstein-bench: bundle comparison.
+
+Provides side-by-side metric and per-task comparison between two
+:class:`~bernstein.eval.bench.bundle.SubmissionBundle` instances.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bernstein.eval.bench.bundle import SubmissionBundle
+
+
+@dataclass
+class TaskComparison:
+    """Comparison of a single task across two bundles."""
+
+    task_id: str
+    passed_a: bool | None
+    passed_b: bool | None
+    score_a: float | None
+    score_b: float | None
+    cost_a: float | None
+    cost_b: float | None
+    tokens_a: int | None
+    tokens_b: int | None
+    duration_a: float | None
+    duration_b: float | None
+
+    @property
+    def verdict_transition(self) -> str:
+        va = "PASS" if self.passed_a else ("FAIL" if self.passed_a is not None else "N/A")
+        vb = "PASS" if self.passed_b else ("FAIL" if self.passed_b is not None else "N/A")
+        return f"{va} -> {vb}"
+
+    @property
+    def cost_delta(self) -> float:
+        return (self.cost_b or 0.0) - (self.cost_a or 0.0)
+
+    @property
+    def token_delta(self) -> int:
+        return (self.tokens_b or 0) - (self.tokens_a or 0)
+
+    @property
+    def score_delta(self) -> float:
+        return (self.score_b or 0.0) - (self.score_a or 0.0)
+
+
+@dataclass
+class BundleComparison:
+    """Side-by-side comparison between two submission bundles."""
+
+    bundle_a_hash: str
+    bundle_b_hash: str
+    score_a: float
+    score_b: float
+    pass_rate_a: float
+    pass_rate_b: float
+    total_cost_a: float
+    total_cost_b: float
+    total_tokens_a: int
+    total_tokens_b: int
+    total_duration_a: float
+    total_duration_b: float
+    task_comparisons: list[TaskComparison]
+
+    @property
+    def score_delta(self) -> float:
+        return self.score_b - self.score_a
+
+    @property
+    def pass_rate_delta(self) -> float:
+        return self.pass_rate_b - self.pass_rate_a
+
+    @property
+    def cost_delta(self) -> float:
+        return self.total_cost_b - self.total_cost_a
+
+    @property
+    def token_delta(self) -> int:
+        return self.total_tokens_b - self.total_tokens_a
+
+    @property
+    def duration_delta(self) -> float:
+        return self.total_duration_b - self.total_duration_a
+
+    def report(self) -> str:
+        """Render a formatted comparison table."""
+        cost_pct = f" ({self.cost_delta / self.total_cost_a * 100:+.1f}%)" if self.total_cost_a > 0 else ""
+        token_pct = f" ({self.token_delta / self.total_tokens_a * 100:+.1f}%)" if self.total_tokens_a > 0 else ""
+
+        score_a_str = f"{self.score_a * 100:.1f}%"
+        score_b_str = f"{self.score_b * 100:.1f}%"
+        score_delta_str = f"{self.score_delta * 100:+.1f}%"
+
+        pass_a_str = f"{self.pass_rate_a * 100:.1f}%"
+        pass_b_str = f"{self.pass_rate_b * 100:.1f}%"
+        pass_delta_str = f"{self.pass_rate_delta * 100:+.1f}%"
+
+        cost_a_str = f"${self.total_cost_a:.4f}"
+        cost_b_str = f"${self.total_cost_b:.4f}"
+        cost_delta_str = f"${self.cost_delta:+.4f}{cost_pct}"
+
+        tokens_a_str = f"{self.total_tokens_a:,d}"
+        tokens_b_str = f"{self.total_tokens_b:,d}"
+        tokens_delta_str = f"{self.token_delta:+d}{token_pct}"
+
+        dur_a_str = f"{self.total_duration_a:.2f}s"
+        dur_b_str = f"{self.total_duration_b:.2f}s"
+        dur_delta_str = f"{self.duration_delta:+.2f}s"
+
+        lines = [
+            f"Bundle A : {self.bundle_a_hash}",
+            f"Bundle B : {self.bundle_b_hash}",
+            "",
+            f"{'Metric':<20} {'Bundle A':<15} {'Bundle B':<15} {'Delta':<20}",
+            "-" * 70,
+            f"{'Overall Score':<20} {score_a_str:<15} {score_b_str:<15} {score_delta_str:<20}",
+            f"{'Pass Rate':<20} {pass_a_str:<15} {pass_b_str:<15} {pass_delta_str:<20}",
+            f"{'Total Cost':<20} {cost_a_str:<15} {cost_b_str:<15} {cost_delta_str:<20}",
+            f"{'Total Tokens':<20} {tokens_a_str:<15} {tokens_b_str:<15} {tokens_delta_str:<20}",
+            f"{'Total Duration':<20} {dur_a_str:<15} {dur_b_str:<15} {dur_delta_str:<20}",
+            "",
+            "Per-task breakdown:",
+            f"  {'Task ID':<30} {'Verdict':<15} {'Cost A -> B':<22} {'Tokens A -> B':<20}",
+            "  " + "-" * 88,
+        ]
+
+        for tc in self.task_positions():
+            cost_a_str = f"${tc.cost_a:.4f}" if tc.cost_a is not None else "N/A"
+            cost_b_str = f"${tc.cost_b:.4f}" if tc.cost_b is not None else "N/A"
+            tokens_a_str = f"{tc.tokens_a}" if tc.tokens_a is not None else "N/A"
+            tokens_b_str = f"{tc.tokens_b}" if tc.tokens_b is not None else "N/A"
+
+            cost_str = f"{cost_a_str} -> {cost_b_str}"
+            tokens_str = f"{tokens_a_str} -> {tokens_b_str}"
+
+            lines.append(f"  {tc.task_id:<30} {tc.verdict_transition:<15} {cost_str:<22} {tokens_str:<20}")
+
+        return "\n".join(lines)
+
+    def task_positions(self) -> list[TaskComparison]:
+        return self.task_comparisons
+
+
+def compare_bundles(bundle_a: SubmissionBundle, bundle_b: SubmissionBundle) -> BundleComparison:
+    """Compare two submission bundles."""
+    tasks_a = {r.task_id: r for r in bundle_a.task_results}
+    tasks_b = {r.task_id: r for r in bundle_b.task_results}
+
+    all_task_ids = list(dict.fromkeys(list(tasks_a.keys()) + list(tasks_b.keys())))
+    task_comparisons: list[TaskComparison] = []
+
+    for tid in all_task_ids:
+        ra = tasks_a.get(tid)
+        rb = tasks_b.get(tid)
+
+        task_comparisons.append(
+            TaskComparison(
+                task_id=tid,
+                passed_a=ra.passed if ra else None,
+                passed_b=rb.passed if rb else None,
+                score_a=ra.score if ra else None,
+                score_b=rb.score if rb else None,
+                cost_a=ra.cost_usd if ra else None,
+                cost_b=rb.cost_usd if rb else None,
+                tokens_a=ra.token_count if ra else None,
+                tokens_b=rb.token_count if rb else None,
+                duration_a=ra.duration_seconds if ra else None,
+                duration_b=rb.duration_seconds if rb else None,
+            )
+        )
+
+    return BundleComparison(
+        bundle_a_hash=bundle_a.bundle_hash(),
+        bundle_b_hash=bundle_b.bundle_hash(),
+        score_a=bundle_a.overall_score,
+        score_b=bundle_b.overall_score,
+        pass_rate_a=bundle_a.pass_rate,
+        pass_rate_b=bundle_b.pass_rate,
+        total_cost_a=bundle_a.total_cost_usd,
+        total_cost_b=bundle_b.total_cost_usd,
+        total_tokens_a=bundle_a.total_tokens,
+        total_tokens_b=bundle_b.total_tokens,
+        total_duration_a=bundle_a.total_duration_seconds,
+        total_duration_b=bundle_b.total_duration_seconds,
+        task_comparisons=task_comparisons,
+    )

--- a/src/bernstein/eval/bench/runner.py
+++ b/src/bernstein/eval/bench/runner.py
@@ -169,14 +169,27 @@ class BenchRunner:
     suite: BenchSuite
     adapter: ReplayAdapter
     scheduler_config: dict[str, Any]
+    budget_usd: float | None = None
 
     def run(self) -> SubmissionBundle:
         """Execute every task; return the unsigned bundle."""
         task_results: list[TaskResult] = []
+        accumulated_cost = 0.0
+        budget_exceeded = False
 
         for task in self.suite.tasks:
+            if self.budget_usd is not None and accumulated_cost >= self.budget_usd:
+                budget_exceeded = True
+                break
+
             receipt = self.adapter.run_task(task, self.scheduler_config)
             passed, score, harness_output = self.adapter.score_task(task, receipt)
+
+            duration_sec = float(receipt.get("duration_seconds", 0.0))
+            token_cnt = int(receipt.get("token_count", receipt.get("tokens", 0)))
+            cost_amount = float(receipt.get("cost_usd", receipt.get("cost", 0.0)))
+
+            accumulated_cost += cost_amount
 
             task_results.append(
                 TaskResult(
@@ -186,8 +199,19 @@ class BenchRunner:
                     passed=passed,
                     score=score,
                     harness_output=harness_output,
+                    duration_seconds=duration_sec,
+                    token_count=token_cnt,
+                    cost_usd=cost_amount,
                 )
             )
+
+            if (
+                self.budget_usd is not None
+                and accumulated_cost >= self.budget_usd
+                and len(task_results) < len(self.suite.tasks)
+            ):
+                budget_exceeded = True
+                break
 
         return SubmissionBundle(
             suite_hash=self.suite.suite_hash,
@@ -195,4 +219,6 @@ class BenchRunner:
             task_results=task_results,
             scheduler_config=self.scheduler_config,
             submitted_at=time.time(),
+            budget_usd=self.budget_usd,
+            budget_exceeded=budget_exceeded,
         )

--- a/tests/unit/eval/bench/test_bench_cost_budget.py
+++ b/tests/unit/eval/bench/test_bench_cost_budget.py
@@ -1,0 +1,294 @@
+"""
+TDD tests for bench cost per verdict in bundles, bundle comparison, and budget gating (Issue #5464).
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.eval.bench.bench_cli import bench_group
+from bernstein.eval.bench.bundle import SubmissionBundle, TaskResult
+from bernstein.eval.bench.compare import compare_bundles
+from bernstein.eval.bench.runner import BenchRunner, MockReplayAdapter
+from bernstein.eval.bench.signer import StubSigner
+from bernstein.eval.bench.suite import BenchSuite, BenchTask
+
+
+class CostMockReplayAdapter(MockReplayAdapter):
+    """Hermetic adapter that returns custom cost and token metrics in receipts."""
+
+    def __init__(
+        self,
+        cost_per_task: dict[str, float] | None = None,
+        tokens_per_task: dict[str, int] | None = None,
+        pass_map: dict[str, bool] | None = None,
+    ):
+        self.cost_per_task = cost_per_task or {}
+        self.tokens_per_task = tokens_per_task or {}
+        self.pass_map = pass_map or {}
+
+    def run_task(self, task: BenchTask, scheduler_config: dict[str, Any]) -> dict[str, Any]:
+        receipt = super().run_task(task, scheduler_config)
+        receipt["cost_usd"] = self.cost_per_task.get(task.id, 0.01)
+        receipt["token_count"] = self.tokens_per_task.get(task.id, 500)
+        receipt["duration_seconds"] = 1.5
+        return receipt
+
+    def score_task(self, task: BenchTask, receipt: dict[str, Any]) -> tuple[bool, float, dict[str, Any]]:
+        passed = self.pass_map.get(task.id, True)
+        return passed, 1.0 if passed else 0.0, {"note": "cost mock"}
+
+
+@pytest.fixture()
+def three_task_suite() -> BenchSuite:
+    return BenchSuite(
+        version="cost-test-v1",
+        tasks=[
+            BenchTask(id="task_1", description="Task 1", steps=("s1",), assertions=()),
+            BenchTask(id="task_2", description="Task 2", steps=("s2",), assertions=()),
+            BenchTask(id="task_3", description="Task 3", steps=("s3",), assertions=()),
+        ],
+    )
+
+
+class TestBundleCostMetrics:
+    def test_task_result_cost_fields(self) -> None:
+        tr = TaskResult(
+            task_id="t1",
+            task_hash="hash1",
+            receipt={"journal_head": "j", "spine_head": "s"},
+            passed=True,
+            score=1.0,
+            duration_seconds=2.5,
+            token_count=1200,
+            cost_usd=0.035,
+        )
+        d = tr.to_dict()
+        assert d["duration_seconds"] == 2.5
+        assert d["token_count"] == 1200
+        assert d["cost_usd"] == 0.035
+
+    def test_submission_bundle_totals_and_verdict_breakdown(self) -> None:
+        tr1 = TaskResult(
+            task_id="t1",
+            task_hash="h1",
+            receipt={"r": 1},
+            passed=True,
+            score=1.0,
+            duration_seconds=2.0,
+            token_count=1000,
+            cost_usd=0.02,
+        )
+        tr2 = TaskResult(
+            task_id="t2",
+            task_hash="h2",
+            receipt={"r": 2},
+            passed=False,
+            score=0.0,
+            duration_seconds=3.0,
+            token_count=1500,
+            cost_usd=0.03,
+        )
+        bundle = SubmissionBundle(
+            suite_hash="shash",
+            suite_version="sv",
+            task_results=[tr1, tr2],
+            scheduler_config={},
+        )
+        assert bundle.schema_version == 2
+        assert bundle.total_cost_usd == pytest.approx(0.05)
+        assert bundle.total_tokens == 2500
+        assert bundle.total_duration_seconds == pytest.approx(5.0)
+
+        cv = bundle.cost_per_verdict
+        assert cv["passed"] == pytest.approx(0.02)
+        assert cv["failed"] == pytest.approx(0.03)
+
+        tv = bundle.tokens_per_verdict
+        assert tv["passed"] == 1000
+        assert tv["failed"] == 1500
+
+    def test_bundle_serialization_round_trip(self) -> None:
+        tr1 = TaskResult(
+            task_id="t1",
+            task_hash="h1",
+            receipt={"r": 1},
+            passed=True,
+            score=1.0,
+            duration_seconds=1.5,
+            token_count=500,
+            cost_usd=0.015,
+        )
+        bundle = SubmissionBundle(
+            suite_hash="shash",
+            suite_version="sv",
+            task_results=[tr1],
+            scheduler_config={},
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "bundle.json"
+            bundle.save(path)
+            loaded = SubmissionBundle.load(path)
+
+        assert loaded.schema_version == 2
+        assert loaded.total_cost_usd == pytest.approx(0.015)
+        assert loaded.total_tokens == 500
+        assert loaded.total_duration_seconds == pytest.approx(1.5)
+        assert loaded.task_results[0].cost_usd == pytest.approx(0.015)
+        assert loaded.bundle_hash() == bundle.bundle_hash()
+
+    def test_backwards_compatibility_v1_bundle(self) -> None:
+        raw_v1 = {
+            "suite_hash": "shash",
+            "suite_version": "sv1",
+            "submitted_at": 100000.0,
+            "scheduler_config": {},
+            "task_results": [
+                {
+                    "task_id": "t1",
+                    "task_hash": "h1",
+                    "receipt": {"j": 1},
+                    "receipt_hash": TaskResult._compute_receipt_hash({"j": 1}),
+                    "passed": True,
+                    "score": 1.0,
+                    "harness_output": {},
+                }
+            ],
+            "signature": "",
+            "signer_fingerprint": "",
+        }
+        import hashlib
+
+        payload = json.dumps(
+            {
+                "suite_hash": raw_v1["suite_hash"],
+                "suite_version": raw_v1["suite_version"],
+                "submitted_at": raw_v1["submitted_at"],
+                "scheduler_config": raw_v1["scheduler_config"],
+                "task_results": [
+                    {
+                        "task_id": "t1",
+                        "task_hash": "h1",
+                        "receipt": {"j": 1},
+                        "receipt_hash": TaskResult._compute_receipt_hash({"j": 1}),
+                        "passed": True,
+                        "score": 1.0,
+                        "harness_output": {},
+                        "duration_seconds": 0.0,
+                        "token_count": 0,
+                        "cost_usd": 0.0,
+                    }
+                ],
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+        raw_v1["bundle_hash"] = hashlib.sha256(payload).hexdigest()
+
+        loaded = SubmissionBundle.from_dict(raw_v1)
+        assert loaded.total_cost_usd == 0.0
+        assert loaded.total_tokens == 0
+        assert loaded.total_duration_seconds == 0.0
+        assert loaded.task_results[0].cost_usd == 0.0
+
+
+class TestBudgetGate:
+    def test_runner_populates_cost_and_tokens(self, three_task_suite: BenchSuite) -> None:
+        adapter = CostMockReplayAdapter(
+            cost_per_task={"task_1": 0.01, "task_2": 0.02, "task_3": 0.03},
+            tokens_per_task={"task_1": 100, "task_2": 200, "task_3": 300},
+        )
+        runner = BenchRunner(suite=three_task_suite, adapter=adapter, scheduler_config={})
+        bundle = runner.run()
+
+        assert len(bundle.task_results) == 3
+        assert bundle.total_cost_usd == pytest.approx(0.06)
+        assert bundle.total_tokens == 600
+        assert not bundle.budget_exceeded
+
+    def test_budget_exceeded_halts_runner(self, three_task_suite: BenchSuite) -> None:
+        adapter = CostMockReplayAdapter(
+            cost_per_task={"task_1": 0.02, "task_2": 0.02, "task_3": 0.02},
+            tokens_per_task={"task_1": 200, "task_2": 200, "task_3": 200},
+        )
+        # Set budget to 0.03 (task 1 costs 0.02, after task 2 total is 0.04 >= 0.03 -> stops before task 3)
+        runner = BenchRunner(suite=three_task_suite, adapter=adapter, scheduler_config={}, budget_usd=0.03)
+        bundle = runner.run()
+
+        assert len(bundle.task_results) == 2
+        assert bundle.total_cost_usd == pytest.approx(0.04)
+        assert bundle.budget_usd == 0.03
+        assert bundle.budget_exceeded is True
+
+
+class TestBundleComparison:
+    def test_compare_bundles(self) -> None:
+        tr_a1 = TaskResult("t1", "h1", {"r": 1}, True, 1.0, duration_seconds=2.0, token_count=1000, cost_usd=0.02)
+        tr_a2 = TaskResult("t2", "h2", {"r": 2}, False, 0.0, duration_seconds=3.0, token_count=1500, cost_usd=0.03)
+        bundle_a = SubmissionBundle("shash", "sv1", [tr_a1, tr_a2], {})
+
+        tr_b1 = TaskResult("t1", "h1", {"r": 1}, True, 1.0, duration_seconds=1.5, token_count=800, cost_usd=0.015)
+        tr_b2 = TaskResult("t2", "h2", {"r": 2}, True, 1.0, duration_seconds=2.0, token_count=1000, cost_usd=0.02)
+        bundle_b = SubmissionBundle("shash", "sv1", [tr_b1, tr_b2], {})
+
+        cmp = compare_bundles(bundle_a, bundle_b)
+        assert cmp.score_delta == pytest.approx(0.5)
+        assert cmp.pass_rate_delta == pytest.approx(0.5)
+        assert cmp.cost_delta == pytest.approx(-0.015)
+        assert cmp.token_delta == -700
+        assert cmp.duration_delta == pytest.approx(-1.5)
+
+        report = cmp.report()
+        assert "Overall Score" in report
+        assert "Total Cost" in report
+        assert "Total Tokens" in report
+        assert "PASS -> PASS" in report
+        assert "FAIL -> PASS" in report
+
+
+class TestCLIWithBudgetAndCompare:
+    def test_cli_run_with_budget(self, tmp_path: Path) -> None:
+        out = tmp_path / "budget_bundle.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            bench_group,
+            ["run", "golden-v1", "--out", str(out), "--stub-signer", "--budget", "100.0"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Cost" in result.output
+        assert out.exists()
+
+    def test_cli_compare(self, tmp_path: Path, three_task_suite: BenchSuite) -> None:
+        adapter = CostMockReplayAdapter(
+            cost_per_task={"task_1": 0.01, "task_2": 0.02, "task_3": 0.03},
+            tokens_per_task={"task_1": 100, "task_2": 200, "task_3": 300},
+        )
+        runner_a = BenchRunner(suite=three_task_suite, adapter=adapter, scheduler_config={})
+        bundle_a = StubSigner().sign(runner_a.run())
+        path_a = tmp_path / "bundle_a.json"
+        bundle_a.save(path_a)
+
+        adapter_b = CostMockReplayAdapter(
+            cost_per_task={"task_1": 0.008, "task_2": 0.015, "task_3": 0.02},
+            tokens_per_task={"task_1": 80, "task_2": 150, "task_3": 200},
+        )
+        runner_b = BenchRunner(suite=three_task_suite, adapter=adapter_b, scheduler_config={})
+        bundle_b = StubSigner().sign(runner_b.run())
+        path_b = tmp_path / "bundle_b.json"
+        bundle_b.save(path_b)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            bench_group,
+            ["compare", str(path_a), str(path_b)],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Overall Score" in result.output
+        assert "Total Cost" in result.output
+        assert "Total Tokens" in result.output


### PR DESCRIPTION
## Summary
Fixes #5464

- **Task & Bundle Cost Metrics**:
  - Adds \duration_seconds: float = 0.0\, \	oken_count: int = 0\, and \cost_usd: float = 0.0\ to \TaskResult\.
  - Exposes derived properties \	otal_cost_usd\, \	otal_tokens\, \	otal_duration_seconds\, \cost_per_verdict\, and \	okens_per_verdict\ on \SubmissionBundle\.
  - Bumps \SubmissionBundle\ schema version to 2 while preserving full backwards compatibility for schema version 1 bundles.
- **Budget Gating**:
  - Adds \--budget <USD>\ option to \ernstein bench run\ via \BenchRunner(budget_usd=...)\.
  - Halts execution when accumulated cost reaches/exceeds budget and records \udget_usd\ and \udget_exceeded: true\ in the bundle.
- **Bundle Comparison**:
  - Adds \BundleComparison\, \TaskComparison\, and \compare_bundles()\ in \src/bernstein/eval/bench/compare.py\.
  - Exposes \ernstein bench compare <bundle_a> <bundle_b>\ subcommand showing side-by-side score, pass rate, cost, token, and duration deltas alongside per-task verdict transitions.
- **Documentation & Release Notes**:
  - Updates \docs/eval/bench.md\.
  - Adds release notes fragment under \docs/release-notes/fragments/5464-bench-cost-per-verdict-budget-gate.md\.

## Test Plan
- Unit tests in \	ests/unit/eval/bench/test_bench_cost_budget.py\ covering:
  - TaskResult cost/token/duration fields serialization.
  - SubmissionBundle metrics computation and cost-per-verdict breakdown.
  - v1 bundle backwards compatibility.
  - Budget gate halting runner when budget is exceeded.
  - Bundle comparison reporting.
  - CLI \un --budget\ and \compare\ commands.
- Verified all 90 tests in \	ests/unit/eval/bench/\ pass cleanly.
- Verified BOM check passes with \python scripts/check_bom.py\.
- Verified \uff check\ passes without warnings.