### PR TITLE
docs(merge-gate): stop restating the queue config, which had drifted

### DIFF
--- a/docs/operations/merge-gate.md
+++ b/docs/operations/merge-gate.md
@@ -58,18 +58,22 @@ gh api -X PATCH "repos/sipyourdrink-ltd/bernstein/branches/main/protection" \
   -f required_pull_request_reviews.required_approving_review_count=1 \
   -f required_pull_request_reviews.require_code_owner_reviews=true \
   -F allow_merge_queue=true
-
-# 2b. Configure the merge-queue policy (sets max group size and timeouts).
-gh api -X PUT "repos/sipyourdrink-ltd/bernstein/branches/main/merge_queue" \
-  -H "Accept: application/vnd.github+json" \
-  -f merge_method=squash \
-  -F max_entries_to_build=5 \
-  -F max_entries_to_merge=5 \
-  -F min_entries_to_merge=1 \
-  -F merge_queue_grouping_strategy=ALLGREEN \
-  -F min_entries_to_merge_wait_minutes=5 \
-  -F max_entries_to_merge_wait_minutes=60
 ```
+
+**2b. Configure the merge-queue policy** using the ruleset payload in
+[merge-queue.md :: Enable](merge-queue.md), which is the declared source of
+truth for these parameters: the shipped ruleset is reconciled *to* that
+document, and `tests/unit/test_merge_queue_runbook_docs.py` holds it to its own
+Tunables table. This page deliberately does not restate the values.
+
+Two of them are load-bearing rather than tuning, and are the reason a second
+copy is not kept here:
+
+- `max_entries_to_merge` must stay `1`. The auto-release gate keys on the push
+  head SHA, so merging N entries in one push skips a version bump anywhere but
+  last - green CI, no tag, no publish, and no error anywhere to notice.
+- `min_entries_to_merge_wait_minutes` is `0`. With one entry merging per push
+  there is no batch to fill, so any wait is pure added latency.
 
 After enabling, `gh pr merge --auto` will route the PR into the merge queue instead of merging immediately. CI then runs against the combined branch GitHub computes for the queued merge group, and the `merge_group:` trigger added to `.github/workflows/ci.yml` makes the existing CI suite respond to that event.
 

--- a/docs/release-notes/fragments/merge-gate-defers-queue-config.md
+++ b/docs/release-notes/fragments/merge-gate-defers-queue-config.md
@@ -1,0 +1,17 @@
+## The merge-gate page stops restating the queue configuration
+
+`docs/operations/merge-gate.md` carried its own copy of the merge-queue
+provisioning payload, and nothing kept it in step with
+`docs/operations/merge-queue.md`, which is the declared source of truth. It had
+drifted: it told an operator to set `max_entries_to_merge=5`, a value the
+runbook pins to `1` and `tests/unit/test_merge_queue_runbook_docs.py` guards,
+because merging several entries in one push advances `main` by N commits under
+a single push event that reports only the last SHA — so the auto-release gate
+skips the version bump for every entry but the last, with green CI, no tag, no
+publish and no error. `min_entries_to_merge_wait_minutes` had drifted too.
+
+Step 2b now links to the runbook's Enable section and explains why those two
+parameters are load-bearing rather than restating any values. A new test holds
+the page to that: a merge-queue parameter may be named on a line that cites the
+runbook, and may not be assigned anywhere else, so a second copy cannot come
+back and go stale unnoticed (#5506).

--- a/tests/unit/test_merge_queue_runbook_docs.py
+++ b/tests/unit/test_merge_queue_runbook_docs.py
@@ -196,3 +196,55 @@ def test_runbook_documents_the_release_path_through_the_queue(
         "github-merge-queue[bot] and does start push-triggered workflows - that "
         "is the evidence the auto-release chain survives the queue"
     )
+
+
+#: Merge-queue parameters an operator can set. A page other than the runbook
+#: that assigns any of these is a second copy of the configuration, and a
+#: second copy is what went stale: `merge-gate.md` carried
+#: `max_entries_to_merge=5` against the runbook's pinned `1` for long enough
+#: that following it would have re-provisioned the queue into the state
+#: `test_batch_size_is_pinned_to_one` exists to prevent.
+QUEUE_PARAMETERS = (
+    "max_entries_to_build",
+    "max_entries_to_merge",
+    "min_entries_to_merge",
+    "min_entries_to_merge_wait_minutes",
+    "max_entries_to_merge_wait_minutes",
+    "check_response_timeout_minutes",
+    "merge_queue_grouping_strategy",
+    "grouping_strategy",
+)
+
+#: `<param>=<value>` or `"<param>": <value>` - an assignment, not a mention.
+_ASSIGNMENT = re.compile(r"(?:{params})\s*(?:=|\"?\s*:)\s*\"?[0-9A-Za-z]".format(params="|".join(QUEUE_PARAMETERS)))
+
+
+def test_merge_gate_does_not_carry_a_second_copy_of_the_queue_config() -> None:
+    """One document sets these values, and it is the runbook.
+
+    `merge-gate.md` is an operator page that used to restate the whole
+    `gh api ... /merge_queue` payload. Nothing kept the two in step, so it
+    drifted: it told the operator to set `max_entries_to_merge=5`, which
+    silently skips a release version bump for every entry but the last -
+    green CI, no tag, no publish, no error. The runbook's own test pins that
+    parameter to `1`; this one stops the second copy coming back.
+
+    Naming a value to explain why it matters is fine as long as the line
+    points at the runbook, so a reader can tell which copy is authoritative
+    and a drifting one is visible. A bare assignment - the kind an operator
+    pastes into a shell - is not.
+    """
+    offenders = sorted(
+        {
+            line.strip()
+            for line in MERGE_GATE.read_text(encoding="utf-8").splitlines()
+            if _ASSIGNMENT.search(line) and RUNBOOK.name not in line
+        }
+    )
+    assert offenders == [], (
+        f"{MERGE_GATE} assigns merge-queue parameters:\n  "
+        + "\n  ".join(offenders)
+        + f"\n\nThese are set in one place, {RUNBOOK}. Link to its Enable "
+        "section instead of restating the values here; a line that must name a "
+        f"value has to cite `{RUNBOOK.name}` on the same line."
+    )


### PR DESCRIPTION
Related: #5506 (the grouping-strategy decision), which is what sent me to these two pages.

## The defect

`docs/operations/merge-gate.md` step 2b carries its own copy of the merge-queue provisioning payload. `docs/operations/merge-queue.md` is the declared source of truth — its own test says "the shipped ruleset is reconciled *to* the document" and diffs its Tunables table against its Enable payload — but nothing held the second copy to it, and it drifted:

| Parameter | merge-gate.md said | Runbook pins |
|---|---|---|
| `max_entries_to_merge` | **5** | **1** |
| `min_entries_to_merge_wait_minutes` | **5** | **0** |
| `max_entries_to_merge_wait_minutes=60` | set | not a tunable |
| `check_response_timeout_minutes` | absent | 240 |

The first row is the one that matters. `test_batch_size_is_pinned_to_one` in `tests/unit/test_merge_queue_runbook_docs.py` exists precisely to keep that value at 1:

> With N entries merged per push, the base branch advances N commits in one push event that reports only the last SHA. auto-release keys on that SHA, so a version bump anywhere but last is skipped with no error.

So an operator re-provisioning the queue by following `merge-gate.md` would have set the queue into the exact state the other page's test exists to prevent — and the failure mode is silent: green CI, no tag, no publish, nothing to notice.

The two pages also disagreed on the API surface (`branches/main/merge_queue` here, a rulesets payload there), which is how the drift went unseen: they do not look like the same instruction.

## The fix

Step 2b now links to [merge-queue.md :: Enable](docs/operations/merge-queue.md) rather than restating it, and keeps only the two facts an operator needs to *not* override — why `max_entries_to_merge` must stay 1, and why the wait is 0.

`test_merge_gate_does_not_carry_a_second_copy_of_the_queue_config` stops the copy coming back. A merge-queue parameter may be *named* on a line that cites `merge-queue.md` — the page has one such line already, explaining why one PR lands per push, and that is worth keeping — but may not be assigned anywhere else. Run against the page as it stood, it fails and lists all six divergent assignments:

```
docs/operations/merge-gate.md assigns merge-queue parameters:
    -F max_entries_to_build=5 \
    -F max_entries_to_merge=5 \
    -F max_entries_to_merge_wait_minutes=60
  Left contains 6 more items...
```

I did not touch the grouping-strategy question itself. #5506 asks for a decision to be recorded either way, and `ALLGREEN` vs `HEADGREEN` is yours to make, not mine to write down as settled — happy to draft the decision record once you say which way it goes.

## Verification

- `pytest tests/unit/test_merge_queue_runbook_docs.py` — 16 passed (15 existing + the new guard)
- The new guard fails on `upstream/main`'s copy of the page and passes on this one
- `ruff check` / `ruff format --check` clean

Release-note fragment: `docs/release-notes/fragments/merge-gate-defers-queue-config.md`.