### PR TITLE
fix(tests): pin evidence-envelope golden vectors to their exact bytes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -29,3 +29,11 @@ tests/fixtures/trust-record-vectors/*.pem -text
 tests/fixtures/agent-card-utf16-vector/*.json -text
 tests/fixtures/agent-card-utf16-vector/*.pem -text
 tests/fixtures/agent-card-utf16-vector/*.sha256 -text
+
+# Evidence-envelope vectors: same byte-exact rule as the three vector sets
+# above. The RFC 8785 canonicalisation, its detached signature and the
+# `.sha256` sidecar are all compared as raw bytes, so no checkout may
+# translate line endings in them.
+tests/fixtures/evidence-envelope-vectors/*.json -text
+tests/fixtures/evidence-envelope-vectors/*.pem -text
+tests/fixtures/evidence-envelope-vectors/*.sha256 -text

--- a/docs/release-notes/fragments/5504-evidence-envelope-vector-line-endings.md
+++ b/docs/release-notes/fragments/5504-evidence-envelope-vector-line-endings.md
@@ -1,0 +1,12 @@
+## Evidence-envelope golden vectors are pinned to their exact bytes
+
+`tests/fixtures/evidence-envelope-vectors/` holds the RFC 8785 canonical
+JSON, the detached signature key and the `.sha256` sidecar that pin the
+evidence-envelope format, and all three are compared as raw bytes. They
+carried no `.gitattributes` rule, so a checkout with line-ending translation
+enabled - the Windows default - could rewrite them on the way to disk and
+fail the comparison against a file that is byte-correct in the repository.
+
+The three sibling vector sets (`receipt-vectors`, `trust-record-vectors`,
+`agent-card-utf16-vector`) already declare `-text` for exactly this reason;
+`evidence-envelope-vectors` now does too.


### PR DESCRIPTION
**Rescoped.** The RFC 8785 canonicalisation this PR originally carried landed on `main` on 2026-09-06 (`fix(compliance): digest evidence packs with the RFC 8785 (JCS)…`), and #5504 is closed as completed. `main`'s `_canonical_json` already delegates to `canonical_envelope_bytes`, with a fuller docstring than this branch had.

One piece did **not** land with it, and this PR is now only that piece.

## The gap

`tests/fixtures/evidence-envelope-vectors/` holds byte-exact golden vectors — the canonical JSON, the signing key, and a `.sha256` sidecar — but carries no `.gitattributes` rule. The three sibling vector sets all do:

```
tests/fixtures/receipt-vectors/*.json        -text
tests/fixtures/trust-record-vectors/*.json   -text
tests/fixtures/agent-card-utf16-vector/*.json -text
```

There is no `text=auto` catch-all, so the newest vector set is the only unprotected one:

```
$ git check-attr text -- tests/fixtures/evidence-envelope-vectors/partial-coverage-envelope.json
  text: unspecified          # before
$ git check-attr text -- tests/fixtures/receipt-vectors/x.json
  text: unset                # the sibling, protected
```

A checkout with line-ending translation enabled — the Windows default — can rewrite a vector that is byte-correct in the repository, and the raw-byte comparison then fails against a file nobody edited.

## The change

Declares `-text` for the three extensions, matching the existing rule verbatim. After:

```
$ git check-attr text -- tests/fixtures/evidence-envelope-vectors/partial-coverage-envelope.json
  text: unset
```

Two files, twenty lines, no source change. Release-note fragment included.
