### PR TITLE
chore(ci): ratchet coverage baseline up to 84.59%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,8 +1,8 @@
 {
   "diff_coverage_floor_percent": 89,
-  "head_sha": "e0c98b3750ad34db49612f3e6909afea42f686c6",
-  "line_rate": 0.8449,
-  "run_id": "33774776359",
-  "total_coverage_percent": 84.49,
-  "updated_at": "2026-09-03T16:35:42+00:00"
+  "head_sha": "c18e88dc660e6a05ee1cb37f53bf4cb3f7f0fe53",
+  "line_rate": 0.8459,
+  "run_id": "33988006865",
+  "total_coverage_percent": 84.59,
+  "updated_at": "2026-09-05T20:28:41+00:00"
 }

--- a/tests/unit/test_claude_hook_url_uses_run_port.py
+++ b/tests/unit/test_claude_hook_url_uses_run_port.py
@@ -11,6 +11,7 @@ import json
 from pathlib import Path
 
 import pytest
+
 from bernstein.adapters.claude import ClaudeCodeAdapter
 
 

--- a/tests/unit/test_task_server_url_resolution.py
+++ b/tests/unit/test_task_server_url_resolution.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+
 from bernstein.core.agents.spawner_core import _render_auth_section, _resolve_task_server_url
 from bernstein.core.defaults import SDD_SERVER_PORT
 


### PR DESCRIPTION
Total line coverage rose on `main`, so the monotonic ratchet
bumped the committed high-water mark in `.coverage-baseline.json`
to **84.59%**.

Measured on `c18e88dc660e6a05ee1cb37f53bf4cb3f7f0fe53` from the
`coverage-report` artifact of CI run
[33988006865](https://github.com/sipyourdrink-ltd/bernstein/actions/runs/33988006865).
Those, and the raw Cobertura `line-rate` the percentage was
rounded from, are recorded in the baseline, so the number in the
diff can be re-derived from the file itself:

```bash
uv run python scripts/coverage_ratchet.py verify \
    --baseline .coverage-baseline.json --require-provenance
```

From here, any later push whose total coverage falls below this
mark is flagged by the LEVEL 2 ratchet. The gate stays advisory
until promoted; see `docs/operations/coverage-ratchet.md`.

Generated by `.github/workflows/coverage-ratchet.yml`.