### PR TITLE
docs: regenerate adapter last-green table from canary receipts

### DIFF
--- a/docs/adapters/conformance-canary.md
+++ b/docs/adapters/conformance-canary.md
@@ -214,15 +214,15 @@ covered under *Chronic-skip handling*.
 | Adapter | Binary | Last-green version | Verified | Receipt |
 |---|---|---|---|---|
 | agy | `agy` | 1.0.0 | 2026-07-11T05:57:23Z (not probed) | `006fb946868d` |
-| aider | `aider` | 0.86.2 | 2026-09-04T09:08:35Z | `35dfc74eb7f7` |
-| claude | `claude` | 2.1.260 | 2026-09-04T09:08:35Z | `8f1733b755fb` |
-| codex | `codex` | 0.153.2 | 2026-09-04T09:08:35Z | `e755565c703e` |
-| copilot | `copilot` | 1.0.82 | 2026-09-04T09:08:35Z | `c6513a600ac9` |
-| gemini | `gemini` | 0.58.0 | 2026-09-04T09:08:35Z | `e74bce6db56e` |
-| kimi | `kimi` | 1.50.0 | 2026-09-04T09:08:35Z | `bc93607cf9e8` |
-| opencode | `opencode` | 1.18.27 | 2026-09-04T09:08:35Z | `70b9837c8a67` |
-| pydantic_ai | `clai` | 2.39.0 | 2026-09-04T09:08:35Z | `bba98ed2bafc` |
-| qwen | `qwen` | 0.23.0 | 2026-09-04T09:08:35Z | `66a4fbec3859` |
+| aider | `aider` | 0.86.2 | 2026-09-06T08:59:25Z | `37a7b17b1e88` |
+| claude | `claude` | 2.1.263 | 2026-09-06T08:59:25Z | `8c124539e820` |
+| codex | `codex` | 0.153.4 | 2026-09-06T08:59:25Z | `e78ca0b801de` |
+| copilot | `copilot` | 1.0.83 | 2026-09-06T08:59:25Z | `6b575f6e8980` |
+| gemini | `gemini` | 0.58.0 | 2026-09-06T08:59:25Z | `a1d3b27fa59f` |
+| kimi | `kimi` | 1.50.0 | 2026-09-06T08:59:25Z | `b3a33bc9c19e` |
+| opencode | `opencode` | 1.18.29 | 2026-09-06T08:59:25Z | `c4f3db579d55` |
+| pydantic_ai | `clai` | 2.40.0 | 2026-09-06T08:59:25Z | `de124f4e3dd0` |
+| qwen | `qwen` | 0.23.0 | 2026-09-06T08:59:25Z | `ab8349b63a7b` |
 <!-- last-green:end -->
 
 ## Operator knobs

--- a/src/bernstein/adapters/last_green.json
+++ b/src/bernstein/adapters/last_green.json
@@ -8,59 +8,59 @@
     },
     "aider": {
       "binary": "aider",
-      "receipt_sha256": "35dfc74eb7f7072821031e424909e047adc4dbd025418c5beb270ea4323aa2b4",
-      "recorded_at": "2026-09-04T09:08:35Z",
+      "receipt_sha256": "37a7b17b1e88cc44b77f242dc700f3c9631c86e9fa90b317fb68529ce5f42fa1",
+      "recorded_at": "2026-09-06T08:59:25Z",
       "version": "0.86.2"
     },
     "claude": {
       "binary": "claude",
-      "receipt_sha256": "8f1733b755fbfb62c31540df7cb3ebfceedfcfb066c5425ac17da0cbbf161172",
-      "recorded_at": "2026-09-04T09:08:35Z",
-      "version": "2.1.260"
+      "receipt_sha256": "8c124539e820b9b00d69831caa4dd45e119fd0ffdf7dad01041b75fbd4dd49de",
+      "recorded_at": "2026-09-06T08:59:25Z",
+      "version": "2.1.263"
     },
     "codex": {
       "binary": "codex",
-      "receipt_sha256": "e755565c703eaef87617d2f0d5fdcb55b2c45c7cafe924bc7b2e443d405d1b72",
-      "recorded_at": "2026-09-04T09:08:35Z",
-      "version": "0.153.2"
+      "receipt_sha256": "e78ca0b801deef1bdc8b2792e898a65af44703c115467b2531a2abb149331275",
+      "recorded_at": "2026-09-06T08:59:25Z",
+      "version": "0.153.4"
     },
     "copilot": {
       "binary": "copilot",
-      "receipt_sha256": "c6513a600ac9096e3364c316666ec6641c425bc350e27aa7663bfaea3d70e92e",
-      "recorded_at": "2026-09-04T09:08:35Z",
-      "version": "1.0.82"
+      "receipt_sha256": "6b575f6e8980394a01f0b2f1b46cbd09cc5bf6df6467a66ebb92f57cbc0d3d1b",
+      "recorded_at": "2026-09-06T08:59:25Z",
+      "version": "1.0.83"
     },
     "gemini": {
       "binary": "gemini",
-      "receipt_sha256": "e74bce6db56e2c6a91a526bd6b9051f15c096ab830ea8a2e35953793ae4253bf",
-      "recorded_at": "2026-09-04T09:08:35Z",
+      "receipt_sha256": "a1d3b27fa59f0f12922f857e5186efe8a5e0557832a27fbaf96132393510b8a5",
+      "recorded_at": "2026-09-06T08:59:25Z",
       "version": "0.58.0"
     },
     "kimi": {
       "binary": "kimi",
-      "receipt_sha256": "bc93607cf9e8dc30f538a224866b25faecc4fd816702ec5e0a83caf36b4f72f4",
-      "recorded_at": "2026-09-04T09:08:35Z",
+      "receipt_sha256": "b3a33bc9c19e7e918b0025e55d4c47c35d61c693206448a9671478e10409d71f",
+      "recorded_at": "2026-09-06T08:59:25Z",
       "version": "1.50.0"
     },
     "opencode": {
       "binary": "opencode",
-      "receipt_sha256": "70b9837c8a6756b285082aac9129e02078b3cdeba489737dbddca33792f5b420",
-      "recorded_at": "2026-09-04T09:08:35Z",
-      "version": "1.18.27"
+      "receipt_sha256": "c4f3db579d55440f070b3abd03b1a39a379fbdb7a62ecff1561371dfc7cb93ed",
+      "recorded_at": "2026-09-06T08:59:25Z",
+      "version": "1.18.29"
     },
     "pydantic_ai": {
       "binary": "clai",
-      "receipt_sha256": "bba98ed2bafc19f144b73b967805c068e87ae833b35e37a2296a6805c5695dd6",
-      "recorded_at": "2026-09-04T09:08:35Z",
-      "version": "2.39.0"
+      "receipt_sha256": "de124f4e3dd061a9d40be2dc821eab874a2df2175c1fd51122a8cb0b125e669e",
+      "recorded_at": "2026-09-06T08:59:25Z",
+      "version": "2.40.0"
     },
     "qwen": {
       "binary": "qwen",
-      "receipt_sha256": "66a4fbec3859e317b69e4114e0d3b2fbbdb1939bc98c70a7b2f9f581172951d7",
-      "recorded_at": "2026-09-04T09:08:35Z",
+      "receipt_sha256": "ab8349b63a7b3c817e1cc44217610772bea7ca95fe93d3cd341178d5cb038e75",
+      "recorded_at": "2026-09-06T08:59:25Z",
       "version": "0.23.0"
     }
   },
-  "projection_sha256": "fb0c4001432f0b3babb0225ac344d05cd94354b6fdb49a4467cda815fb821757",
+  "projection_sha256": "c968ecfed5cb99f10b2414e4f343de04c14e37759162260f8b7e2e4b20b26adc",
   "schema_version": 2
 }

--- a/tests/unit/test_claude_hook_url_uses_run_port.py
+++ b/tests/unit/test_claude_hook_url_uses_run_port.py
@@ -11,6 +11,7 @@ import json
 from pathlib import Path
 
 import pytest
+
 from bernstein.adapters.claude import ClaudeCodeAdapter
 
 

--- a/tests/unit/test_task_server_url_resolution.py
+++ b/tests/unit/test_task_server_url_resolution.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+
 from bernstein.core.agents.spawner_core import _render_auth_section, _resolve_task_server_url
 from bernstein.core.defaults import SDD_SERVER_PORT
 


### PR DESCRIPTION
Nightly adapter conformance canary regeneration of the per-adapter last-green projection (packaged last_green.json + the docs table). Every row is anchored to the receipt that attested it; receipts for this run are attached to the workflow run as artifacts.

Workflow run: https://github.com/sipyourdrink-ltd/bernstein/actions/runs/33955851636