### PR TITLE
fix(quality): select directory-scanning guards from the diffs they cover

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -473,3 +473,43 @@ Alias resolution feeds the cached `imports` lists, so changing it means
 bumping `_ANALYZER_CACHE_VERSION` and `_COMPAT_CACHE_VERSION` in
 `src/bernstein/core/quality/test_impact.py`. File hashes alone will not
 invalidate a map whose edges were derived under the old rule.
+
+### Guards that scan a directory must declare the tree
+
+A structural guard reads its subject instead of importing it, so the
+import graph has no edge to offer. For a guard that reads a *named*
+file the selector recovers one anyway: `extract_path_literals` harvests
+the paths a test writes, and reading `AGENTS.md` is what makes the
+guard name it.
+
+A guard that walks a *directory* names nothing a changed path can
+match. It holds a root assembled from segments
+(`REPO_ROOT / "src" / "bernstein"`) and passes `"*.py"` to `rglob`, and
+neither half is a repo path. `test_cast_alias_form` fails on any new
+module under `src/bernstein` that declares a string-valued cast alias,
+and before this edge existed no diff selected it - so such a PR went
+green in its own lane and failed for the first time in the merge queue,
+where the failure blocks every entry behind it.
+
+Such a guard declares the tree it walks as a module-level
+`SCANNED_TREE` (or `SCANNED_TREES` for several), spelled repo-relative,
+and drives its own scan from that constant so the two cannot drift:
+
+```python
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCANNED_TREE = "src/bernstein/**/*.py"
+
+for path in sorted(REPO_ROOT.glob(SCANNED_TREE)):
+    ...
+```
+
+The declaration is deliberate rather than inferred. Harvesting every
+glob-shaped string was measured first and rejected: `"src/*.py"` is
+fixture data in eight tests here, and honouring those bound thirteen
+unrelated tests to every change under `src`, a set that would grow
+silently as fixtures are added. Matching is `fnmatch` against every
+suffix of the changed path, so `*` crosses `/` and `**/` also matches
+zero directories, the way `Path.glob` treats it.
+
+This edge feeds the cached map, so changing it means bumping
+`_COMPAT_CACHE_VERSION` for the same reason alias resolution does.

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -511,5 +511,14 @@ silently as fixtures are added. Matching is `fnmatch` against every
 suffix of the changed path, so `*` crosses `/` and `**/` also matches
 zero directories, the way `Path.glob` treats it.
 
+Declaring a tree puts the guard on every PR that touches it, so a
+whole-tree guard has to be cheap. Build the index once with
+`@lru_cache(maxsize=1)` rather than per test: `test_token_orphans`,
+`test_orchestration_reachability` and `test_security_controls_are_wired`
+each re-parsed `src`, `tests` and `scripts` on every call, and caching
+the three of them cut about two minutes off a PR that touches `src`.
+Return an immutable or plain-`dict` value from a cached builder - a
+`defaultdict` that escapes a cache inserts on lookup.
+
 This edge feeds the cached map, so changing it means bumping
 `_COMPAT_CACHE_VERSION` for the same reason alias resolution does.

--- a/src/bernstein/core/quality/test_impact.py
+++ b/src/bernstein/core/quality/test_impact.py
@@ -12,6 +12,7 @@ import json
 import logging
 from contextlib import suppress
 from dataclasses import dataclass
+from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import Any, cast
 
@@ -25,7 +26,7 @@ logger = logging.getLogger(__name__)
 # every existing entry potentially short of edges even though its file hashes
 # still match.
 _ANALYZER_CACHE_VERSION = "4"
-_COMPAT_CACHE_VERSION = "5"
+_COMPAT_CACHE_VERSION = "6"
 _WORKFLOW_PATH_PREFIX = ".github/workflows/"
 
 # Upper bound on a harvested path literal. Long strings in a test are prose,
@@ -234,6 +235,53 @@ def extract_path_literals(path: Path) -> set[str]:
     }
 
 
+#: Module-level name a test binds to declare the tree it walks. A leading
+#: underscore is ignored so a module can keep its own naming convention.
+_SCANNED_TREE_NAMES = frozenset({"SCANNED_TREE", "SCANNED_TREES"})
+
+
+def extract_scanned_trees(path: Path) -> set[str]:
+    """Return the globs a test declares as the trees it scans.
+
+    ``extract_path_literals`` recovers an edge for a guard that reads a named
+    file, because reading it is what makes the guard name it. A guard that
+    walks a *directory* names no such thing: it holds a root built from path
+    segments and passes ``"*.py"`` to ``rglob``, and neither half is a repo
+    path that any changed file can match.
+
+    Harvesting anything glob-shaped instead of a declaration was measured and
+    rejected. Test files are full of glob-shaped fixture data -- ``"src/*.py"``
+    appears in eight tests as an argument to a path-matching rule under test --
+    and honouring those bound thirteen unrelated tests to every change under
+    ``src``. Worse, the set grows silently: adding a fixture string would
+    enrol a test in a tree it never reads.
+
+    So this edge is declared. The cost is that a new scanning guard has to say
+    what it scans; the guard is already writing the glob, and binding the scan
+    to the declared name keeps the two from drifting apart.
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return set()
+
+    declared: set[str] = set()
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id.lstrip("_") in _SCANNED_TREE_NAMES for target in node.targets
+        ):
+            continue
+        values: list[ast.expr] = list(node.value.elts) if isinstance(node.value, ast.List | ast.Tuple) else [node.value]
+        declared.update(
+            value.value.strip().strip("/")
+            for value in values
+            if isinstance(value, ast.Constant) and isinstance(value.value, str) and value.value.strip()
+        )
+    return declared
+
+
 def _string_dict_literal(node: ast.expr) -> dict[str, str]:
     """Return the ``str -> str`` pairs of a dict literal, ignoring the rest."""
     if not isinstance(node, ast.Dict):
@@ -355,6 +403,7 @@ def build_compat_dep_map(
                 "hash": _file_hash(test_file),
                 "imports": sorted(resolve_module_aliases(extract_project_imports(test_file, prefixes), aliases)),
                 "paths": sorted(extract_path_literals(test_file)),
+                "globs": sorted(extract_scanned_trees(test_file)),
             }
 
     source_imports: dict[str, dict[str, Any]] = {}
@@ -491,6 +540,18 @@ def _build_path_to_tests_map(test_deps: dict[str, object]) -> dict[str, set[str]
     return path_to_tests
 
 
+def _build_glob_to_tests_map(test_deps: dict[str, object]) -> dict[str, set[str]]:
+    """Build a reverse map from a declared scan glob to the tests declaring it."""
+    glob_to_tests: dict[str, set[str]] = {}
+    for test_rel, entry in test_deps.items():
+        if not isinstance(entry, dict):
+            continue
+        entry_dict = cast("_JsonObject", entry)
+        for glob in _normalize_string_list(entry_dict.get("globs", [])):
+            glob_to_tests.setdefault(glob, set()).add(test_rel)
+    return glob_to_tests
+
+
 def _path_match_keys(rel_path: str) -> set[str]:
     """Return every suffix of ``rel_path`` a test could have written.
 
@@ -503,15 +564,41 @@ def _path_match_keys(rel_path: str) -> set[str]:
     return {"/".join(parts[index:]) for index in range(len(parts))}
 
 
+def _glob_match_patterns(literal: str) -> tuple[str, ...]:
+    """Return the ``fnmatch`` patterns a declared scan glob stands for.
+
+    ``**/`` matches zero directories for ``pathlib.Path.glob`` but not for
+    ``fnmatch``, so ``src/bernstein/**/*.py`` would cover every nested module
+    and silently miss the three that sit directly in the package. Emitting the
+    collapsed pattern alongside the written one lets a guard declare the exact
+    string it passes to ``glob()`` and be selected for everything that string
+    actually walks.
+
+    Note that ``*`` crosses ``/`` under ``fnmatch``, so ``src/bernstein/*.py``
+    also matches nested modules. The error direction is a guard that runs with
+    nothing to check, which is the trade the suffix-key rule already makes.
+    """
+    return tuple(dict.fromkeys((literal, literal.replace("**/", ""))))
+
+
 def _tests_reading_changed_paths(
     changed_files: list[str],
     path_to_tests: dict[str, set[str]],
+    glob_to_tests: dict[str, set[str]],
 ) -> set[str]:
-    """Return tests that name any changed path as a string literal."""
+    """Return tests that name any changed path, by literal or by declared glob."""
     affected: set[str] = set()
+    globs = [(_glob_match_patterns(glob), tests) for glob, tests in glob_to_tests.items()]
     for rel_path in changed_files:
-        for key in _path_match_keys(rel_path):
+        keys = _path_match_keys(rel_path)
+        for key in keys:
             affected.update(path_to_tests.get(key, set()))
+        # Case-sensitive matching: git reports posix paths, while ``fnmatch``
+        # folds case against the host's rules, so an index built on macOS and
+        # one built in CI would otherwise not select the same tests.
+        for patterns, tests in globs:
+            if tests - affected and any(fnmatchcase(key, pattern) for pattern in patterns for key in keys):
+                affected.update(tests)
     return affected
 
 
@@ -679,7 +766,13 @@ def compat_get_affected_tests(
     # import graph has no edge to offer for them. Selecting on the paths a test
     # names is what puts a markdown, INI or registry-parsing guard in front of
     # the diff that breaks it, rather than on main after the merge.
-    affected_tests.update(_tests_reading_changed_paths(changed_files, _build_path_to_tests_map(test_deps)))
+    affected_tests.update(
+        _tests_reading_changed_paths(
+            changed_files,
+            _build_path_to_tests_map(test_deps),
+            _build_glob_to_tests_map(test_deps),
+        )
+    )
     # A generated file is named by the module that generates it, not by the
     # guard that checks it. The tests bound directly to that module are the ones
     # that can notice; its transitive importers cannot, so this edge stops at

--- a/tests/unit/test_cast_alias_form.py
+++ b/tests/unit/test_cast_alias_form.py
@@ -36,7 +36,10 @@ import ast
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-SOURCE_ROOT = REPO_ROOT / "src" / "bernstein"
+#: The tree this guard walks, spelled as a repo-relative glob. A guard that
+#: scans a directory imports nothing from it, so this literal is the only
+#: edge the affected-test selector can bind a change inside the tree to.
+SCANNED_TREE = "src/bernstein/**/*.py"
 
 #: Module-level assignments whose name marks them as a cast target.
 _CAST_PREFIX = "_CAST_"
@@ -63,7 +66,7 @@ def _string_valued_cast_aliases(tree: ast.Module) -> list[tuple[str, int]]:
 def test_no_cast_alias_is_declared_as_a_string() -> None:
     """A string here type-checks as `str`, so every cast through it is untyped."""
     offenders: list[str] = []
-    for path in sorted(SOURCE_ROOT.rglob("*.py")):
+    for path in sorted(REPO_ROOT.glob(SCANNED_TREE)):
         try:
             tree = ast.parse(path.read_text(encoding="utf-8"))
         except SyntaxError:  # pragma: no cover - a parse failure is another test's problem

--- a/tests/unit/test_core_has_no_directory_vendor_sdk.py
+++ b/tests/unit/test_core_has_no_directory_vendor_sdk.py
@@ -14,7 +14,11 @@ import ast
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-CORE_ROOT = REPO_ROOT / "src" / "bernstein" / "core"
+#: The tree this guard walks, spelled as a repo-relative glob. A guard that
+#: scans a directory imports nothing from it, so this literal is the only
+#: edge the affected-test selector can bind a change inside the tree to.
+SCANNED_TREE = "src/bernstein/core/**/*.py"
+CORE_ROOT = REPO_ROOT / SCANNED_TREE.split("/**/", 1)[0]
 
 #: Top-level distributions that speak a specific identity directory or IdP.
 #: Adapters may depend on these; core may not. Cloud-storage and secret-store

--- a/tests/unit/test_docs_url_hygiene.py
+++ b/tests/unit/test_docs_url_hygiene.py
@@ -12,14 +12,18 @@ from __future__ import annotations
 
 from pathlib import Path
 
-_SRC = Path(__file__).resolve().parents[2] / "src" / "bernstein"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+#: The tree this guard walks, spelled as a repo-relative glob. A guard that
+#: scans a directory imports nothing from it, so this literal is the only
+#: edge the affected-test selector can bind a change inside the tree to.
+_SCANNED_TREE = "src/bernstein/**/*.py"
 
 _DEAD_DOCS_HOST = "chernistry.github.io"
 
 
 def _dead_link_sites() -> list[str]:
     hits: list[str] = []
-    for py in _SRC.rglob("*.py"):
+    for py in _REPO_ROOT.glob(_SCANNED_TREE):
         try:
             text = py.read_text(encoding="utf-8")
         except UnicodeDecodeError:

--- a/tests/unit/test_orchestration_reachability.py
+++ b/tests/unit/test_orchestration_reachability.py
@@ -30,13 +30,20 @@ from __future__ import annotations
 import ast
 import re
 from collections import defaultdict
+from functools import lru_cache
 from pathlib import Path
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PACKAGE = REPO_ROOT / "src" / "bernstein" / "core" / "orchestration"
-SEARCHED = ("src", "tests", "scripts")
+#: The trees this guard walks, spelled as repo-relative globs. It reads the
+#: whole search space rather than importing it, so these literals are the only
+#: edge the affected-test selector can bind a change to. Both directions matter:
+#: a new entry point inside the subject package, and a change anywhere else that
+#: drops the last reference to one.
+SCANNED_TREES = ["src/**/*.py", "tests/**/*.py", "scripts/**/*.py"]
+SEARCHED = tuple(tree.split("/", 1)[0] for tree in SCANNED_TREES)
 
 #: The 27 already unreachable when this guard landed. Pre-existing debt, deliberately NOT
 #: fixed here: this change removes one dead run loop, and deleting three more modules in
@@ -78,8 +85,12 @@ SELF = Path(__file__).resolve()
 _IDENT = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
 
+@lru_cache(maxsize=1)
 def _reference_index() -> dict[str, set[str]]:
     """``{module_stem: {names other files reach through it}}``.
+
+    Built once per session: the uncached shape re-parsed ``src``, ``tests`` and
+    ``scripts`` for each of the three tests below.
 
     Read off the AST, not the text. Two earlier shapes of this were wrong in opposite
     directions, and both are worth naming because either would have shipped a guard that
@@ -120,7 +131,7 @@ def _reference_index() -> dict[str, set[str]]:
                     if stem != own:
                         for alias in node.names:
                             refs[stem].add(alias.name)
-    return refs
+    return dict(refs)
 
 
 def _unreachable_in(path: Path, source: str, refs: dict[str, set[str]]) -> list[str]:
@@ -179,15 +190,16 @@ def _unreachable_in(path: Path, source: str, refs: dict[str, set[str]]) -> list[
     return sorted(set(funcs) - seen)
 
 
-def _scan() -> dict[str, list[str]]:
+@lru_cache(maxsize=1)
+def _scan() -> dict[str, tuple[str, ...]]:
     refs = _reference_index()
-    found: dict[str, list[str]] = {}
+    found: dict[str, tuple[str, ...]] = {}
     for path in sorted(PACKAGE.glob("*.py")):
         if path.name == "__init__.py":
             continue
         dead = _unreachable_in(path, path.read_text(encoding="utf-8"), refs)
         if dead:
-            found[path.name] = dead
+            found[path.name] = tuple(dead)
     return found
 
 

--- a/tests/unit/test_security_controls_are_wired.py
+++ b/tests/unit/test_security_controls_are_wired.py
@@ -36,13 +36,20 @@ from __future__ import annotations
 import ast
 import re
 from collections import defaultdict
+from functools import lru_cache
 from pathlib import Path
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PACKAGE = REPO_ROOT / "src" / "bernstein" / "core" / "security"
-SEARCHED = ("src", "tests", "scripts")
+#: The trees this guard walks, spelled as repo-relative globs. It reads the
+#: whole search space rather than importing it, so these literals are the only
+#: edge the affected-test selector can bind a change to. Both directions matter:
+#: a new entry point inside the subject package, and a change anywhere else that
+#: drops the last reference to one.
+SCANNED_TREES = ["src/**/*.py", "tests/**/*.py", "scripts/**/*.py"]
+SEARCHED = tuple(tree.split("/", 1)[0] for tree in SCANNED_TREES)
 SELF = Path(__file__).resolve()
 
 #: The 20 still PROVED uncalled: each name appears nowhere outside its own module, in
@@ -112,8 +119,14 @@ def _module_aliases(tree: ast.AST) -> dict[str, str]:
     return aliases
 
 
+@lru_cache(maxsize=1)
 def _static_references() -> dict[str, set[str]]:
-    """``{module_stem: {names reached through it statically}}``, alias-aware."""
+    """``{module_stem: {names reached through it statically}}``, alias-aware.
+
+    Built once per session. The uncached shape re-parsed ``src``, ``tests`` and
+    ``scripts`` on every call -- eight full passes across the five tests below --
+    and cost about ninety seconds of wall time on its own.
+    """
     refs: dict[str, set[str]] = defaultdict(set)
     for top in SEARCHED:
         for path in (REPO_ROOT / top).rglob("*.py"):
@@ -135,9 +148,10 @@ def _static_references() -> dict[str, set[str]]:
                     if stem != own:
                         for a in node.names:
                             refs[stem].add(a.name)
-    return refs
+    return dict(refs)
 
 
+@lru_cache(maxsize=1)
 def _written_anywhere() -> set[str]:
     """Every identifier-shaped token appearing outside `core/security/`.
 
@@ -157,7 +171,8 @@ def _written_anywhere() -> set[str]:
     return seen
 
 
-def _classify() -> tuple[set[str], set[str]]:
+@lru_cache(maxsize=1)
+def _classify() -> tuple[frozenset[str], frozenset[str]]:
     """``(proved_uncalled, unproven)`` over public functions in `core/security/`."""
     refs = _static_references()
     written = _written_anywhere()
@@ -183,7 +198,7 @@ def _classify() -> tuple[set[str], set[str]]:
                 continue
             entry = f"{path.name}:{node.name}"
             (proved if node.name not in written else unproven).add(entry)
-    return proved, unproven
+    return frozenset(proved), frozenset(unproven)
 
 
 def test_no_security_control_is_proved_uncalled() -> None:

--- a/tests/unit/test_shipped_tree_imports_only_shipped_code.py
+++ b/tests/unit/test_shipped_tree_imports_only_shipped_code.py
@@ -19,7 +19,10 @@ import ast
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-PACKAGE_ROOT = REPO_ROOT / "src" / "bernstein"
+#: The tree this guard walks, spelled as a repo-relative glob. A guard that
+#: scans a directory imports nothing from it, so this literal is the only
+#: edge the affected-test selector can bind a change inside the tree to.
+SCANNED_TREE = "src/bernstein/**/*.py"
 
 #: Top-level directories that live in the repository and never in the wheel.
 REPO_ONLY_ROOTS = frozenset({"scripts", "tests", "tools", "benchmarks", "docs", "examples"})
@@ -38,7 +41,7 @@ def _imported_roots(tree: ast.AST) -> set[str]:
 
 def test_no_shipped_module_imports_a_repository_only_directory() -> None:
     offenders: list[str] = []
-    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+    for path in sorted(REPO_ROOT.glob(SCANNED_TREE)):
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         for root in sorted(_imported_roots(tree) & REPO_ONLY_ROOTS):
             offenders.append(f"{path.relative_to(REPO_ROOT)} imports {root!r}")

--- a/tests/unit/test_test_impact_glob_literals.py
+++ b/tests/unit/test_test_impact_glob_literals.py
@@ -154,6 +154,36 @@ def test_a_new_source_module_selects_the_repo_tree_guards() -> None:
     assert "tests/unit/test_cast_alias_form.py" in selected
     assert "tests/unit/test_shipped_tree_imports_only_shipped_code.py" in selected
     assert "tests/unit/test_core_has_no_directory_vendor_sdk.py" in selected
+    # The reachability guards fail on exactly the reported shape: a new module
+    # under a scanned package with nothing calling into it.
+    assert "tests/unit/test_security_controls_are_wired.py" in selected
+    assert "tests/unit/test_orchestration_reachability.py" in selected
+
+
+def test_a_test_only_change_selects_the_guards_that_search_the_test_tree() -> None:
+    """A reachability guard reads ``tests/`` too, and says so.
+
+    Dropping the last caller of a control is how an allowlist entry goes stale,
+    and a test file is a caller like any other. Declaring only the subject
+    package would leave that direction uncovered.
+    """
+    src_root = _REPO_ROOT / "src"
+    dep_map = build_compat_dep_map(_REPO_ROOT, src_root, [_REPO_ROOT / "tests" / "unit"])
+
+    selected = {
+        p.relative_to(_REPO_ROOT).as_posix()
+        for p in compat_get_affected_tests(
+            ["tests/unit/test_router.py"],
+            dep_map,
+            root=_REPO_ROOT,
+            src_root=src_root,
+        )
+    }
+
+    assert "tests/unit/test_security_controls_are_wired.py" in selected
+    assert "tests/unit/test_orchestration_reachability.py" in selected
+    # ...while a guard scoped to the source tree stays out of a test-only diff.
+    assert "tests/unit/test_cast_alias_form.py" not in selected
 
 
 def test_an_unrelated_change_does_not_select_the_source_tree_guards() -> None:

--- a/tests/unit/test_test_impact_glob_literals.py
+++ b/tests/unit/test_test_impact_glob_literals.py
@@ -1,0 +1,174 @@
+"""A guard that scans a directory must be selected by the diff that breaks it.
+
+A structural guard reads its subject instead of importing it, so the import
+graph offers no edge and ``extract_path_literals`` recovers one from the paths
+the guard names. That recovery stops at guards that name a *file*. A guard that
+walks a *directory* names nothing a changed path can match: it holds a root
+built from path segments and hands ``"*.py"`` to ``rglob``.
+
+The consequence is not an abstract missing edge. ``test_cast_alias_form`` walks
+every module under ``src/bernstein`` and fails on a new one that declares a
+string-valued cast alias. Nothing selected it for that diff, so such a PR was
+green in its own lane and failed for the first time in the merge queue, where
+the failure blocks every entry behind it.
+
+The edge is declared rather than inferred. Harvesting every glob-shaped string
+was measured first and rejected: ``"src/*.py"`` appears in eight tests as
+fixture data for a path-matching rule under test, and honouring those bound
+thirteen unrelated tests to every change under ``src``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bernstein.core.quality.test_impact import (
+    build_compat_dep_map,
+    compat_get_affected_tests,
+    extract_scanned_trees,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _scanner_fixture(tmp_path: Path, body: str) -> tuple[Path, Path]:
+    """A guard whose module body is ``body``, importing nothing from the tree."""
+    src = tmp_path / "src"
+    tests = tmp_path / "tests" / "unit"
+
+    _write(src / "proj" / "__init__.py", "")
+    _write(src / "proj" / "core" / "__init__.py", "")
+    _write(src / "proj" / "core" / "widget.py", "VALUE = 1\n")
+    _write(tests / "test_tree_scan.py", f"{body}\n\n\ndef test_it() -> None:\n    assert True\n")
+    return src, tests
+
+
+def _selected(tmp_path: Path, src: Path, tests: Path, changed: str) -> set[str]:
+    dep_map = build_compat_dep_map(tmp_path, src, [tests], {"proj"})
+    return {
+        p.relative_to(tmp_path).as_posix()
+        for p in compat_get_affected_tests([changed], dep_map, root=tmp_path, src_root=src)
+    }
+
+
+def test_a_guard_declaring_the_tree_it_scans_is_selected_for_a_file_inside_it(tmp_path: Path) -> None:
+    """The edge this map exists to provide, for a directory-shaped subject."""
+    src, tests = _scanner_fixture(tmp_path, 'SCANNED_TREE = "src/proj/core/*.py"')
+
+    assert "tests/unit/test_tree_scan.py" in _selected(tmp_path, src, tests, "src/proj/core/widget.py")
+
+
+def test_a_declared_tree_that_excludes_the_change_is_not_selected(tmp_path: Path) -> None:
+    """Negative control: the match must be the glob, not the presence of one."""
+    src, tests = _scanner_fixture(tmp_path, 'SCANNED_TREE = "src/proj/adapters/*.py"')
+
+    assert "tests/unit/test_tree_scan.py" not in _selected(tmp_path, src, tests, "src/proj/core/widget.py")
+
+
+def test_a_glob_shaped_fixture_string_does_not_create_an_edge(tmp_path: Path) -> None:
+    """The reason this edge is declared rather than inferred.
+
+    ``"src/*.py"`` is fixture data in eight tests in this repository. Binding a
+    test to a tree because it mentions a pattern would enrol it in every change
+    under that tree, and would keep doing so as fixtures are added.
+    """
+    src, tests = _scanner_fixture(tmp_path, 'PATTERN_UNDER_TEST = "src/proj/core/*.py"')
+
+    assert "tests/unit/test_tree_scan.py" not in _selected(tmp_path, src, tests, "src/proj/core/widget.py")
+
+
+def test_a_recursive_declaration_reaches_a_module_directly_inside_the_tree(tmp_path: Path) -> None:
+    """``**/`` matches zero directories for ``pathlib``, so it must here too.
+
+    Otherwise a guard declaring the exact string it passes to ``glob()`` covers
+    every nested module and silently misses the ones sitting directly in the
+    package -- the shallowest files, and the easiest to get wrong.
+    """
+    src, tests = _scanner_fixture(tmp_path, 'SCANNED_TREE = "src/proj/**/*.py"')
+    _write(src / "proj" / "shallow.py", "VALUE = 2\n")
+
+    assert "tests/unit/test_tree_scan.py" in _selected(tmp_path, src, tests, "src/proj/shallow.py")
+
+
+def test_a_recursive_declaration_still_reaches_a_nested_module(tmp_path: Path) -> None:
+    """The written form must keep working alongside its collapsed variant."""
+    src, tests = _scanner_fixture(tmp_path, 'SCANNED_TREE = "src/proj/**/*.py"')
+
+    assert "tests/unit/test_tree_scan.py" in _selected(tmp_path, src, tests, "src/proj/core/widget.py")
+
+
+def test_several_trees_may_be_declared_at_once(tmp_path: Path) -> None:
+    """A guard that walks more than one top declares them as a sequence."""
+    src, tests = _scanner_fixture(tmp_path, 'SCANNED_TREES = ["scripts/*.py", "src/proj/core/*.py"]')
+
+    assert "tests/unit/test_tree_scan.py" in _selected(tmp_path, src, tests, "src/proj/core/widget.py")
+
+
+def test_a_leading_underscore_does_not_hide_the_declaration(tmp_path: Path) -> None:
+    """A module may keep its own private-name convention."""
+    src, tests = _scanner_fixture(tmp_path, '_SCANNED_TREE = "src/proj/core/*.py"')
+
+    assert "tests/unit/test_tree_scan.py" in _selected(tmp_path, src, tests, "src/proj/core/widget.py")
+
+
+def test_a_declaration_inside_a_function_is_not_harvested(tmp_path: Path) -> None:
+    """Only a module-level binding declares the subject of the whole file."""
+    body = 'def _helper() -> str:\n    SCANNED_TREE = "src/proj/core/*.py"\n    return SCANNED_TREE'
+    src, tests = _scanner_fixture(tmp_path, body)
+
+    assert "tests/unit/test_tree_scan.py" not in _selected(tmp_path, src, tests, "src/proj/core/widget.py")
+
+
+def test_extraction_ignores_a_non_string_declaration(tmp_path: Path) -> None:
+    """A malformed declaration must not crash the map build."""
+    _write(tmp_path / "t.py", "SCANNED_TREE = 3\nSCANNED_TREES = [1, 'src/proj/*.py']\n")
+
+    assert extract_scanned_trees(tmp_path / "t.py") == {"src/proj/*.py"}
+
+
+def test_a_new_source_module_selects_the_repo_tree_guards() -> None:
+    """Regression pin on the reported case, against the real source tree.
+
+    ``test_cast_alias_form`` fails on a new module anywhere under
+    ``src/bernstein`` that declares ``_CAST_X = "..."``. Before the declared
+    glob edge existed the selector returned it for no such diff at all.
+    """
+    src_root = _REPO_ROOT / "src"
+    dep_map = build_compat_dep_map(_REPO_ROOT, src_root, [_REPO_ROOT / "tests" / "unit"])
+
+    selected = {
+        p.relative_to(_REPO_ROOT).as_posix()
+        for p in compat_get_affected_tests(
+            ["src/bernstein/core/security/zz_probe.py"],
+            dep_map,
+            root=_REPO_ROOT,
+            src_root=src_root,
+        )
+    }
+
+    assert "tests/unit/test_cast_alias_form.py" in selected
+    assert "tests/unit/test_shipped_tree_imports_only_shipped_code.py" in selected
+    assert "tests/unit/test_core_has_no_directory_vendor_sdk.py" in selected
+
+
+def test_an_unrelated_change_does_not_select_the_source_tree_guards() -> None:
+    """The declared trees must still bound the edge against the real repo."""
+    src_root = _REPO_ROOT / "src"
+    dep_map = build_compat_dep_map(_REPO_ROOT, src_root, [_REPO_ROOT / "tests" / "unit"])
+
+    selected = {
+        p.relative_to(_REPO_ROOT).as_posix()
+        for p in compat_get_affected_tests(
+            ["docs/index.md"],
+            dep_map,
+            root=_REPO_ROOT,
+            src_root=src_root,
+        )
+    }
+
+    assert "tests/unit/test_cast_alias_form.py" not in selected


### PR DESCRIPTION
## What

Teaches `--affected` to select a guard that **scans a directory**, and wires the six guards in that class. Also caches the two whole-tree guards whose cost previously made wiring them unaffordable.

## Why

A structural guard reads its subject instead of importing it, so the import graph has no edge to offer. For a guard that reads a *named* file the selector recovers one anyway — `extract_path_literals` harvests the paths a test writes.

A guard that walks a *directory* names nothing a changed path can match. It holds a root assembled from segments (`REPO_ROOT / "src" / "bernstein"`) and hands `"*.py"` to `rglob`; neither half is a repo path.

Reproduced on `main` — a new module under `src/bernstein/core/security/` declaring a string-valued cast alias:

- `test_cast_alias_form` → **FAILED**
- `scripts/test_impact.py --print-paths` returned it → **0 times**

Such a PR is green in its own lane and fails for the first time in the merge queue, where the failure blocks every entry behind it. Six guards were in this state: the cast-alias, shipped-tree, vendor-SDK and docs-URL guards, plus both reachability guards — the ones that actually fail on a caller-less new module.

## How

A test declares the tree it walks as a module-level `SCANNED_TREE` (or `SCANNED_TREES`), spelled repo-relative, and drives its own scan from that constant so the two cannot drift. The selector matches declarations with `fnmatch` against every suffix key of a changed path; `**/` is also matched with zero directories so a declaration means what `Path.glob` means.

**The edge is declared, not inferred.** Harvesting anything glob-shaped was implemented and measured first, then rejected: `"src/*.py"` is fixture data in eight tests here, and honouring those bound thirteen unrelated tests to every change under `src` — a set that would keep growing silently as fixtures are added. That variant cost +2.4%; the declared form costs +0.83%.

**Caching before wiring.** `test_security_controls_are_wired` and `test_orchestration_reachability` rebuilt their reference index on every call — eight full `rglob` + `ast.parse` passes over `src`, `tests` and `scripts` in the first, three in the second. That is the shape `test_token_orphans` already fixed, and the same fix applies.

| Guard | Before | After |
|---|---|---|
| `test_security_controls_are_wired` | 101s | 22s |
| `test_orchestration_reachability` | 43s | 18s |

Cached builders return a plain `dict` or a `frozenset` — a `defaultdict` escaping an `lru_cache` inserts on lookup.

`_COMPAT_CACHE_VERSION` is bumped: file hashes alone will not invalidate a map whose edges were derived under the old rule.

## Measurements

Over 40 recent commits:

| | |
|---|---|
| Affected-set growth | **+0.83%** |
| Commits losing an existing edge | **0** |
| Added wall time, PR touching `src` | **~40s** (≈145s had the scans stayed uncached) |
| docs-only diffs | unchanged |

## Verification

- `tests/unit/test_test_impact_glob_literals.py` — 12 tests, fail before / pass after. Includes the negative control that a glob-shaped *fixture* string creates no edge, and a repo-level pin that a new module under `core/security/` selects all six guards.
- The rewritten globs scan byte-identical file sets to the `rglob` calls they replace (2086 / 1479 files).
- 210 targeted tests pass: every `test_impact` and gate-runner suite, all six guards, and `test_token_orphans`.
- ruff + format + mypy clean.
- One batch failure seen while verifying (`test_approval_workflow_e2e`) is **pre-existing test-order pollution** — identical failure at the identical point on clean `origin/main`.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes (mypy clean on the changed module)
- [x] Tests pass (targeted; see Verification)
- [x] New code has type hints

### Documentation duty

- [x] `docs/contributing/testing.md` — new section documenting the convention and the caching requirement
- [x] User-visible README section updated — N/A, internal test tooling
- [x] `docs/api/` schema regenerated — N/A, no public surface change
- [x] `bernstein agents-md sync` — N/A, no new module
- [x] Tests cover the documented behaviour