### PR TITLE
fix(persistence): trigger state and fleet contexts are written crash-safely

### DIFF
--- a/docs/release-notes/fragments/atomic-state-writes.md
+++ b/docs/release-notes/fragments/atomic-state-writes.md
@@ -1,0 +1,9 @@
+## Trigger state and fleet contexts are written crash-safely
+
+Two runtime stores had a local `_atomic_write` helper that renamed a temporary file into place without ever calling `fsync`, so a power loss could make the rename durable while the bytes behind it were not.
+
+For `.sdd/runtime/triggers/`, what survives that is a zero-length `counters.json`, and the store's own loader answers an unparseable state file by quarantining it and raising `TriggerStateCorruptError`.
+
+For `.sdd/fleet/contexts/`, what survives is a truncated `active.json`, which `_active_field` reads as "no context active": the fleet silently falls back to four-layer precedence while the audit chain still records the activation. That writer also used one fixed temporary name per target with no lock around it, so two concurrent activations could write the same temporary and publish a mix of both.
+
+Both now go through `write_atomic_bytes` in `core/persistence/atomic_write.py`, the module that already centralises this pattern: a per-writer temporary name, `fsync` of the file, `fsync` of the containing directory, and owner-only permissions on runtime state.

--- a/src/bernstein/core/events/state.py
+++ b/src/bernstein/core/events/state.py
@@ -23,6 +23,8 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
+from bernstein.core.persistence.atomic_write import write_atomic_text
+
 if sys.platform == "win32":  # pragma: no cover - exercised only on Windows
     import msvcrt
 
@@ -124,9 +126,16 @@ def _load(path: Path) -> dict[str, Any]:
 
 
 def _atomic_write(path: Path, data: dict[str, Any]) -> None:
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(json.dumps(data, ensure_ascii=False, separators=(",", ":"), sort_keys=True), encoding="utf-8")
-    tmp.replace(path)
+    """Persist *data* through the crash-safe write path.
+
+    The previous local implementation wrote the temporary file and renamed
+    it without ever calling ``fsync``, so the rename could reach the disk
+    while the bytes behind it did not. What survived a power loss was a
+    zero-length ``counters.json``, and :func:`_load` answers that by
+    quarantining the file and raising ``TriggerStateCorruptError`` -- the
+    exact outcome the temp-and-rename dance is there to avoid.
+    """
+    write_atomic_text(path, json.dumps(data, ensure_ascii=False, separators=(",", ":"), sort_keys=True))
 
 
 class TriggerStateStore:

--- a/src/bernstein/core/fleet/context.py
+++ b/src/bernstein/core/fleet/context.py
@@ -36,11 +36,11 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
-import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.persistence.atomic_write import write_atomic_text
 from bernstein.core.security.audit_chain import record_fleet_context_activate
 
 if TYPE_CHECKING:
@@ -353,7 +353,19 @@ _validate_name = validate_context_name
 
 
 def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(".json.tmp")
-    tmp.write_text(json.dumps(payload, sort_keys=True, indent=2), encoding="utf-8")
-    os.replace(tmp, path)
+    """Persist *payload* through the crash-safe write path.
+
+    Two properties the previous local implementation did not have, both of
+    which :meth:`ContextStore.activate` states as guarantees:
+
+    * ``fsync``. The rename could reach the disk while the bytes behind it
+      did not, leaving a zero-length ``active.json``. ``_active_field``
+      answers an unparseable pointer with ``None``, so the fleet silently
+      falls back to four-layer precedence while the audit chain still
+      records the activation.
+    * A temporary name unique per writer. ``path.with_suffix(".json.tmp")``
+      is one fixed slot per target, and nothing here holds a lock, so two
+      activations could write the same temporary at once and publish a
+      torn mix of both.
+    """
+    write_atomic_text(path, json.dumps(payload, sort_keys=True, indent=2))

--- a/tests/unit/fleet/test_fleet_context.py
+++ b/tests/unit/fleet/test_fleet_context.py
@@ -10,6 +10,7 @@ no context active, the four-layer precedence is unchanged.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -177,3 +178,126 @@ def test_create_list_get(tmp_path: Path) -> None:
     store.create(OperatingContext(name="staging", server_url="https://staging"))
     assert store.list_names() == ["dev", "staging"]
     assert store.get("dev").server_url == "http://localhost:8052"
+
+
+# ---------------------------------------------------------------------------
+# Durability of the context files and the activation pointer
+# ---------------------------------------------------------------------------
+
+
+def _context(name: str = "staging-fleet") -> OperatingContext:
+    return OperatingContext(
+        name=name,
+        server_url="https://staging.example",
+        store_dsn="postgres://s/db",
+        adapter_defaults={"model": "claude", "effort": "medium"},
+        budget_envelope="staging-budget",
+    )
+
+
+def _fsync_spy(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    """Record every ``os.fsync`` the write path performs."""
+    seen: list[int] = []
+    real = os.fsync
+
+    def spy(fd: int) -> None:
+        seen.append(fd)
+        real(fd)
+
+    monkeypatch.setattr(os, "fsync", spy)
+    return seen
+
+
+def test_the_activation_pointer_is_fsynced_before_it_is_published(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An audited activation must not survive as a pointer full of nothing.
+
+    ``activate`` records the audit event first so a live pointer always has
+    its record. Without an fsync the inverse happens instead: the rename is
+    durable, the bytes are not, and ``_active_field`` answers the truncated
+    pointer with ``None``. The fleet silently drops back to four-layer
+    precedence while the chain still says the context was activated.
+    """
+    project = tmp_path / "proj"
+    project.mkdir()
+    store = _store(project, _chain(tmp_path))
+    store.create(_context())
+    seen = _fsync_spy(monkeypatch)
+    store.activate("staging-fleet")
+    assert seen, "the activation pointer was published without being fsynced"
+
+
+def test_a_context_definition_is_fsynced_before_it_is_published(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    store = _store(project, _chain(tmp_path))
+    seen = _fsync_spy(monkeypatch)
+    store.create(_context())
+    assert seen, "the context definition was published without being fsynced"
+
+
+def test_writing_leaves_no_temporary_behind(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    store = _store(project, _chain(tmp_path))
+    store.create(_context())
+    store.activate("staging-fleet")
+    root = project / ".sdd" / "fleet" / "contexts"
+    assert [p.name for p in root.iterdir() if ".tmp" in p.name] == []
+
+
+def test_concurrent_writers_do_not_share_one_temporary_slot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Nothing here holds a lock, so the temporary name must be per-writer.
+
+    ``path.with_suffix(".json.tmp")`` gave every writer of one target the
+    same slot: two activations could write it at once and publish a torn
+    mix of both.
+    """
+    project = tmp_path / "proj"
+    project.mkdir()
+    store = _store(project, _chain(tmp_path))
+    store.create(_context())
+
+    temporaries: list[str] = []
+    from bernstein.core.persistence import atomic_write
+
+    real = atomic_write._tmp_path_for
+
+    def record(path: Path) -> Path:
+        chosen = real(path)
+        temporaries.append(chosen.name)
+        return chosen
+
+    monkeypatch.setattr(atomic_write, "_tmp_path_for", record)
+    store.activate("staging-fleet")
+    store.activate("staging-fleet")
+    assert len(temporaries) == 2
+    assert temporaries[0] != temporaries[1]
+
+
+def test_a_failed_write_leaves_the_previous_pointer_intact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    store = _store(project, _chain(tmp_path))
+    store.create(_context())
+    store.create(_context("prod-fleet"))
+    store.activate("staging-fleet")
+
+    def boom(*_args: object, **_kwargs: object) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr("bernstein.core.persistence.atomic_write.os.replace", boom)
+    with pytest.raises(OSError):
+        store.activate("prod-fleet")
+
+    monkeypatch.undo()
+    assert store.active_name() == "staging-fleet"
+    root = project / ".sdd" / "fleet" / "contexts"
+    assert [p.name for p in root.iterdir() if ".tmp" in p.name] == []

--- a/tests/unit/test_events_state_isolation.py
+++ b/tests/unit/test_events_state_isolation.py
@@ -7,6 +7,7 @@ not interleave state (tested with concurrent workers).
 
 from __future__ import annotations
 
+import os
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -111,3 +112,69 @@ def test_windows_lock_path_uses_msvcrt(tmp_path: Path, monkeypatch: pytest.Monke
 
     assert store.increment("gate.result") == 1
     assert modes == [_FakeMsvcrt.LK_LOCK, _FakeMsvcrt.LK_UNLCK]
+
+
+def _fsync_spy(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    """Record every ``os.fsync`` the write path performs."""
+    seen: list[int] = []
+    real = os.fsync
+
+    def spy(fd: int) -> None:
+        seen.append(fd)
+        real(fd)
+
+    monkeypatch.setattr(os, "fsync", spy)
+    return seen
+
+
+def test_a_counter_write_is_fsynced_before_it_is_published(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A rename that outlives its own bytes is what _load quarantines.
+
+    The write path used to rename the temporary into place without ever
+    calling fsync, so a power loss could leave a durable directory entry
+    pointing at a zero-length file. The next boot reads that, raises
+    TriggerStateCorruptError and quarantines the state.
+    """
+    store = TriggerStateStore(tmp_path / ".sdd" / "runtime" / "triggers")
+    seen = _fsync_spy(monkeypatch)
+    store.increment("k")
+    assert seen, "counters were published without being fsynced"
+
+
+def test_an_expectation_write_is_fsynced_before_it_is_published(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = TriggerStateStore(tmp_path / ".sdd" / "runtime" / "triggers")
+    seen = _fsync_spy(monkeypatch)
+    store.open_expectation("k", {"payload": 1})
+    assert seen, "expectations were published without being fsynced"
+
+
+def test_a_write_leaves_no_temporary_behind(tmp_path: Path) -> None:
+    root = tmp_path / ".sdd" / "runtime" / "triggers"
+    store = TriggerStateStore(root)
+    store.increment("k")
+    store.open_expectation("e", {"payload": 1})
+    assert [p.name for p in root.iterdir() if ".tmp" in p.name] == []
+
+
+def test_a_failed_write_leaves_the_previous_counters_readable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The point of temp-and-rename: a failure loses the update, not the file."""
+    root = tmp_path / ".sdd" / "runtime" / "triggers"
+    store = TriggerStateStore(root)
+    store.increment("k", amount=7)
+
+    def boom(*_args: object, **_kwargs: object) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr("bernstein.core.persistence.atomic_write.os.replace", boom)
+    with pytest.raises(OSError):
+        store.increment("k")
+
+    monkeypatch.undo()
+    assert TriggerStateStore(root).get_counter("k") == 7
+    assert [p.name for p in root.iterdir() if ".tmp" in p.name] == []


### PR DESCRIPTION
## What

Two runtime stores stop hand-rolling `_atomic_write` and call `write_atomic_text` from `core/persistence/atomic_write.py`, the module that already exists for this.

## Why

Both local helpers renamed a temporary into place without ever calling `fsync`:

```python
# core/events/state.py
tmp = path.with_suffix(path.suffix + ".tmp")
tmp.write_text(json.dumps(data, ...), encoding="utf-8")
tmp.replace(path)

# core/fleet/context.py
tmp = path.with_suffix(".json.tmp")
tmp.write_text(json.dumps(payload, ...), encoding="utf-8")
os.replace(tmp, path)
```

That is atomic for a concurrent *reader*, which is what the name promises, but it is not durable. A power loss can make the rename durable while the bytes behind it are not, and each store has a specific way of losing:

**`.sdd/runtime/triggers/`** ends up with a zero-length `counters.json`. `_load`, twenty lines above the writer in the same file, answers an unparseable state file by quarantining it and raising `TriggerStateCorruptError`. The module spends real code handling exactly the corruption its own writer can produce.

**`.sdd/fleet/contexts/`** ends up with a truncated `active.json`. `_active_field` catches `JSONDecodeError` and returns `None`, so this reads as "no context active": the fleet silently falls back to four-layer precedence and resolves different effective settings, while the audit chain still holds the `fleet.context_activate` record. `ContextStore.activate` writes the audit event first so a live pointer always has its record; this is the inverse, a record with a dead pointer, and it is the one the missing fsync produces.

The fleet writer has a second problem. `path.with_suffix(".json.tmp")` is one fixed slot per target, and nothing in `ContextStore` takes a lock, so two concurrent activations can write the same temporary at once and publish a mix of both. That is against `activate`'s own docstring: "the pointer write is atomic, so an effective config resolution sees the context layer entirely or not at all."

The trigger store is not exposed to that second issue: every write there runs under `_exclusive_lock(self._root)`. Only the fsync applies to it.

## How

`write_atomic_bytes` (via `write_atomic_text`) supplies the four things the copies were missing or getting wrong:

1. a temporary name carrying the PID and four random bytes, so writers cannot collide
2. `fsync` of the file before the rename
3. `fsync` of the containing directory after it, so the rename itself is durable
4. `0o600`, which its docstring justifies for runtime state that "may carry task metadata, session tokens, or other material that should not be world-readable"

Point 4 is a behaviour change worth a reviewer's eye: both stores wrote `0644` before. Both live under `.sdd/` and are single-operator local state (`.sdd/runtime/triggers/`, and `.sdd/fleet/contexts` from `ctx_cmd.py`), so the tighter mode looks right, but say the word and I will keep the old mode instead.

The serialisation is byte-for-byte unchanged in both cases, so no existing file is rewritten differently.

## Scope

There are 17 hand-rolled `_atomic_write*` helpers under `src/`. This PR converts the two that skip `fsync` entirely, because those are the ones with a correctness bug. The rest (`approval/queue.py`, `chat/bindings.py`, `lineage/store.py`, `volunteer/budget.py` and others) use `mkstemp`/`NamedTemporaryFile` and do fsync the file; they only miss the directory fsync, which is a smaller and separable question. Happy to follow up on those if you want them collapsed too.

## Tests

Seven new tests, all failing on `main`:

`tests/unit/test_events_state_isolation.py`
- a counter write is fsynced before it is published
- an expectation write is fsynced before it is published
- a failed write leaves the previous counters readable
- a write leaves no temporary behind (passed before too, kept as a guard)

`tests/unit/fleet/test_fleet_context.py`
- the activation pointer is fsynced before it is published
- a context definition is fsynced before it is published
- two writers of one target do not share a temporary slot
- a failed write leaves the previous pointer intact
- writing leaves no temporary behind (passed before too)

The fsync tests spy on `os.fsync` for the duration of one store call, which is the defect stated directly rather than through a simulated power cut.

```
uv run pytest tests/unit/test_events_state_isolation.py tests/unit/fleet -q
182 passed, 3 failed
```

The three failures are `tests/unit/fleet/test_config.py::test_parse_minimal`, `::test_parse_explicit_name_and_url` and `::test_duplicate_names_flagged`, all failing identically on `main` in this checkout and untouched by this change.

## Checklist

- [x] `ruff check src/` passes
- [x] `pyright` reports the same 3 pre-existing errors across both modules as `main`, none new
- [x] `lint-imports` passes (3 contracts kept)
- [x] Release note fragment added: `docs/release-notes/fragments/atomic-state-writes.md`

### Documentation duty

- [x] N/A for README and `docs/operations/`: neither store's interface, file location or serialisation changes. The module docstring in `core/persistence/atomic_write.py` already documents the pattern these two now follow, and both local helpers gained a docstring naming the failure they used to allow.
- [x] N/A for `docs/api/` and `agents-md sync`: no new module, no public API or schema change.
