### PR TITLE
fix(security): secret-leak guardrail knows the current token formats

### DIFF
--- a/docs/release-notes/fragments/secret-leak-modern-token-formats.md
+++ b/docs/release-notes/fragments/secret-leak-modern-token-formats.md
@@ -1,0 +1,3 @@
+## Secret-leak guardrail knows the current token formats
+
+`SecretLeakGuardrail` scanned agent output for `sk-`/`sk_`, `ghp_`, `AKIA` and an RSA PEM header. Every credential format minted since those patterns were written passed through: OpenAI project keys (`sk-proj-`), Anthropic keys (`sk-ant-api03-`), GitHub fine-grained personal access tokens (`github_pat_`), the rest of the classic GitHub token family (`gho_`, `ghu_`, `ghs_`, `ghr_`), and any PEM private key that is not RSA, including the Ed25519 keys this project mints for lineage signing. All of them are now recognised. The legacy patterns are unchanged, since a provider adding a prefix does not retire the old one.

--- a/src/bernstein/core/security/guardrail_pipeline.py
+++ b/src/bernstein/core/security/guardrail_pipeline.py
@@ -128,10 +128,27 @@ class SecretLeakGuardrail:
 
     name = "secret_leak"
 
+    #: One signature per credential shape a provider documents as fixed.
+    #: A provider that adds a prefix does not retire the old one, so the
+    #: legacy forms stay alongside the current ones. Order is cosmetic:
+    #: every pattern is searched and each hit is reported separately.
     PATTERNS: ClassVar[list[str]] = [
+        # OpenAI project keys. The legacy ``sk-``/``sk_`` body below stops
+        # at the first hyphen, so it never covers this one.
+        r"sk-proj-[A-Za-z0-9_-]{20,}",
+        # Anthropic API and admin keys: sk-ant-api03-xxx, sk-ant-admin01-xxx.
+        r"sk-ant-[a-z]+[0-9]*-[A-Za-z0-9_-]{20,}",
         r"(?:sk-|sk_)[a-zA-Z0-9]{20,}",
-        r"ghp_[a-zA-Z0-9]{36}",
-        r"-----BEGIN\s+(?:RSA\s+)?PRIVATE\s+KEY-----",
+        # GitHub fine-grained personal access token.
+        r"github_pat_[A-Za-z0-9_]{22,}",
+        # Classic GitHub tokens, which share one 36-character body:
+        # ghp_ personal, gho_ OAuth, ghu_ user-to-server,
+        # ghs_ server-to-server, ghr_ refresh.
+        r"gh[pousr]_[a-zA-Z0-9]{36}",
+        # Any PEM private key, not only RSA. This project mints Ed25519
+        # signing keys of its own, and an OPENSSH, EC, DSA or ENCRYPTED
+        # body is the same disclosure as an RSA one.
+        r"-----BEGIN\s+(?:[A-Z0-9]+\s+)?PRIVATE\s+KEY-----",
         r"AKIA[0-9A-Z]{16}",
     ]
 

--- a/tests/property/test_capability_matrix_bughunt.py
+++ b/tests/property/test_capability_matrix_bughunt.py
@@ -303,26 +303,17 @@ def test_asi06_scans_trusted_content_for_hijack_patterns() -> None:
     assert detect_asi06_memory_poisoning(ctx).passed is False
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Bug: SecretLeakGuardrail patterns predate the new OpenAI sk-proj-, "
-        "GitHub fine-grained github_pat_, and Anthropic sk-ant- tokens. "
-        "Class affected: SecretLeakGuardrail. Severity: HIGH."
-    ),
-)
 def test_secret_leak_catches_modern_token_formats() -> None:
-    """Bug: SecretLeakGuardrail signature pack is out of date.
+    """SecretLeakGuardrail carries the current token signatures (FIXED).
 
-    Root cause: regex set still targets ``sk-/sk_`` (legacy OpenAI),
-    ``ghp_`` (legacy classic PAT), and ``AKIA`` only. Modern tokens -
-    ``sk-proj-XXXX`` (OpenAI projects), ``github_pat_XXXX`` (GitHub
-    fine-grained PAT), ``sk-ant-api03-XXXX`` (Anthropic) - sail past.
+    This was an ``xfail(strict=True)`` recording a HIGH-severity gap: the
+    regex set targeted ``sk-``/``sk_`` (legacy OpenAI), ``ghp_`` (legacy
+    classic PAT) and ``AKIA`` only, so ``sk-proj-XXXX`` (OpenAI projects),
+    ``github_pat_XXXX`` (GitHub fine-grained PAT) and ``sk-ant-api03-XXXX``
+    (Anthropic) all sailed past.
 
-    Attacker model: secret-exfiltration via agent output. Severity is
+    Attacker model: secret exfiltration through agent output. Severity is
     HIGH because every successful exfil is a credential takeover.
-    Pattern improvement: extend ``PATTERNS`` with the three new
-    canonical prefixes.
     """
     g = SecretLeakGuardrail()
     payload = "leak: sk-proj-" + "A" * 40

--- a/tests/unit/test_guardrail_pipeline.py
+++ b/tests/unit/test_guardrail_pipeline.py
@@ -131,6 +131,39 @@ class TestSecretLeakGuardrail:
         result = g.check_output("-----BEGIN RSA PRIVATE KEY-----\nMIIE...", {})
         assert not result.passed
 
+    def test_catches_openai_project_key(self) -> None:
+        g = SecretLeakGuardrail()
+        assert not g.check_output("leak: sk-proj-" + "A" * 40, {}).passed
+
+    def test_catches_anthropic_key(self) -> None:
+        g = SecretLeakGuardrail()
+        assert not g.check_output("leak: sk-ant-api03-" + "A" * 95, {}).passed
+
+    def test_catches_github_fine_grained_pat(self) -> None:
+        g = SecretLeakGuardrail()
+        assert not g.check_output("leak: github_pat_" + "A" * 82, {}).passed
+
+    @pytest.mark.parametrize("prefix", ["ghp_", "gho_", "ghu_", "ghs_", "ghr_"])
+    def test_catches_every_classic_github_token_prefix(self, prefix: str) -> None:
+        """The classic family shares one body; only ``ghp_`` was listed."""
+        g = SecretLeakGuardrail()
+        assert not g.check_output(f"token: {prefix}{'a' * 36}", {}).passed
+
+    @pytest.mark.parametrize("label", ["", "RSA ", "EC ", "DSA ", "OPENSSH ", "ENCRYPTED "])
+    def test_catches_every_pem_private_key_label(self, label: str) -> None:
+        """This project mints Ed25519 keys, so RSA is not the only PEM to catch."""
+        g = SecretLeakGuardrail()
+        assert not g.check_output(f"-----BEGIN {label}PRIVATE KEY-----\nMIIE...", {}).passed
+
+    def test_passes_public_key_header(self) -> None:
+        """A public key is not a secret and must not trip the guardrail."""
+        g = SecretLeakGuardrail()
+        assert g.check_output("-----BEGIN PUBLIC KEY-----\nMCow...", {}).passed
+
+    def test_passes_prose_that_merely_mentions_a_prefix(self) -> None:
+        g = SecretLeakGuardrail()
+        assert g.check_output("Rotate the sk-proj- key and the github_pat_ token.", {}).passed
+
     def test_catches_aws_key(self) -> None:
         g = SecretLeakGuardrail()
         result = g.check_output("AKIAIOSFODNN7EXAMPLE", {})


### PR DESCRIPTION
## What

`SecretLeakGuardrail` recognises the credential formats providers mint today, not only the ones that existed when the pattern list was written.

## Why

The pattern list was `sk-`/`sk_`, `ghp_`, `AKIA` and an RSA PEM header. Everything newer passed straight through an agent's output, and each miss is a credential takeover:

| Format | Why it was missed |
| --- | --- |
| `sk-proj-XXXX` (OpenAI projects) | the legacy `sk-` body is `[a-zA-Z0-9]{20,}`, which stops at the hyphen after `proj` |
| `sk-ant-api03-XXXX` (Anthropic) | same reason, stops after `ant` |
| `github_pat_XXXX` (GitHub fine-grained PAT) | no pattern at all |
| `gho_`, `ghu_`, `ghs_`, `ghr_` | only `ghp_` was listed, though the whole classic family shares one 36-character body |
| `-----BEGIN OPENSSH/EC/DSA/ENCRYPTED PRIVATE KEY-----` | the label group was `(?:RSA\s+)?`, and this project mints Ed25519 signing keys of its own |

`tests/property/test_capability_matrix_bughunt.py` already carried a `strict=True` xfail for the first three, marked HIGH severity. That test is the merge gate this PR flips. The classic GitHub family and the non-RSA PEM labels are the same defect class found while writing the fix, so they are folded in rather than left for a second pass.

## How

Three prefixes are matched explicitly rather than by widening the legacy `sk-` body charset to include hyphens, so a violation still names the shape it matched and a rotation runbook can tell an OpenAI project key from an Anthropic one.

`gh[pousr]_` collapses the classic family into the pattern that was already there.

The PEM label group becomes `(?:[A-Z0-9]+\s+)?`, one optional word. No nested quantifier, so there is no backtracking cost, and `-----BEGIN PUBLIC KEY-----` still does not match.

The legacy patterns are untouched. A provider adding a prefix does not retire the old one, and a key minted in 2023 is as leakable as one minted today.

## Tests

`test_secret_leak_catches_modern_token_formats` loses its `xfail` marker, with the docstring rewritten in the FIXED form the file uses for its earlier findings.

Added to `TestSecretLeakGuardrail` in `tests/unit/test_guardrail_pipeline.py`:

- one case per new prefix
- parametrized over all five classic GitHub prefixes
- parametrized over all six PEM labels, including the empty one
- two negatives: `-----BEGIN PUBLIC KEY-----` and prose that mentions `sk-proj-` and `github_pat_` without a token body

```
uv run pytest tests/unit/test_guardrail_pipeline.py tests/property/test_capability_matrix_bughunt.py \
  tests/unit/test_guardrails.py tests/unit/test_layered_guardrails.py tests/integration/test_pipeline_e2e.py -q
82 passed, 6 xfailed
```

## Checklist

- [x] `ruff check src/` passes
- [x] `lint-imports` passes
- [x] Release note fragment added: `docs/release-notes/fragments/secret-leak-modern-token-formats.md`

### Documentation duty

- [x] N/A for README and `docs/operations/`: `SecretLeakGuardrail` is an internal pipeline component with no documented user surface, and this PR changes which strings it recognises, not how it is configured or invoked.
- [x] N/A for `docs/api/` and `agents-md sync`: no new module, no public API or schema change.
