### PR TITLE
fix(ci): pin the affected-test base to the run's base commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1871,17 +1871,26 @@ jobs:
       - uses: ./.github/actions/bootstrap
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Fetch base ref for impacted-test selection
+      - name: Fetch base commit for impacted-test selection
         if: github.event_name == 'pull_request' && runner.os != 'Windows'
         env:
-          BASE_REF: ${{ github.base_ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
+          # Fetch the base by sha, never by branch name. `github.base_ref`
+          # resolves when the step runs, and the shards of one run do not run
+          # together - slot contention has staggered them by hours. Each shard
+          # then compared against a different `main`, computed a different
+          # affected set, and `--shard i/N` partitioned a different list in
+          # each job, so the four slices stopped covering the union: some
+          # files ran twice and others ran nowhere while every shard reported
+          # success (#5421). The payload sha is fixed for the run, so every
+          # shard - at any start time, in any re-run attempt - selects from
+          # one list and the slices are a partition of it again.
           git fetch --no-tags --depth=1 origin \
-            "refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+            "${BASE_SHA}:refs/remotes/origin/pr-base"
       - name: Run isolated test suite (Linux/macOS)
         if: runner.os != 'Windows'
         env:
-          BASE_REF: ${{ github.base_ref }}
           EVENT_NAME: ${{ github.event_name }}
           PYTHON_VERSION: ${{ matrix.python-version }}
           SHARD: ${{ matrix.shard }}
@@ -1896,11 +1905,11 @@ jobs:
             coverage_args=(--coverage)
           fi
           if [ "${EVENT_NAME}" = "pull_request" ] && \
-             git rev-parse --verify "refs/remotes/origin/${BASE_REF}" >/dev/null 2>&1; then
+             git rev-parse --verify refs/remotes/origin/pr-base >/dev/null 2>&1; then
             uv run python scripts/run_tests.py --parallel 4 \
               "${coverage_args[@]}" \
               --shard "${SHARD}/${SHARD_COUNT}" \
-              --affected "refs/remotes/origin/${BASE_REF}"
+              --affected refs/remotes/origin/pr-base
           else
             uv run python scripts/run_tests.py --parallel 4 \
               "${coverage_args[@]}" \
@@ -2140,16 +2149,25 @@ jobs:
       - uses: ./.github/actions/bootstrap
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Fetch base ref for impacted-test selection
+      - name: Fetch base commit for impacted-test selection
         if: github.event_name == 'pull_request'
         env:
-          BASE_REF: ${{ github.base_ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
+          # Fetch the base by sha, never by branch name. `github.base_ref`
+          # resolves when the step runs, and the shards of one run do not run
+          # together - slot contention has staggered them by hours. Each shard
+          # then compared against a different `main`, computed a different
+          # affected set, and `--shard i/N` partitioned a different list in
+          # each job, so the four slices stopped covering the union: some
+          # files ran twice and others ran nowhere while every shard reported
+          # success (#5421). The payload sha is fixed for the run, so every
+          # shard - at any start time, in any re-run attempt - selects from
+          # one list and the slices are a partition of it again.
           git fetch --no-tags --depth=1 origin \
-            "refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+            "${BASE_SHA}:refs/remotes/origin/pr-base"
       - name: Run isolated test suite
         env:
-          BASE_REF: ${{ github.base_ref }}
           EVENT_NAME: ${{ github.event_name }}
           SHARD: ${{ matrix.shard }}
           SHARD_COUNT: ${{ env.MACOS_SHARD_COUNT }}
@@ -2159,10 +2177,10 @@ jobs:
           # across all 4 cells, so per-push macOS coverage is the
           # complete suite rather than a fixed quarter of it.
           if [ "${EVENT_NAME}" = "pull_request" ] && \
-             git rev-parse --verify "refs/remotes/origin/${BASE_REF}" >/dev/null 2>&1; then
+             git rev-parse --verify refs/remotes/origin/pr-base >/dev/null 2>&1; then
             uv run python scripts/run_tests.py --parallel 4 \
               --shard "${SHARD}/${SHARD_COUNT}" \
-              --affected "refs/remotes/origin/${BASE_REF}"
+              --affected refs/remotes/origin/pr-base
           else
             uv run python scripts/run_tests.py --parallel 4 \
               --shard "${SHARD}/${SHARD_COUNT}"

--- a/docs/release-notes/fragments/affected-test-base-pinned-to-run.md
+++ b/docs/release-notes/fragments/affected-test-base-pinned-to-run.md
@@ -1,0 +1,21 @@
+## Sharded pull-request test lanes compare against a pinned base commit
+
+Each shard of the pull-request test lane resolved its own comparison base from
+the base branch name and re-ran the impacted-test selector itself. `--shard i/N`
+partitions whatever list it is handed, so the shards only cover the whole
+affected set when every shard computed the same list, and nothing enforced
+that. Runner-slot contention routinely staggers the shards of one run by hours;
+when the base branch advanced in between, the late shard compared against a
+different commit, selected a different set, and the slices stopped covering
+their union -- some files ran twice while others ran in no shard at all, with
+every shard still reporting success. A test importing a changed module could
+therefore be skipped by the pull-request lane and only fail later in the
+merge-queue lane, which runs the suite in full.
+
+Both sharded lanes now fetch the base commit named on the event payload and
+compare against that sha. The payload is fixed for the run, so every shard --
+whatever time it starts, and in any re-run attempt -- selects from one list and
+the slices are a partition of it again. Because the pinned sha is the commit the
+pull-request merge was computed against, the selection is also the change's own
+diff rather than the accumulated difference between two branch tips, so the
+lane selects a smaller and more accurate set of tests.

--- a/tests/unit/fleet/test_fleet_context.py
+++ b/tests/unit/fleet/test_fleet_context.py
@@ -249,9 +249,7 @@ def test_writing_leaves_no_temporary_behind(tmp_path: Path) -> None:
     assert [p.name for p in root.iterdir() if ".tmp" in p.name] == []
 
 
-def test_concurrent_writers_do_not_share_one_temporary_slot(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_concurrent_writers_do_not_share_one_temporary_slot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Nothing here holds a lock, so the temporary name must be per-writer.
 
     ``path.with_suffix(".json.tmp")`` gave every writer of one target the
@@ -280,9 +278,7 @@ def test_concurrent_writers_do_not_share_one_temporary_slot(
     assert temporaries[0] != temporaries[1]
 
 
-def test_a_failed_write_leaves_the_previous_pointer_intact(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_a_failed_write_leaves_the_previous_pointer_intact(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     project = tmp_path / "proj"
     project.mkdir()
     store = _store(project, _chain(tmp_path))

--- a/tests/unit/scripts/test_run_tests_affected_base_pinned.py
+++ b/tests/unit/scripts/test_run_tests_affected_base_pinned.py
@@ -1,0 +1,158 @@
+"""The affected-test base must be a run-pinned commit, not a moving branch ref.
+
+Every shard of one CI run selects its own slice with
+``run_tests.py --shard i/N --affected <base>``. ``--shard`` partitions whatever
+list it is handed, so the shards cover the whole affected set only when all of
+them computed the *same* list. Nothing in the runner enforces that: each shard
+resolves the base and re-runs the selector on its own.
+
+That held only while the shards started together. Runner-slot contention broke
+it: on one pull request shards 2-4 started at 21:28 and shard 1 at 23:47, and
+the commit they each resolved from the base *branch* had moved six commits in
+between. The two groups partitioned two different lists, so 267 files ran twice
+and 596 ran in no shard at all - among them a test importing the changed
+module, which the merge-queue lane then failed on. All four shards had reported
+success.
+
+Taking the base from a commit sha carried on the event payload removes the race
+by construction: the payload is fixed for the run, so every shard - whatever
+time it starts, and in any re-run attempt - selects from one list and the
+slices are a partition of it again. The guards below pin that both sharded
+lanes take their base from that sha, that neither reaches for a ref that can
+move under them, and that the ref written by the fetch is the ref the selector
+is actually pointed at.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+# The event-payload field naming the base commit. Unlike ``github.base_ref`` -
+# a branch name, resolved whenever the step happens to run - this is a sha
+# fixed when the event was created, so two shards of one run cannot disagree
+# about it.
+PINNED_BASE_EXPRESSION = "github.event.pull_request.base.sha"
+
+# A branch name, and therefore a base that can move between two shards of one
+# run. Naming it in an affected lane is the regression this module exists for.
+MOVING_BASE_EXPRESSION = "github.base_ref"
+
+# The fetch step both lanes use to put the base commit in the local repository.
+# Matched on its name so the guard keeps its subject even when the refspec is
+# rewritten - which is exactly the edit it has to catch.
+FETCH_STEP_NAME_MARKER = "impacted-test selection"
+
+
+def _ci_jobs() -> dict[str, Any]:
+    """Return the job table of the main CI workflow."""
+    yaml = pytest.importorskip("yaml", reason="pyyaml is required to read the workflow")
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "ci.yml has no jobs table"
+    return jobs
+
+
+def _steps(job: object) -> list[dict[str, Any]]:
+    """Return the step list of a job, tolerating a malformed entry."""
+    if not isinstance(job, dict):
+        return []
+    return [step for step in (job.get("steps") or []) if isinstance(step, dict)]
+
+
+def _env_values(step: dict[str, Any]) -> list[str]:
+    """Return the values a step sets in its own ``env`` block."""
+    env = step.get("env")
+    return [str(value) for value in env.values()] if isinstance(env, dict) else []
+
+
+def _affected_lanes() -> dict[str, tuple[dict[str, Any], dict[str, Any]]]:
+    """Return ``{job id: (base-fetch step, --affected run step)}`` for each lane.
+
+    A lane that runs ``--affected`` without exactly one matching fetch step is
+    reported as a failure rather than skipped: the guard would otherwise go
+    quiet on the very edit that moves the base somewhere it cannot see.
+    """
+    lanes: dict[str, tuple[dict[str, Any], dict[str, Any]]] = {}
+    for job_id, job in _ci_jobs().items():
+        steps = _steps(job)
+        run_steps = [s for s in steps if isinstance(s.get("run"), str) and "--affected" in s["run"]]
+        if not run_steps:
+            continue
+        fetch_steps = [s for s in steps if FETCH_STEP_NAME_MARKER in str(s.get("name", ""))]
+        assert len(fetch_steps) == 1, (
+            f"job {job_id!r} runs --affected but has {len(fetch_steps)} steps named "
+            f"{FETCH_STEP_NAME_MARKER!r}; the guard cannot tell where its base comes from"
+        )
+        assert len(run_steps) == 1, f"job {job_id!r} has {len(run_steps)} --affected steps"
+        lanes[job_id] = (fetch_steps[0], run_steps[0])
+    return lanes
+
+
+@pytest.fixture(scope="module")
+def affected_lanes() -> dict[str, tuple[dict[str, Any], dict[str, Any]]]:
+    """Return the sharded lanes that select their tests with ``--affected``."""
+    lanes = _affected_lanes()
+    assert lanes, "no ci.yml job runs run_tests.py --affected; this guard has lost its subject"
+    return lanes
+
+
+def test_base_is_fetched_from_the_pinned_event_sha(
+    affected_lanes: dict[str, tuple[dict[str, Any], dict[str, Any]]],
+) -> None:
+    """Each lane fetches its base from the sha carried on the event payload."""
+    for job_id, (fetch_step, _) in affected_lanes.items():
+        assert any(PINNED_BASE_EXPRESSION in value for value in _env_values(fetch_step)), (
+            f"job {job_id!r} does not fetch its affected base from {PINNED_BASE_EXPRESSION}; "
+            "a base that is not pinned to the run lets two shards select different lists"
+        )
+
+
+@pytest.mark.parametrize("half", [0, 1], ids=["fetch-step", "run-step"])
+def test_no_step_of_an_affected_lane_reads_the_base_branch_name(
+    affected_lanes: dict[str, tuple[dict[str, Any], dict[str, Any]]],
+    half: int,
+) -> None:
+    """Neither half of a lane derives its base from a ref that can move mid-run."""
+    for job_id, steps in affected_lanes.items():
+        offenders = [v for v in _env_values(steps[half]) if MOVING_BASE_EXPRESSION in v]
+        assert not offenders, (
+            f"job {job_id!r} takes its affected base from {MOVING_BASE_EXPRESSION} "
+            f"({offenders}); a shard scheduled hours later resolves a different commit "
+            "and partitions a different list, so files fall out of every shard"
+        )
+
+
+def test_base_is_not_fetched_from_a_branch_head(
+    affected_lanes: dict[str, tuple[dict[str, Any], dict[str, Any]]],
+) -> None:
+    """The base fetch names a commit, not the current head of a branch."""
+    for job_id, (fetch_step, _) in affected_lanes.items():
+        assert "refs/heads/" not in fetch_step["run"], (
+            f"job {job_id!r} fetches a branch head for its affected base; fetch the pinned "
+            "sha instead so every shard of the run compares against the same commit"
+        )
+
+
+def test_selector_is_pointed_at_the_ref_the_fetch_writes(
+    affected_lanes: dict[str, tuple[dict[str, Any], dict[str, Any]]],
+) -> None:
+    """``--affected`` names the ref the base fetch created, so the two cannot drift.
+
+    Half a migration - a fetch writing one ref while the selector still reads
+    another - leaves the lane comparing against whatever the old ref happens to
+    hold, which is the same silent-wrong-base failure in a new shape.
+    """
+    for job_id, (fetch_step, run_step) in affected_lanes.items():
+        written = re.findall(r":(refs/remotes/\S+?)\"", fetch_step["run"])
+        assert len(written) == 1, f"job {job_id!r}: expected the base fetch to write exactly one ref, found {written}"
+        assert f"--affected {written[0]}" in run_step["run"], (
+            f"job {job_id!r} fetches the base into {written[0]} but does not pass that ref to "
+            "--affected; the selector would compare against a ref nothing in this job wrote"
+        )

--- a/tests/unit/test_constraint_manifest.py
+++ b/tests/unit/test_constraint_manifest.py
@@ -79,7 +79,10 @@ class TestConstraintLayerRejection:
         decision = gate.route(proposal)
 
         assert decision.outcome == ApprovalOutcome.BLOCKED
-        assert decision.reason == "Proposal targets constraint layer / locked file(s): src/bernstein/core/security/audit.py"
+        assert (
+            decision.reason
+            == "Proposal targets constraint layer / locked file(s): src/bernstein/core/security/audit.py"
+        )
         assert decision.requires_human is True
 
         # Verify audit record was written to decisions.jsonl
@@ -128,11 +131,7 @@ class TestCodeownersDrift:
         # Each entry in manifest must match at least one codeowner pattern
         for entry in CONSTRAINT_MANIFEST:
             norm_entry = entry.lstrip("/")
-            matched = any(
-                norm_entry.startswith(p.rstrip("*"))
-                or p == "*"
-                for p in owner_patterns
-            )
+            matched = any(norm_entry.startswith(p.rstrip("*")) or p == "*" for p in owner_patterns)
             assert matched, f"Constraint manifest entry {entry!r} not covered by any pattern in {owner_patterns}"
 
     def test_every_hash_locked_module_in_manifest(self) -> None:
@@ -174,19 +173,30 @@ class TestNoBehaviorChangeOutsideManifest:
         gate = ApprovalGate(decisions_dir=tmp_path / "evolution")
 
         # L0 config auto-approved
-        l0 = _make_proposal(id="L0-safe", risk_level=RiskLevel.L0_CONFIG, target_files=[".sdd/config.yaml"], confidence=0.98)
+        l0 = _make_proposal(
+            id="L0-safe", risk_level=RiskLevel.L0_CONFIG, target_files=[".sdd/config.yaml"], confidence=0.98
+        )
         assert gate.route(l0).outcome == ApprovalOutcome.AUTO_APPROVED
 
         # L1 template auto-approved
-        l1 = _make_proposal(id="L1-safe", risk_level=RiskLevel.L1_TEMPLATE, target_files=["templates/roles/backend.md"], confidence=0.98)
+        l1 = _make_proposal(
+            id="L1-safe", risk_level=RiskLevel.L1_TEMPLATE, target_files=["templates/roles/backend.md"], confidence=0.98
+        )
         assert gate.route(l1).outcome == ApprovalOutcome.AUTO_APPROVED
 
         # L2 logic human review
-        l2 = _make_proposal(id="L2-safe", risk_level=RiskLevel.L2_LOGIC, target_files=[".sdd/config/routing.yaml"], confidence=0.98)
+        l2 = _make_proposal(
+            id="L2-safe", risk_level=RiskLevel.L2_LOGIC, target_files=[".sdd/config/routing.yaml"], confidence=0.98
+        )
         assert gate.route(l2).outcome == ApprovalOutcome.HUMAN_REVIEW_4H
 
         # L3 structural blocked with standard L3 message
-        l3 = _make_proposal(id="L3-safe", risk_level=RiskLevel.L3_STRUCTURAL, target_files=["src/bernstein/core/models.py"], confidence=0.98)
+        l3 = _make_proposal(
+            id="L3-safe",
+            risk_level=RiskLevel.L3_STRUCTURAL,
+            target_files=["src/bernstein/core/models.py"],
+            confidence=0.98,
+        )
         d3 = gate.route(l3)
         assert d3.outcome == ApprovalOutcome.BLOCKED
         assert "L3_STRUCTURAL changes require human-only review" in d3.reason

--- a/tests/unit/test_cross_platform_ci.py
+++ b/tests/unit/test_cross_platform_ci.py
@@ -138,20 +138,29 @@ class TestCIWorkflowExists:
                 f"docs_pattern={docs_pattern}, observability_pattern={observability_pattern}"
             )
 
-    def test_pull_request_test_job_fetches_base_ref_for_impacted_tests(self) -> None:
+    def test_pull_request_test_job_fetches_base_commit_for_impacted_tests(self) -> None:
+        """The base is fetched by sha, so shards that start apart still agree.
+
+        The shards of one run are not scheduled together - slot contention has
+        staggered them by hours - and each one resolves this base and re-runs
+        the selector itself. A base branch *name* therefore resolves to
+        different commits in different shards, which makes each shard partition
+        a different affected set; see
+        ``tests/unit/scripts/test_run_tests_affected_base_pinned.py``.
+        """
         data = _load_ci_workflow()
         steps = _ci_test_steps(data)
-        fetch_steps = [step for step in steps if step.get("name") == "Fetch base ref for impacted-test selection"]
+        fetch_steps = [step for step in steps if step.get("name") == "Fetch base commit for impacted-test selection"]
         assert len(fetch_steps) == 1
         fetch_step = fetch_steps[0]
         assert fetch_step.get("if") == "github.event_name == 'pull_request' && runner.os != 'Windows'"
         env = fetch_step.get("env") or {}
-        assert env.get("BASE_REF") == "${{ github.base_ref }}", (
-            "BASE_REF must be bound via env: to avoid template injection (zizmor)"
+        assert env.get("BASE_SHA") == "${{ github.event.pull_request.base.sha }}", (
+            "BASE_SHA must be bound via env: to avoid template injection (zizmor)"
         )
         run_script = fetch_step.get("run", "")
-        assert "refs/heads/${BASE_REF}" in run_script
-        assert "refs/remotes/origin/${BASE_REF}" in run_script
+        assert "${BASE_SHA}:refs/remotes/origin/pr-base" in run_script
+        assert "refs/heads/" not in run_script
 
     def test_pull_request_test_job_uses_affected_runner_with_fallback(self) -> None:
         data = _load_ci_workflow()
@@ -162,12 +171,12 @@ class TestCIWorkflowExists:
         unix_steps = [step for step in run_steps if "Linux/macOS" in (step.get("name") or "")]
         assert len(unix_steps) == 1
         env = unix_steps[0].get("env") or {}
-        assert env.get("BASE_REF") == "${{ github.base_ref }}", (
-            "BASE_REF must be bound via env: to avoid template injection (zizmor)"
+        assert env.get("EVENT_NAME") == "${{ github.event_name }}", (
+            "EVENT_NAME must be bound via env: to avoid template injection (zizmor)"
         )
+        assert "BASE_REF" not in env, "the affected base must come from the run-pinned base sha, not a branch name"
         run_script = unix_steps[0].get("run", "")
-        assert "--affected" in run_script
-        assert "refs/remotes/origin/${BASE_REF}" in run_script
+        assert "--affected refs/remotes/origin/pr-base" in run_script
         assert "uv run python scripts/run_tests.py" in run_script
         assert "--parallel 4" in run_script
 

--- a/tests/unit/test_events_state_isolation.py
+++ b/tests/unit/test_events_state_isolation.py
@@ -127,9 +127,7 @@ def _fsync_spy(monkeypatch: pytest.MonkeyPatch) -> list[int]:
     return seen
 
 
-def test_a_counter_write_is_fsynced_before_it_is_published(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_a_counter_write_is_fsynced_before_it_is_published(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A rename that outlives its own bytes is what _load quarantines.
 
     The write path used to rename the temporary into place without ever
@@ -160,9 +158,7 @@ def test_a_write_leaves_no_temporary_behind(tmp_path: Path) -> None:
     assert [p.name for p in root.iterdir() if ".tmp" in p.name] == []
 
 
-def test_a_failed_write_leaves_the_previous_counters_readable(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_a_failed_write_leaves_the_previous_counters_readable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """The point of temp-and-rename: a failure loses the update, not the file."""
     root = tmp_path / ".sdd" / "runtime" / "triggers"
     store = TriggerStateStore(root)


### PR DESCRIPTION
## Defect

Each shard of the sharded pull-request test lanes (`test`, `test-macos`) resolved its own comparison base from the base branch *name* and re-ran the impacted-test selector itself. `--shard i/N` partitions whatever list it is handed, so the shards only cover the whole affected set when every shard computed the same list — and nothing enforced that.

Runner-slot contention routinely staggers the shards of one run. When the base branch advanced in between, the late shard resolved a different commit, selected a different set, and the four slices stopped covering their union: some files ran in two shards, others ran in none, and every shard still reported success.

Worked example, from a run whose four shard logs are still readable:

| | shards 2–4 | shard 1 |
|---|---|---|
| started | 21:28 | 23:47 (same attempt) |
| `origin/main` resolved to | `1611d8e3` | `fd08e0ab` (6 commits later) |
| affected set computed | 1386 files | 1827 files |

The two groups partitioned two different lists. Result: 267 files ran twice, 596 ran in no shard at all. One of the 596 imported the module the change touched and failed — the merge-queue lane, which runs the suite in full, caught it after the pull-request lane had gone green.

The blow-up is amplified by the checkout being shallow: `fetch-depth: 1` plus a `--depth=1` base fetch leaves no merge base, so `git diff base...HEAD` exits 128 and `scripts/test_impact.py` falls back to the two-dot form. Two-dot compares the two *trees*, so every commit landing on the base branch after the merge ref was computed enters the changed-file set in reverse — which is why a 7-file change selected 1498 test files, and why the set moved as the branch moved. `ci.yml` already records this hazard for another job (`# Using --depth=1 here previously caused ... merge-base diffs to fail`); the sharded lanes never got the same treatment.

## Change

Both lanes fetch `github.event.pull_request.base.sha` into `refs/remotes/origin/pr-base` and compare against that sha. The payload is fixed for the run, so every shard — at any start time, in any re-run attempt — selects from one list and the slices are a partition of it again.

The pinned sha is also the commit the pull-request merge was computed against, so the comparison is the change's own diff. Replaying the same run against the pinned base:

- affected set is **203 files, identical** under both base tips the shards saw;
- the four buckets are a true partition (47 + 51 + 53 + 52 = 203 = union);
- the test that only the merge queue caught is owned by shard 4, so the pull-request lane would have failed on it.

Selecting the change's own diff rather than the difference between two branch tips also makes the lane smaller and more accurate (203 files rather than 1498).

## Tests

`tests/unit/scripts/test_run_tests_affected_base_pinned.py` pins that both lanes take their base from the run-pinned sha, that neither half of a lane reaches for a branch name, and that the ref the fetch writes is the ref the selector is pointed at (so a half-migration cannot leave the lane reading a stale ref). Verified failing on the pre-change workflow — all five fail — and passing after.

`tests/unit/test_cross_platform_ci.py` pinned the previous shape and is updated to the new one, keeping its `env:`-binding assertion so the sha still cannot be interpolated into the shell body.

## Verification

- `run_tests.py --affected HEAD` over this change: 91 passed, 0 failed, 1 collected nothing (`tests/integration/cluster/test_real_2node.py`, unchanged by this branch).
- `ruff check` / `ruff format --check` clean on both test files; `actionlint .github/workflows/ci.yml` clean, same as before the change.

## Known residual

`actions/checkout` still resolves `refs/pull/N/merge`, which GitHub can recompute when the base branch moves, so `HEAD` itself is not pinned to the run. It did not drift in the run above — all four shards checked out the same merge commit across the 2h19m stagger — and it is a separate change with its own trade-off (a pinned `github.sha` can be garbage-collected), so it is left alone here.