### PR TITLE
fix(quality): migrate the agent_outcomes table on connect

### DIFF
--- a/docs/release-notes/fragments/5493-confidence-ledger-schema-migration.md
+++ b/docs/release-notes/fragments/5493-confidence-ledger-schema-migration.md
@@ -1,0 +1,3 @@
+## Confidence ledger upgrades its own table on connect
+
+The empirical-confidence ledger creates `agent_outcomes` with `CREATE TABLE IF NOT EXISTS`, so a database written by an earlier version was never brought forward and every recorded outcome failed with `table agent_outcomes has no column named sampled_at`. The store now inspects the table on connect and renames the older `recorded_at` column to `sampled_at`, preserving existing rows, row ids, and the lookup index. The rename runs under `BEGIN IMMEDIATE` so concurrent processes sharing the file serialise against each other, and a table carrying neither column name is left untouched rather than guessed at (#5493).

--- a/src/bernstein/core/quality/empirical_confidence.py
+++ b/src/bernstein/core/quality/empirical_confidence.py
@@ -29,6 +29,10 @@ Schema (single table, ``agent_outcomes``):
 
 Indexes are created on ``(agent_type, decision_key)`` for fast aggregate
 queries.
+
+Databases written before ``sampled_at`` was named that way carry a
+``recorded_at`` column instead. They are upgraded in place on connect; see
+:meth:`_OutcomeStore._rename_legacy_timestamp_column`.
 """
 
 from __future__ import annotations
@@ -166,6 +170,15 @@ CREATE INDEX IF NOT EXISTS idx_agent_outcomes_lookup
 """
 
 
+_TABLE = "agent_outcomes"
+
+_TIMESTAMP_COLUMN = "sampled_at"
+"""Current name of the outcome timestamp column."""
+
+_LEGACY_TIMESTAMP_COLUMN = "recorded_at"
+"""Name the timestamp column carried before it was renamed to ``sampled_at``."""
+
+
 class _OutcomeStore:
     """Thin SQLite wrapper around the ``agent_outcomes`` table.
 
@@ -186,7 +199,56 @@ class _OutcomeStore:
     def _migrate(self) -> None:
         with self._migration_lock, self._connect() as conn:
             conn.executescript(_SCHEMA)
+            self._rename_legacy_timestamp_column(conn)
             conn.commit()
+
+    @staticmethod
+    def _column_names(conn: sqlite3.Connection) -> set[str]:
+        return {row[1] for row in conn.execute(f"PRAGMA table_info({_TABLE})")}
+
+    @classmethod
+    def _rename_legacy_timestamp_column(cls, conn: sqlite3.Connection) -> None:
+        """Upgrade a pre-``sampled_at`` table in place.
+
+        ``CREATE TABLE IF NOT EXISTS`` leaves an existing table alone, so an
+        install created before the timestamp column was renamed keeps
+        ``recorded_at`` forever and every append fails against it. Renaming
+        preserves rows, row ids, and the lookup index. The resulting column
+        order differs from a freshly created table, which is immaterial
+        because every statement here names the columns it touches.
+        """
+        columns = cls._column_names(conn)
+        if _TIMESTAMP_COLUMN in columns:
+            return
+        if _LEGACY_TIMESTAMP_COLUMN not in columns:
+            # Neither name present: not a schema this module wrote. Leave it
+            # untouched so the failure surfaces at the query that needs it.
+            logger.warning(
+                "Table %s has neither %s nor %s; leaving schema untouched",
+                _TABLE,
+                _TIMESTAMP_COLUMN,
+                _LEGACY_TIMESTAMP_COLUMN,
+            )
+            return
+        # The module lock only covers threads; ``BEGIN IMMEDIATE`` serialises
+        # the rename against other processes holding the same file open.
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            if _TIMESTAMP_COLUMN not in cls._column_names(conn):
+                conn.execute(f"ALTER TABLE {_TABLE} RENAME COLUMN {_LEGACY_TIMESTAMP_COLUMN} TO {_TIMESTAMP_COLUMN}")
+        except BaseException:
+            # Never let a failed rollback mask why the rename failed.
+            with suppress(sqlite3.DatabaseError):
+                conn.execute("ROLLBACK")
+            raise
+        else:
+            conn.execute("COMMIT")
+            logger.info(
+                "Migrated %s: renamed %s to %s",
+                _TABLE,
+                _LEGACY_TIMESTAMP_COLUMN,
+                _TIMESTAMP_COLUMN,
+            )
 
     @contextmanager
     def _connect(self) -> Iterator[sqlite3.Connection]:

--- a/tests/unit/quality/test_empirical_confidence.py
+++ b/tests/unit/quality/test_empirical_confidence.py
@@ -9,6 +9,7 @@ Covers:
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -236,3 +237,107 @@ def test_router_falls_back_to_tier_without_sample(db_path: Path, monkeypatch: py
     # Falls back to the heuristic tier confidence, not 1.0.
     assert haiku.confidence != pytest.approx(1.0)
     assert haiku.confidence in (0.4, 0.6, 0.8)
+
+
+# ---------------------------------------------------------------------------
+# Schema migration from the pre-``sampled_at`` layout
+# ---------------------------------------------------------------------------
+
+
+_LEGACY_SCHEMA = """
+CREATE TABLE agent_outcomes (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_type    TEXT NOT NULL,
+    decision_key  TEXT NOT NULL,
+    outcome       INTEGER NOT NULL CHECK (outcome IN (0, 1)),
+    evidence_uri  TEXT,
+    recorded_at   REAL NOT NULL
+);
+CREATE INDEX idx_agent_outcomes_lookup
+    ON agent_outcomes (agent_type, decision_key);
+"""
+
+
+def _make_legacy_db(path: Path, rows: list[tuple[str, str, int, str | None, float]]) -> None:
+    """Write a database using the pre-``sampled_at`` column layout."""
+    conn = sqlite3.connect(path)
+    try:
+        conn.executescript(_LEGACY_SCHEMA)
+        conn.executemany(
+            "INSERT INTO agent_outcomes "
+            "(agent_type, decision_key, outcome, evidence_uri, recorded_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            rows,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _columns(path: Path) -> list[str]:
+    conn = sqlite3.connect(path)
+    try:
+        return [row[1] for row in conn.execute("PRAGMA table_info(agent_outcomes)")]
+    finally:
+        conn.close()
+
+
+def test_legacy_database_is_migrated_and_stays_usable(db_path: Path) -> None:
+    """An install carrying the old ``recorded_at`` column keeps working."""
+    _make_legacy_db(
+        db_path,
+        [
+            ("router", "decision-a", 1, "run://1", 100.0),
+            ("router", "decision-a", 0, None, 200.0),
+        ],
+    )
+
+    query = ConfidenceQuery(db_path=db_path, min_samples=1)
+
+    assert "sampled_at" in _columns(db_path)
+    assert "recorded_at" not in _columns(db_path)
+
+    # Pre-existing rows survive the rename, timestamps included.
+    conn = sqlite3.connect(db_path)
+    try:
+        preserved = conn.execute(
+            "SELECT agent_type, decision_key, outcome, evidence_uri, sampled_at FROM agent_outcomes ORDER BY id"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert preserved == [
+        ("router", "decision-a", 1, "run://1", 100.0),
+        ("router", "decision-a", 0, None, 200.0),
+    ]
+
+    # And the ledger accepts new writes on the migrated table.
+    query.record("router", "decision-a", 1, evidence_uri="run://3")
+
+    result = query.get("router", "decision-a")
+    assert result.samples == 3
+    assert result.value == pytest.approx(2 / 3)
+
+
+def test_migration_is_idempotent_across_reopens(db_path: Path) -> None:
+    """Re-opening a migrated database neither re-renames nor loses rows."""
+    _make_legacy_db(db_path, [("router", "k", 1, None, 100.0)])
+
+    ConfidenceQuery(db_path=db_path, min_samples=1).record("router", "k", 0)
+    reopened = ConfidenceQuery(db_path=db_path, min_samples=1)
+    reopened.record("router", "k", 1)
+
+    assert _columns(db_path).count("sampled_at") == 1
+    result = reopened.get("router", "k")
+    assert result.samples == 3
+    assert result.value == pytest.approx(2 / 3)
+
+
+def test_fresh_database_is_unaffected_by_the_migration(db_path: Path) -> None:
+    """A database created from scratch still gets the current schema."""
+    query = ConfidenceQuery(db_path=db_path, min_samples=1)
+    query.record("router", "k", 1)
+
+    columns = _columns(db_path)
+    assert "sampled_at" in columns
+    assert "recorded_at" not in columns
+    assert query.get("router", "k").samples == 1


### PR DESCRIPTION
## Problem

`empirical_confidence.py` creates its table with `CREATE TABLE IF NOT EXISTS agent_outcomes (...)`, which by definition leaves an existing table alone. Databases created before the timestamp column was named `sampled_at` carry `recorded_at`, so on an upgraded install every `append()` raises:

```
sqlite3.OperationalError: table agent_outcomes has no column named sampled_at
```

CI never sees it: a fresh database always gets the current schema, so the failure only reaches operators who have been running the ledger for a while. The database resolves via `BERNSTEIN_CONFIDENCE_DB`, else `~/.local/share/bernstein/empirical-confidence.db`.

Reproduced against a copy of a real on-disk ledger with the old layout:

```
$ BERNSTEIN_CONFIDENCE_DB=/tmp/legacy.db uv run pytest tests/unit/test_evolution_loop.py -q
5 failed, 31 passed
```

All five are `test_run_cycle_does_not_close_the_issue_for_a_category_with_no_sink` parametrizations. With the fix applied, the same command against the same database: `36 passed`.

## Change

`_OutcomeStore._migrate` now inspects `PRAGMA table_info` after applying the DDL and renames `recorded_at` to `sampled_at` when it finds the older layout.

- The rename preserves rows, row ids, and the lookup index. Resulting column order differs from a freshly created table, which is immaterial because every statement here names the columns it touches.
- It runs inside `BEGIN IMMEDIATE`, re-checking the column set under the write lock, so processes opening the same file serialise against each other — the module lock covers only threads.
- A table carrying neither column name is left untouched with a warning rather than guessed at, so an unrecognised schema fails at the query that needs it instead of being silently rewritten.

## Tests

Three regression tests in `tests/unit/quality/test_empirical_confidence.py` build a database with the pre-`sampled_at` layout and assert:

- the rename happens, and existing rows keep their values and timestamps;
- `record()` / `get()` work against the migrated table;
- reopening is idempotent — no second rename, no lost rows;
- a fresh database is unaffected.

All three fail on `main` with the `OperationalError` above.

## Verification

```
uv run ruff check                 # All checks passed
uv run ruff format --check        # already formatted
uv run pytest ...                 # 103 passed
```

The pytest run covers `tests/unit/quality/test_empirical_confidence.py` plus every suite that touches this module: `test_evolution_loop.py`, `test_evolution_admission.py`, `test_evolution_applicator_admission.py`, `test_evolution_upgrade_executor_admission.py`, `test_hoeffding_confidence_sequence.py`.

Also smoke-tested end to end on a copy of a real old-schema ledger: the migration logs, `record_outcome()` writes, and `ConfidenceQuery.get()` reads back correctly.