### PR TITLE
fix(agents): wait for the process group, not just the wrapper, before declaring a session dead

### DIFF
--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -6784,12 +6784,27 @@ class AgentSpawner:
         return alive
 
     def _check_alive_process(self, session: AgentSession) -> bool | None:
-        """Check liveness via stored subprocess. Returns None if no proc stored."""
+        """Check liveness via stored subprocess. Returns None if no proc stored.
+
+        Adapters spawn with ``start_new_session=True``, so the wrapper leads
+        its own process group (pgid == pid) and a grandchild it forks (the
+        real CLI tool, or a fork of it) can survive the wrapper's own exit.
+        Polling only the wrapper reports the session dead the moment it
+        exits even when the group is not empty, letting
+        ``drain_before_cleanup`` seal the run's journal while a grandchild
+        is still writing to the worktree. Report alive until the whole
+        group is gone, matching the group-aware check already used on the
+        escalation-kill path (``process_group_alive``, issue #2643).
+        """
         proc = self._procs.get(session.id)
         if proc is None:
             return None
         exit_code = proc.poll()
         if exit_code is not None:
+            from bernstein.core.config.platform_compat import process_group_alive
+
+            if process_group_alive(proc.pid):
+                return True
             session.exit_code = exit_code
             return False
         return True

--- a/tests/unit/test_spawner.py
+++ b/tests/unit/test_spawner.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import ctypes
+import os
 import re
 import subprocess
 import threading
@@ -212,6 +214,64 @@ class TestLifecycle:
 
         session = AgentSession(id="test-1", role="backend", pid=99)
         assert spawner.check_alive(session) is False
+
+    def test_check_alive_process_waits_for_surviving_group_member(self, tmp_path: Path, mock_adapter_factory) -> None:
+        """Issue #5272: a grandchild in the wrapper's process group must keep
+        the session alive after the wrapper itself exits.
+
+        Adapters spawn with start_new_session=True, so the wrapper leads its
+        own process group (pgid == pid); the real CLI tool or a fork of it
+        can outlive the wrapper inside that group. Polling only the wrapper
+        PID declares the session dead the instant it exits, which lets
+        drain_before_cleanup seal the run's journal while a group member is
+        still running.
+        """
+        _PR_SET_CHILD_SUBREAPER = 36
+        # Mark this test process as a child subreaper so the grandchild
+        # below reparents here instead of to the unreaping test-runner PID 1,
+        # or the liveness read below never settles.
+        ctypes.CDLL(None, use_errno=True).prctl(_PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0)
+
+        adapter = mock_adapter_factory()
+        spawner = AgentSpawner(adapter, tmp_path, tmp_path, use_worktrees=False)
+
+        proc = subprocess.Popen(["sh", "-c", "sleep 2 & exit 0"], start_new_session=True)
+        session = AgentSession(id="test-1", role="backend", pid=proc.pid)
+        spawner._procs[session.id] = proc
+
+        def _reap_orphans() -> None:
+            while True:
+                try:
+                    pid, _ = os.waitpid(-1, os.WNOHANG)
+                except ChildProcessError:
+                    return
+                if pid == 0:
+                    return
+
+        try:
+            proc.wait(timeout=5)  # the wrapper has exited
+            assert proc.poll() is not None
+
+            # The group is still alive: the backgrounded `sleep 2` is a member.
+            group_alive = True
+            try:
+                os.killpg(proc.pid, 0)
+            except ProcessLookupError:
+                group_alive = False
+            assert group_alive, "test is broken: grandchild already reaped"
+
+            assert spawner.check_alive(session) is True
+
+            deadline = time.time() + 6
+            while time.time() < deadline:
+                _reap_orphans()
+                if spawner.check_alive(session) is False:
+                    break
+                time.sleep(0.2)
+            else:
+                raise AssertionError("session never settled to dead after the grandchild exited")
+        finally:
+            _reap_orphans()
 
     def test_kill_sends_kill_and_marks_dead(self, tmp_path: Path, mock_adapter_factory) -> None:
         adapter = mock_adapter_factory()


### PR DESCRIPTION
## What

`_check_alive_process` reports a session dead the moment its wrapper subprocess exits, even if the wrapper's process group still has a running member.

## Why

Adapters spawn with `start_new_session=True`, so the wrapper leads its own process group (pgid == pid). The real CLI tool, or a fork it makes, can outlive the wrapper inside that same group. `drain_before_cleanup` uses `check_alive` to decide when it is safe to let the run proceed to `_seal_journal_into_lineage_spine`, so a wrapper that exits early can let finalization seal the run receipt while a grandchild is still writing to the worktree.

This codebase already has the group-aware primitive for this: `process_group_alive()` in `platform_compat.py`, built for the same shape of bug on the escalation-kill path (its docstring cites issue #2643: a reap path using lead-PID liveness "would report the group dead the moment the leader has already been reaped"). `_check_alive_process` is a second instance of the same gap that was never brought in line, alongside a third: `_stop_demo_processes` in `cli/run_confirm.py` already documents the identical fix for demo teardown, citing issue #2799.

Fixes #5272.

## How

When the wrapper's `proc.poll()` shows it has exited, check `process_group_alive(proc.pid)` before declaring the session dead. If the group still has a live member, report the session alive; only mark it dead once the whole group is gone.

Scoped to the liveness check that gates finalization. `reap_subprocess` (spawner_merge.py) still only reaps the wrapper, which is a separate, narrower concern (cleanup of an already-decided-dead session) than the finalization race this issue describes.

## Verification

- New regression test spawns a real subprocess matching the adapters' own shape (`start_new_session=True`, a backgrounded grandchild, wrapper exits immediately): `check_alive` wrongly reports the session dead while its group is still alive today, and settles correctly with this fix applied.
- `tests/unit/test_spawner.py` plus the other unit test files touching `check_alive`/drain/reap, and the zombie-agent chaos test, all still pass (python:3.13-slim, the version this PR's CI leg runs).
- `ruff`, `typos`, and `vulture` are clean on both changed files; `mypy` reports no issues, though neither file is in the strict gate.
- I have not run this against the Windows or macOS legs, mutation testing, or the integration/e2e/property suites. `process_group_alive` already has its own Windows fallback and this diff does not touch it.
