### PR TITLE
fix: a leading dot in a filename is part of the name

### DIFF
--- a/docs/release-notes/fragments/leading-dot-slash-prefix-strip.md
+++ b/docs/release-notes/fragments/leading-dot-slash-prefix-strip.md
@@ -6,4 +6,4 @@ In the tag-conformance check (`core/admission/tags.py`) that let a changed path 
 
 In `bernstein history` (`cli/commands/maintenance_cmd.py`) only the relative branch called it, so the two spellings of one path disagreed and the command reported no history for a dotfile named by an absolute path, while also echoing the wrong name back.
 
-Both now normalise through `Path.as_posix`, which already drops the redundant `.` and `//` components and leaves a leading dot alone.
+Both now normalise through `Path.as_posix`, which already drops the redundant `.` and `//` components and leaves a leading dot alone (#5498).

--- a/docs/release-notes/fragments/leading-dot-slash-prefix-strip.md
+++ b/docs/release-notes/fragments/leading-dot-slash-prefix-strip.md
@@ -1,0 +1,9 @@
+## A leading dot in a filename is part of the name
+
+Two path normalisers wrote `lstrip("./")` where they meant "drop a redundant `./` prefix". `str.lstrip` takes a set of characters, not a prefix, so it removed every leading `.` and `/`: `.github/workflows/ci.yml` became `github/workflows/ci.yml`.
+
+In the tag-conformance check (`core/admission/tags.py`) that let a changed path satisfy an allow-prefix from a directory the contract never named, so a task declaring `docs-only` could write `.docs/` and receive a signed receipt saying it was conformant.
+
+In `bernstein history` (`cli/commands/maintenance_cmd.py`) only the relative branch called it, so the two spellings of one path disagreed and the command reported no history for a dotfile named by an absolute path, while also echoing the wrong name back.
+
+Both now normalise through `Path.as_posix`, which already drops the redundant `.` and `//` components and leaves a leading dot alone.

--- a/src/bernstein/cli/commands/maintenance_cmd.py
+++ b/src/bernstein/cli/commands/maintenance_cmd.py
@@ -64,6 +64,12 @@ def _normalize_repo_path(workdir: Path, target: Path | str) -> str:
         workdir: Repository root.
         target: Absolute or relative path string.
 
+    Both branches must agree on a given file or the caller compares an
+    argument against archive entries that name the same path and finds no
+    match. ``Path.as_posix`` is what makes them agree: it already drops the
+    redundant ``.`` and ``//`` components a relative path may carry, and it
+    leaves a leading dot in a name alone.
+
     Returns:
         Repo-relative path when possible, otherwise a normalized POSIX string.
     """
@@ -73,7 +79,7 @@ def _normalize_repo_path(workdir: Path, target: Path | str) -> str:
             return candidate.resolve().relative_to(workdir.resolve()).as_posix()
         except ValueError:
             return candidate.as_posix()
-    return candidate.as_posix().lstrip("./")
+    return candidate.as_posix()
 
 
 def _history_rows(workdir: Path, file_path: Path, *, limit: int) -> list[HistoryRow]:

--- a/src/bernstein/core/admission/tags.py
+++ b/src/bernstein/core/admission/tags.py
@@ -65,7 +65,11 @@ class TagContract:
             if pure.is_absolute() or ".." in pure.parts:
                 offenders.append(path)
                 continue
-            norm = path.lstrip("./")
+            # ``as_posix`` on the parsed path drops the redundant ``.`` and
+            # ``//`` components a diff may carry, and leaves a leading dot in
+            # a name alone: ``.github/`` is a directory called ``.github``,
+            # not ``github``.
+            norm = pure.as_posix()
             if any(norm.startswith(bad) for bad in self.forbidden_prefixes):
                 offenders.append(path)
                 continue

--- a/tests/unit/test_admission_hardening.py
+++ b/tests/unit/test_admission_hardening.py
@@ -255,6 +255,29 @@ def test_no_src_dotdot_escape_is_a_violation() -> None:
     assert check_conformance(("no-src",), ("build/../src/secret.py",))
 
 
+def test_a_dotfile_keeps_its_leading_dot_in_the_prefix_check() -> None:
+    """A tag contract compares directory names, and ``.github`` is one.
+
+    ``lstrip("./")`` removed every leading ``.`` and ``/``, so a changed
+    ``.docs/leak.md`` normalised to ``docs/leak.md`` and satisfied the
+    ``docs-only`` allow-prefix from a directory the contract never named.
+    """
+    from bernstein.core.admission.tags import check_conformance
+
+    assert check_conformance(("docs-only",), (".docs/leak.md",))
+    assert check_conformance(("tests-only",), (".tests/leak.py",))
+    # And a real dotfile outside the allow-list stays a violation, as before.
+    assert check_conformance(("docs-only",), (".github/workflows/ci.yml",))
+
+
+def test_a_redundant_leading_dot_slash_is_still_conformant() -> None:
+    """``./docs/guide.md`` names the same file as ``docs/guide.md``."""
+    from bernstein.core.admission.tags import check_conformance
+
+    assert check_conformance(("docs-only",), ("./docs/guide.md",)) == ()
+    assert check_conformance(("tests-only",), ("tests/./unit/test_x.py",)) == ()
+
+
 # ---------------------------------------------------------------------------
 # Item 7: ledger_id path traversal is rejected (already hardened via containment)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_maintenance_cmd.py
+++ b/tests/unit/test_maintenance_cmd.py
@@ -89,6 +89,90 @@ def test_history_filters_archive_by_owned_file(tmp_path: Path) -> None:
     assert payload["tasks"][0]["task_id"] == "task-auth"
 
 
+def test_history_matches_a_dotfile_by_absolute_path(tmp_path: Path) -> None:
+    """The relative and absolute spellings of one path must agree.
+
+    ``lstrip("./")`` stripped every leading ``.`` and ``/``, so the relative
+    branch turned ``.github/workflows/ci.yml`` into ``github/workflows/ci.yml``
+    while the absolute branch, which never called it, kept the dot. A record
+    naming the file was then unreachable from the absolute argument.
+    """
+    archive_path = tmp_path / ".sdd" / "archive" / "tasks.jsonl"
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    archive_path.write_text(
+        json.dumps(
+            {
+                "task_id": "task-ci",
+                "title": "Fix the workflow",
+                "role": "infra",
+                "status": "done",
+                "created_at": 1.0,
+                "completed_at": 2.0,
+                "duration_seconds": 1.0,
+                "result_summary": "done",
+                "cost_usd": None,
+                "assigned_agent": "sess-ci",
+                "owned_files": [".github/workflows/ci.yml"],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    absolute = tmp_path / ".github" / "workflows" / "ci.yml"
+    result = runner.invoke(cli, ["history", str(absolute), "--json", "--workdir", str(tmp_path)])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["file"] == ".github/workflows/ci.yml"
+    assert [task["task_id"] for task in payload["tasks"]] == ["task-ci"]
+
+
+def test_history_reports_the_dotfile_path_it_was_given(tmp_path: Path) -> None:
+    """A leading dot belongs to the name and is echoed back intact."""
+    archive_path = tmp_path / ".sdd" / "archive" / "tasks.jsonl"
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    archive_path.write_text("", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["history", ".bernstein/state.json", "--json", "--workdir", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)["file"] == ".bernstein/state.json"
+
+
+def test_history_ignores_a_redundant_leading_dot_slash(tmp_path: Path) -> None:
+    """``./src/auth.py`` and ``src/auth.py`` are the same file."""
+    archive_path = tmp_path / ".sdd" / "archive" / "tasks.jsonl"
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    archive_path.write_text(
+        json.dumps(
+            {
+                "task_id": "task-auth",
+                "title": "Fix auth flow",
+                "role": "backend",
+                "status": "done",
+                "created_at": 1.0,
+                "completed_at": 2.0,
+                "duration_seconds": 1.0,
+                "result_summary": "done",
+                "cost_usd": None,
+                "assigned_agent": "sess-auth",
+                "owned_files": ["./src/auth.py"],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["history", "src/auth.py", "--json", "--workdir", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert [task["task_id"] for task in json.loads(result.output)["tasks"]] == ["task-auth"]
+
+
 def test_cleanup_removes_only_inactive_worktrees(tmp_path: Path) -> None:
     tasks_path = tmp_path / ".sdd" / "runtime" / "tasks.jsonl"
     _write_task_record(tasks_path, task_id="task-live", status="claimed", assigned_agent="sess-live")


### PR DESCRIPTION
## What

Two path normalisers used `lstrip("./")` where they meant "drop a redundant `./` prefix".

## Why

`str.lstrip` takes a *set of characters*, not a prefix. It strips every leading `.` and `/`:

```python
".github/workflows/ci.yml".lstrip("./")  # 'github/workflows/ci.yml'
".bernstein/state.json".lstrip("./")     # 'bernstein/state.json'
```

**`core/admission/tags.py`** compares each changed path against a tag contract's allow- and forbid-prefixes, and seals the result into a signed conformance receipt. With the dot removed, a path could satisfy a prefix from a directory the contract never named: a task declaring `docs-only` that wrote `.docs/leak.md` normalised to `docs/leak.md` and earned a receipt saying it stayed inside `docs/`. The same misreading runs the other way, flagging `.src/x.py` against a `no-src` contract that says nothing about `.src/`.

The traversal and absolute-path guard directly above is unaffected: it runs on `PurePosixPath` before this line and still rejects `docs/../src/x` and `/etc/passwd`.

**`cli/commands/maintenance_cmd.py`** normalises both the CLI argument and every archived `owned_files` entry so the two can be compared, but only the relative branch called `lstrip`; the absolute branch returns `relative_to(...).as_posix()` and never did. The two spellings of one path therefore disagreed:

```
bernstein history .github/workflows/ci.yml            # works
bernstein history /repo/.github/workflows/ci.yml      # "No archived tasks recorded"
```

The echoed path in the `--json` output, the empty-result message and the table title were wrong by the same character.

## How

Neither site needs the call. `Path.as_posix` already drops the redundant `.` and `//` components that pathlib normalises away, and leaves a leading dot in a name alone:

```python
Path("./src/x.py").as_posix()               # 'src/x.py'
Path("src//x.py").as_posix()                # 'src/x.py'
Path(".github/workflows/ci.yml").as_posix() # '.github/workflows/ci.yml'
```

`tags.py` reuses the `PurePosixPath` it had already built for the guard above rather than parsing the string twice. `maintenance_cmd.py` drops the call and gains a docstring line saying the two branches have to agree, which is the property that broke.

The repository already spells this correctly at `core/evidence/run_artifacts.py:203` (`posixpath.normpath(...).removeprefix("./")`), so this brings the two outliers in line.

## Tests

`tests/unit/test_admission_hardening.py`:

- `test_a_dotfile_keeps_its_leading_dot_in_the_prefix_check` (fails on `main`): `.docs/leak.md` and `.tests/leak.py` are violations of `docs-only` and `tests-only`, and `.github/workflows/ci.yml` stays a violation of `docs-only`.
- `test_a_redundant_leading_dot_slash_is_still_conformant`: `./docs/guide.md` and `tests/./unit/test_x.py` remain conformant, so the normalisation the call *was* doing is not lost.

`tests/unit/test_maintenance_cmd.py`:

- `test_history_matches_a_dotfile_by_absolute_path` (fails on `main`)
- `test_history_reports_the_dotfile_path_it_was_given` (fails on `main`)
- `test_history_ignores_a_redundant_leading_dot_slash` — this one passed before as well, kept as a regression guard for the behaviour that is preserved.

```
uv run pytest tests/unit/test_admission_hardening.py tests/unit/test_maintenance_cmd.py \
  tests/unit/test_cli_history.py -q
49 passed
```

Three of the six new assertions fail on `main` and pass here; the rest pin behaviour the change must not alter.

## Checklist

- [x] `ruff check src/` passes
- [x] `lint-imports` passes
- [x] Release note fragment added: `docs/release-notes/fragments/leading-dot-slash-prefix-strip.md`

### Documentation duty

- [x] N/A for README and `docs/operations/`: `bernstein history` accepting a path is unchanged, and the tag contracts documented elsewhere are unchanged. This corrects how a path was read, not what either surface offers.
- [x] N/A for `docs/api/` and `agents-md sync`: no new module, no public API or schema change.
