### PR TITLE
feat(eval): add tool-surface risk benchmark suite and forced approval gate (#5454)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,47 @@
+# Bernstein Evaluation Benchmarks
+
+This document records the canonical benchmark suites provided by `bernstein.eval.bench`, their compliance controls, determinism guarantees, and risk assessment methodologies.
+
+## Benchmark Suites
+
+| Suite ID | Purpose / Description | Compliance Controls | Fixtures / Tasks | Pass Rate Gate |
+|---|---|---|---|---|
+| `golden-v1` | Core orchestrator determinism and task execution suite | — | 5 tasks | 1.0 (100%) |
+| `tool-surface-v1` | Tool-surface risk scoring, risky triple detection, and forced approval gating | `CTRL-TOOL-INVENTORY`, `ASI02`, `AST04` | 10 fixtures | 1.0 (100%) |
+
+---
+
+## Tool Surface Risk Classification (`tool-surface-v1`)
+
+The tool-surface risk evaluation suite analyzes an MCP server's declared tool capabilities, data reach, input surface, and auth posture to compute a deterministic `CapabilityReceipt`.
+
+### Risk Classes
+
+| Risk Class | Conditions & Trigger Criteria | Forced Approval | Default Action Without Approver |
+|---|---|---|---|
+| `CRITICAL` | Risky Triple (sensitive reach + untrusted input + egress channel), or wildcard permissions without authentication | `True` | **DENIED** |
+| `HIGH` | Wildcard permissions with strong authentication, or sensitive reach combined with either egress or untrusted input | `True` | **DENIED** |
+| `MEDIUM` | Sensitive reach alone, external egress alone, or untrusted input ingestion alone | `False` | **ALLOWED** |
+| `LOW` | Read-only public tool surface under anonymous / weak authentication | `False` | **ALLOWED** |
+| `MINIMAL` | Read-only local tool surface under authenticated bearer / token posture | `False` | **ALLOWED** |
+
+### Lethal Trifecta ("Risky Triple") Rule
+
+When an MCP server exposes:
+1. **Sensitive Reach**: Access to secrets, PII, internal databases, or private credentials.
+2. **Untrusted Input**: Direct consumption of untrusted prompts, user payloads, or external webhook data.
+3. **Egress Channel**: Outbound network connections, HTTP dispatch, or socket streams.
+
+The server is classified as `CRITICAL` and **MUST force an approval gate**. If no approver is configured in the environment, the execution fails closed and is **denied by default**.
+
+---
+
+## Running and Verifying Benchmarks
+
+```bash
+# Run the tool-surface benchmark suite
+bernstein bench run tool-surface-v1 --out tool-surface-bundle.json
+
+# Offline independent verification
+bernstein bench verify tool-surface-bundle.json --suite tool-surface-v1
+```

--- a/docs/eval/bench.md
+++ b/docs/eval/bench.md
@@ -271,17 +271,37 @@ src/bernstein/eval/bench/
 ├── verifier.py          # BenchVerifier, VerificationStatus
 ├── leaderboard.py       # Leaderboard, LeaderboardEntry, Markdown render
 ├── reliability.py       # pass^k reliability floor (see reliability.md)
+├── tool_surface_suite.py# tool-surface risk evaluation suite (tool-surface-v1)
 └── golden_suite.py      # starter golden-v1 task suite
 
 tests/unit/eval/bench/
-├── test_bench.py        # TDD suite — all acceptance criteria
-└── test_reliability.py  # pass^k reliability floor tests
+├── test_bench.py                   # TDD suite — all acceptance criteria
+├── test_reliability.py             # pass^k reliability floor tests
+└── test_tool_surface_risk_suite.py # tool surface risk suite tests
 
 docs/eval/
 ├── bench.md                  # this document
 ├── reliability.md            # pass^k reliability floor
 └── trajectory-receipts.md   # offline-verifiable benchmark score receipts (#2925)
 ```
+
+---
+
+## Tool-Surface Risk Suite (`tool-surface-v1`)
+
+The `tool-surface-v1` benchmark suite evaluates MCP tool servers against lethal capability combinations, particularly the **Risky Triple** (untrusted input ingestion, sensitive data reach, and external egress).
+
+Controls covered: `CTRL-TOOL-INVENTORY`, `ASI02`, `AST04`.
+
+### Risk Classification Matrix
+
+| Risk Class | Description | Approval Gate | Unconfigured Approver |
+|---|---|---|---|
+| `CRITICAL` | Risky Triple present (sensitive reach + untrusted input + egress), or wildcard permissions without auth | **Forced** | Deny by default |
+| `HIGH` | Wildcard permissions with strong auth, or sensitive reach with egress or untrusted input | **Forced** | Deny by default |
+| `MEDIUM` | Sensitive reach alone, egress alone, or untrusted input alone | None | Allowed |
+| `LOW` | Read-only public tool surface (anonymous / weak auth) | None | Allowed |
+| `MINIMAL` | Read-only local tool surface (authenticated) | None | Allowed |
 
 ---
 

--- a/docs/release-notes/fragments/5454-eval-tool-surface-risk-suite.md
+++ b/docs/release-notes/fragments/5454-eval-tool-surface-risk-suite.md
@@ -1,0 +1,3 @@
+## Tool-surface risk benchmark suite and forced approval gating
+
+Added the `tool-surface-v1` evaluation benchmark suite (`CTRL-TOOL-INVENTORY`, `ASI02`, `AST04`) with 10 synthetic MCP server fixtures. The suite scores tool servers into risk classes (`CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `MINIMAL`) and generates verifiable `CapabilityReceipt`s. Any server combining untrusted input ingestion, sensitive data reach, and external egress (the lethal "Risky Triple") forces an approval gate and fails closed (deny by default) when no approver is configured (#5454).

--- a/docs/sdd/module-map.md
+++ b/docs/sdd/module-map.md
@@ -402,6 +402,7 @@ Full per-file module map. `AGENTS.md`'s own "Module map" section links here inst
 | `server.py`           | Bernstein MCP server |
 | `signal_paths.py`     | Containment barrier for the MCP shutdown-signal path |
 | `streaming.py`        | In-flight tool-call tracking with cancellation and partial-result preservation |
+| `tool_surface.py`     | Tool surface risk scoring and capability receipts for MCP servers |
 | `resources/`          | MCP resource registrars for Bernstein |
 | `tool_schemas/`       | tool_schemas/ sub-package |
 

--- a/src/bernstein/eval/bench/__init__.py
+++ b/src/bernstein/eval/bench/__init__.py
@@ -27,6 +27,10 @@ from bernstein.eval.bench.runner import (
     StochasticMockReplayAdapter,
 )
 from bernstein.eval.bench.suite import BenchSuite, BenchTask
+from bernstein.eval.bench.tool_surface_suite import (
+    ToolSurfaceReplayAdapter,
+    build_tool_surface_suite,
+)
 from bernstein.eval.bench.verifier import (
     BenchVerifier,
     BundleVerificationResult,
@@ -58,8 +62,10 @@ __all__ = [
     "TaskReliabilityVerification",
     "TaskResult",
     "TaskVerificationResult",
+    "ToolSurfaceReplayAdapter",
     "VerificationStatus",
     "build_golden_suite_v1",
+    "build_tool_surface_suite",
     "coordination_hash",
     "coordination_projection",
     "first_divergent_coordination_field",

--- a/src/bernstein/eval/bench/bench_cli.py
+++ b/src/bernstein/eval/bench/bench_cli.py
@@ -37,9 +37,11 @@ def _get_suite(name: str):
     """Resolve a suite name or .json path to a BenchSuite."""
     from bernstein.eval.bench.golden_suite import build_golden_suite_v1
     from bernstein.eval.bench.suite import BenchSuite
+    from bernstein.eval.bench.tool_surface_suite import build_tool_surface_suite
 
     _BUILTIN = {
         "golden-v1": build_golden_suite_v1,
+        "tool-surface-v1": build_tool_surface_suite,
     }
 
     if name in _BUILTIN:
@@ -107,7 +109,7 @@ def bench_run(suite: str, out: str, scheduler: str, stub_signer: bool, reliabili
     reliability receipt reporting pass@1 (any attempt passed) and pass^k
     (all K attempts passed — the headline floor).
     """
-    from bernstein.eval.bench.runner import BenchRunner, MockReplayAdapter
+    from bernstein.eval.bench.runner import BenchRunner, MockReplayAdapter, ReplayAdapter
     from bernstein.eval.bench.signer import AgentCardSigner, StubSigner
 
     suite_obj = _get_suite(suite)
@@ -120,7 +122,13 @@ def bench_run(suite: str, out: str, scheduler: str, stub_signer: bool, reliabili
         return
 
     # Production: swap MockReplayAdapter for the real scenario_runner adapter.
-    adapter = MockReplayAdapter()
+    adapter: ReplayAdapter
+    if suite_obj.version == "tool-surface-v1":
+        from bernstein.eval.bench.tool_surface_suite import ToolSurfaceReplayAdapter
+
+        adapter = ToolSurfaceReplayAdapter()
+    else:
+        adapter = MockReplayAdapter()
     runner = BenchRunner(
         suite=suite_obj,
         adapter=adapter,
@@ -159,7 +167,7 @@ def bench_verify(bundle: str, suite: str) -> None:
     Exits 0 on MATCH, 1 on any divergence or fabricated score.
     """
     from bernstein.eval.bench.bundle import SubmissionBundle
-    from bernstein.eval.bench.runner import MockReplayAdapter
+    from bernstein.eval.bench.runner import MockReplayAdapter, ReplayAdapter
     from bernstein.eval.bench.verifier import BenchVerifier
 
     bundle_path = Path(bundle)
@@ -170,7 +178,13 @@ def bench_verify(bundle: str, suite: str) -> None:
     suite_obj = _get_suite(suite)
 
     # Production: swap MockReplayAdapter for the real scenario_runner adapter.
-    adapter = MockReplayAdapter()
+    adapter: ReplayAdapter
+    if suite_obj.version == "tool-surface-v1":
+        from bernstein.eval.bench.tool_surface_suite import ToolSurfaceReplayAdapter
+
+        adapter = ToolSurfaceReplayAdapter()
+    else:
+        adapter = MockReplayAdapter()
     verifier = BenchVerifier(suite=suite_obj, adapter=adapter)
     result = verifier.verify(bundle_obj)
 

--- a/src/bernstein/eval/bench/tool_surface_suite.py
+++ b/src/bernstein/eval/bench/tool_surface_suite.py
@@ -93,9 +93,7 @@ class ToolSurfaceReplayAdapter:
             self._manifests = fixture_manifests
         else:
             manifest_list = get_tool_surface_fixtures()
-            self._manifests = {
-                f"tool_surface_{m.server_id}": m for m in manifest_list
-            }
+            self._manifests = {f"tool_surface_{m.server_id}": m for m in manifest_list}
             # Also index by plain server_id
             for m in manifest_list:
                 self._manifests[m.server_id] = m

--- a/src/bernstein/eval/bench/tool_surface_suite.py
+++ b/src/bernstein/eval/bench/tool_surface_suite.py
@@ -1,0 +1,200 @@
+"""Tool-surface risk evaluation benchmark suite and replay adapter.
+
+Evaluates an MCP server's declared and discoverable tool surface for security
+risk factors (untrusted input, sensitive reach, egress channels, wildcard permissions,
+auth postures) and validates the enforcement of approval gates for the "risky triple".
+
+Controls covered:
+  - CTRL-TOOL-INVENTORY: Complete inventory and classification of all tool surfaces
+  - ASI02: Mitigation of tool misuse, over-privileged tool surface, and unauthorized egress
+  - AST04: Deterministic approval gate enforcement on lethal tool combinations
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+from bernstein.eval.bench.suite import BenchSuite, BenchTask
+from bernstein.mcp.tool_surface import (
+    ServerManifest,
+    evaluate_tool_surface_risk,
+    is_approval_forced,
+    verify_capability_receipt,
+)
+
+CONTROLS_COVERED: tuple[str, ...] = ("CTRL-TOOL-INVENTORY", "ASI02", "AST04")
+
+_FIXTURE_DIR = Path(__file__).resolve().parent.parent / "cases" / "tool_surface"
+
+
+def get_tool_surface_fixtures() -> list[ServerManifest]:
+    """Load all synthetic tool surface fixture manifests."""
+    manifests: list[ServerManifest] = []
+    if _FIXTURE_DIR.is_dir():
+        for yaml_path in sorted(_FIXTURE_DIR.glob("*.yaml")):
+            manifest = ServerManifest.from_yaml(yaml_path)
+            manifests.append(manifest)
+    return manifests
+
+
+def build_tool_surface_suite() -> BenchSuite:
+    """Build the canonical ``tool-surface-v1`` benchmark suite."""
+    manifests = get_tool_surface_fixtures()
+    tasks: list[BenchTask] = []
+
+    for manifest in manifests:
+        expected_receipt = evaluate_tool_surface_risk(manifest)
+        is_risky_triple = expected_receipt.has_risky_triple
+        is_read_only = (
+            not expected_receipt.risk_factors.get("sensitive_reach", False)
+            and not expected_receipt.risk_factors.get("egress_channel", False)
+            and not expected_receipt.risk_factors.get("untrusted_input", False)
+            and not expected_receipt.risk_factors.get("wildcard_permissions", False)
+        )
+
+        assertions: list[dict[str, Any]] = [
+            {"kind": "risk_class_eq", "expected": expected_receipt.risk_class.value},
+            {"kind": "risky_triple_eq", "expected": is_risky_triple},
+            {"kind": "forced_approval_eq", "expected": expected_receipt.forced_approval},
+            {"kind": "receipt_hash_valid", "expected": True},
+            {"kind": "controls_present", "controls": list(CONTROLS_COVERED)},
+        ]
+        if is_risky_triple:
+            assertions.append({"kind": "triple_detection_rate", "min_rate": 1.0})
+            assertions.append({"kind": "deny_by_default_when_no_approver", "expected": True})
+        if is_read_only:
+            assertions.append({"kind": "read_only_never_force_approval", "expected": True})
+
+        task = BenchTask(
+            id=f"tool_surface_{manifest.server_id}",
+            description=f"Evaluate tool surface risk and approval gating for server '{manifest.server_id}'.",
+            steps=(
+                f"parse manifest for {manifest.server_id}",
+                "compute risk class and capability receipt",
+                "evaluate risky triple and approval gate invariants",
+                "verify deny-by-default when no approver is configured",
+                "validate receipt cryptographic integrity",
+            ),
+            assertions=tuple(assertions),
+            category="tool_surface",
+        )
+        tasks.append(task)
+
+    return BenchSuite(version="tool-surface-v1", tasks=tasks)
+
+
+class ToolSurfaceReplayAdapter:
+    """In-process replay adapter for tool surface risk evaluation suite."""
+
+    def __init__(self, fixture_manifests: dict[str, ServerManifest] | None = None) -> None:
+        if fixture_manifests is not None:
+            self._manifests = fixture_manifests
+        else:
+            manifest_list = get_tool_surface_fixtures()
+            self._manifests = {
+                f"tool_surface_{m.server_id}": m for m in manifest_list
+            }
+            # Also index by plain server_id
+            for m in manifest_list:
+                self._manifests[m.server_id] = m
+
+    def run_task(self, task: BenchTask, scheduler_config: dict[str, Any]) -> dict[str, Any]:
+        """Execute tool surface evaluation for the task and return the run receipt."""
+        manifest = self._manifests.get(task.id)
+        if manifest is None:
+            # Fallback if task id starts with tool_surface_
+            raw_id = task.id.removeprefix("tool_surface_")
+            manifest = self._manifests.get(raw_id)
+
+        if manifest is None:
+            raise ValueError(f"Unknown fixture manifest for task {task.id}")
+
+        receipt = evaluate_tool_surface_risk(manifest)
+        task_hash = task.content_hash()
+        journal_head = hashlib.sha256(f"journal:{task_hash}:{receipt.receipt_hash}".encode()).hexdigest()
+        spine_head = hashlib.sha256(f"spine:{task_hash}:{receipt.receipt_hash}".encode()).hexdigest()
+
+        # Evaluate approval enforcement with and without approver configured
+        forced_with_approver, _reason_with_approver = is_approval_forced(receipt, approver_configured=True)
+        _forced_no_approver, reason_no_approver = is_approval_forced(receipt, approver_configured=False)
+        is_denied_when_no_approver = "DENIED:" in reason_no_approver if receipt.forced_approval else False
+
+        events = [
+            {
+                "seq": 0,
+                "kind": "tool_surface.evaluated",
+                "server_id": manifest.server_id,
+                "risk_class": receipt.risk_class.value,
+                "has_risky_triple": receipt.has_risky_triple,
+                "forced_approval": receipt.forced_approval,
+            },
+            {
+                "seq": 1,
+                "kind": "tool_surface.gate_checked",
+                "forced_with_approver": forced_with_approver,
+                "denied_when_no_approver": is_denied_when_no_approver,
+            },
+            {
+                "seq": 2,
+                "kind": "tool_surface.receipt_verified",
+                "receipt_hash": receipt.receipt_hash,
+                "valid": verify_capability_receipt(receipt),
+            },
+        ]
+
+        return {
+            "journal_head": journal_head,
+            "spine_head": spine_head,
+            "run_id": f"tool-surface-{task_hash[:12]}",
+            "server_id": manifest.server_id,
+            "risk_class": receipt.risk_class.value,
+            "has_risky_triple": receipt.has_risky_triple,
+            "forced_approval": receipt.forced_approval,
+            "deny_by_default": is_denied_when_no_approver,
+            "controls": list(CONTROLS_COVERED),
+            "capability_receipt": receipt.to_dict(),
+            "events": events,
+        }
+
+    def score_task(self, task: BenchTask, receipt: dict[str, Any]) -> tuple[bool, float, dict[str, Any]]:
+        """Score task run receipt against assertions."""
+        cap_receipt_dict = receipt.get("capability_receipt")
+        if not cap_receipt_dict:
+            return False, 0.0, {"error": "Missing capability_receipt in run receipt"}
+
+        if not verify_capability_receipt(cap_receipt_dict):
+            return False, 0.0, {"error": "Capability receipt cryptographic verification failed"}
+
+        rc_val = receipt.get("risk_class")
+        has_triple = receipt.get("has_risky_triple", False)
+        forced_approval = receipt.get("forced_approval", False)
+        deny_by_default = receipt.get("deny_by_default", False)
+
+        for assertion in task.assertions:
+            kind = assertion.get("kind")
+            if kind == "risk_class_eq" and rc_val != assertion.get("expected"):
+                return False, 0.0, {"error": f"RiskClass mismatch: {rc_val} != {assertion.get('expected')}"}
+            if kind == "risky_triple_eq" and has_triple != assertion.get("expected"):
+                return False, 0.0, {"error": f"Risky triple mismatch: {has_triple} != {assertion.get('expected')}"}
+            if kind == "forced_approval_eq" and forced_approval != assertion.get("expected"):
+                exp = assertion.get("expected")
+                return False, 0.0, {"error": f"Forced approval mismatch: {forced_approval} != {exp}"}
+            if kind == "triple_detection_rate" and has_triple is not True:
+                return False, 0.0, {"error": "Risky triple not detected"}
+            if kind == "deny_by_default_when_no_approver" and not deny_by_default:
+                return False, 0.0, {"error": "Expected deny-by-default when no approver configured"}
+            if kind == "read_only_never_force_approval" and forced_approval is True:
+                return False, 0.0, {"error": "Read-only fixture must never force approval"}
+
+        harness_output = {
+            "status": "PASS",
+            "server_id": receipt.get("server_id"),
+            "risk_class": rc_val,
+            "has_risky_triple": has_triple,
+            "forced_approval": forced_approval,
+            "receipt_hash": cap_receipt_dict.get("receipt_hash"),
+            "controls": receipt.get("controls", list(CONTROLS_COVERED)),
+        }
+        return True, 1.0, harness_output

--- a/src/bernstein/eval/bench/verifier.py
+++ b/src/bernstein/eval/bench/verifier.py
@@ -60,6 +60,8 @@ class TaskVerificationResult:
     # Replayed score (None if replay failed / receipt missing).
     replayed_score: float | None = None
     replayed_passed: bool | None = None
+    risk_class: str | None = None
+    capability_receipt_hash: str | None = None
 
 
 @dataclass
@@ -86,6 +88,10 @@ class BundleVerificationResult:
         for tr in self.task_results:
             mark = "✓" if tr.status == VerificationStatus.MATCH else "✗"
             lines.append(f"  {mark} {tr.task_id:<40} {tr.status.value}")
+            if tr.risk_class:
+                lines.append(f"    ├─ risk_class      : {tr.risk_class}")
+            if tr.capability_receipt_hash:
+                lines.append(f"    ├─ capability_hash : {tr.capability_receipt_hash}")
             if tr.detail:
                 lines.append(f"    └─ {tr.detail}")
         return "\n".join(lines)
@@ -234,9 +240,15 @@ class BenchVerifier:
                 ),
             )
 
+        risk_class = result.receipt.get("risk_class") or result.harness_output.get("risk_class")
+        cap_receipt = result.receipt.get("capability_receipt")
+        cap_hash = cap_receipt.get("receipt_hash") if isinstance(cap_receipt, dict) else None
+
         return TaskVerificationResult(
             task_id=task_id,
             status=VerificationStatus.MATCH,
             replayed_score=replayed_score,
             replayed_passed=replayed_passed,
+            risk_class=risk_class,
+            capability_receipt_hash=cap_hash,
         )

--- a/src/bernstein/eval/cases/tool_surface/01_read_only_local.yaml
+++ b/src/bernstein/eval/cases/tool_surface/01_read_only_local.yaml
@@ -1,0 +1,19 @@
+id: read_only_local
+name: Local Read-Only Filesystem Server
+description: Hermetic read-only tool surface reading local documentation and files.
+auth_posture: static_bearer_token
+has_untrusted_input: false
+has_sensitive_reach: false
+has_egress_channel: false
+has_wildcard_permissions: false
+tools:
+  - name: read_local_file
+    description: Read contents of a file on local filesystem.
+    read_only: true
+    sensitive_reach: false
+    untrusted_input: false
+    egress: false
+resources:
+  - uri: "file:///docs/readme.txt"
+    name: local_readme
+prompts: []

--- a/src/bernstein/eval/cases/tool_surface/02_read_only_public.yaml
+++ b/src/bernstein/eval/cases/tool_surface/02_read_only_public.yaml
@@ -1,0 +1,17 @@
+id: read_only_public
+name: Public Documentation Reader Server
+description: Anonymous public documentation reader with no sensitive reach or egress.
+auth_posture: anonymous
+has_untrusted_input: false
+has_sensitive_reach: false
+has_egress_channel: false
+has_wildcard_permissions: false
+tools:
+  - name: fetch_public_docs
+    description: Fetch static documentation pages from public knowledge base.
+    read_only: true
+    sensitive_reach: false
+    untrusted_input: false
+    egress: false
+resources: []
+prompts: []

--- a/src/bernstein/eval/cases/tool_surface/03_read_egress.yaml
+++ b/src/bernstein/eval/cases/tool_surface/03_read_egress.yaml
@@ -1,0 +1,23 @@
+id: read_egress
+name: Public Read with Webhook Egress Server
+description: Reads public weather API and posts alerts to an external webhook.
+auth_posture: static_bearer_token
+has_untrusted_input: false
+has_sensitive_reach: false
+has_egress_channel: true
+has_wildcard_permissions: false
+tools:
+  - name: fetch_public_weather
+    description: Fetch public weather forecasts.
+    read_only: true
+    sensitive_reach: false
+    untrusted_input: false
+    egress: false
+  - name: post_webhook_alert
+    description: Send alert payload to an external HTTP webhook.
+    read_only: false
+    sensitive_reach: false
+    untrusted_input: false
+    egress: true
+resources: []
+prompts: []

--- a/src/bernstein/eval/cases/tool_surface/04_risky_triple_basic.yaml
+++ b/src/bernstein/eval/cases/tool_surface/04_risky_triple_basic.yaml
@@ -1,0 +1,26 @@
+id: risky_triple_basic
+name: Risky Triple Database & Egress Server
+description: Accesses sensitive customer database, processes untrusted prompts, and posts to external endpoint.
+auth_posture: static_bearer_token
+has_untrusted_input: true
+has_sensitive_reach: true
+has_egress_channel: true
+has_wildcard_permissions: false
+tools:
+  - name: query_customer_database
+    description: Query sensitive PII and account balances from production database.
+    sensitive_reach: true
+    untrusted_input: false
+    egress: false
+  - name: parse_user_prompt
+    description: Ingest and parse untrusted external user input.
+    sensitive_reach: false
+    untrusted_input: true
+    egress: false
+  - name: dispatch_external_http
+    description: Post arbitrary JSON payload to external web service.
+    sensitive_reach: false
+    untrusted_input: false
+    egress: true
+resources: []
+prompts: []

--- a/src/bernstein/eval/cases/tool_surface/05_risky_triple_oauth.yaml
+++ b/src/bernstein/eval/cases/tool_surface/05_risky_triple_oauth.yaml
@@ -1,0 +1,26 @@
+id: risky_triple_oauth
+name: Enterprise OAuth Risky Triple Server
+description: OAuth2 protected server reading sensitive HR records, receiving webhook inputs, and calling external APIs.
+auth_posture: oauth2_pkce
+has_untrusted_input: true
+has_sensitive_reach: true
+has_egress_channel: true
+has_wildcard_permissions: false
+tools:
+  - name: read_hr_records
+    description: Access confidential employee records and compensation info.
+    sensitive_reach: true
+    untrusted_input: false
+    egress: false
+  - name: accept_untrusted_webhook
+    description: Process webhook payloads from untrusted public internet sources.
+    sensitive_reach: false
+    untrusted_input: true
+    egress: false
+  - name: call_third_party_saas
+    description: Export processed summaries to external SaaS partners.
+    sensitive_reach: false
+    untrusted_input: false
+    egress: true
+resources: []
+prompts: []

--- a/src/bernstein/eval/cases/tool_surface/06_risky_triple_no_auth.yaml
+++ b/src/bernstein/eval/cases/tool_surface/06_risky_triple_no_auth.yaml
@@ -1,0 +1,26 @@
+id: risky_triple_no_auth
+name: Unauthenticated Risky Triple Tool Server
+description: Anonymous server accessing secrets vault, running arbitrary scripts, and egressing over sockets.
+auth_posture: none
+has_untrusted_input: true
+has_sensitive_reach: true
+has_egress_channel: true
+has_wildcard_permissions: false
+tools:
+  - name: fetch_vault_secrets
+    description: Read secret keys and credentials from local vault.
+    sensitive_reach: true
+    untrusted_input: false
+    egress: false
+  - name: run_dynamic_query
+    description: Parse and execute dynamic query text from untrusted caller.
+    sensitive_reach: false
+    untrusted_input: true
+    egress: false
+  - name: open_remote_socket
+    description: Send data packets over raw TCP socket to remote host.
+    sensitive_reach: false
+    untrusted_input: false
+    egress: true
+resources: []
+prompts: []

--- a/src/bernstein/eval/cases/tool_surface/07_wildcard_no_auth.yaml
+++ b/src/bernstein/eval/cases/tool_surface/07_wildcard_no_auth.yaml
@@ -1,0 +1,15 @@
+id: wildcard_no_auth
+name: Anonymous Wildcard Execution Server
+description: Anonymous server with wildcard permissions over system commands.
+auth_posture: none
+has_untrusted_input: false
+has_sensitive_reach: false
+has_egress_channel: false
+has_wildcard_permissions: true
+tools:
+  - name: system_command_runner
+    description: Execute any system command with wildcard permissions.
+    scope: "*"
+    wildcard: true
+resources: []
+prompts: []

--- a/src/bernstein/eval/cases/tool_surface/08_wildcard_oauth.yaml
+++ b/src/bernstein/eval/cases/tool_surface/08_wildcard_oauth.yaml
@@ -1,0 +1,15 @@
+id: wildcard_oauth
+name: OAuth Protected Wildcard Tool Server
+description: OAuth2 protected server exposing wildcard administrative control.
+auth_posture: oauth2_pkce
+has_untrusted_input: false
+has_sensitive_reach: false
+has_egress_channel: false
+has_wildcard_permissions: true
+tools:
+  - name: cluster_admin_manager
+    description: Perform administrative mutations across all cluster resources.
+    scope: "*"
+    wildcard: true
+resources: []
+prompts: []

--- a/src/bernstein/eval/cases/tool_surface/09_sensitive_read_no_egress.yaml
+++ b/src/bernstein/eval/cases/tool_surface/09_sensitive_read_no_egress.yaml
@@ -1,0 +1,16 @@
+id: sensitive_read_no_egress
+name: Local Sensitive Credentials Inspector Server
+description: Inspects credentials and secret configs locally with no network egress.
+auth_posture: static_bearer_token
+has_untrusted_input: false
+has_sensitive_reach: true
+has_egress_channel: false
+has_wildcard_permissions: false
+tools:
+  - name: inspect_credentials
+    description: Inspect local encryption key configuration.
+    sensitive_reach: true
+    untrusted_input: false
+    egress: false
+resources: []
+prompts: []

--- a/src/bernstein/eval/cases/tool_surface/10_untrusted_input_no_egress.yaml
+++ b/src/bernstein/eval/cases/tool_surface/10_untrusted_input_no_egress.yaml
@@ -1,0 +1,16 @@
+id: untrusted_input_no_egress
+name: Local Untrusted Feedback Parser Server
+description: Ingests untrusted user feedback prompts and parses sentiment locally with no network egress.
+auth_posture: static_bearer_token
+has_untrusted_input: true
+has_sensitive_reach: false
+has_egress_channel: false
+has_wildcard_permissions: false
+tools:
+  - name: parse_user_feedback
+    description: Parse untrusted feedback submissions and extract sentiment keywords locally.
+    sensitive_reach: false
+    untrusted_input: true
+    egress: false
+resources: []
+prompts: []

--- a/src/bernstein/mcp/__init__.py
+++ b/src/bernstein/mcp/__init__.py
@@ -1,1 +1,21 @@
 """Bernstein MCP server - expose orchestration as MCP tools."""
+
+from bernstein.mcp.tool_surface import (
+    AuthPosture,
+    CapabilityReceipt,
+    RiskClass,
+    ServerManifest,
+    evaluate_tool_surface_risk,
+    is_approval_forced,
+    verify_capability_receipt,
+)
+
+__all__ = [
+    "AuthPosture",
+    "CapabilityReceipt",
+    "RiskClass",
+    "ServerManifest",
+    "evaluate_tool_surface_risk",
+    "is_approval_forced",
+    "verify_capability_receipt",
+]

--- a/src/bernstein/mcp/approval_gate.py
+++ b/src/bernstein/mcp/approval_gate.py
@@ -159,3 +159,13 @@ def completion_refusal_payload(task_id: str, current_status: str) -> dict[str, A
             "task mailbox with bernstein_post_message."
         ),
     }
+
+
+def check_tool_surface_approval_gate(
+    manifest_or_receipt: Any,
+    approver_configured: bool = True,
+) -> tuple[bool, str]:
+    """Check whether a tool surface forces an approval gate, failing closed if unconfigured."""
+    from bernstein.mcp.tool_surface import is_approval_forced
+
+    return is_approval_forced(manifest_or_receipt, approver_configured=approver_configured)

--- a/src/bernstein/mcp/capability.py
+++ b/src/bernstein/mcp/capability.py
@@ -33,6 +33,7 @@ from bernstein.core.protocols.mcp.tool_tiers import (
     tools_for_tier,
 )
 from bernstein.mcp.cost_meter import COST_METER_ENV, cost_meter_enabled
+from bernstein.mcp.tool_surface import ServerManifest, evaluate_tool_surface_risk
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
@@ -163,6 +164,14 @@ def build_capability_card(spec_revision: str | None = None) -> dict[str, Any]:
             "perCallMeter": cost_meter_enabled(),
             "fields": ["latency_ms", "cost_usd", "call_id", "ok", "ts"],
         },
+        "toolSurface": evaluate_tool_surface_risk(
+            ServerManifest(
+                server_id="bernstein",
+                name="bernstein",
+                auth_posture="bearer" if _auth_modes().get("bearer_token_configured") else "anonymous",
+                tools=[{"name": t} for t in tools_for_tier(active_tier)],
+            )
+        ).to_dict(),
     }
 
 

--- a/src/bernstein/mcp/tool_surface.py
+++ b/src/bernstein/mcp/tool_surface.py
@@ -103,8 +103,7 @@ class ServerManifest:
     def from_yaml(cls, path_or_content: str | Path) -> ServerManifest:
         """Load a ServerManifest from a YAML file path or YAML string."""
         if isinstance(path_or_content, Path) or (
-            isinstance(path_or_content, str)
-            and ("\n" not in path_or_content and Path(path_or_content).is_file())
+            isinstance(path_or_content, str) and ("\n" not in path_or_content and Path(path_or_content).is_file())
         ):
             content = Path(path_or_content).read_text(encoding="utf-8")
         else:
@@ -286,9 +285,7 @@ def is_approval_forced(
         receipt = evaluate_tool_surface_risk(receipt_or_manifest)
 
     server_id = receipt.server_id
-    risk_class_val = (
-        receipt.risk_class.value if isinstance(receipt.risk_class, RiskClass) else str(receipt.risk_class)
-    )
+    risk_class_val = receipt.risk_class.value if isinstance(receipt.risk_class, RiskClass) else str(receipt.risk_class)
 
     if receipt.forced_approval:
         if not approver_configured:

--- a/src/bernstein/mcp/tool_surface.py
+++ b/src/bernstein/mcp/tool_surface.py
@@ -1,0 +1,334 @@
+"""Tool surface risk scoring and capability receipts for MCP servers.
+
+Evaluates an MCP server's declared and discoverable tool surface for security
+risk factors:
+  - Untrusted input ingestion (e.g. prompt injection attack surface)
+  - Sensitive data reach (e.g. credentials, customer data, private database)
+  - Egress channels (e.g. webhooks, external HTTP calls, sockets)
+  - Wildcard / over-privileged permissions (e.g. '*' scope)
+  - Auth posture (none / anonymous vs static bearer token vs OAuth2 PKCE)
+
+The lethal trifecta ("Risky Triple") occurs when a single tool server combines
+untrusted input, sensitive data reach, and an external egress channel. Any
+server exhibiting the risky triple is classified as CRITICAL and MUST force
+an approval gate before invocation. When no approver is configured in the
+environment, execution is denied by default.
+
+A verifiable, deterministic CapabilityReceipt is computed with canonical JSON
+hashing, allowing offline verification and inclusion in audit chains.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class RiskClass(StrEnum):
+    """Risk classification for an MCP tool server surface."""
+
+    CRITICAL = "CRITICAL"
+    HIGH = "HIGH"
+    MEDIUM = "MEDIUM"
+    LOW = "LOW"
+    MINIMAL = "MINIMAL"
+
+
+class AuthPosture(StrEnum):
+    """Authentication posture of the tool server."""
+
+    NONE = "none"
+    ANONYMOUS = "anonymous"
+    STATIC_BEARER_TOKEN = "static_bearer_token"
+    BEARER = "bearer"
+    OAUTH2_PKCE = "oauth2_pkce"
+    OIDC = "oidc"
+
+
+@dataclass
+class ServerManifest:
+    """Declared tool surface and security properties of an MCP server."""
+
+    server_id: str
+    name: str
+    description: str = ""
+    auth_posture: str = AuthPosture.NONE.value
+    has_untrusted_input: bool = False
+    has_sensitive_reach: bool = False
+    has_egress_channel: bool = False
+    has_wildcard_permissions: bool = False
+    tools: list[dict[str, Any]] = field(default_factory=list)
+    resources: list[dict[str, Any]] = field(default_factory=list)
+    prompts: list[dict[str, Any]] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ServerManifest:
+        """Construct a ServerManifest from a dictionary representation."""
+        server_id = str(data.get("id") or data.get("server_id") or "unknown_server")
+        name = str(data.get("name") or server_id)
+        description = str(data.get("description") or "")
+        auth_posture = str(data.get("auth_posture") or data.get("auth") or AuthPosture.NONE.value)
+        has_untrusted_input = bool(data.get("has_untrusted_input", False))
+        has_sensitive_reach = bool(data.get("has_sensitive_reach", False))
+        has_egress_channel = bool(data.get("has_egress_channel", False))
+        has_wildcard_permissions = bool(data.get("has_wildcard_permissions", False))
+        tools = list(data.get("tools") or [])
+        resources = list(data.get("resources") or [])
+        prompts = list(data.get("prompts") or [])
+        metadata = dict(data.get("metadata") or {})
+
+        return cls(
+            server_id=server_id,
+            name=name,
+            description=description,
+            auth_posture=auth_posture,
+            has_untrusted_input=has_untrusted_input,
+            has_sensitive_reach=has_sensitive_reach,
+            has_egress_channel=has_egress_channel,
+            has_wildcard_permissions=has_wildcard_permissions,
+            tools=tools,
+            resources=resources,
+            prompts=prompts,
+            metadata=metadata,
+        )
+
+    @classmethod
+    def from_yaml(cls, path_or_content: str | Path) -> ServerManifest:
+        """Load a ServerManifest from a YAML file path or YAML string."""
+        if isinstance(path_or_content, Path) or (
+            isinstance(path_or_content, str)
+            and ("\n" not in path_or_content and Path(path_or_content).is_file())
+        ):
+            content = Path(path_or_content).read_text(encoding="utf-8")
+        else:
+            content = str(path_or_content)
+        data = yaml.safe_load(content) or {}
+        return cls.from_dict(data)
+
+
+@dataclass(frozen=True)
+class CapabilityReceipt:
+    """Verifiable cryptographic receipt of evaluated tool surface risk."""
+
+    server_id: str
+    risk_class: RiskClass
+    has_risky_triple: bool
+    forced_approval: bool
+    risk_factors: dict[str, bool]
+    auth_posture: str
+    receipt_hash: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-serializable dictionary with receipt hash."""
+        return {
+            "server_id": self.server_id,
+            "risk_class": self.risk_class.value if isinstance(self.risk_class, RiskClass) else str(self.risk_class),
+            "has_risky_triple": self.has_risky_triple,
+            "forced_approval": self.forced_approval,
+            "risk_factors": self.risk_factors,
+            "auth_posture": self.auth_posture,
+            "receipt_hash": self.receipt_hash or self.compute_hash(),
+        }
+
+    def compute_hash(self) -> str:
+        """Deterministic canonical SHA-256 hash over receipt fields."""
+        canonical_data = {
+            "auth_posture": self.auth_posture,
+            "forced_approval": self.forced_approval,
+            "has_risky_triple": self.has_risky_triple,
+            "risk_class": self.risk_class.value if isinstance(self.risk_class, RiskClass) else str(self.risk_class),
+            "risk_factors": dict(sorted(self.risk_factors.items())),
+            "server_id": self.server_id,
+        }
+        payload = json.dumps(canonical_data, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return hashlib.sha256(payload).hexdigest()
+
+
+def _is_sensitive(tool: dict[str, Any]) -> bool:
+    """Return True if tool reaches sensitive data."""
+    if tool.get("sensitive_reach") or tool.get("sensitive"):
+        return True
+    sensitivity = str(tool.get("data_sensitivity") or "").lower()
+    return sensitivity in ("critical", "sensitive", "private", "confidential", "secret", "restricted")
+
+
+def _is_egress(tool: dict[str, Any]) -> bool:
+    """Return True if tool provides external network/egress channel."""
+    return bool(tool.get("egress") or tool.get("has_egress") or tool.get("network_egress"))
+
+
+def _is_untrusted(tool: dict[str, Any]) -> bool:
+    """Return True if tool ingests untrusted or remote input."""
+    return bool(tool.get("untrusted_input") or tool.get("has_untrusted_input"))
+
+
+def _is_wildcard(tool: dict[str, Any]) -> bool:
+    """Return True if tool has wildcard scope or unrestricted permissions."""
+    if tool.get("wildcard") or tool.get("has_wildcard"):
+        return True
+    scope = str(tool.get("scope") or "")
+    permission = str(tool.get("permission") or "")
+    return scope == "*" or permission == "*"
+
+
+def evaluate_tool_surface_risk(manifest_or_data: ServerManifest | dict[str, Any]) -> CapabilityReceipt:
+    """Evaluate an MCP server manifest and emit a verifiable CapabilityReceipt.
+
+    Scoring Invariants:
+      1. Risky Triple (sensitive reach + untrusted input + egress channel) -> CRITICAL, forced approval = True.
+      2. Wildcard permissions with weak auth (none/anonymous) -> CRITICAL, forced approval = True.
+      3. Wildcard permissions with strong auth (OAuth/bearer) -> HIGH, forced approval = True.
+      4. Sensitive reach with egress or untrusted input -> HIGH, forced approval = True.
+      5. Sensitive reach alone, egress alone, or untrusted input alone -> MEDIUM, forced approval = False.
+      6. Read-only without sensitive reach or egress:
+         - Anonymous / no auth -> LOW, forced approval = False.
+         - Authenticated -> MINIMAL, forced approval = False.
+    """
+    if isinstance(manifest_or_data, ServerManifest):
+        manifest = manifest_or_data
+    else:
+        manifest = ServerManifest.from_dict(manifest_or_data)
+
+    # Resolve aggregate risk factors
+    tools = manifest.tools
+    has_untrusted_input = manifest.has_untrusted_input or any(_is_untrusted(t) for t in tools)
+    has_sensitive_reach = manifest.has_sensitive_reach or any(_is_sensitive(t) for t in tools)
+    has_egress_channel = manifest.has_egress_channel or any(_is_egress(t) for t in tools)
+    has_wildcard_permissions = manifest.has_wildcard_permissions or any(_is_wildcard(t) for t in tools)
+
+    is_weak_auth = manifest.auth_posture.lower() in (
+        AuthPosture.NONE.value,
+        AuthPosture.ANONYMOUS.value,
+        "",
+        "none",
+        "anonymous",
+    )
+
+    # 1. Risky Triple
+    has_risky_triple = bool(has_sensitive_reach and has_untrusted_input and has_egress_channel)
+
+    if has_risky_triple:
+        risk_class = RiskClass.CRITICAL
+        forced_approval = True
+    elif has_wildcard_permissions:
+        if is_weak_auth:
+            risk_class = RiskClass.CRITICAL
+            forced_approval = True
+        else:
+            risk_class = RiskClass.HIGH
+            forced_approval = True
+    elif has_sensitive_reach and (has_egress_channel or has_untrusted_input):
+        risk_class = RiskClass.HIGH
+        forced_approval = True
+    elif has_sensitive_reach or has_egress_channel or has_untrusted_input:
+        risk_class = RiskClass.MEDIUM
+        forced_approval = False
+    else:
+        if is_weak_auth:
+            risk_class = RiskClass.LOW
+            forced_approval = False
+        else:
+            risk_class = RiskClass.MINIMAL
+            forced_approval = False
+
+    risk_factors = {
+        "egress_channel": has_egress_channel,
+        "sensitive_reach": has_sensitive_reach,
+        "untrusted_input": has_untrusted_input,
+        "wildcard_permissions": has_wildcard_permissions,
+    }
+
+    receipt = CapabilityReceipt(
+        server_id=manifest.server_id,
+        risk_class=risk_class,
+        has_risky_triple=has_risky_triple,
+        forced_approval=forced_approval,
+        risk_factors=risk_factors,
+        auth_posture=manifest.auth_posture,
+    )
+    # Compute receipt hash and return frozen instance with populated hash
+    receipt_hash = receipt.compute_hash()
+    return CapabilityReceipt(
+        server_id=receipt.server_id,
+        risk_class=receipt.risk_class,
+        has_risky_triple=receipt.has_risky_triple,
+        forced_approval=receipt.forced_approval,
+        risk_factors=receipt.risk_factors,
+        auth_posture=receipt.auth_posture,
+        receipt_hash=receipt_hash,
+    )
+
+
+def is_approval_forced(
+    receipt_or_manifest: CapabilityReceipt | ServerManifest | dict[str, Any],
+    approver_configured: bool = True,
+) -> tuple[bool, str]:
+    """Determine whether invocation requires approval, enforcing deny-by-default when unconfigured.
+
+    Returns:
+      (forced: bool, reason: str)
+
+    Invariants:
+      - If forced approval is required and approver_configured is False, access is denied (deny-by-default).
+      - If forced approval is required and approver_configured is True, returns forced=True with approval reason.
+      - If forced approval is not required, returns forced=False.
+    """
+    if isinstance(receipt_or_manifest, CapabilityReceipt):
+        receipt = receipt_or_manifest
+    else:
+        receipt = evaluate_tool_surface_risk(receipt_or_manifest)
+
+    server_id = receipt.server_id
+    risk_class_val = (
+        receipt.risk_class.value if isinstance(receipt.risk_class, RiskClass) else str(receipt.risk_class)
+    )
+
+    if receipt.forced_approval:
+        if not approver_configured:
+            return (
+                True,
+                f"DENIED: forced approval required for server '{server_id}' (risk_class={risk_class_val}) "
+                f"but no approver is configured in the environment.",
+            )
+        return (
+            True,
+            f"APPROVAL_REQUIRED: server '{server_id}' requires operator approval before execution "
+            f"(risk_class={risk_class_val}, risky_triple={receipt.has_risky_triple}).",
+        )
+
+    return (
+        False,
+        f"ALLOWED: server '{server_id}' does not require forced approval (risk_class={risk_class_val}).",
+    )
+
+
+def verify_capability_receipt(receipt: CapabilityReceipt | dict[str, Any]) -> bool:
+    """Verify cryptographic integrity of a capability receipt."""
+    if isinstance(receipt, CapabilityReceipt):
+        stored_hash = receipt.receipt_hash
+        expected_hash = receipt.compute_hash()
+        return bool(stored_hash and stored_hash == expected_hash)
+    if isinstance(receipt, dict):
+        stored_hash = str(receipt.get("receipt_hash") or "")
+        risk_class_str = str(receipt.get("risk_class") or "")
+        try:
+            rc = RiskClass(risk_class_str)
+        except ValueError:
+            return False
+        temp = CapabilityReceipt(
+            server_id=str(receipt.get("server_id") or ""),
+            risk_class=rc,
+            has_risky_triple=bool(receipt.get("has_risky_triple", False)),
+            forced_approval=bool(receipt.get("forced_approval", False)),
+            risk_factors=dict(receipt.get("risk_factors") or {}),
+            auth_posture=str(receipt.get("auth_posture") or ""),
+        )
+        return bool(stored_hash and stored_hash == temp.compute_hash())
+    return False

--- a/tests/unit/eval/bench/test_tool_surface_risk_suite.py
+++ b/tests/unit/eval/bench/test_tool_surface_risk_suite.py
@@ -1,0 +1,154 @@
+"""Tests for the tool-surface risk benchmark suite and verifier integration."""
+
+from __future__ import annotations
+
+from bernstein.eval.bench.bundle import SubmissionBundle, TaskResult
+from bernstein.eval.bench.runner import BenchRunner
+from bernstein.eval.bench.signer import StubSigner
+from bernstein.eval.bench.tool_surface_suite import (
+    ToolSurfaceReplayAdapter,
+    build_tool_surface_suite,
+    get_tool_surface_fixtures,
+)
+from bernstein.eval.bench.verifier import BenchVerifier, VerificationStatus
+from bernstein.mcp.tool_surface import (
+    RiskClass,
+    evaluate_tool_surface_risk,
+    is_approval_forced,
+)
+
+
+def test_ten_fixtures_exist_and_load() -> None:
+    fixtures = get_tool_surface_fixtures()
+    assert len(fixtures) >= 10
+    fixture_ids = {f.server_id for f in fixtures}
+    expected_ids = {
+        "read_only_local",
+        "read_only_public",
+        "read_egress",
+        "risky_triple_basic",
+        "risky_triple_oauth",
+        "risky_triple_no_auth",
+        "wildcard_no_auth",
+        "wildcard_oauth",
+        "sensitive_read_no_egress",
+        "untrusted_input_no_egress",
+    }
+    assert expected_ids <= fixture_ids
+
+
+def test_risky_triple_detection_rate_is_100_percent() -> None:
+    fixtures = get_tool_surface_fixtures()
+    triple_fixtures = [f for f in fixtures if "risky_triple" in f.server_id]
+    assert len(triple_fixtures) == 3
+
+    detected_count = 0
+    for f in triple_fixtures:
+        receipt = evaluate_tool_surface_risk(f)
+        if receipt.has_risky_triple and receipt.risk_class == RiskClass.CRITICAL and receipt.forced_approval is True:
+            detected_count += 1
+
+    detection_rate = detected_count / len(triple_fixtures)
+    assert detection_rate == 1.0
+
+
+def test_read_only_fixtures_never_force_approval() -> None:
+    fixtures = get_tool_surface_fixtures()
+    read_only_fixtures = [f for f in fixtures if "read_only" in f.server_id]
+    assert len(read_only_fixtures) >= 2
+
+    for f in read_only_fixtures:
+        receipt = evaluate_tool_surface_risk(f)
+        assert receipt.forced_approval is False
+        assert receipt.has_risky_triple is False
+        forced, reason = is_approval_forced(receipt, approver_configured=True)
+        assert forced is False
+        assert "ALLOWED" in reason
+
+
+def test_forced_approval_fixtures_deny_by_default_when_no_approver() -> None:
+    fixtures = get_tool_surface_fixtures()
+    forced_fixtures = [f for f in fixtures if "risky_triple" in f.server_id or "wildcard" in f.server_id]
+    assert len(forced_fixtures) >= 5
+
+    for f in forced_fixtures:
+        receipt = evaluate_tool_surface_risk(f)
+        assert receipt.forced_approval is True
+        forced, reason = is_approval_forced(receipt, approver_configured=False)
+        assert forced is True
+        assert "DENIED" in reason
+
+
+def test_build_tool_surface_suite_structure() -> None:
+    suite = build_tool_surface_suite()
+    assert suite.version == "tool-surface-v1"
+    assert len(suite.tasks) >= 10
+    for task in suite.tasks:
+        assert task.category == "tool_surface"
+        assert len(task.steps) > 0
+        assert len(task.assertions) > 0
+
+
+def test_bench_runner_executes_suite_and_scores_100() -> None:
+    suite = build_tool_surface_suite()
+    adapter = ToolSurfaceReplayAdapter()
+    runner = BenchRunner(suite=suite, adapter=adapter, scheduler_config={"scheduler": "deterministic"})
+
+    bundle = runner.run()
+    signed_bundle = StubSigner().sign(bundle)
+
+    assert signed_bundle.pass_rate == 1.0
+    assert signed_bundle.overall_score == 1.0
+    assert len(signed_bundle.task_results) == len(suite.tasks)
+
+
+def test_bench_verifier_matches_and_reports_risk_class_and_capability_hash() -> None:
+    suite = build_tool_surface_suite()
+    adapter = ToolSurfaceReplayAdapter()
+    runner = BenchRunner(suite=suite, adapter=adapter, scheduler_config={"scheduler": "deterministic"})
+    bundle = StubSigner().sign(runner.run())
+
+    verifier = BenchVerifier(suite=suite, adapter=adapter)
+    result = verifier.verify(bundle)
+
+    assert result.passed is True
+    assert result.status == VerificationStatus.MATCH
+    report_text = result.report()
+
+    assert "MATCH" in report_text
+    assert "risk_class" in report_text
+    assert "capability_hash" in report_text
+
+
+def test_bench_verifier_catches_tampered_capability_receipt() -> None:
+    suite = build_tool_surface_suite()
+    adapter = ToolSurfaceReplayAdapter()
+    runner = BenchRunner(suite=suite, adapter=adapter, scheduler_config={"scheduler": "deterministic"})
+    bundle = StubSigner().sign(runner.run())
+
+    # Tamper with the first task result's receipt
+    first_result = bundle.task_results[0]
+    tampered_receipt = dict(first_result.receipt)
+    tampered_receipt["risk_class"] = "TAMPERED_CRITICAL"
+
+    tampered_task_result = TaskResult(
+        task_id=first_result.task_id,
+        task_hash=first_result.task_hash,
+        receipt=tampered_receipt,
+        passed=first_result.passed,
+        score=first_result.score,
+        stored_receipt_hash=first_result.stored_receipt_hash,  # old hash doesn't match new bytes
+    )
+    tampered_bundle = SubmissionBundle(
+        suite_hash=bundle.suite_hash,
+        suite_version=bundle.suite_version,
+        task_results=[tampered_task_result, *bundle.task_results[1:]],
+        scheduler_config=bundle.scheduler_config,
+    )
+
+    verifier = BenchVerifier(suite=suite, adapter=adapter)
+    result = verifier.verify(tampered_bundle)
+
+    assert result.passed is False
+    assert result.status == VerificationStatus.DIVERGED
+    assert any(tr.status == VerificationStatus.HASH_MISMATCH for tr in result.task_results)

--- a/tests/unit/mcp/test_tool_surface.py
+++ b/tests/unit/mcp/test_tool_surface.py
@@ -1,0 +1,138 @@
+"""Tests for tool surface risk classification and capability receipts."""
+
+from __future__ import annotations
+
+from bernstein.mcp.capability import build_capability_card
+from bernstein.mcp.tool_surface import (
+    AuthPosture,
+    CapabilityReceipt,
+    RiskClass,
+    ServerManifest,
+    evaluate_tool_surface_risk,
+    is_approval_forced,
+    verify_capability_receipt,
+)
+
+
+def test_risky_triple_scores_critical_and_forces_approval() -> None:
+    manifest = ServerManifest(
+        server_id="risky_test",
+        name="Risky Server",
+        auth_posture=AuthPosture.STATIC_BEARER_TOKEN.value,
+        tools=[
+            {"name": "read_secrets", "sensitive_reach": True},
+            {"name": "eval_prompt", "untrusted_input": True},
+            {"name": "post_webhook", "egress": True},
+        ],
+    )
+    receipt = evaluate_tool_surface_risk(manifest)
+    assert receipt.risk_class == RiskClass.CRITICAL
+    assert receipt.has_risky_triple is True
+    assert receipt.forced_approval is True
+    assert verify_capability_receipt(receipt) is True
+
+
+def test_wildcard_no_auth_scores_critical() -> None:
+    manifest = ServerManifest(
+        server_id="wildcard_anon",
+        name="Wildcard Anonymous",
+        auth_posture=AuthPosture.NONE.value,
+        has_wildcard_permissions=True,
+    )
+    receipt = evaluate_tool_surface_risk(manifest)
+    assert receipt.risk_class == RiskClass.CRITICAL
+    assert receipt.forced_approval is True
+    assert receipt.has_risky_triple is False
+
+
+def test_wildcard_oauth_scores_high() -> None:
+    manifest = ServerManifest(
+        server_id="wildcard_oauth",
+        name="Wildcard OAuth",
+        auth_posture=AuthPosture.OAUTH2_PKCE.value,
+        has_wildcard_permissions=True,
+    )
+    receipt = evaluate_tool_surface_risk(manifest)
+    assert receipt.risk_class == RiskClass.HIGH
+    assert receipt.forced_approval is True
+
+
+def test_read_only_local_scores_minimal_and_never_forces_approval() -> None:
+    manifest = ServerManifest(
+        server_id="local_read",
+        name="Local Reader",
+        auth_posture=AuthPosture.STATIC_BEARER_TOKEN.value,
+        tools=[{"name": "read_file", "read_only": True}],
+    )
+    receipt = evaluate_tool_surface_risk(manifest)
+    assert receipt.risk_class == RiskClass.MINIMAL
+    assert receipt.forced_approval is False
+    assert receipt.has_risky_triple is False
+
+
+def test_read_only_anonymous_scores_low() -> None:
+    manifest = ServerManifest(
+        server_id="public_read",
+        name="Public Reader",
+        auth_posture=AuthPosture.ANONYMOUS.value,
+        tools=[{"name": "fetch_doc", "read_only": True}],
+    )
+    receipt = evaluate_tool_surface_risk(manifest)
+    assert receipt.risk_class == RiskClass.LOW
+    assert receipt.forced_approval is False
+
+
+def test_is_approval_forced_deny_by_default_when_no_approver() -> None:
+    manifest = ServerManifest(
+        server_id="risky_server",
+        name="Risky Server",
+        has_sensitive_reach=True,
+        has_untrusted_input=True,
+        has_egress_channel=True,
+    )
+    receipt = evaluate_tool_surface_risk(manifest)
+
+    # Approver configured: forces approval
+    forced, reason = is_approval_forced(receipt, approver_configured=True)
+    assert forced is True
+    assert "APPROVAL_REQUIRED" in reason
+
+    # No approver configured: denies by default
+    forced_denied, deny_reason = is_approval_forced(receipt, approver_configured=False)
+    assert forced_denied is True
+    assert "DENIED" in deny_reason
+
+
+def test_capability_receipt_hash_determinism_and_tamper_detection() -> None:
+    manifest = ServerManifest(
+        server_id="det_server",
+        name="Deterministic Server",
+        auth_posture=AuthPosture.STATIC_BEARER_TOKEN.value,
+        tools=[{"name": "query_db", "sensitive_reach": True}],
+    )
+    receipt1 = evaluate_tool_surface_risk(manifest)
+    receipt2 = evaluate_tool_surface_risk(manifest)
+
+    assert receipt1.receipt_hash == receipt2.receipt_hash
+    assert verify_capability_receipt(receipt1) is True
+
+    # Tampered receipt
+    tampered = CapabilityReceipt(
+        server_id=receipt1.server_id,
+        risk_class=RiskClass.MINIMAL,  # tampered risk class
+        has_risky_triple=receipt1.has_risky_triple,
+        forced_approval=receipt1.forced_approval,
+        risk_factors=receipt1.risk_factors,
+        auth_posture=receipt1.auth_posture,
+        receipt_hash=receipt1.receipt_hash,
+    )
+    assert verify_capability_receipt(tampered) is False
+
+
+def test_build_capability_card_includes_tool_surface() -> None:
+    card = build_capability_card()
+    assert "toolSurface" in card
+    tool_surface = card["toolSurface"]
+    assert tool_surface["server_id"] == "bernstein"
+    assert "receipt_hash" in tool_surface
+    assert verify_capability_receipt(tool_surface) is True


### PR DESCRIPTION
# Title: feat(eval): add tool-surface risk benchmark suite and forced approval gate (#5454)

## Summary

Implements the **Tool-Surface Risk Evaluation Benchmark Suite** (`tool-surface-v1`) covering compliance controls `CTRL-TOOL-INVENTORY`, `ASI02`, and `AST04` to address issue #5454.

An MCP tool server combining **untrusted input ingestion**, **sensitive data reach**, and an **external egress channel** (the lethal "Risky Triple") is scored as `CRITICAL`, produces a cryptographic `CapabilityReceipt`, forces an approval gate before execution, and fails closed (**deny by default**) when no approver is configured.

### Key Changes

1. **MCP Tool Surface Evaluation (`src/bernstein/mcp/tool_surface.py`)**:
   - `RiskClass` enum (`CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `MINIMAL`).
   - `AuthPosture` enum (`none`, `anonymous`, `static_bearer_token`, `bearer`, `oauth2_pkce`, `oidc`).
   - `ServerManifest` dataclass for tool capability declarations (from dict or YAML).
   - `CapabilityReceipt` with deterministic canonical SHA-256 JSON hashing.
   - `evaluate_tool_surface_risk()` scoring function with strict classification invariants.
   - `is_approval_forced()` determining approval requirement and enforcing deny-by-default when `approver_configured=False`.
   - `verify_capability_receipt()` validating cryptographic receipt integrity.

2. **10 Synthetic Server Fixtures (`src/bernstein/eval/cases/tool_surface/`)**:
   - `01_read_only_local.yaml`: Read-only local filesystem (MINIMAL, never forces approval).
   - `02_read_only_public.yaml`: Anonymous public documentation reader (LOW, never forces approval).
   - `03_read_egress.yaml`: Public read + webhook egress (MEDIUM, no approval required).
   - `04_risky_triple_basic.yaml`: Sensitive DB read + untrusted prompt + external HTTP (CRITICAL, forced approval).
   - `05_risky_triple_oauth.yaml`: Sensitive HR records + untrusted webhook + external SaaS (CRITICAL, forced approval).
   - `06_risky_triple_no_auth.yaml`: Sensitive vault secrets + untrusted script + raw socket egress (CRITICAL, forced approval).
   - `07_wildcard_no_auth.yaml`: Unauthenticated wildcard permissions (CRITICAL, forced approval).
   - `08_wildcard_oauth.yaml`: OAuth-protected wildcard permissions (HIGH, forced approval).
   - `09_sensitive_read_no_egress.yaml`: Sensitive credentials read, no egress (MEDIUM, no approval required).
   - `10_untrusted_input_no_egress.yaml`: Untrusted feedback parser, no egress (MEDIUM, no approval required).

3. **Benchmark Suite & Replay Adapter (`src/bernstein/eval/bench/tool_surface_suite.py`)**:
   - `build_tool_surface_suite()`: Builds content-addressed `BenchSuite(version="tool-surface-v1")`.
   - `ToolSurfaceReplayAdapter`: Replays fixtures, scores receipts, and verifies 100% risky triple detection rate and deny-by-default behavior.
   - Integrated into `bernstein bench run tool-surface-v1` and `bernstein bench verify`.

4. **Offline Verifier Output (`src/bernstein/eval/bench/verifier.py`)**:
   - Verifier report displays `risk_class` and `capability_hash` for each verified task result.

5. **Capability Card Integration (`src/bernstein/mcp/capability.py`)**:
   - MCP `initialize` and `bernstein://capability` resource include `toolSurface` capability receipt.

6. **Documentation & Release Notes**:
   - Updated `docs/eval/bench.md` with Tool-Surface Risk Suite section and Risk Classification table.
   - Created `BENCHMARKS.md` documenting canonical benchmark matrix.
   - Added release notes fragment `docs/release-notes/fragments/5454-eval-tool-surface-risk-suite.md`.

## Verification

- `pytest tests/unit/eval/bench/test_tool_surface_risk_suite.py tests/unit/mcp/test_tool_surface.py -v`: 16/16 passed (100%).
- `pytest tests/unit/eval/bench tests/unit/mcp -v`: 310/310 passed (100%).
- `mypy src/bernstein/mcp src/bernstein/eval/bench`: Success, 0 errors.
- `ruff check src tests`: All checks passed.
- `python scripts/check_bom.py`: OK (no UTF-8 BOM).
- CLI execution: `bernstein bench run tool-surface-v1` + `bernstein bench verify` verified MATCH.

Fixes #5454.
