### PR TITLE
fix(adapters): stamp selected registry key and disambiguate reverse lookup (#5497)

### DIFF
--- a/docs/release-notes/fragments/5497-adapter-registry-name-reverse-lookup.md
+++ b/docs/release-notes/fragments/5497-adapter-registry-name-reverse-lookup.md
@@ -1,0 +1,3 @@
+## Reverse lookup disambiguation for multi-key adapter classes
+
+Adapter instances obtained via `get_adapter(key)` now carry their selected `registry_name`, ensuring `registry_name_for` reliably resolves the selected key rather than guessing based on dictionary insertion order when a class is registered under multiple keys (such as `GeminiAdapter` under `antigravity` and `gemini`) (#5497).

--- a/src/bernstein/adapters/registry.py
+++ b/src/bernstein/adapters/registry.py
@@ -266,7 +266,9 @@ def get_adapter(cli_name: str, *, admission_gate: AdmissionGateLike | None = Non
     if cli_name == "generic":
         if admission_gate is not None:
             admission_gate.admit(cli_name)
-        return GenericAdapter(cli_command="generic-cli", display_name="Generic CLI")
+        instance = GenericAdapter(cli_command="generic-cli", display_name="Generic CLI")
+        instance.registry_name = cli_name
+        return instance
 
     _load_entrypoint_adapters()
 
@@ -287,9 +289,9 @@ def get_adapter(cli_name: str, *, admission_gate: AdmissionGateLike | None = Non
     if admission_gate is not None:
         admission_gate.admit(cli_name)
 
-    if isinstance(adapter_cls, CLIAdapter):
-        return adapter_cls
-    return adapter_cls()
+    instance = adapter_cls if isinstance(adapter_cls, CLIAdapter) else adapter_cls()
+    instance.registry_name = cli_name
+    return instance
 
 
 def removed_adapter_message(cli_name: str) -> str | None:
@@ -326,19 +328,20 @@ def registry_name_for(adapter: CLIAdapter) -> str | None:
         adapter: A live :class:`CLIAdapter` instance.
 
     Returns:
-        The registry key, or ``None`` when the adapter is not registered.
+        The registry key, or ``None`` when the adapter is not registered or ambiguous.
     """
+    _load_entrypoint_adapters()
     explicit = getattr(adapter, "registry_name", "") or ""
     if explicit and explicit in _ADAPTERS:
         return explicit
 
-    _load_entrypoint_adapters()
     adapter_type = type(adapter)
+    matching_names: list[str] = []
     for name, entry in _ADAPTERS.items():
-        if entry is adapter:
-            return name
-        if inspect.isclass(entry) and entry is adapter_type:
-            return name
+        if entry is adapter or (inspect.isclass(entry) and entry is adapter_type):
+            matching_names.append(name)
+    if len(matching_names) == 1:
+        return matching_names[0]
     return None
 
 

--- a/tests/unit/adapters/test_adapter_registry_name_resolution.py
+++ b/tests/unit/adapters/test_adapter_registry_name_resolution.py
@@ -1,0 +1,115 @@
+"""Unit tests for adapter registry_name resolution and reverse lookup (#5497).
+
+Guarantees:
+1. `get_adapter(key)` stamps `instance.registry_name = key` on the returned instance.
+2. `registry_name_for` returns the selected key for instances resolved via `get_adapter`.
+3. An ambiguous class registered under multiple keys (e.g. `GeminiAdapter`) returns `None`
+   from `registry_name_for` when instantiated directly without stamping, rather than silently
+   relying on dictionary insertion order.
+4. Single-key adapters continue to resolve correctly when unstamped.
+5. Admission evidence for `gemini` vs `antigravity` names their own adapter key and binary.
+"""
+
+from __future__ import annotations
+
+from bernstein.adapters.admission import gather_admission_evidence
+from bernstein.adapters.aider import AiderAdapter
+from bernstein.adapters.base import CLIAdapter
+from bernstein.adapters.claude import ClaudeCodeAdapter
+from bernstein.adapters.codex import CodexAdapter
+from bernstein.adapters.gemini import GeminiAdapter
+from bernstein.adapters.registry import (
+    _ADAPTERS,
+    get_adapter,
+    register_adapter,
+    registry_name_for,
+)
+
+
+def teardown_function() -> None:
+    """Clean up any temporary test registrations."""
+    _ADAPTERS.pop("test_dual_1", None)
+    _ADAPTERS.pop("test_dual_2", None)
+
+
+def test_get_adapter_stamps_registry_name() -> None:
+    """get_adapter stamps the requested registry key onto the returned instance."""
+    gemini = get_adapter("gemini")
+    assert gemini.registry_name == "gemini"
+
+    antigravity = get_adapter("antigravity")
+    assert antigravity.registry_name == "antigravity"
+
+    generic = get_adapter("generic")
+    assert generic.registry_name == "generic"
+
+    claude = get_adapter("claude")
+    assert claude.registry_name == "claude"
+
+
+def test_registry_name_for_gemini_and_antigravity() -> None:
+    """registry_name_for disambiguates GeminiAdapter instances by their stamped key."""
+    gemini = get_adapter("gemini")
+    assert registry_name_for(gemini) == "gemini"
+
+    antigravity = get_adapter("antigravity")
+    assert registry_name_for(antigravity) == "antigravity"
+
+
+def test_registry_name_for_ambiguous_class_returns_none_when_unstamped() -> None:
+    """An unstamped instance of a dual-registered class returns None rather than guessing."""
+    bare_gemini = GeminiAdapter()
+    assert getattr(bare_gemini, "registry_name", "") == ""
+    assert registry_name_for(bare_gemini) is None
+
+
+def test_single_key_adapters_continue_to_resolve_when_unstamped() -> None:
+    """Single-key adapters resolve via class reverse-lookup even without explicit stamping."""
+    bare_claude = ClaudeCodeAdapter()
+    assert registry_name_for(bare_claude) == "claude"
+
+    bare_aider = AiderAdapter()
+    assert registry_name_for(bare_aider) == "aider"
+
+    bare_codex = CodexAdapter()
+    assert registry_name_for(bare_codex) == "codex"
+
+
+def test_multi_registered_custom_adapter_disambiguation() -> None:
+    """A custom adapter registered under two keys requires stamping to disambiguate."""
+
+    class CustomMultiAdapter(CLIAdapter):
+        def spawn(self, **kwargs):  # type: ignore[no-untyped-def]
+            raise NotImplementedError
+
+        def name(self) -> str:
+            return "CustomMulti"
+
+    register_adapter("test_dual_1", CustomMultiAdapter)
+    register_adapter("test_dual_2", CustomMultiAdapter)
+
+    # Unstamped instance is ambiguous
+    bare = CustomMultiAdapter()
+    assert registry_name_for(bare) is None
+
+    # Stamped via get_adapter resolves to the respective key
+    inst1 = get_adapter("test_dual_1")
+    assert inst1.registry_name == "test_dual_1"
+    assert registry_name_for(inst1) == "test_dual_1"
+
+    inst2 = get_adapter("test_dual_2")
+    assert inst2.registry_name == "test_dual_2"
+    assert registry_name_for(inst2) == "test_dual_2"
+
+
+def test_admission_evidence_for_gemini_and_antigravity() -> None:
+    """Admission evidence for gemini and antigravity names their own key and binary."""
+    ev_gemini = gather_admission_evidence("gemini")
+    assert ev_gemini.adapter == "gemini"
+    assert ev_gemini.binary == "gemini"
+    assert ev_gemini.contract_hash != ""
+
+    ev_antigravity = gather_admission_evidence("antigravity")
+    assert ev_antigravity.adapter == "antigravity"
+    assert ev_antigravity.binary == "antigravity"
+    assert ev_antigravity.contract_hash != ""


### PR DESCRIPTION
## Summary
Fixes #5497.

When an adapter class is registered under multiple keys (such as `GeminiAdapter` under both `antigravity` and `gemini`), `registry_name_for` previously walked `_ADAPTERS` and returned whichever key was inserted first (`antigravity`). As a result, an operator running `--cli gemini` had their run gated against `antigravity.yaml` and probed for the `antigravity` binary rather than `gemini.yaml` and `gemini`.

### Changes:
1. **Key Stamping**: `get_adapter(cli_name)` now stamps `instance.registry_name = cli_name` on the instantiated/resolved adapter instance so it carries the operator-selected key.
2. **Reverse Lookup Disambiguation**: `registry_name_for(adapter)` prefers `adapter.registry_name`, and when falling back to class/instance matching across `_ADAPTERS`, refuses to guess if multiple keys match (returning `None` when unstamped rather than silently picking dict insertion order).
3. **Compatibility**: All single-key adapters continue resolving without change when unstamped.
4. **Tests**: Added test suite in `tests/unit/adapters/test_adapter_registry_name_resolution.py` verifying key stamping, reverse lookup disambiguation, single-key resolution, and admission evidence gathering.
5. **Release Notes**: Added fragment `docs/release-notes/fragments/5497-adapter-registry-name-reverse-lookup.md`.

## Verification
- `pytest tests/unit/adapters/test_adapter_registry_name_resolution.py tests/unit/test_adapter_admission.py tests/unit/test_spawner_adapter_admission.py tests/unit/test_adapter_registry.py tests/unit/adapters/test_registry.py` (99 passed)
- `importlinter`: 3 kept, 0 broken
- `ruff check` & `ruff format`: clean
- BOM check: 0 BOMs
