### PR TITLE
feat(trace): `trace follow` reports every trace referencing one entity (#5114)

### DIFF
--- a/docs/release-notes/fragments/5114-trace-follow.md
+++ b/docs/release-notes/fragments/5114-trace-follow.md
@@ -1,0 +1,15 @@
+## `bernstein trace follow` reports every trace that references one entity
+
+`trace show` globs `.sdd/traces/` for a task id and prints whichever file
+matched, once. An entity id — a task, a run, a grant — appears across several
+traces, and nothing joined them, so following one across a run meant exporting
+the store and grepping it.
+
+`bernstein trace follow <entity-id>` reports every index entry that references
+the entity, oldest first, with `--as-json` for a machine reader. The entity is
+matched against the trace id, the task id and the digest, which are the three
+spellings by which an index row can name one.
+
+Ordering is by start time with trace id as the tiebreak, and timestamps render
+in UTC, so a finished run prints byte-identically on every invocation rather
+than inheriting the order traces happened to be written in (#5114).

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -1137,6 +1137,7 @@ def trace_cmd(ctx: click.Context, traces_dir: str) -> None:
       bernstein trace show <task-id>      Pretty-print a task trace
       bernstein trace serve --port 8765   Run the local read-only viewer
       bernstein trace verify <trace-id>   Confirm on-disk bytes match sha256
+      bernstein trace follow <entity-id>  Every trace entry referencing one entity
       bernstein trace reindex             Rebuild .sdd/traces/index.jsonl
     """
     ctx.obj = {"traces_dir": traces_dir}
@@ -1192,6 +1193,81 @@ def trace_show_cmd(ctx: click.Context, task_id: str, as_json: bool) -> None:
     """Show execution trace for a task."""
     traces_dir = (ctx.obj or {}).get("traces_dir", ".sdd/traces")
     _trace_show_task(task_id, traces_dir=traces_dir, as_json=as_json)
+
+
+@trace_cmd.command("follow")
+@click.argument("entity_id")
+@click.option(
+    "--as-json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Output the matched index entries as JSON.",
+)
+@click.pass_context
+def trace_follow_cmd(ctx: click.Context, entity_id: str, as_json: bool) -> None:
+    """Show every trace entry that references ENTITY_ID, oldest first.
+
+    `trace show` globs filenames for one task id and prints whichever file
+    matches, once. An entity id -- a task, a run, a grant -- appears across
+    several traces, and following it meant exporting and grepping.
+
+    Ordering is by start time, and ties break on trace id, so a finished run
+    prints byte-identically on every invocation.
+    """
+    from bernstein.core.observability.trace_store import ContentAddressedTraceStore
+
+    traces_dir = (ctx.obj or {}).get("traces_dir", ".sdd/traces")
+    traces_path = Path(traces_dir)
+    if not traces_path.exists():
+        console.print(f"[red]Traces directory not found:[/red] {traces_path}")
+        raise SystemExit(1)
+
+    store = ContentAddressedTraceStore(traces_path)
+    # `search(text=...)` matches trace_id, task_id or sha256 -- the three
+    # spellings by which an index row can reference an entity.
+    matches = store.search(text=entity_id)
+    # Sorted rather than index order: `reindex` rebuilds by walking the blob
+    # tree, so the file's order is a filesystem artefact and would make the
+    # same finished run print differently after a rebuild.
+    matches.sort(key=lambda entry: (entry.started_at, entry.trace_id))
+
+    if not matches:
+        console.print(f"[yellow]No trace entries reference:[/yellow] {entity_id}")
+        raise SystemExit(1)
+
+    if as_json:
+        console.print_json(json.dumps([entry.to_dict() for entry in matches]))
+        return
+
+    from rich.table import Table
+
+    table = Table(
+        title=f"Traces referencing {entity_id}",
+        show_header=True,
+        header_style="bold cyan",
+    )
+    table.add_column("Started")
+    table.add_column("Trace")
+    table.add_column("Task")
+    table.add_column("Model")
+    table.add_column("Bytes", justify="right")
+    for entry in matches:
+        table.add_row(
+            _trace_timestamp(entry.started_at),
+            entry.trace_id,
+            entry.task_id or "-",
+            entry.model or "-",
+            str(entry.byte_size),
+        )
+    console.print(table)
+    suffix = "y" if len(matches) == 1 else "ies"
+    console.print(f"[dim]{len(matches)} entr{suffix}[/dim]")
+
+
+def _trace_timestamp(epoch: float) -> str:
+    """Render a trace timestamp in UTC, so output does not follow the reader."""
+    return dt.datetime.fromtimestamp(epoch, tz=dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 @trace_cmd.command("serve")

--- a/tests/unit/cli/test_trace_follow.py
+++ b/tests/unit/cli/test_trace_follow.py
@@ -1,0 +1,140 @@
+"""`bernstein trace follow <entity-id>`: every trace entry that names one entity.
+
+`trace show` globs `.sdd/traces/` for a task id and prints whichever file
+matched, once. An entity id -- a task, a run, a grant -- appears across several
+traces, and nothing joined them, so following one meant exporting the store and
+grepping it (#5114).
+
+The acceptance criterion that shapes the implementation is the third one: for a
+finished run the output must be byte-identical across invocations. `reindex`
+rebuilds `index.jsonl` by walking the blob tree, so index order is a filesystem
+artefact; the ordering here is explicit and total.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.advanced_cmd import trace_cmd
+from bernstein.core.observability.trace_store import (
+    ContentAddressedTraceStore,
+    TraceMetadataHints,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> ContentAddressedTraceStore:
+    """A store holding three traces for one task and one for another."""
+    traces = tmp_path / ".sdd" / "traces"
+    traces.mkdir(parents=True)
+    store = ContentAddressedTraceStore(traces)
+    # Written out of order on purpose: index order is a write/filesystem
+    # artefact, and `follow` must not inherit it.
+    for body, trace_id, task_id, started in (
+        (b'{"event": "third"}', "trace-c", "T-100", 300.0),
+        (b'{"event": "first"}', "trace-a", "T-100", 100.0),
+        (b'{"event": "second"}', "trace-b", "T-100", 200.0),
+        (b'{"event": "other"}', "trace-z", "T-999", 150.0),
+    ):
+        store.put(
+            body,
+            hints=TraceMetadataHints(trace_id=trace_id, task_id=task_id, started_at=started),
+        )
+    return store
+
+
+def _follow(store: ContentAddressedTraceStore, *args: str) -> tuple[int, str]:
+    result = CliRunner().invoke(trace_cmd, ["--traces-dir", str(store.root), "follow", *args])
+    return result.exit_code, result.output
+
+
+def test_follow_reports_every_trace_that_references_the_entity(
+    store: ContentAddressedTraceStore,
+) -> None:
+    """The join `trace show` never did: one entity, all of its traces."""
+    code, output = _follow(store, "T-100", "--as-json")
+    assert code == 0
+    entries = json.loads(output)
+    assert [entry["trace_id"] for entry in entries] == ["trace-a", "trace-b", "trace-c"]
+
+
+def test_entries_are_ordered_by_start_time_not_index_order(
+    store: ContentAddressedTraceStore,
+) -> None:
+    """`trace-c` was written first and starts last; order follows the run."""
+    _, output = _follow(store, "T-100", "--as-json")
+    starts = [entry["started_at"] for entry in json.loads(output)]
+    assert starts == sorted(starts)
+
+
+def test_a_finished_run_prints_byte_identically_across_invocations(
+    store: ContentAddressedTraceStore,
+) -> None:
+    """Acceptance criterion 3, and the reason ordering is explicit.
+
+    Index order is a write-order artefact, so the ordering here is explicit
+    and total: start time, then trace id. Nothing in the output is derived
+    from the clock or the locale of the reader.
+
+    Note this does NOT survive `store.reindex()`, but for a reason outside
+    this command: `reindex` rebuilds from the blob tree alone and cannot
+    recover hint-supplied metadata, so `trace_id` collapses to a hash prefix
+    and `task_id`/`started_at` are lost. That is a store-level defect, not an
+    ordering one, and is reported separately.
+    """
+    first_code, first = _follow(store, "T-100", "--as-json")
+    second_code, second = _follow(store, "T-100", "--as-json")
+    assert (first_code, second_code) == (0, 0)
+    assert first == second
+    assert first == _follow(store, "T-100", "--as-json")[1]
+
+
+def test_a_trace_for_another_entity_is_not_reported(store: ContentAddressedTraceStore) -> None:
+    """The filter has to actually filter, or `follow` is just `index`."""
+    _, output = _follow(store, "T-100", "--as-json")
+    assert all(entry["task_id"] == "T-100" for entry in json.loads(output))
+
+
+def test_an_entity_named_by_trace_id_is_followed_too(store: ContentAddressedTraceStore) -> None:
+    """An entity id reaches the index as a trace id as often as a task id."""
+    code, output = _follow(store, "trace-z", "--as-json")
+    assert code == 0
+    assert [entry["trace_id"] for entry in json.loads(output)] == ["trace-z"]
+
+
+def test_an_entity_with_no_traces_exits_non_zero(store: ContentAddressedTraceStore) -> None:
+    """Silence would read as "this ran and produced nothing"."""
+    code, output = _follow(store, "T-nothing")
+    assert code == 1
+    assert "No trace entries reference" in output
+
+
+def test_a_missing_traces_directory_is_named(tmp_path: Path) -> None:
+    """The other way `follow` can legitimately produce no rows."""
+    result = CliRunner().invoke(trace_cmd, ["--traces-dir", str(tmp_path / "absent"), "follow", "T-100"])
+    assert result.exit_code == 1
+    assert "Traces directory not found" in result.output
+
+
+def test_the_table_names_each_trace_and_its_task(store: ContentAddressedTraceStore) -> None:
+    """The human form carries the same rows as `--as-json`."""
+    code, output = _follow(store, "T-100")
+    assert code == 0
+    condensed = " ".join(output.split())
+    assert "trace-a" in condensed
+    assert "3 entries" in condensed
+
+
+def test_timestamps_are_utc_so_output_does_not_follow_the_reader(
+    store: ContentAddressedTraceStore,
+) -> None:
+    """A local-time render would break the byte-identical guarantee across hosts."""
+    _, output = _follow(store, "trace-a")
+    assert "1970-01-01T00:01:40Z" in " ".join(output.split())


### PR DESCRIPTION
Slice 1 of #5114 — `follow` over the trace store alone.

## What it does

`trace show` globs `.sdd/traces/` for a task id and prints whichever file matched, once. An entity id — a task, a run, a grant — appears across several traces, and nothing joined them.

`bernstein trace follow <entity-id>` reports every index entry that references the entity, oldest first:

```
$ bernstein trace follow T-100
                    Traces referencing T-100
┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┓
┃ Started              ┃ Trace   ┃ Task  ┃ Model ┃ Bytes ┃
┡━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━┩
│ 1970-01-01T00:01:40Z │ trace-a │ T-100 │ -     │ 18    │
│ 1970-01-01T00:03:20Z │ trace-b │ T-100 │ -     │ 18    │
│ 1970-01-01T00:05:00Z │ trace-c │ T-100 │ -     │ 18    │
└──────────────────────┴─────────┴───────┴───────┴───────┘
3 entries
```

The entity is matched against trace id, task id and digest — the three spellings by which an index row can name one. `--as-json` emits the rows.

## The ordering, and why it is explicit

Acceptance criterion 3 is "for a finished run the output is byte-identical across invocations". Index order cannot deliver that: `index.jsonl` is appended in write order, and `reindex` rebuilds it by walking the blob tree, so line order is a filesystem artefact. Ordering here is total — start time, then trace id — and timestamps render in UTC so output does not follow the reader's locale.

## A separate defect I hit while testing this

I first wrote the byte-identity test to survive a `store.reindex()`, and it failed. `reindex()` loses hint-supplied metadata entirely:

```
BEFORE reindex:   trace-c  T-100  300.0
                  trace-a  T-100  100.0
AFTER  reindex:   00e9b157f462c187  ''  0.0
                  ef08e2db488d6806  ''  0.0
```

`ContentAddressedTraceStore.put(..., hints=TraceMetadataHints(...))` records `trace_id`, `task_id` and `started_at` in the index, but nothing persists them beside the blob, so a rebuild derives what it can from the bytes and drops the rest. `trace_id` collapses to a digest prefix, `task_id` empties, `started_at` zeroes.

That is a store-level data-loss bug, not an ordering one, and it is pre-existing — `trace show`, `serve` and `search` all read the same index. I have **not** touched it here, and the test asserts byte-identity across repeated invocations (the actual criterion) rather than across a rebuild. Happy to file it, or take it, if you want — it makes `trace reindex` lossy for any trace stored with hints.

## Not in this PR

Slices 2 (cross-source join with the work ledger and audit chain) and 3 (`--since`, `--out`, live mode).

## Verification

- `pytest tests/unit/cli/test_trace_follow.py tests/unit/cli/test_advanced_cmd_trace.py` — 19 passed
- `pytest tests/unit -k trace` — 350 passed
- `pytest tests/unit/test_feature_matrix_drift.py` — 16 passed (a subcommand needs no matrix row)
- `mypy --config-file mypy.gate.ini` clean; `ruff check` / `ruff format --check` clean

Fragment: `docs/release-notes/fragments/5114-trace-follow.md`.