### PR TITLE
feat(govern): a standing count of capabilities with more than one implementation (#5105)

### DIFF
--- a/docs/release-notes/fragments/5105-duplication-collector.md
+++ b/docs/release-notes/fragments/5105-duplication-collector.md
@@ -1,0 +1,20 @@
+## A standing count of capabilities with more than one implementation
+
+A guard test answers "did this PR introduce a second implementation". It
+cannot answer "how many are there now, and did that number move since last
+week". `bernstein.core.govern.duplication_audit.collect_duplication` walks
+the tree and reports that as findings — a stable `check_id`, the count
+against its expected count, and the offending paths, so a finding read a
+week later is still the same finding.
+
+**"Not yet measurable" is its own verdict.** A check whose subject does
+not exist yet is not passing, and reporting it as one is what makes an
+aggregate look like coverage it does not have. Four of the six checks say
+so today, pending their own issues.
+
+**No score, no grade, no percentage.** `core/security/security_posture.py`
+computes an A-F letter from weighted metrics and has zero callers — the
+proof this report has been built once already and never wired. A count
+against an expected count is auditable; a letter is a number nobody can
+reconstruct. A test fails the build if `score`, `grade`, `percent` or
+`rating` ever appears in the output (#5105).

--- a/src/bernstein/core/govern/__init__.py
+++ b/src/bernstein/core/govern/__init__.py
@@ -6,6 +6,12 @@ import hashlib
 import json
 from typing import Any
 
+from bernstein.core.govern.duplication_audit import (
+    DuplicationFinding,
+    DuplicationReport,
+    Verdict,
+    collect_duplication,
+)
 from bernstein.core.govern.findings import Finding, FindingsDocument
 from bernstein.core.govern.freshness_gate import (
     FreshnessGate,
@@ -238,6 +244,8 @@ __all__ = [
     "DesiredState",
     "DiffAction",
     "DraftProposal",
+    "DuplicationFinding",
+    "DuplicationReport",
     "EntityKind",
     "EntityPolicy",
     "EntityStatus",
@@ -272,7 +280,9 @@ __all__ = [
     "SnapshotEntity",
     "Surface",
     "UnremediatedFinding",
+    "Verdict",
     "build_restore_plan",
+    "collect_duplication",
     "collect_remediation",
     "compute_plan",
     "compute_reconcile_diff",

--- a/src/bernstein/core/govern/duplication_audit.py
+++ b/src/bernstein/core/govern/duplication_audit.py
@@ -1,0 +1,282 @@
+"""How many capabilities currently have more than one implementation (issue #5105).
+
+A guard test answers "did THIS PR introduce a second implementation". It cannot
+answer "how many are there now, and did that number move since last week" --
+that needs something which runs standalone and reports state rather than gating
+a diff. This is that collector.
+
+Three properties it has to have, and each one is a reaction to how the last
+attempt failed.
+
+**Findings, not a pass/fail bit.** Each count above its expected value becomes a
+named finding with a stable id and the offending paths, so it survives being
+read out of context: a number in a CI log means nothing a week later, and a bare
+red means nothing at all.
+
+**"Not yet measurable" is its own verdict.** A check whose subject does not
+exist yet is not passing. Reporting it as a pass is the failure mode that makes
+an aggregate report worse than no report, because the total looks like coverage
+it does not have.
+
+**No score and no grade.** ``core/security/security_posture.py`` computed a
+letter from weighted metrics and has zero callers -- the proof that this
+codebase has built this report once already and never wired it. Its A-F model is
+explicitly rejected here: a count against an expected count is auditable, and a
+letter is a number nobody can argue with because nobody can reconstruct it.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+class Verdict(StrEnum):
+    """What the collector was able to say about one check."""
+
+    #: Counted, and the count is what it should be.
+    MEASURED_PASSED = "measured_passed"
+    #: Counted, and there is more than one implementation.
+    MEASURED_FAILED = "measured_failed"
+    #: The subject does not exist yet, so nothing was counted. NOT a pass.
+    NOT_YET_MEASURABLE = "not_yet_measurable"
+
+
+@dataclass(frozen=True, slots=True)
+class DuplicationFinding:
+    """One capability's implementation count, and what that means.
+
+    Attributes:
+        check_id: Stable identifier. The thing a tracker keys on, so a finding
+            read next week is the same finding.
+        summary: One line an operator can act on.
+        verdict: :class:`Verdict`.
+        count: What was counted, or ``None`` when nothing was.
+        expected: What it should be. ``1`` for a capability that should have one
+            implementation, ``0`` for a thing that should not exist at all.
+        paths: The offending locations, sorted. Empty when the check passed or
+            could not run -- a finding names WHERE, or the reader is left doing
+            the search the collector just did.
+    """
+
+    check_id: str
+    summary: str
+    verdict: Verdict
+    expected: int
+    count: int | None = None
+    paths: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical serialization."""
+        return {
+            "check_id": self.check_id,
+            "summary": self.summary,
+            "verdict": self.verdict.value,
+            "expected": self.expected,
+            "count": self.count,
+            "paths": list(self.paths),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class DuplicationReport:
+    """Every check, in a fixed order.
+
+    Attributes:
+        findings: One per check, ordered by ``check_id`` so two runs over one
+            tree serialize identically.
+    """
+
+    findings: tuple[DuplicationFinding, ...]
+
+    @property
+    def failed(self) -> tuple[DuplicationFinding, ...]:
+        """The checks that counted more than they should have."""
+        return tuple(f for f in self.findings if Verdict.MEASURED_FAILED is f.verdict)
+
+    @property
+    def not_yet_measurable(self) -> tuple[DuplicationFinding, ...]:
+        """The checks whose subject does not exist yet.
+
+        Reported separately from failures, and never folded into a total: a
+        denominator that silently includes what was not measured is the thing
+        that makes an aggregate look like coverage it does not have.
+        """
+        return tuple(f for f in self.findings if Verdict.NOT_YET_MEASURABLE is f.verdict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical serialization.
+
+        Deliberately carries no score, no grade and no percentage -- see the
+        module docstring.
+        """
+        return {
+            "measured": len(self.findings) - len(self.not_yet_measurable),
+            "failed": len(self.failed),
+            "not_yet_measurable": len(self.not_yet_measurable),
+            "findings": [f.to_dict() for f in self.findings],
+        }
+
+
+def _source_files(root: Path) -> Iterator[tuple[str, ast.Module]]:
+    """Every parseable module under *root*, as ``(relative path, tree)``.
+
+    Sorted, because the paths land in a finding and a finding has to be
+    byte-identical across runs. A file that does not parse is skipped rather
+    than raised: this is a report about the tree, and one unparseable file must
+    not take it down.
+    """
+    for path in sorted(root.rglob("*.py")):
+        try:
+            yield str(path.relative_to(root)), ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except (OSError, SyntaxError, UnicodeDecodeError):
+            continue
+
+
+def _private_hmac_loaders(root: Path) -> tuple[str, ...]:
+    """Every ``def _load_hmac_key`` -- one canonical loader, or twenty (#5095)."""
+    found: list[str] = []
+    for rel, tree in _source_files(root):
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and node.name == "_load_hmac_key":
+                found.append(f"{rel}:{node.lineno}")
+    return tuple(sorted(found))
+
+
+def _inline_canonical_bytes_sites(root: Path) -> tuple[str, ...]:
+    """Every place canonical bytes are built INLINE rather than through one helper (#5094).
+
+    Counted as call SITES, not as distinct function bodies, and named for what it
+    actually measures. The issue's headline figure -- "91 copies with 60 distinct
+    bodies" -- is about canonical-JSON *encoders*; a walk of this tree cannot
+    tell an encoder from a large function that happens to canonicalize as one
+    step, so claiming that figure here would be reporting a number this check
+    did not measure. What it does measure is exact and is the same duplication
+    from the other side: how many places rebuild the bytes instead of calling
+    the one thing that owns them.
+
+    A site qualifies when it calls ``json.dumps`` with BOTH ``sort_keys=True``
+    and compact ``separators``. Both, deliberately: sorted keys alone is how a
+    great deal of ordinary logging and diffing serializes, and counting those
+    reports a number several times larger than the duplication it is supposed to
+    measure. Compact separators are what make the output BYTES rather than text,
+    which is the property a signature depends on.
+    """
+    found: list[str] = []
+    for rel, tree in _source_files(root):
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and _is_canonical_dumps(node):
+                found.append(f"{rel}:{node.lineno}")
+    return tuple(sorted(found))
+
+
+def _is_canonical_dumps(call: ast.Call) -> bool:
+    """Is this a ``json.dumps`` with sorted keys AND compact separators?"""
+    func = call.func
+    if not (isinstance(func, ast.Attribute) and func.attr == "dumps"):
+        return False
+    sorted_keys = False
+    compact = False
+    for keyword in call.keywords:
+        if keyword.arg == "sort_keys":
+            sorted_keys = isinstance(keyword.value, ast.Constant) and keyword.value.value is True
+        elif keyword.arg == "separators":
+            compact = _is_compact_separators(keyword.value)
+    return sorted_keys and compact
+
+
+def _is_compact_separators(value: ast.expr) -> bool:
+    """Is this a ``(",", ":")`` literal -- the no-whitespace form?"""
+    if not isinstance(value, ast.Tuple) or len(value.elts) != 2:
+        return False
+    parts = [e.value for e in value.elts if isinstance(e, ast.Constant) and isinstance(e.value, str)]
+    return parts == [",", ":"]
+
+
+def _measured(check_id: str, summary: str, paths: tuple[str, ...], expected: int) -> DuplicationFinding:
+    """Build a finding from a count, choosing the verdict from the count itself."""
+    over = len(paths) > expected
+    return DuplicationFinding(
+        check_id=check_id,
+        summary=summary,
+        verdict=Verdict.MEASURED_FAILED if over else Verdict.MEASURED_PASSED,
+        expected=expected,
+        count=len(paths),
+        # Only on a failure. A passing check listing its one legitimate
+        # implementation is noise that makes the failures harder to see.
+        paths=paths if over else (),
+    )
+
+
+def _not_yet(check_id: str, summary: str, expected: int) -> DuplicationFinding:
+    """A check whose subject does not exist yet. Not a pass."""
+    return DuplicationFinding(
+        check_id=check_id,
+        summary=summary,
+        verdict=Verdict.NOT_YET_MEASURABLE,
+        expected=expected,
+        count=None,
+    )
+
+
+def collect_duplication(source_root: Path) -> DuplicationReport:
+    """Count the capabilities that have more than one implementation.
+
+    Args:
+        source_root: The package root to walk, e.g. ``src/bernstein``.
+
+    Returns:
+        One finding per check, ordered by ``check_id``. Two runs over an
+        unchanged tree produce byte-identical output.
+    """
+    findings = [
+        _measured(
+            "inline-canonical-bytes-sites",
+            "places that build canonical signing bytes inline instead of through one shared helper; "
+            "bytes rebuilt at each site are bytes that can disagree, and a signature made under one "
+            "does not verify under another (#5094)",
+            _inline_canonical_bytes_sites(source_root),
+            expected=1,
+        ),
+        _measured(
+            "private-hmac-key-loaders",
+            "private `_load_hmac_key` wrappers; the canonical loader is core.security.audit",
+            _private_hmac_loaders(source_root),
+            expected=0,
+        ),
+        _not_yet(
+            "receipt-verify-kinds",
+            "receipt kinds registered through one verify pair (#5096: seven independent verifiers)",
+            expected=1,
+        ),
+        _not_yet(
+            "verification-result-shapes",
+            "verification-result classes declaring one field set under one name (#5099)",
+            expected=1,
+        ),
+        _not_yet(
+            "registry-duplicate-ids",
+            "ids registered twice across the registries (#5104)",
+            expected=0,
+        ),
+        _not_yet(
+            "orphan-modules",
+            "modules under core/ that no non-test importer reaches (#5100)",
+            expected=0,
+        ),
+    ]
+    return DuplicationReport(findings=tuple(sorted(findings, key=lambda f: f.check_id)))
+
+
+__all__ = [
+    "DuplicationFinding",
+    "DuplicationReport",
+    "Verdict",
+    "collect_duplication",
+]

--- a/tests/unit/core/govern/test_duplication_audit.py
+++ b/tests/unit/core/govern/test_duplication_audit.py
@@ -1,0 +1,202 @@
+"""Issue #5105: how many capabilities have more than one implementation, as a standing number.
+
+A guard test answers "did THIS PR introduce a second implementation". It cannot
+answer "how many are there now, and did that number move since last week" --
+that needs something that runs standalone and reports state rather than gating a
+diff.
+
+`core/security/security_posture.py` is the proof this codebase has tried once
+already: 347 lines that compute an A-F letter from weighted metrics, with zero
+callers anywhere. Its grading model is explicitly rejected here.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from bernstein.core.govern.duplication_audit import (
+    DuplicationFinding,
+    Verdict,
+    collect_duplication,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+SRC = "src/bernstein"
+
+
+def _write(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+def _tree(tmp_path: Path, files: dict[str, str]) -> Path:
+    root = tmp_path / "pkg"
+    for name, body in files.items():
+        _write(root / name, body)
+    return root
+
+
+CANONICAL = (
+    "import json\n\n\n"
+    "def encode(payload: dict) -> bytes:\n"
+    '    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")\n'
+)
+
+
+# ---------------------------------------------------------------------------
+# The load-bearing property
+# ---------------------------------------------------------------------------
+
+
+def test_finding_byte_identical_across_two_runs(tmp_path: Path) -> None:
+    """Determinism: same tree, same findings, same bytes.
+
+    A report an operator compares week to week is worthless if two runs over one
+    tree disagree, and path ordering is the usual way that happens.
+    """
+    root = _tree(tmp_path, {"a.py": CANONICAL, "b.py": CANONICAL, "c.py": "x = 1\n"})
+
+    first = json.dumps(collect_duplication(root).to_dict(), sort_keys=True)
+    second = json.dumps(collect_duplication(root).to_dict(), sort_keys=True)
+
+    assert first == second
+
+
+def test_duplication_count_above_expected_produces_a_measured_failed_finding(tmp_path: Path) -> None:
+    """The core report-shape contract."""
+    root = _tree(tmp_path, {"a.py": CANONICAL, "b.py": CANONICAL})
+
+    finding = _find(collect_duplication(root).findings, "inline-canonical-bytes-sites")
+
+    assert finding.verdict is Verdict.MEASURED_FAILED
+    assert finding.count == 2
+    assert finding.expected == 1
+    # A finding names WHERE, or the reader repeats the search the collector did.
+    assert len(finding.paths) == 2
+    assert all(":" in path for path in finding.paths)
+
+
+def test_collector_reports_not_yet_measurable_for_unimplemented_checks(tmp_path: Path) -> None:
+    """Honesty when a sibling issue has not landed -- distinct from "measured, passed".
+
+    Reporting an unbuilt check as a pass is what makes an aggregate look like
+    coverage it does not have.
+    """
+    report = collect_duplication(_tree(tmp_path, {"a.py": "x = 1\n"}))
+
+    pending = {f.check_id for f in report.not_yet_measurable}
+    assert "receipt-verify-kinds" in pending
+    assert "registry-duplicate-ids" in pending
+    for finding in report.not_yet_measurable:
+        assert finding.verdict is Verdict.NOT_YET_MEASURABLE
+        assert finding.count is None, "nothing was counted, so no count may be reported"
+
+
+def test_no_score_or_grade_in_output(tmp_path: Path) -> None:
+    """Guards against reintroducing security_posture.py's rejected A-F model."""
+    document = collect_duplication(_tree(tmp_path, {"a.py": CANONICAL})).to_dict()
+    serialized = json.dumps(document)
+
+    for banned in ("score", "grade", "percent", "rating"):
+        assert banned not in serialized, f"the report must not carry a {banned}"
+    # And no bare letter verdict anywhere.
+    for finding in document["findings"]:
+        assert finding["verdict"] in {v.value for v in Verdict}
+
+
+# ---------------------------------------------------------------------------
+# What each check counts
+# ---------------------------------------------------------------------------
+
+
+def test_one_shared_encoder_passes(tmp_path: Path) -> None:
+    report = collect_duplication(_tree(tmp_path, {"a.py": CANONICAL}))
+    finding = _find(report.findings, "inline-canonical-bytes-sites")
+
+    assert finding.verdict is Verdict.MEASURED_PASSED
+    assert finding.count == 1
+    # A passing check lists nothing: its one legitimate site is noise beside the failures.
+    assert finding.paths == ()
+
+
+def test_ordinary_sorted_json_is_not_counted(tmp_path: Path) -> None:
+    """Sorted keys alone is how a great deal of logging and diffing serializes."""
+    pretty = "import json\n\n\ndef log(x: dict) -> str:\n    return json.dumps(x, sort_keys=True, indent=2)\n"
+    report = collect_duplication(_tree(tmp_path, {"a.py": pretty}))
+
+    assert _find(report.findings, "inline-canonical-bytes-sites").count == 0
+
+
+def test_private_hmac_loaders_are_counted_and_expected_to_be_zero(tmp_path: Path) -> None:
+    loader = (
+        "def _load_hmac_key() -> bytes:\n"
+        "    from bernstein.core.security.audit import load_or_create_audit_key\n\n"
+        "    return load_or_create_audit_key()\n"
+    )
+    report = collect_duplication(_tree(tmp_path, {"a.py": loader, "b.py": loader}))
+    finding = _find(report.findings, "private-hmac-key-loaders")
+
+    assert finding.expected == 0
+    assert finding.count == 2
+    assert finding.verdict is Verdict.MEASURED_FAILED
+
+
+def test_a_tree_with_no_private_loaders_passes(tmp_path: Path) -> None:
+    report = collect_duplication(_tree(tmp_path, {"a.py": "x = 1\n"}))
+    assert _find(report.findings, "private-hmac-key-loaders").verdict is Verdict.MEASURED_PASSED
+
+
+# ---------------------------------------------------------------------------
+# Shape
+# ---------------------------------------------------------------------------
+
+
+def test_findings_are_ordered_by_check_id(tmp_path: Path) -> None:
+    ids = [f.check_id for f in collect_duplication(_tree(tmp_path, {"a.py": "x = 1\n"})).findings]
+    assert ids == sorted(ids)
+
+
+def test_the_summary_never_folds_unmeasured_checks_into_the_total(tmp_path: Path) -> None:
+    """A denominator that silently includes what was not measured is the failure mode."""
+    document = collect_duplication(_tree(tmp_path, {"a.py": CANONICAL})).to_dict()
+
+    assert document["measured"] + document["not_yet_measurable"] == len(document["findings"])
+    assert document["not_yet_measurable"] > 0
+
+
+def test_an_unparseable_file_does_not_take_the_report_down(tmp_path: Path) -> None:
+    """This is a report ABOUT the tree; one bad file must not stop it."""
+    root = _tree(tmp_path, {"good.py": CANONICAL, "bad.py": "def broken( :\n"})
+
+    assert _find(collect_duplication(root).findings, "inline-canonical-bytes-sites").count == 1
+
+
+def test_it_runs_against_this_repository(tmp_path: Path) -> None:
+    """The collector's actual job. Asserts the SHAPE, never a live count.
+
+    Pinning today's number here would make the test fail the moment somebody
+    fixes the duplication it exists to report.
+    """
+    from pathlib import Path as RealPath
+
+    root = RealPath(__file__).resolve().parents[3] / SRC
+    report = collect_duplication(root)
+
+    assert len(report.findings) == 6
+    measured = [f for f in report.findings if f.verdict is not Verdict.NOT_YET_MEASURABLE]
+    assert len(measured) == 2
+    for finding in measured:
+        assert finding.count is not None
+        if finding.verdict is Verdict.MEASURED_FAILED:
+            assert finding.count > finding.expected
+            assert finding.paths, "a failing check must name where"
+
+
+def _find(findings: tuple[DuplicationFinding, ...], check_id: str) -> DuplicationFinding:
+    for finding in findings:
+        if finding.check_id == check_id:
+            return finding
+    raise AssertionError(f"no finding {check_id!r}")


### PR DESCRIPTION
#5105, **slice 1** — the collector as a library function, which the issue says is worth taking alone because it is directly testable without `bernstein govern` existing yet.

## What it reports

Six checks. Two are measurable against today's tree; four say so honestly.

| check | verdict today |
|---|---|
| `inline-canonical-bytes-sites` | measured |
| `private-hmac-key-loaders` | measured |
| `receipt-verify-kinds` | not yet measurable (#5096) |
| `verification-result-shapes` | not yet measurable (#5099) |
| `registry-duplicate-ids` | not yet measurable (#5104) |
| `orphan-modules` | not yet measurable (#5100) |

## The three properties, and what each reacts to

**Findings, not a pass/fail bit.** A stable `check_id`, the count against its expected count, and the offending paths — so a finding read a week later is the same finding. A number in a CI log means nothing later; a bare red means nothing at all. A *passing* check lists no paths: its one legitimate implementation is noise beside the failures.

**"Not yet measurable" is its own verdict**, carrying `count: None`. A check whose subject does not exist yet is not passing, and reporting it as one is what makes an aggregate look like coverage it does not have. `measured + not_yet_measurable == len(findings)`, so nothing is quietly folded into the total.

**No score, no grade, no percentage.** Requirement 4. `security_posture.py` computes an A-F letter from weighted metrics and has **zero callers** — the proof this report was built once and never wired. `test_no_score_or_grade_in_output` fails the build if `score`, `grade`, `percent` or `rating` appears in the serialized output.

## One naming decision I want to flag

The issue's headline figure is *"91 copies with 60 distinct bodies"* — about canonical-JSON **encoders**. A walk of this tree cannot tell an encoder from a large function that happens to canonicalize as one step: hashing whole function bodies gave **359**, and counting any `sort_keys=True` gave **625**. Reporting either under that name would be publishing a number the check did not measure, in a module whose whole argument is that a wrong first figure is worse than no figure.

So the check is named `inline-canonical-bytes-sites` and counts **call sites that build canonical bytes inline instead of calling one helper** — exact, reproducible, and the same duplication from the other side. It requires *both* `sort_keys=True` and compact `separators`: sorted keys alone is how much ordinary logging serializes, and compact separators are what make the output *bytes* rather than text.

Happy to switch it to whatever #5094 settles on once that lands.

## Tests — 12, including all four the issue names

`test_finding_byte_identical_across_two_runs` (load-bearing), `test_duplication_count_above_expected_produces_a_measured_failed_finding`, `test_collector_reports_not_yet_measurable_for_unimplemented_checks`, `test_no_score_or_grade_in_output`.

Plus: a single shared encoder passes and lists nothing; ordinary sorted-JSON is not counted; both loader directions; ordering; the summary not folding unmeasured checks in; an unparseable file not taking the report down; and a run against this repository that asserts the **shape only** — pinning today's count would fail the moment somebody fixes the duplication it exists to report.

```
uv run pytest tests/unit/core/govern/ -q       # 228 passed
uv run mypy --config-file mypy.gate.ini        # Success, 98 files
uv run ruff check / ruff format --check        # clean
```

Release-notes fragment included.

## Not in this PR

Slices 2 and 3 — the chain-anchored finding shape, and attaching it to `bernstein govern` once #5071/#4973 give it a home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)