### PR TITLE
fix(security): residency guard returns a verdict for a URL it cannot parse

### DIFF
--- a/docs/release-notes/fragments/residency-guard-unparseable-url.md
+++ b/docs/release-notes/fragments/residency-guard-unparseable-url.md
@@ -1,0 +1,3 @@
+## Residency guard returns a verdict for a URL it cannot parse
+
+Under the `eu-residency` profile, `OllamaAdapter` refuses to spawn against an endpoint it cannot prove is self-hosted. The check read the hostname with `urllib.parse.urlparse`, which raises `ValueError` on a bracketed-IPv6 netloc carrying userinfo (`http://[::1]@evil.com:8000`) and on a stray or unclosed bracket (`http://a]b`, `http://[::1`). The guard did not catch it, so those URLs left `spawn()` as a traceback instead of the residency refusal the docstring promises. A URL the parser refuses is now False, alongside the empty and unrecognised ones. Well-formed bracketed IPv6 literals such as `http://[::1]:11434` are unaffected.

--- a/src/bernstein/adapters/ollama.py
+++ b/src/bernstein/adapters/ollama.py
@@ -187,12 +187,24 @@ class OllamaAdapter(CLIAdapter):
             base_url: The configured Ollama / OpenAI-compatible base URL.
 
         Returns:
-            True if the endpoint looks self-hosted, False otherwise.
+            True if the endpoint looks self-hosted, False otherwise. A URL
+            this function cannot parse is False, never an exception: the
+            caller is a residency check, and a guard that raises stops the
+            spawn with a traceback instead of a residency verdict.
         """
         import ipaddress
         from urllib.parse import urlparse
 
-        host = (urlparse(base_url).hostname or "").lower()
+        try:
+            host = (urlparse(base_url).hostname or "").lower()
+        except ValueError:
+            # urlsplit rejects a bracketed-IPv6 netloc carrying userinfo
+            # ("http://[::1]@evil.com:8000") and an unclosed or stray bracket
+            # ("http://[::1", "http://a]b"). None of those names an endpoint
+            # whose residency can be established, so they fail closed with
+            # the rest of the unparseable inputs rather than escaping as a
+            # ValueError from inside spawn().
+            return False
         if not host:
             # Empty / malformed URL - fail closed under residency mode.
             return False

--- a/tests/property/test_lineage_eu_bughunt.py
+++ b/tests/property/test_lineage_eu_bughunt.py
@@ -873,19 +873,40 @@ class TestMixedEndpointHandling:
         # destination. Asserting False here pins the right semantics.
         assert adapter._is_self_hosted_endpoint(url) is False, url
 
-    @pytest.mark.xfail(
-        reason=(
-            "Operational bug: Python 3.12+ urllib.parse.urlsplit raises "
-            "ValueError on a bracketed-IPv6 netloc with userinfo "
-            "(e.g. 'http://[::1]@evil.com:8000'). The residency guard "
-            "doesn't catch the parse error, so a malformed URL crashes "
-            "spawn instead of cleanly returning False. Fix: wrap urlparse "
-            "in try/except ValueError and fail closed. Tracked as a "
-            "follow-up."
-        ),
-        strict=True,
-    )
     def test_ipv6_userinfo_does_not_mask_real_host(self) -> None:
+        """A bracketed-IPv6 netloc with userinfo fails closed (FIXED).
+
+        This was an ``xfail(strict=True)``: ``urllib.parse.urlsplit``
+        raises ``ValueError`` on this shape, and the guard did not catch
+        it, so a malformed URL left ``spawn()`` with a traceback instead
+        of a residency verdict.
+        """
         url = "http://[::1]@evil.com:8000"
         adapter = OllamaAdapter()
         assert adapter._is_self_hosted_endpoint(url) is False, url
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://[::1]@evil.com:8000",
+            "http://[::1",
+            "http://a]b",
+            "http://[",
+            "http://]",
+        ],
+    )
+    def test_an_unparseable_url_is_a_verdict_not_an_exception(self, url: str) -> None:
+        """Every URL urlsplit refuses lands on False, the fail-closed answer.
+
+        The guard runs inside ``spawn()`` under the residency profile. A
+        raise there reads as a crash rather than as the refusal it should
+        be, and hides which endpoint was rejected and why.
+        """
+        adapter = OllamaAdapter()
+        assert adapter._is_self_hosted_endpoint(url) is False, url
+
+    @pytest.mark.parametrize("url", ["http://[::1]:11434", "http://[fe80::1]", "http://[fc00::1]:8080"])
+    def test_a_well_formed_bracketed_ipv6_literal_still_resolves(self, url: str) -> None:
+        """Catching the parse error must not swallow the addresses that work."""
+        adapter = OllamaAdapter()
+        assert adapter._is_self_hosted_endpoint(url) is True, url


### PR DESCRIPTION
## What

`OllamaAdapter._is_self_hosted_endpoint` returns `False` for a URL `urlparse` refuses, instead of letting the `ValueError` escape.

## Why

The guard runs inside `spawn()` under the `eu-residency` profile, and decides whether the run is allowed to proceed at all. `urllib.parse.urlparse` raises `ValueError` on three shapes:

```python
urlparse("http://[::1]@evil.com:8000")  # bracketed IPv6 netloc with userinfo
urlparse("http://[::1")                 # unclosed bracket
urlparse("http://a]b")                  # stray bracket
```

None was caught, so an operator who set `OLLAMA_API_BASE` to one of them got a traceback out of `spawn()` rather than the `RESIDENCY_VIOLATION` message that names the endpoint and says what to do about it. The function's own docstring already promised the other answer: "Empty / malformed URL - fail closed under residency mode."

`tests/property/test_lineage_eu_bughunt.py` carried a `strict=True` xfail for the userinfo case, with the fix written out in the reason. That test is the merge gate this PR flips. The two bracket shapes are the same defect found while writing it.

## How

One `try`/`except ValueError` around the hostname read, returning `False`, with a comment naming the three shapes so the next reader does not have to rediscover which URLs `urlsplit` refuses. The docstring's Returns section now states that an unparseable URL is `False` and never an exception, and why that matters for a guard.

The `except` is deliberately narrow. `ValueError` is what `urlsplit` raises for a netloc it cannot read; anything else out of the parser is a fault worth surfacing.

## Tests

The `xfail` marker comes off `test_ipv6_userinfo_does_not_mask_real_host`, with a FIXED docstring.

Two parametrized cases added to `TestMixedEndpointHandling`:

- every shape `urlsplit` refuses lands on `False`
- a well-formed bracketed IPv6 literal (`http://[::1]:11434`, `http://[fe80::1]`, `http://[fc00::1]:8080`) still resolves to `True`, so catching the parse error does not swallow the addresses that work

One case I tried and removed, in case a reviewer wonders: `http://[::1]@[fe80::2]` parses fine and its real host is a link-local address, so `True` is the correct verdict there and it does not belong in the unparseable list.

```
uv run pytest tests/property/test_lineage_eu_bughunt.py tests/unit/test_deepseek_v4_eu_residency.py \
  tests/integration/test_deepseek_eu_residency_loopback.py -q
115 passed, 3 xfailed
```

The three remaining xfails in that file are the unrelated KMS JWK, HSM stub and Article 12(4) spawn-hook findings.

## Checklist

- [x] `ruff check src/` passes
- [x] `pyright src/bernstein/adapters/ollama.py` reports the same 6 pre-existing errors as `main`, none new
- [x] `lint-imports` passes
- [x] Release note fragment added: `docs/release-notes/fragments/residency-guard-unparseable-url.md`

### Documentation duty

- [x] N/A for README and `docs/operations/`: the residency behaviour they document is unchanged, and a URL that used to crash was never a documented way to pass the guard.
- [x] N/A for `docs/api/` and `agents-md sync`: no new module, no public API or schema change.
