### PR TITLE
feat(config): `config explain` names the layer and the file every value came from (#5110)

### DIFF
--- a/docs/operations/global-config.md
+++ b/docs/operations/global-config.md
@@ -17,6 +17,7 @@ bernstein config list                  # show every known key, value, and source
 bernstein config diff                  # diff project bernstein.yaml against built-in defaults
 bernstein config validate              # validate project model policy / providers
 bernstein config conflicts             # show settings where sources disagree
+bernstein config explain [<key>]       # every effective value, its layer, and the file it came from
 bernstein config view-mode <mode>      # set dashboard detail level
 ```
 
@@ -52,6 +53,46 @@ Same resolution, applied to every key in the built-in defaults table
 (`cli`, `budget`, `max_agents`, `effort`, `model`), rendered as a table of
 key / value / source / full resolution chain. Same `--project-dir` flag as
 `get`.
+
+### `bernstein config explain [KEY]`
+
+Answers "why is this value what it is". With no `KEY`, every known key is
+listed; with one, the layers consulted for it are printed highest-precedence
+first.
+
+```bash
+bernstein config explain                # survey every key
+bernstein config explain cli            # one key, with the layers consulted
+bernstein config explain cli --json     # machine-readable
+```
+
+It differs from `config list` in two ways: it names the **file** each layer was
+read from, and `--json` emits a shape a CI check can gate on:
+
+```json
+{
+  "precedence": ["seed", "session", "project", "context", "global", "default"],
+  "settings": [
+    {
+      "key": "cli",
+      "value": "codex",
+      "layer": "project",
+      "path": "/srv/app/.sdd/config.yaml",
+      "chain": [{ "source": "project", "value": "codex", "path": "/srv/app/.sdd/config.yaml" },
+                { "source": "default", "value": "claude", "path": null }]
+    }
+  ]
+}
+```
+
+The payload carries the precedence it resolved by, so a caller does not have to
+hardcode the order. Values are the redacted ones -- a resolution report is what
+an operator pastes into an issue, so a secret must not be the thing that leaks.
+
+An unknown key exits non-zero and lists the known ones, rather than reporting
+the setting as unresolved.
+
+`--project-dir` selects which project's `.sdd/config.yaml` is consulted.
 
 ### `bernstein config diff`
 
@@ -93,7 +134,7 @@ full detail.
 
 ## Precedence
 
-`bernstein config get`/`list`/`conflicts` resolve a key across, from
+`bernstein config get`/`list`/`explain`/`conflicts` resolve a key across, from
 highest to lowest precedence:
 
 1. **seed** — the run-seed (`bernstein.yaml`) value actually enforced by the
@@ -111,8 +152,13 @@ highest to lowest precedence:
    `max_agents=6`, `effort=max`, `model=None`,
    `host_isolation_tier=none`, `host_isolation_evidence=""`).
 
-Only `bernstein config set`/`get`/`list`/`conflicts`/`view-mode` operate on
-this precedence chain. `bernstein config diff` is a separate, narrower tool
+In code this order has exactly one definition, `CONFIG_PRECEDENCE` in
+`src/bernstein/core/config/home.py`; `tests/unit/test_config_explain_cmd.py`
+fails if the resolver, the command, or the `ConfigSource` vocabulary parts ways
+with it.
+
+Only `bernstein config set`/`get`/`list`/`explain`/`conflicts`/`view-mode`
+operate on this precedence chain. `bernstein config diff` is a separate, narrower tool
 that only compares the project seed file to built-in defaults.
 
 ## Known config keys

--- a/docs/release-notes/fragments/5110-config-explain.md
+++ b/docs/release-notes/fragments/5110-config-explain.md
@@ -1,0 +1,19 @@
+## `bernstein config explain` names the layer every value came from
+
+"Why is this value what it is" had no command. `config list` printed the
+effective value and its source but never the file it was read from, and emitted
+nothing a script could read, so a CI check that wanted to assert "this came from
+the project layer, not from an environment variable" had nothing to gate on.
+
+`bernstein config explain [KEY]` prints every effective value with its layer and
+the path it was read from, highest-precedence first. `--json` emits
+`{precedence, settings[{key, value, layer, path, chain}]}` — carrying the order
+it resolved by, so a caller does not hardcode it. Printed values are the
+redacted ones: a resolution report is what an operator pastes into an issue.
+
+The precedence order now has one definition in code, `CONFIG_PRECEDENCE`. It had
+been written out in prose twice in `core/config/home.py` and both copies had
+gone stale — the module header described four layers and `resolve_config`
+described five, while the resolver has built six since `context` was added.
+Neither is restated now, and a test fails if a layer is added to `ConfigSource`
+without being placed in the order (#5110).

--- a/src/bernstein/cli/commands/workspace_cmd.py
+++ b/src/bernstein/cli/commands/workspace_cmd.py
@@ -11,7 +11,7 @@ All commands are registered with the main CLI group in main.py.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import click
 
@@ -251,6 +251,100 @@ def config_list(project_dir: str) -> None:
         )
 
     console.print(table)
+
+
+@config_group.command("explain")
+@click.argument("key", required=False)
+@click.option("--project-dir", default=".", show_default=True, help="Project directory for precedence check.")
+@click.option("--json", "as_json", is_flag=True, help="Emit machine-readable resolution instead of a table.")
+def config_explain(key: str | None, project_dir: str, as_json: bool) -> None:
+    """Show where each effective config value came from.
+
+    With no KEY, every key is listed. `config list` answers the same question
+    for a human reader; this command adds the file each layer was read from
+    and a `--json` shape a CI check can gate on.
+
+    Example: bernstein config explain cli --json
+    """
+    import json as _json
+
+    from rich.table import Table
+
+    from bernstein.core.config.home import (
+        _DEFAULTS,  # type: ignore[reportPrivateUsage]
+        CONFIG_LAYER_DESCRIPTIONS,
+        CONFIG_PRECEDENCE,
+        BernsteinHome,
+        ConfigSource,
+        resolve_config,
+    )
+
+    home = BernsteinHome.default()
+    keys = [key] if key else sorted(_DEFAULTS.keys())
+    if key and key not in _DEFAULTS:
+        console.print(f"[red]unknown config key:[/red] {key}")
+        console.print(f"[dim]known keys: {', '.join(sorted(_DEFAULTS))}[/dim]")
+        raise SystemExit(1)
+
+    rows: list[dict[str, Any]] = []
+    for name in keys:
+        result = resolve_config(name, home=home, project_dir=Path(project_dir))
+        # The redacted value is what gets printed. A resolution report is
+        # exactly the output an operator pastes into an issue, so a secret
+        # resolved from any layer must not be the thing that leaks.
+        chain = [
+            {
+                "source": layer["source"],
+                "value": layer["redacted_value"],
+                "path": layer["path"],
+            }
+            for layer in result["source_chain"]
+        ]
+        rows.append(
+            {
+                "key": name,
+                "value": chain[0]["value"] if chain else None,
+                "layer": result["source"],
+                "path": chain[0]["path"] if chain else None,
+                "chain": chain,
+            }
+        )
+
+    if as_json:
+        console.print_json(
+            _json.dumps(
+                {
+                    "precedence": list(CONFIG_PRECEDENCE),
+                    "settings": rows,
+                }
+            )
+        )
+        return
+
+    console.print("[dim]precedence (highest first): " + " > ".join(CONFIG_PRECEDENCE) + "[/dim]")
+    table = Table(show_header=True, header_style=_STYLE_BOLD_MAGENTA)
+    table.add_column("Key")
+    table.add_column("Value")
+    table.add_column("Layer")
+    table.add_column("Read from")
+    styles = {"seed": "green", "session": "magenta", "project": "cyan", "context": "blue", "global": "yellow"}
+    for row in rows:
+        layer = str(row["layer"])
+        style = styles.get(layer, "dim")
+        table.add_row(
+            str(row["key"]),
+            str(row["value"]),
+            f"[{style}]{layer}[/{style}]",
+            str(row["path"] or "-"),
+        )
+    console.print(table)
+
+    if key:
+        winning = cast("ConfigSource", rows[0]["layer"])
+        console.print(f"\n[dim]{CONFIG_LAYER_DESCRIPTIONS.get(winning, '')}[/dim]")
+        console.print("[dim]layers consulted, highest first:[/dim]")
+        for step in cast("list[dict[str, Any]]", rows[0]["chain"]):
+            console.print(f"  [dim]{step['source']}[/dim] = {step['value']!r}  [dim]{step['path'] or ''}[/dim]")
 
 
 @config_group.command("diff")

--- a/src/bernstein/core/config/home.py
+++ b/src/bernstein/core/config/home.py
@@ -2,8 +2,11 @@
 
 Provides cross-project config storage, catalog cache, and cost tracking.
 
-Config precedence (highest to lowest):
-  session overrides > project .sdd/config.yaml > ~/.bernstein/config.yaml > built-in defaults
+Config precedence is defined once, by ``CONFIG_PRECEDENCE`` below, and every
+statement of it elsewhere should point at that tuple rather than restate it.
+Two copies of this list had already gone stale in this file: the header said
+four layers and ``resolve_config`` said five, while the resolver has built six
+since ``context`` was added.
 
 Environment overrides (take priority over all file-based config layers):
   BERNSTEIN_CLI         Default CLI adapter (e.g. claude, codex, gemini, qwen).
@@ -69,6 +72,31 @@ model: null
 """
 
 ConfigSource = Literal["seed", "session", "project", "context", "global", "default"]
+
+
+#: Every config layer, highest precedence first. This is the ONLY definition of
+#: the order: :func:`resolve_config` builds its chain in exactly this sequence,
+#: ``bernstein config explain`` prints it in this sequence, and
+#: ``test_config_precedence_is_defined_once`` fails if a layer is added to
+#: :data:`ConfigSource` without being placed here (#5110).
+CONFIG_PRECEDENCE: tuple[ConfigSource, ...] = (
+    "seed",
+    "session",
+    "project",
+    "context",
+    "global",
+    "default",
+)
+
+#: What each layer is, for an operator asking where a value came from.
+CONFIG_LAYER_DESCRIPTIONS: dict[ConfigSource, str] = {
+    "seed": "run seed (bernstein.yaml) — the value the orchestrator enforces at runtime",
+    "session": "session-only override (environment variable or caller-provided)",
+    "project": "<project>/.sdd/config.yaml",
+    "context": "the active context's config, selected within the project",
+    "global": "~/.bernstein/config.yaml",
+    "default": "built-in default",
+}
 
 
 class ConfigProvenanceLayer(TypedDict):
@@ -422,13 +450,10 @@ def resolve_config(
 ) -> ConfigResolution:
     """Resolve the effective value for *key* across all config layers.
 
-    Precedence (highest first):
-    1. Run seed overrides (``bernstein.yaml``, the value the orchestrator
-       actually enforces at runtime - see ``seed_overrides``)
-    2. Session-only overrides (environment or caller-provided)
-    3. ``<project>/.sdd/config.yaml``
-    4. ``~/.bernstein/config.yaml``
-    5. Built-in defaults
+    Layers are appended in :data:`CONFIG_PRECEDENCE` order, highest first, so
+    ``source_chain[0]`` is always the winner. The order is not restated here:
+    the copy that used to live in this docstring omitted ``context`` and stayed
+    wrong for as long as nothing compared it to the code.
 
     Args:
         key: Config key to look up.

--- a/tests/unit/test_config_explain_cmd.py
+++ b/tests/unit/test_config_explain_cmd.py
@@ -1,0 +1,178 @@
+"""`bernstein config explain`, and the one definition of the precedence order.
+
+"Why is this value what it is" had no command: an operator read every config
+file by hand and guessed at precedence. `config list` answers it for a human
+but names no file and emits no machine-readable shape, so a CI check that
+wanted to assert "this came from the project layer, not the environment" had
+nothing to read (#5110).
+
+The order itself is the other half. It was stated twice in prose in
+`core/config/home.py` and both copies had drifted from the resolver -- the
+module header said four layers, `resolve_config` said five, and the code built
+six. `CONFIG_PRECEDENCE` is now the only statement of it, and the tests below
+fail if the resolver, the command, or the `ConfigSource` vocabulary parts ways
+with it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, get_args
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.workspace_cmd import config_group
+from bernstein.core.config.home import (
+    CONFIG_LAYER_DESCRIPTIONS,
+    CONFIG_PRECEDENCE,
+    BernsteinHome,
+    ConfigSource,
+    resolve_config,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    """A project whose `.sdd/config.yaml` sets two keys."""
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir()
+    (sdd / "config.yaml").write_text("cli: codex\nmax_agents: 3\n", encoding="utf-8")
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Keep the developer's real ~/.bernstein out of the resolution."""
+    monkeypatch.setenv("BERNSTEIN_HOME", str(tmp_path / "home"))
+    for leaked in ("BERNSTEIN_CLI", "BERNSTEIN_EFFORT", "BERNSTEIN_MAX_AGENTS", "BERNSTEIN_MODEL"):
+        monkeypatch.delenv(leaked, raising=False)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# The order, defined once
+# ---------------------------------------------------------------------------
+
+
+def test_config_precedence_is_defined_once() -> None:
+    """Every layer the vocabulary admits has a place in the order.
+
+    Adding a source to `ConfigSource` without placing it in
+    `CONFIG_PRECEDENCE` would leave the resolver building a chain the command
+    cannot order -- which is how `context` came to exist in the code while two
+    docstrings still described the five-layer world.
+    """
+    assert set(CONFIG_PRECEDENCE) == set(get_args(ConfigSource))
+    assert len(CONFIG_PRECEDENCE) == len(set(CONFIG_PRECEDENCE))
+
+
+def test_every_layer_is_described_for_an_operator() -> None:
+    """A layer that cannot be explained is not an answer to "where did this come from"."""
+    assert set(CONFIG_LAYER_DESCRIPTIONS) == set(CONFIG_PRECEDENCE)
+    assert all(CONFIG_LAYER_DESCRIPTIONS[layer].strip() for layer in CONFIG_PRECEDENCE)
+
+
+def test_the_resolver_builds_its_chain_in_that_order(project: Path) -> None:
+    """The printed order is the resolver's order, not a second opinion."""
+    rank = {layer: index for index, layer in enumerate(CONFIG_PRECEDENCE)}
+    for key in ("cli", "max_agents", "budget"):
+        chain = resolve_config(key, home=BernsteinHome.default(), project_dir=project)["source_chain"]
+        ranks = [rank[layer["source"]] for layer in chain]
+        assert ranks == sorted(ranks), f"{key} chain out of precedence order: {ranks}"
+
+
+def test_the_winning_source_is_the_head_of_the_chain(project: Path) -> None:
+    """`source` and `source_chain[0]` cannot disagree about who won."""
+    resolution = resolve_config("cli", home=BernsteinHome.default(), project_dir=project)
+    assert resolution["source_chain"][0]["source"] == resolution["source"]
+
+
+# ---------------------------------------------------------------------------
+# The command
+# ---------------------------------------------------------------------------
+
+
+def _explain(*args: str) -> tuple[int, str]:
+    result = CliRunner().invoke(config_group, ["explain", *args])
+    return result.exit_code, result.output
+
+
+def test_explain_names_the_layer_a_value_came_from(project: Path) -> None:
+    """The whole point: a project-set value is reported as project, not default."""
+    code, output = _explain("cli", "--project-dir", str(project), "--json")
+    assert code == 0
+    payload = json.loads(output)
+    setting = payload["settings"][0]
+    assert setting["key"] == "cli"
+    assert setting["value"] == "codex"
+    assert setting["layer"] == "project"
+    assert setting["path"] is not None
+    assert setting["path"].endswith("config.yaml")
+
+
+def test_explain_reports_the_file_each_layer_was_read_from(project: Path) -> None:
+    """`config list` answers the layer question but never names the file."""
+    _, output = _explain("max_agents", "--project-dir", str(project), "--json")
+    chain = json.loads(output)["settings"][0]["chain"]
+    project_layer = next(layer for layer in chain if layer["source"] == "project")
+    assert Path(project_layer["path"]).is_file()
+
+
+def test_a_session_override_outranks_the_project_file(project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The direction an operator most often needs confirmed."""
+    monkeypatch.setenv("BERNSTEIN_CLI", "gemini")
+    _, output = _explain("cli", "--project-dir", str(project), "--json")
+    setting = json.loads(output)["settings"][0]
+    assert setting["value"] == "gemini"
+    assert setting["layer"] == "session"
+
+
+def test_the_json_payload_carries_the_order_it_resolved_by(project: Path) -> None:
+    """A caller reading the report does not have to hardcode the precedence."""
+    _, output = _explain("--project-dir", str(project), "--json")
+    assert json.loads(output)["precedence"] == list(CONFIG_PRECEDENCE)
+
+
+def test_with_no_key_every_setting_is_reported(project: Path) -> None:
+    """The survey form, which is what an operator opens first."""
+    _, output = _explain("--project-dir", str(project), "--json")
+    keys = {setting["key"] for setting in json.loads(output)["settings"]}
+    assert {"cli", "max_agents", "budget", "model", "effort"} <= keys
+
+
+def test_an_unknown_key_exits_non_zero_and_lists_the_known_ones(project: Path) -> None:
+    """A typo must not read as "this setting resolves to nothing"."""
+    code, output = _explain("clii", "--project-dir", str(project))
+    assert code == 1
+    assert "unknown config key" in output
+    assert "cli" in output
+
+
+def test_the_table_states_the_precedence_it_used(project: Path) -> None:
+    """The human output answers "in what order" without a second command."""
+    _, output = _explain("cli", "--project-dir", str(project))
+    condensed = " ".join(output.split())
+    assert "seed > session > project" in condensed
+
+
+def test_a_redacted_value_is_what_gets_printed(project: Path) -> None:
+    """A resolution report is what an operator pastes into an issue.
+
+    The command prints `redacted_value`, never the raw one, so a secret
+    resolved from any layer is not the thing that leaks.
+    """
+    _, output = _explain("--project-dir", str(project), "--json")
+    for setting in json.loads(output)["settings"]:
+        for layer in setting["chain"]:
+            resolution = resolve_config(setting["key"], home=BernsteinHome.default(), project_dir=project)
+            match = next(
+                (entry for entry in resolution["source_chain"] if entry["source"] == layer["source"]),
+                None,
+            )
+            assert match is not None
+            assert layer["value"] == match["redacted_value"]


### PR DESCRIPTION
Slice 1 of #5110, plus the "resolution order defined in one place" acceptance criterion.

## What I found first

The issue describes the gap through `config diff`, which compares one file against hardcoded defaults. But the layered resolver the issue asks for in slice 2 **already exists**: `resolve_config` in `core/config/home.py` builds a six-layer chain (`seed → session → project → context → global → default`), each layer carrying `value`, `redacted_value` and the `path` it was read from, and `config get` / `list` / `conflicts` already resolve through it.

So slice 2 is largely landed. What is missing from slice 1 is narrower and still real:

- nothing emits `--json`, so a CI check that wants to assert "this came from the project layer, not from an environment variable" has nothing to read;
- nothing prints the **file** a layer was read from — `config list` names the layer but not the path;
- the resolution order is stated in prose rather than defined once.

## The stale order

That last one had already bitten. The order was written out twice in `core/config/home.py`, and **both copies were wrong**:

| where | said |
|---|---|
| module header | 4 layers — `session > project > global > default` |
| `resolve_config` docstring | 5 layers — no `context` |
| the resolver | **6** layers |
| `docs/operations/global-config.md` | 6 layers — correct |

`context` has existed in the code and in the docs while both in-code descriptions described a world without it.

`CONFIG_PRECEDENCE` is now the only definition. Neither docstring restates it, and `test_config_precedence_is_defined_once` fails if a source joins the `ConfigSource` literal without being given a place in the order — which is exactly how `context` slipped in unnoticed.

## The command

```
$ bernstein config explain --project-dir /srv/app
precedence (highest first): seed > session > project > context > global > default
┏━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Key        ┃ Value ┃ Layer   ┃ Read from                ┃
┡━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ cli        │ codex │ project │ /srv/app/.sdd/config.yaml│
│ effort     │ low   │ session │ -                        │
│ max_agents │ 3     │ project │ /srv/app/.sdd/config.yaml│
└────────────┴───────┴─────────┴──────────────────────────┘
```

`--json` emits `{precedence, settings[{key, value, layer, path, chain}]}`, carrying the order it resolved by so a caller does not hardcode it.

Two details worth calling out:

- **Printed values are `redacted_value`, never the raw one.** A resolution report is precisely what an operator pastes into an issue, so a secret resolved from any layer must not be the thing that leaks. `test_a_redacted_value_is_what_gets_printed` pins it for every key and every layer.
- **An unknown key exits 1 and lists the known keys**, rather than reporting the setting as resolving to nothing.

## Not in this PR

Slice 3 — validating each layer against `config_schema.py` before the merge — is a separate change; this one only reads what the resolver produces.

## Verification

- `pytest tests/unit/test_config_explain_cmd.py` — 12 passed
- `pytest tests/unit/test_home.py tests/unit/test_workspace.py tests/unit/test_workspace_config_provenance.py` — 55 passed
- `pytest tests/unit -k config` — 1840 passed, 2 skipped
- `pytest tests/unit/test_feature_matrix_drift.py` — 16 passed (a subcommand needs no matrix row; checked)
- `mypy` clean on both touched files; `mypy --config-file mypy.gate.ini` clean
- `ruff check` / `ruff format --check` clean

Docs: `docs/operations/global-config.md`. Fragment: `docs/release-notes/fragments/5110-config-explain.md`.