### PR TITLE
feat(quality): record producing identity and independence class in adjudication records (#5473)

### DIFF
--- a/docs/release-notes/fragments/5473-adjudication-producer-identity.md
+++ b/docs/release-notes/fragments/5473-adjudication-producer-identity.md
@@ -1,0 +1,3 @@
+## Adjudication producer identity and independence classification
+
+Adjudication records now explicitly record the producing identity (`produced_by`) of the agent or model whose work was judged, alongside its independence classification (`adjudication_class`: `independent`, `weak`, `unattributed`, `unresolved`). Records bind producer identities into the canonical JCS byte representation while maintaining additive backward compatibility for historical records without a producer. Cross-model reviewer selection rejects model overrides that collide with the authoring model (#5473).

--- a/src/bernstein/core/quality/adjudication.py
+++ b/src/bernstein/core/quality/adjudication.py
@@ -68,6 +68,19 @@ class PanelMode(StrEnum):
     MAKER_CHECKER = "maker_checker"
 
 
+class AdjudicationClass(StrEnum):
+    """Independence classification of an adjudication record."""
+
+    #: Panel judges are strictly independent from the producing identity.
+    INDEPENDENT = "independent"
+    #: Panel contains a judge sharing model/identity with the producing identity.
+    WEAK = "weak"
+    #: Record carries no producing identity (legacy/unattributed).
+    UNATTRIBUTED = "unattributed"
+    #: Producing identity is empty or unresolved.
+    UNRESOLVED = "unresolved"
+
+
 def _canonical_json(value: Any) -> bytes:
     """Serialise *value* to canonical JSON bytes (sorted keys, tight separators)."""
     return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
@@ -76,6 +89,88 @@ def _canonical_json(value: Any) -> bytes:
 def _sha256_of(value: Any) -> str:
     """Return the ``sha256:``-prefixed digest of *value*'s canonical JSON."""
     return "sha256:" + hashlib.sha256(_canonical_json(value)).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class ProducerIdentity:
+    """Identity of the producer (agent/model/run) whose work is being adjudicated."""
+
+    model: str
+    temperature: float = 0.0
+    prompt_hash: str = ""
+    served_model: str = ""
+
+    def identity_hash(self) -> str:
+        """Return identity digest over model + served_model + temp + prompt_hash."""
+        return _sha256_of(
+            {
+                "model": self.model,
+                "prompt_hash": self.prompt_hash,
+                "served_model": self.served_model,
+                "temperature": self.temperature,
+            }
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "model": self.model,
+            "temperature": self.temperature,
+            "prompt_hash": self.prompt_hash,
+        }
+        if self.served_model:
+            d["served_model"] = self.served_model
+        return d
+
+
+def _coerce_producer(producer: ProducerIdentity | JudgeConfig | dict[str, Any] | str | None) -> ProducerIdentity | None:
+    """Coerce various producer representations into a :class:`ProducerIdentity`."""
+    if producer is None:
+        return None
+    if isinstance(producer, ProducerIdentity):
+        return producer
+    if isinstance(producer, JudgeConfig):
+        return ProducerIdentity(
+            model=producer.model,
+            temperature=producer.temperature,
+            prompt_hash=producer.prompt_hash,
+        )
+    if isinstance(producer, str):
+        return ProducerIdentity(model=producer)
+    if isinstance(producer, dict):
+        return ProducerIdentity(
+            model=str(producer.get("model", "")),
+            temperature=float(producer.get("temperature", 0.0)),
+            prompt_hash=str(producer.get("prompt_hash", "")),
+            served_model=str(producer.get("served_model", "")),
+        )
+    return None
+
+
+def _classify_adjudication(panel: PanelConfig, producer: ProducerIdentity | None) -> AdjudicationClass:
+    """Classify the independence of a panel relative to the producing identity."""
+    if producer is None:
+        return AdjudicationClass.UNATTRIBUTED
+    if (
+        not producer.model.strip()
+        or producer.model.strip().lower() == "unresolved"
+        or producer.served_model.strip().lower() == "unresolved"
+    ):
+        return AdjudicationClass.UNRESOLVED
+
+    producer_ident = producer.identity_hash()
+    p_model = producer.model.strip().lower()
+    p_served = producer.served_model.strip().lower() if producer.served_model else ""
+
+    for judge in panel.judges:
+        if judge.identity_hash() == producer_ident:
+            return AdjudicationClass.WEAK
+        j_model = judge.model.strip().lower()
+        if j_model == p_model:
+            return AdjudicationClass.WEAK
+        if p_served and j_model == p_served:
+            return AdjudicationClass.WEAK
+
+    return AdjudicationClass.INDEPENDENT
 
 
 @dataclass(frozen=True, slots=True)
@@ -211,6 +306,8 @@ class AdjudicationRecord:
         final_verdict: The aggregated terminal verdict.
         timestamp: Integer timestamp (stable across replays of a fixture).
         journal_entry_hash: Spine anchor over the record's canonical bytes.
+        produced_by: Producing agent/model/identity dictionary, if known.
+        adjudication_class: Independence classification of the adjudication.
     """
 
     run_id: str
@@ -221,10 +318,12 @@ class AdjudicationRecord:
     final_verdict: Verdict
     timestamp: int
     journal_entry_hash: str = ""
+    produced_by: dict[str, Any] | None = None
+    adjudication_class: str = ""
 
     def _binding(self) -> dict[str, Any]:
         """Return the anchor-free binding (the bytes the spine hashes)."""
-        return {
+        d: dict[str, Any] = {
             "run_id": self.run_id,
             "inputs_hash": self.inputs_hash,
             "rubric_hash": self.rubric_hash,
@@ -233,6 +332,11 @@ class AdjudicationRecord:
             "final_verdict": self.final_verdict.value,
             "timestamp": self.timestamp,
         }
+        if self.produced_by is not None:
+            if self.adjudication_class:
+                d["adjudication_class"] = self.adjudication_class
+            d["produced_by"] = self.produced_by
+        return d
 
     def to_canonical_bytes(self) -> bytes:
         """Serialise the anchor-free binding to canonical JSON bytes."""
@@ -281,6 +385,7 @@ def adjudicate(
     panel: PanelConfig,
     judge_verdicts: tuple[JudgeVerdict, ...],
     now: int,
+    produced_by: ProducerIdentity | JudgeConfig | dict[str, Any] | str | None = None,
 ) -> AdjudicationRecord:
     """Bind inputs + rubric + panel + verdicts into an anchored, signed record.
 
@@ -301,6 +406,8 @@ def adjudicate(
         panel: The independent panel configuration.
         judge_verdicts: Per-judge verdicts in panel declaration order.
         now: Integer timestamp; recorded and used as the spine timestamp.
+        produced_by: Identity of the agent/model that produced the work being
+            adjudicated.
 
     Returns:
         The anchored :class:`AdjudicationRecord`.
@@ -314,6 +421,11 @@ def adjudicate(
         if verdict.config.identity_hash() != judge.identity_hash():
             raise ValueError("judge_verdicts are not aligned with the panel's judges in declaration order")
 
+    producer = _coerce_producer(produced_by)
+    producer_dict = producer.to_dict() if producer is not None else None
+    adj_class = _classify_adjudication(panel, producer) if producer is not None else None
+    adj_class_str = adj_class.value if adj_class is not None else ""
+
     final = _aggregate(panel.mode, panel.judges, judge_verdicts)
     record = AdjudicationRecord(
         run_id=run_id,
@@ -323,6 +435,8 @@ def adjudicate(
         per_judge_verdict=tuple(v.to_dict() for v in judge_verdicts),
         final_verdict=final,
         timestamp=now,
+        produced_by=producer_dict,
+        adjudication_class=adj_class_str,
     )
 
     spine = LineageSpine(lineage_root, run_id=run_id, hmac_key=hmac_key)
@@ -345,6 +459,8 @@ def adjudicate(
         final_verdict=record.final_verdict,
         timestamp=record.timestamp,
         journal_entry_hash=anchor,
+        produced_by=record.produced_by,
+        adjudication_class=record.adjudication_class,
     )
     # Persist the full record (binding + anchor) for offline `gate verify`.
     out_dir = records_dir(lineage_root, run_id)
@@ -389,6 +505,7 @@ class AdjudicationVerifyResult:
 
     ok: bool
     reason: str = ""
+    adjudication_class: str = ""
 
 
 def verify_adjudication(
@@ -421,7 +538,7 @@ def verify_adjudication(
 
     # Reconstruct the panel from the record to re-run the independence check.
     try:
-        _panel_from_dict(record.panel_config)
+        panel = _panel_from_dict(record.panel_config)
     except PanelIndependenceError as exc:
         return AdjudicationVerifyResult(ok=False, reason=f"panel is not independent: {exc}")
 
@@ -446,7 +563,13 @@ def verify_adjudication(
             ok=False,
             reason="recorded journal_entry_hash does not match the spine anchor over the record bytes",
         )
-    return AdjudicationVerifyResult(ok=True)
+
+    adj_class = record.adjudication_class or (
+        _classify_adjudication(panel, _coerce_producer(record.produced_by)).value
+        if record.produced_by is not None
+        else AdjudicationClass.UNATTRIBUTED.value
+    )
+    return AdjudicationVerifyResult(ok=True, adjudication_class=adj_class)
 
 
 def _panel_from_dict(panel_config: dict[str, Any]) -> PanelConfig:
@@ -469,6 +592,10 @@ def read_record(path: Path) -> AdjudicationRecord | None:
         return None
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
+        produced_by = raw.get("produced_by")
+        if produced_by is not None and not isinstance(produced_by, dict):
+            produced_by = None
+        adj_class = str(raw.get("adjudication_class", ""))
         return AdjudicationRecord(
             run_id=str(raw["run_id"]),
             inputs_hash=str(raw["inputs_hash"]),
@@ -478,6 +605,8 @@ def read_record(path: Path) -> AdjudicationRecord | None:
             final_verdict=Verdict(str(raw["final_verdict"])),
             timestamp=int(raw["timestamp"]),
             journal_entry_hash=str(raw.get("journal_entry_hash", "")),
+            produced_by=produced_by,
+            adjudication_class=adj_class,
         )
     except (json.JSONDecodeError, KeyError, TypeError, ValueError):
         return None
@@ -548,6 +677,7 @@ __all__ = [
     "FEATURE_CHECKER",
     "FEATURE_MAKER",
     "FEATURE_PANEL",
+    "AdjudicationClass",
     "AdjudicationRecord",
     "AdjudicationVerifyResult",
     "CostMode",
@@ -556,6 +686,7 @@ __all__ = [
     "PanelConfig",
     "PanelIndependenceError",
     "PanelMode",
+    "ProducerIdentity",
     "Verdict",
     "adjudicate",
     "attribute_cost",

--- a/src/bernstein/core/quality/cross_model_verifier.py
+++ b/src/bernstein/core/quality/cross_model_verifier.py
@@ -159,12 +159,14 @@ class CrossModelVerdict:
         feedback: One-line summary from the reviewer.
         issues: Specific issues found (empty when approved).
         reviewer_model: Model that performed the review.
+        writer_model: Model that wrote the code being reviewed.
     """
 
     verdict: Literal["approve", "request_changes"]
     feedback: str
     issues: list[str] = field(default_factory=list[str])
     reviewer_model: str = ""
+    writer_model: str = ""
 
 
 def select_reviewer_model(writer_model: str, override: str | None = None) -> str:
@@ -178,6 +180,11 @@ def select_reviewer_model(writer_model: str, override: str | None = None) -> str
         OpenRouter model identifier for the reviewer.
     """
     if override:
+        if override.strip().lower() == writer_model.strip().lower():
+            raise ValueError(
+                f"non-independent reviewer: override model '{override}' "
+                f"collides with writer model '{writer_model}' on model axis"
+            )
         return override
     lower = writer_model.lower()
     for prefix, reviewer in _WRITER_TO_REVIEWER.items():
@@ -226,7 +233,7 @@ def _build_prompt(task: Task, diff: str, conventions_block: str = "") -> str:
     )
 
 
-def _parse_response(raw: str, reviewer_model: str) -> CrossModelVerdict:
+def _parse_response(raw: str, reviewer_model: str, writer_model: str = "") -> CrossModelVerdict:
     """Parse the reviewer LLM response into a CrossModelVerdict.
 
     Defaults to "approve" when the response cannot be parsed, so a reviewer
@@ -257,6 +264,7 @@ def _parse_response(raw: str, reviewer_model: str) -> CrossModelVerdict:
             feedback="Reviewer returned unparseable response - defaulting to approve",
             issues=[],
             reviewer_model=reviewer_model,
+            writer_model=writer_model,
         )
 
     raw_verdict = str(data.get("verdict", "approve")).lower()
@@ -273,6 +281,7 @@ def _parse_response(raw: str, reviewer_model: str) -> CrossModelVerdict:
         feedback=str(data.get("feedback", "")),
         issues=issues,
         reviewer_model=reviewer_model,
+        writer_model=writer_model,
     )
 
 
@@ -324,6 +333,7 @@ async def verify_with_cross_model(
             feedback=result.reasoning,
             issues=issues,
             reviewer_model=", ".join(voter_models),
+            writer_model=writer_model,
         )
 
     # --- Single-reviewer path (backward-compatible QUORUM 1-of-1) ---
@@ -379,9 +389,10 @@ async def verify_with_cross_model(
             feedback=f"Reviewer call failed: {exc}",
             issues=[],
             reviewer_model=reviewer,
+            writer_model=writer_model,
         )
 
-    verdict = _parse_response(raw, reviewer)
+    verdict = _parse_response(raw, reviewer, writer_model=writer_model)
     logger.info(
         "cross_model_verifier: task=%s verdict=%s issues=%d",
         task.id,

--- a/tests/unit/quality/test_adjudication.py
+++ b/tests/unit/quality/test_adjudication.py
@@ -17,12 +17,14 @@ from pathlib import Path
 import pytest
 
 from bernstein.core.quality.adjudication import (
+    AdjudicationClass,
     AdjudicationRecord,
     CostMode,
     JudgeConfig,
     JudgeVerdict,
     PanelConfig,
     PanelIndependenceError,
+    ProducerIdentity,
     Verdict,
     adjudicate,
     attribute_cost,
@@ -276,3 +278,167 @@ def test_cost_mode_attributes_maker_and_checker(tmp_path: Path) -> None:
     totals = ledger.totals_by("feature_label")
     assert totals.get("adjudication.maker", 0.0) == pytest.approx(0.001)
     assert totals.get("adjudication.checker", 0.0) == pytest.approx(0.02)
+
+
+# ---------------------------------------------------------------------------
+# Producer identity & Independence classification (Issue #5473)
+# ---------------------------------------------------------------------------
+
+
+def test_verdict_record_names_the_producing_identity(tmp_path: Path) -> None:
+    cfg_m, v_m = _judge("judge-a", 0.0, "maker")
+    cfg_c, v_c = _judge("judge-b", 0.0, "checker")
+    panel = PanelConfig(judges=(cfg_m, cfg_c))
+    producer = ProducerIdentity(model="writer-model", temperature=0.0, prompt_hash="writer-prompt")
+
+    rec_with = adjudicate(
+        run_id="run-p1",
+        lineage_root=tmp_path / "with" / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        inputs={"diff": "abc"},
+        rubric={"rule": "r"},
+        panel=panel,
+        judge_verdicts=(v_m, v_c),
+        now=1000,
+        produced_by=producer,
+    )
+    rec_without = adjudicate(
+        run_id="run-p1",
+        lineage_root=tmp_path / "without" / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        inputs={"diff": "abc"},
+        rubric={"rule": "r"},
+        panel=panel,
+        judge_verdicts=(v_m, v_c),
+        now=1000,
+    )
+
+    assert "produced_by" in rec_with._binding()
+    assert rec_with.produced_by == producer.to_dict()
+    assert rec_with.to_canonical_bytes() != rec_without.to_canonical_bytes()
+    assert "produced_by" not in rec_without._binding()
+
+
+def test_same_identity_adjudication_verifies_as_the_weaker_class(tmp_path: Path) -> None:
+    # Panel where one judge shares identity_hash / model with the producer
+    cfg_m, v_m = _judge("model-shared", 0.0, "prompt-a")
+    cfg_c, v_c = _judge("model-other", 0.0, "prompt-b")
+    panel = PanelConfig(judges=(cfg_m, cfg_c))
+    producer = ProducerIdentity(model="model-shared", temperature=0.0, prompt_hash="prompt-a")
+    root = tmp_path / ".sdd" / "lineage"
+
+    record = adjudicate(
+        run_id="run-weak",
+        lineage_root=root,
+        hmac_key=_KEY,
+        inputs={"diff": "abc"},
+        rubric={"rule": "r"},
+        panel=panel,
+        judge_verdicts=(v_m, v_c),
+        now=1000,
+        produced_by=producer,
+    )
+
+    assert record.adjudication_class == AdjudicationClass.WEAK.value
+    assert record._binding()["adjudication_class"] == "weak"
+
+    res = verify_adjudication(
+        run_id="run-weak",
+        lineage_root=root,
+        hmac_key=_KEY,
+        record=record,
+        claimed_inputs={"diff": "abc"},
+    )
+    assert res.ok is True
+    assert res.adjudication_class == AdjudicationClass.WEAK.value
+
+
+def test_disjoint_panel_verifies_as_independent(tmp_path: Path) -> None:
+    # Producer is disjoint from both judges
+    cfg_m, v_m = _judge("judge-model-1", 0.0, "prompt-1")
+    cfg_c, v_c = _judge("judge-model-2", 0.0, "prompt-2")
+    panel = PanelConfig(judges=(cfg_m, cfg_c))
+    producer = ProducerIdentity(model="writer-model-3", temperature=0.0, prompt_hash="writer-prompt")
+    root = tmp_path / ".sdd" / "lineage"
+
+    record = adjudicate(
+        run_id="run-indep",
+        lineage_root=root,
+        hmac_key=_KEY,
+        inputs={"diff": "abc"},
+        rubric={"rule": "r"},
+        panel=panel,
+        judge_verdicts=(v_m, v_c),
+        now=1000,
+        produced_by=producer,
+    )
+
+    assert record.adjudication_class == AdjudicationClass.INDEPENDENT.value
+    assert record._binding()["adjudication_class"] == "independent"
+
+    res = verify_adjudication(
+        run_id="run-indep",
+        lineage_root=root,
+        hmac_key=_KEY,
+        record=record,
+        claimed_inputs={"diff": "abc"},
+    )
+    assert res.ok is True
+    assert res.adjudication_class == AdjudicationClass.INDEPENDENT.value
+
+
+def test_unresolved_served_identity_is_recorded_as_unresolved(tmp_path: Path) -> None:
+    # Producer with empty model or unresolved served id
+    cfg_m, v_m = _judge("judge-model-1", 0.0, "prompt-1")
+    cfg_c, v_c = _judge("judge-model-2", 0.0, "prompt-2")
+    panel = PanelConfig(judges=(cfg_m, cfg_c))
+    producer = ProducerIdentity(model="", temperature=0.0, prompt_hash="")
+    root = tmp_path / ".sdd" / "lineage"
+
+    record = adjudicate(
+        run_id="run-unres",
+        lineage_root=root,
+        hmac_key=_KEY,
+        inputs={"diff": "abc"},
+        rubric={"rule": "r"},
+        panel=panel,
+        judge_verdicts=(v_m, v_c),
+        now=1000,
+        produced_by=producer,
+    )
+
+    assert record.adjudication_class == AdjudicationClass.UNRESOLVED.value
+    assert record.adjudication_class != AdjudicationClass.INDEPENDENT.value
+    assert record._binding()["adjudication_class"] == "unresolved"
+
+
+def test_pre_change_record_bytes_and_anchor_are_unchanged(tmp_path: Path) -> None:
+    cfg_m, v_m = _judge("cheap", 0.0, "maker")
+    cfg_c, v_c = _judge("capable", 0.0, "checker")
+    panel = PanelConfig(judges=(cfg_m, cfg_c))
+    root = tmp_path / ".sdd" / "lineage"
+
+    record = adjudicate(
+        run_id="run-1",
+        lineage_root=root,
+        hmac_key=_KEY,
+        inputs={"diff": "abc"},
+        rubric={"rule": "r"},
+        panel=panel,
+        judge_verdicts=(v_m, v_c),
+        now=1234,
+    )
+
+    golden_canonical_bytes = (
+        b'{"final_verdict":"pass","inputs_hash":"sha256:cc31825db96b4536e157d5d858e844ff7ce60d8c527185db379f52c7e4cf62e0",'
+        b'"panel_config":{"judges":[{"model":"cheap","prompt_hash":"maker","temperature":0.0},'
+        b'{"model":"capable","prompt_hash":"checker","temperature":0.0}],"mode":"panel"},'
+        b'"per_judge_verdict":[{"config":{"model":"cheap","prompt_hash":"maker","temperature":0.0},'
+        b'"rationale_hash":"r-cheap","verdict":"pass"},{"config":{"model":"capable","prompt_hash":"checker","temperature":0.0},'
+        b'"rationale_hash":"r-capable","verdict":"pass"}],"rubric_hash":"sha256:ce8a65c46a1261a17cefa23dd79ad2a6085a9f038741cce241caa16d9d311aab",'
+        b'"run_id":"run-1","timestamp":1234}'
+    )
+    golden_anchor = "sha256:adbe08f270b0ac9897b66c01836d18ef9823b54ac2061bba6c17f136effba21c"
+
+    assert record.to_canonical_bytes() == golden_canonical_bytes
+    assert record.journal_entry_hash == golden_anchor

--- a/tests/unit/test_cross_model_verifier.py
+++ b/tests/unit/test_cross_model_verifier.py
@@ -64,6 +64,17 @@ class TestSelectReviewerModel:
         reviewer = select_reviewer_model("claude-sonnet", override=override)
         assert reviewer == override
 
+    def test_reviewer_override_equal_to_writer_is_refused(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            select_reviewer_model("anthropic/claude-3-5-sonnet", override="anthropic/claude-3-5-sonnet")
+        assert "non-independent" in str(excinfo.value).lower()
+
+    def test_policy_refusal_names_the_colliding_axis(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            select_reviewer_model("openai/gpt-4o", override="openai/gpt-4o")
+        msg = str(excinfo.value)
+        assert "model" in msg or "adapter" in msg or "served" in msg or "family" in msg
+
     def test_unknown_writer_returns_default(self) -> None:
         reviewer = select_reviewer_model("some/unknown-model-xyz")
         assert reviewer  # returns non-empty default


### PR DESCRIPTION
Fixes #5473

### Summary of Changes

1. **Producer Identity & Independence Classification**:
   - Added `ProducerIdentity` dataclass with `model`, `temperature`, `prompt_hash`, `served_model`, and canonical `identity_hash()`.
   - Added `AdjudicationClass` enum (`independent`, `weak`, `unattributed`, `unresolved`).
   - Implemented `_classify_adjudication(panel, producer)` to structurally evaluate independence:
     - `unattributed` if `produced_by` is omitted (historical records).
     - `unresolved` if the author model is missing or marked unresolved.
     - `weak` if any judge shares `identity_hash`, `model`, or `served_model` with the producer.
     - `independent` if the panel is fully disjoint from the producing identity.

2. **Adjudication Record & JCS Canonical Binding**:
   - Added `produced_by: dict[str, Any] | None = None` just after the record's binding fields and `adjudication_class: str = ""`.
   - Updated `_binding()`: When `produced_by` is provided, serializes `produced_by` and `adjudication_class`. When `produced_by`�2���V�&�F�f�V�G2&R�֗GFVBg&���&��F��r��F�V�7W&R7G&�7B'�FR�f�"�'�FR&6�v&B6��F�&�ƗG�v�F�&R�W��7F��r&V6�&G2�B7��R�6��'2���WFFVBF�VF�6FR��F�66WB�F����&�GV6VE�'��&�GV6W$�FV�F�G���VFvT6��f�r�F�7E�7G"�����7G"����R����V���WFFVBfW&�g��F�VF�6F��ₖ�BF�VF�6F���fW&�g�&W7V�F`F�&W�'BfW&�f�VBF�VF�6F����6�76���WFFVB&VE�&V6�&B��F�FW6W&�Ɨ�R&�GV6VE�'��BF�VF�6F����6�76ࠣ2���7&�72���FV�fW&�f�W"b�fW'&�FR6��Ɨ6���&VgW6¢����FFVBw&�FW%���FVâ7G"�"&F�7&�74��FV�fW&F�7F7&�72��B6��7G'V7F���6�FW2���6V�V7E�&Wf�WvW%���FVw&�FW%���FV���fW'&�FR���rfƖFFW2��FWV�FV�6R�B&�6W2FW67&�F�fRf�VTW'&�&�֖�rF�R6��ƖF��r��FV���2�b�W�Ɩ6�B�fW'&�FR�F6�W2F�Rw&�FW"��FV�ࠣB���FW7F��rbF�7V�V�FF��⢣���FFVBV��BFW7G26�fW&��r&�GV6W"�FV�F�G�&V6�&F��r���FWV�FV�6R6�76�f�6F������FWV�FV�Bg2vV�g2V�&W6��fVB���fW'&�FR&VgW6���B'�FR�f�"�'�FRv��FV�6GW&R&6�v&B6��F�&�ƗG����FFVB&V�V6R��FRg&v�V�BF�72�&V�V6R���FW2�g&v�V�G2�SCs2�F�VF�6F����&�GV6W"֖FV�F�G���F��