### PR TITLE
docs: an integration index naming each system the way you name it (#5023)

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Everything deep lives on the [docs site](https://bernstein.readthedocs.io/):
 | [cloud execution](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/cloudflare/cloudflare-overview.md) | experimental: run agents on Cloudflare Workers with R2 workspace sync against your own account. The hosted `api.bernstein.run` service is not yet available |
 | [datasources](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/operations/datasources.md) | read-only query receipts, plus a query driver that binds each result to the schema snapshot it was derived against |
 | [agent catalogs](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/operations/agent-catalogs.md) | point roles at agent definitions outside the built-in templates - a generic YAML/SKILL.md directory, or a Claude Code plugin-layout tree |
+| [integrations](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/integrations.md) | what Bernstein bridges to, by the name you call it: SCIM, OIDC, Vault, OPA/Cedar, SPIFFE, OpenTelemetry, MCP, A2A - with what is shipped, what is wired, and what is not planned |
 | [security](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/operations/security.md) | scorecard, fuzzing, hardening |
 | [architecture](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/architecture/ARCHITECTURE.md) | how it works under the hood |
 

--- a/docs/i18n/README.ar.md
+++ b/docs/i18n/README.ar.md
@@ -242,7 +242,7 @@ bernstein volunteer browse --budget 60
 يغطي [دليل المتبرع](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/donor-guide.md) تشغيل العامل والميزانية التي تحددها، ويغطي [دليل المشروع](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/project-guide.md) إعلان البيان، ويوضح [نموذج التهديد](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/threat-model.md) ما يحميه كل حد وما لا يحميه. لم يُصدر بعد المشغّل ذو الأمر الواحد: الأوامر الفرعية العاملة اليوم هي `verify` و`browse` و`hub`.
 
 ### ما وراء الصفحة الرئيسية
-<!-- l10n: en="beyond the front page" hash="sha256:ee01fbaaebd6" -->
+<!-- l10n: en="beyond the front page" hash="sha256:7dc120ea1ae4" -->
 
 كل التفاصيل المعمقة متوفرة على [موقع التوثيق](https://bernstein.readthedocs.io/):
 

--- a/docs/i18n/README.bn.md
+++ b/docs/i18n/README.bn.md
@@ -242,7 +242,7 @@ bernstein volunteer browse --budget 60
 [দাতা নির্দেশিকা](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/donor-guide.md) ওয়ার্কার চালানো ও আপনার নির্ধারিত বাজেট, [প্রকল্প নির্দেশিকা](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/project-guide.md) ম্যানিফেস্ট ঘোষণা, এবং [হুমকি মডেল](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/threat-model.md) প্রতিটি সীমানা কী রক্ষা করে আর কী করে না তা বর্ণনা করে। এক-কমান্ডের রানার এখনও প্রকাশিত হয়নি: আজ `verify`, `browse` ও `hub` কার্যকর সাব-কমান্ড।
 
 ### প্রথম পাতার বাইরে
-<!-- l10n: en="beyond the front page" hash="sha256:ee01fbaaebd6" -->
+<!-- l10n: en="beyond the front page" hash="sha256:7dc120ea1ae4" -->
 
 গভীরের সবকিছু থাকে [ডকুমেন্টেশন সাইটে](https://bernstein.readthedocs.io/):
 

--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -242,7 +242,7 @@ bernstein volunteer browse --budget 60
 Der [Spenderleitfaden](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/donor-guide.md) behandelt den Betrieb eines Workers und das Budget, das Sie setzen, der [Projektleitfaden](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/project-guide.md) das Deklarieren eines Manifests, und das [Bedrohungsmodell](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/threat-model.md) beschreibt, wovor jede Grenze schützt und wovor nicht. Der Runner mit einem einzigen Befehl ist noch nicht veröffentlicht: Heute sind `verify`, `browse` und `hub` die funktionierenden Unterbefehle.
 
 ### hinter den Kulissen
-<!-- l10n: en="beyond the front page" hash="sha256:ee01fbaaebd6" -->
+<!-- l10n: en="beyond the front page" hash="sha256:7dc120ea1ae4" -->
 
 Alle weiterführenden Details finden sich auf der [Dokumentations-Website](https://bernstein.readthedocs.io/):
 

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -242,7 +242,7 @@ bernstein volunteer browse --budget 60
 La [guía del donante](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/donor-guide.md) cubre la ejecución de un worker y el presupuesto que fijas, la [guía del proyecto](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/project-guide.md) cubre la declaración de un manifiesto, y el [modelo de amenazas](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/threat-model.md) indica qué protege y qué no cada frontera. El ejecutor de un solo comando aún no se ha publicado: hoy `verify`, `browse` y `hub` son los subcomandos que funcionan.
 
 ### más allá de la portada
-<!-- l10n: en="beyond the front page" hash="sha256:ee01fbaaebd6" -->
+<!-- l10n: en="beyond the front page" hash="sha256:7dc120ea1ae4" -->
 
 Todo lo profundo vive en el [sitio de documentación](https://bernstein.readthedocs.io/):
 

--- a/docs/i18n/README.fi.md
+++ b/docs/i18n/README.fi.md
@@ -242,7 +242,7 @@ bernstein volunteer browse --budget 60
 [Lahjoittajan opas](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/donor-guide.md) käsittelee workerin ajamisen ja asettamasi budjetin, [projektin opas](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/project-guide.md) manifestin ilmoittamisen, ja [uhkamalli](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/threat-model.md) kertoo, miltä kukin raja suojaa ja miltä ei. Yhden komennon ajuria ei ole vielä julkaistu: tänään toimivat alikomennot ovat `verify`, `browse` ja `hub`.
 
 ### etusivun lisäksi
-<!-- l10n: en="beyond the front page" hash="sha256:ee01fbaaebd6" -->
+<!-- l10n: en="beyond the front page" hash="sha256:7dc120ea1ae4" -->
 
 Kaikki syvällisempi materiaali löytyy [dokumentaatiosivustolta](https://bernstein.readthedocs.io/):
 

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -242,7 +242,7 @@ bernstein volunteer browse --budget 60
 Le [guide du donateur](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/donor-guide.md) couvre l'exécution d'un worker et le budget que vous fixez, le [guide du projet](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/project-guide.md) couvre la déclaration d'un manifeste, et le [modèle de menaces](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/threat-model.md) indique ce que chaque frontière protège et ne protège pas. Le lanceur en une seule commande n'est pas encore livré : aujourd'hui `verify`, `browse` et `hub` sont les sous-commandes qui fonctionnent.
 
 ### au-delà de la page d'accueil
-<!-- l10n: en="beyond the front page" hash="sha256:ee01fbaaebd6" -->
+<!-- l10n: en="beyond the front page" hash="sha256:7dc120ea1ae4" -->
 
 Toutes les ressources approfondies sont réunies sur le [site de documentation](https://bernstein.readthedocs.io/) :
 

--- a/docs/i18n/README.he.md
+++ b/docs/i18n/README.he.md
@@ -242,7 +242,7 @@ bernstein volunteer browse --budget 60
 [מדריך התורם](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/donor-guide.md) מכסה הרצת worker ואת התקציב שאתה קובע, [מדריך הפרויקט](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/project-guide.md) מכסה הצהרה על מניפסט, ו[מודל האיומים](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/threat-model.md) מפרט מפני מה כל גבול מגן ומפני מה לא. המריץ בפקודה אחת עדיין לא שוחרר: כיום `verify`, `browse` ו-`hub` הן תת-הפקודות שעובדות.
 
 ### מעבר לעמוד הראשי
-<!-- l10n: en="beyond the front page" hash="sha256:ee01fbaaebd6" -->
+<!-- l10n: en="beyond the front page" hash="sha256:7dc120ea1ae4" -->
 
 כל החומר המעמיק נמצא ב[אתר התיעוד](https://bernstein.readthedocs.io/):
 

--- a/docs/i18n/README.hi.md
+++ b/docs/i18n/README.hi.md
@@ -242,7 +242,7 @@ bernstein volunteer browse --budget 60
 [दाता मार्गदर्शिका](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/donor-guide.md) वर्कर चलाने और आपके तय किए बजट को कवर करती है, [प्रोजेक्ट मार्गदर्शिका](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/project-guide.md) मैनिफ़ेस्ट घोषित करना, और [ख़तरा मॉडल](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/threat-model.md) बताता है कि हर सीमा किससे बचाती है और किससे नहीं। एक ही कमांड वाला रनर अभी जारी नहीं हुआ है: आज `verify`, `browse` और `hub` काम करने वाले सब-कमांड हैं।
 
 ### पहले पन्ने से आगे
-<!-- l10n: en="beyond the front page" hash="sha256:ee01fbaaebd6" -->
+<!-- l10n: en="beyond the front page" hash="sha256:7dc120ea1ae4" -->
 
 गहराई की हर चीज़ [डॉक्स साइट](https://bernstein.readthedocs.io/) पर रहती है:
 

--- a/docs/i18n/README.id.md
+++ b/docs/i18n/README.id.md
@@ -242,7 +242,7 @@ bernstein volunteer browse --budget 60
 [Panduan donor](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/donor-guide.md) membahas menjalankan worker dan anggaran yang Anda tetapkan, [panduan proyek](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/project-guide.md) membahas mendeklarasikan manifes, dan [model ancaman](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/threat-model.md) menyatakan apa yang dilindungi dan tidak dilindungi setiap batas. Peluncur satu perintah belum dirilis: hari ini `verify`, `browse`, dan `hub` adalah subperintah yang berfungsi.
 
 ### di luar halaman utama
-<!-- l10n: en="beyond the front page" hash="sha256:ee01fbaaebd6" -->
+<!-- l10n: en="beyond the front page" hash="sha256:7dc120ea1ae4" -->
 
 Semua dokumentasi mendalam tersedia di [situs dokumentasi](https://bernstein.readthedocs.io/):
 

--- a/docs/i18n/README.it.md
+++ b/docs/i18n/README.it.md
@@ -242,7 +242,7 @@ bernstein volunteer browse --budget 60
 La [guida del donatore](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/donor-guide.md) copre l'esecuzione di un worker e il budget che imposti, la [guida del progetto](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/project-guide.md) copre la dichiarazione di un manifesto, e il [modello delle minacce](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/threat-model.md) indica cosa ciascun confine protegge e cosa no. L'esecutore a comando singolo non è ancora rilasciato: oggi `verify`, `browse` e `hub` sono i sottocomandi funzionanti.
 
 ### oltre la pagina principale
-<!-- l10n: en="beyond the front page" hash="sha256:ee01fbaaebd6" -->
+<!-- l10n: en="beyond the front page" hash="sha256:7dc120ea1ae4" -->
 
 Tutte le informazioni approfondite sono disponibili sul [sito della documentazione](https://bernstein.readthedocs.io/):
 

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -242,7 +242,7 @@ bernstein volunteer browse --budget 60
 [提供者ガイド](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/donor-guide.md) はワーカーの実行と自分で設定する予算を、[プロジェクトガイド](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/project-guide.md) はマニフェストの宣言を、[脅威モデル](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/threat-model.md) は各境界が何を守り何を守らないかを扱います。単一コマンドのランナーはまだ出荷されていません。現在動くサブコマンドは `verify`、`browse`、`hub` です。
 
 ### 表紙の先へ
-<!-- l10n: en="beyond the front page" hash="sha256:ee01fbaaebd6" -->
+<!-- l10n: en="beyond the front page" hash="sha256:7dc120ea1ae4" -->
 
 踏み込んだ内容はすべて[ドキュメントサイト](https://bernstein.readthedocs.io/)にある:
 

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -242,7 +242,7 @@ bernstein volunteer browse --budget 60
 [기여자 가이드](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/donor-guide.md)는 워커 실행과 직접 정하는 예산을, [프로젝트 가이드](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/project-guide.md)는 매니페스트 선언을, [위협 모델](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/threat-model.md)은 각 경계가 무엇을 막고 무엇을 막지 않는지를 다룹니다. 한 번의 명령으로 실행하는 러너는 아직 출시되지 않았습니다. 오늘 동작하는 하위 명령은 `verify`, `browse`, `hub` 입니다.
 
 ### 표지 너머
-<!-- l10n: en="beyond the front page" hash="sha256:ee01fbaaebd6" -->
+<!-- l10n: en="beyond the front page" hash="sha256:7dc120ea1ae4" -->
 
 깊이 들어가는 내용은 모두 [문서 사이트](https://bernstein.readthedocs.io/)에 있다:
 

--- a/docs/i18n/README.nl.md
+++ b/docs/i18n/README.nl.md
@@ -242,7 +242,7 @@ bernstein volunteer browse --budget 60
 De [donateursgids](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/donor-guide.md) behandelt het draaien van een worker en het budget dat je instelt, de [projectgids](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/project-guide.md) behandelt het declareren van een manifest, en het [dreigingsmodel](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/threat-model.md) beschrijft waartegen elke grens wel en niet beschermt. De runner met één commando is nog niet uitgebracht: vandaag zijn `verify`, `browse` en `hub` de werkende subcommando's.
 
 ### voorbij de voorpagina
-<!-- l10n: en="beyond the front page" hash="sha256:ee01fbaaebd6" -->
+<!-- l10n: en="beyond the front page" hash="sha256:7dc120ea1ae4" -->
 
 Alle diepgaande documentatie staat op de [documentatiesite](https://bernstein.readthedocs.io/):
 

--- a/docs/i18n/README.pl.md
+++ b/docs/i18n/README.pl.md
@@ -242,7 +242,7 @@ bernstein volunteer browse --budget 60
 [Przewodnik darczyńcy](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/donor-guide.md) opisuje uruchamianie workera i budżet, który ustawiasz, [przewodnik projektu](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/project-guide.md) - deklarowanie manifestu, a [model zagrożeń](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/threat-model.md) mówi, przed czym każda granica chroni, a przed czym nie. Uruchamianie jedną komendą nie zostało jeszcze wydane: dziś działają podkomendy `verify`, `browse` i `hub`.
 
 ### poza stroną główną
-<!-- l10n: en="beyond the front page" hash="sha256:ee01fbaaebd6" -->
+<!-- l10n: en="beyond the front page" hash="sha256:7dc120ea1ae4" -->
 
 Szczegółowa dokumentacja znajduje się w [serwisie dokumentacji](https://bernstein.readthedocs.io/):
 

--- a/docs/i18n/README.pt.md
+++ b/docs/i18n/README.pt.md
@@ -242,7 +242,7 @@ bernstein volunteer browse --budget 60
 O [guia do doador](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/donor-guide.md) cobre a execução de um worker e o orçamento que você define, o [guia do projeto](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/project-guide.md) cobre a declaração de um manifesto, e o [modelo de ameaças](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/threat-model.md) diz o que cada fronteira protege e o que não protege. O executor de um único comando ainda não foi lançado: hoje `verify`, `browse` e `hub` são os subcomandos que funcionam.
 
 ### além da página inicial
-<!-- l10n: en="beyond the front page" hash="sha256:ee01fbaaebd6" -->
+<!-- l10n: en="beyond the front page" hash="sha256:7dc120ea1ae4" -->
 
 Tudo aprofundado reside no [site de documentação](https://bernstein.readthedocs.io/):
 

--- a/docs/i18n/README.ru.md
+++ b/docs/i18n/README.ru.md
@@ -242,7 +242,7 @@ bernstein volunteer browse --budget 60
 [Руководство донора](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/donor-guide.md) описывает запуск воркера и бюджет, который вы задаёте, [руководство проекта](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/project-guide.md) — объявление манифеста, а [модель угроз](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/threat-model.md) — что каждая граница защищает, а что нет. Запуск одной командой ещё не выпущен: сегодня работают подкоманды `verify`, `browse` и `hub`.
 
 ### за пределами первой страницы
-<!-- l10n: en="beyond the front page" hash="sha256:ee01fbaaebd6" -->
+<!-- l10n: en="beyond the front page" hash="sha256:7dc120ea1ae4" -->
 
 Всё глубокое живёт на [сайте документации](https://bernstein.readthedocs.io/):
 

--- a/docs/i18n/README.sv.md
+++ b/docs/i18n/README.sv.md
@@ -242,7 +242,7 @@ bernstein volunteer browse --budget 60
 [Givarguiden](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/donor-guide.md) täcker hur du kör en worker och budgeten du sätter, [projektguiden](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/project-guide.md) täcker att deklarera ett manifest, och [hotmodellen](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/threat-model.md) anger vad varje gräns skyddar mot och inte. Körning med ett enda kommando är ännu inte släppt: i dag är `verify`, `browse` och `hub` de underkommandon som fungerar.
 
 ### bortom förstasidan
-<!-- l10n: en="beyond the front page" hash="sha256:ee01fbaaebd6" -->
+<!-- l10n: en="beyond the front page" hash="sha256:7dc120ea1ae4" -->
 
 All fördjupad information finns på [dokumentationswebbplatsen](https://bernstein.readthedocs.io/):
 

--- a/docs/i18n/README.th.md
+++ b/docs/i18n/README.th.md
@@ -242,7 +242,7 @@ bernstein volunteer browse --budget 60
 [คู่มือผู้บริจาค](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/donor-guide.md) ครอบคลุมการรัน worker และงบประมาณที่คุณกำหนด [คู่มือโปรเจกต์](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/project-guide.md) ครอบคลุมการประกาศ manifest และ [แบบจำลองภัยคุกคาม](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/threat-model.md) ระบุว่าขอบเขตแต่ละชั้นป้องกันอะไรและไม่ป้องกันอะไร ตัวรันแบบคำสั่งเดียวยังไม่ถูกปล่อยออกมา วันนี้คำสั่งย่อยที่ใช้งานได้คือ `verify`, `browse` และ `hub`
 
 ### เนื้อหาเชิงลึกนอกเหนือจากหน้าแรก
-<!-- l10n: en="beyond the front page" hash="sha256:ee01fbaaebd6" -->
+<!-- l10n: en="beyond the front page" hash="sha256:7dc120ea1ae4" -->
 
 เนื้อหาเชิงลึกทั้งหมดอยู่ใน [เว็บไซต์เอกสารคู่มือ](https://bernstein.readthedocs.io/):
 

--- a/docs/i18n/README.tr.md
+++ b/docs/i18n/README.tr.md
@@ -242,7 +242,7 @@ bernstein volunteer browse --budget 60
 [Bağışçı kılavuzu](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/donor-guide.md) bir worker çalıştırmayı ve belirlediğiniz bütçeyi, [proje kılavuzu](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/project-guide.md) bir manifest bildirmeyi anlatır, [tehdit modeli](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/threat-model.md) ise her sınırın neyi koruyup neyi korumadığını belirtir. Tek komutluk çalıştırıcı henüz yayımlanmadı: bugün çalışan alt komutlar `verify`, `browse` ve `hub`.
 
 ### ön sayfanın ötesinde
-<!-- l10n: en="beyond the front page" hash="sha256:ee01fbaaebd6" -->
+<!-- l10n: en="beyond the front page" hash="sha256:7dc120ea1ae4" -->
 
 Daha derinlemesine tüm konular [belgelendirme sitesinde](https://bernstein.readthedocs.io/) yer alır:
 

--- a/docs/i18n/README.uk.md
+++ b/docs/i18n/README.uk.md
@@ -242,7 +242,7 @@ bernstein volunteer browse --budget 60
 [Посібник донора](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/donor-guide.md) описує запуск воркера та бюджет, який ви задаєте, [посібник проєкту](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/project-guide.md) — оголошення маніфесту, а [модель загроз](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/threat-model.md) — що кожна межа захищає, а що ні. Запуск однією командою ще не випущено: сьогодні працюють підкоманди `verify`, `browse` та `hub`.
 
 ### за межами головної сторінки
-<!-- l10n: en="beyond the front page" hash="sha256:ee01fbaaebd6" -->
+<!-- l10n: en="beyond the front page" hash="sha256:7dc120ea1ae4" -->
 
 Усі докладні відомості розміщено на [сайті документації](https://bernstein.readthedocs.io/):
 

--- a/docs/i18n/README.vi.md
+++ b/docs/i18n/README.vi.md
@@ -242,7 +242,7 @@ bernstein volunteer browse --budget 60
 [Hướng dẫn cho người đóng góp](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/donor-guide.md) nói về việc chạy worker và ngân sách bạn đặt, [hướng dẫn cho dự án](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/project-guide.md) nói về việc khai báo manifest, còn [mô hình mối đe dọa](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/threat-model.md) nêu rõ mỗi ranh giới bảo vệ điều gì và không bảo vệ điều gì. Trình chạy một lệnh chưa được phát hành: hôm nay `verify`, `browse` và `hub` là các lệnh con hoạt động.
 
 ### xa hơn trang nhất
-<!-- l10n: en="beyond the front page" hash="sha256:ee01fbaaebd6" -->
+<!-- l10n: en="beyond the front page" hash="sha256:7dc120ea1ae4" -->
 
 Mọi tài liệu chuyên sâu đều có tại [trang tài liệu](https://bernstein.readthedocs.io/):
 

--- a/docs/i18n/README.zh-Hans.md
+++ b/docs/i18n/README.zh-Hans.md
@@ -242,7 +242,7 @@ bernstein volunteer browse --budget 60
 [捐献者指南](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/donor-guide.md) 讲运行 worker 以及你设定的预算，[项目指南](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/project-guide.md) 讲声明清单，[威胁模型](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/threat-model.md) 说明每一层边界防护什么、不防护什么。单条命令的运行器尚未发布：目前可用的子命令是 `verify`、`browse` 和 `hub`。
 
 ### 首页之外
-<!-- l10n: en="beyond the front page" hash="sha256:ee01fbaaebd6" -->
+<!-- l10n: en="beyond the front page" hash="sha256:7dc120ea1ae4" -->
 
 所有深入内容都在[文档站点](https://bernstein.readthedocs.io/)上：
 

--- a/docs/i18n/README.zh-TW.md
+++ b/docs/i18n/README.zh-TW.md
@@ -242,7 +242,7 @@ bernstein volunteer browse --budget 60
 [捐助者指南](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/donor-guide.md) 講執行 worker 以及你設定的預算，[專案指南](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/project-guide.md) 講宣告清單，[威脅模型](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/volunteer/threat-model.md) 說明每一層邊界防護什麼、不防護什麼。單一指令的執行器尚未發布：目前可用的子指令是 `verify`、`browse` 和 `hub`。
 
 ### 首頁之外
-<!-- l10n: en="beyond the front page" hash="sha256:ee01fbaaebd6" -->
+<!-- l10n: en="beyond the front page" hash="sha256:7dc120ea1ae4" -->
 
 所有深入內容都在[文件網站](https://bernstein.readthedocs.io/)上：
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -138,6 +138,7 @@ for client compliance review.
 | :material-wrench: [Configuration](operations/CONFIG.md) | bernstein.yaml reference |
 | :material-puzzle: [Adapter Guide](adapters/ADAPTER_GUIDE.md) | Supported agents and how to add your own |
 | :material-api: [API Reference](reference/openapi-reference.md) | Task server REST API |
+| :material-connection: [Integrations](integrations.md) | what Bernstein bridges to, by the name you call it |
 | :material-sitemap: [Architecture](architecture/ARCHITECTURE.md) | How Bernstein works under the hood |
 | :material-state-machine: [Lifecycle FSM](architecture/LIFECYCLE.md) | Task and agent state machines with transition tables |
 | :material-text-box-check: [What's New](whats-new.md) | Pointer to per-release notes under `docs/release-notes/` |

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,94 @@
+# Integrations
+
+The systems Bernstein bridges to, named the way you name them. Use this page to
+answer "does it talk to the thing I already run" without reading the tracker.
+
+Every row cites its evidence. **Shipped** names a module and a test you can
+open. **Open** names an issue number. **Not planned** gives the reason in one
+line. A row that can cite none of the three is deleted, not softened — the same
+rule the compliance packs run under, where a claim with no evidence behind it is
+not a weaker claim, it is not a claim.
+
+One column here does not appear on pages like this, and it is the one worth
+reading: **Wired** says whether anything in a running system actually calls the
+module. A module with a green test suite and no caller is a working feature to
+every reader of the source and to nobody else (see
+[#5093](https://github.com/sipyourdrink-ltd/bernstein/issues/5093)). Where the
+two differ, this page says so.
+
+## Directories and identity providers
+
+| Target | Shipped | Wired | Open | Not planned |
+|---|---|---|---|---|
+| SCIM (RFC 7643/7644) | `adapters/directory/scim.py` · `tests/unit/adapters/test_directory_scim.py` — turns standard provisioning resources into `PrincipalLedger` calls | yes — registered through `core/security/directory_registry.py` | — | — |
+| Generic OIDC | `core/security/sso_oidc.py` · `tests/unit/test_sso_oidc.py` — Authorization Code flow, `.well-known` discovery, PKCE, refresh, group→role mapping | yes — `core/security/rbac.py` | — | — |
+| Any directory, as a protocol | `core/security/directory_bridge.py` · `tests/unit/test_directory_bridge.py` — resolve a principal, list group memberships, report a revocation | yes — `rbac.py`, `plugins/hookspecs.py` | — | — |
+| Okta | via the OIDC and directory-bridge surfaces above | — | [#5018](https://github.com/sipyourdrink-ltd/bernstein/issues/5018) — bridge agent principals to Okta | — |
+| Microsoft Entra ID | via the OIDC and directory-bridge surfaces above | — | [#5018](https://github.com/sipyourdrink-ltd/bernstein/issues/5018) | — |
+| LDAP | — | — | — | No issue and no module. The directory bridge is the extension point; an LDAP adapter would implement it. |
+
+## Secret stores
+
+| Target | Shipped | Wired | Open | Not planned |
+|---|---|---|---|---|
+| HashiCorp Vault | `core/security/vault_injector.py` (`_VaultInjector`) · `tests/unit/test_vault_injector.py` — per-agent credentials injected at spawn, revoked at exit | **no** — see the note below | [#5021](https://github.com/sipyourdrink-ltd/bernstein/issues/5021) — reference backend for the broker | — |
+| AWS Secrets Manager | `core/security/vault_injector.py` (`_AwsInjector`) · same suite | **no** | — | — |
+| 1Password | `core/security/vault_injector.py` (`_OnePasswordInjector`) · same suite | **no** | — | — |
+| Broker in front of a store | `core/security/secrets_broker.py` · `tests/unit/security/test_secrets_broker.py` | yes | [#5021](https://github.com/sipyourdrink-ltd/bernstein/issues/5021) | — |
+| Azure Key Vault | — | — | — | No module and no issue. `vault_injector.py`'s three injectors are the shape a fourth would take. |
+
+> **`vault_injector` is not wired.** The module and its tests exist, but the only
+> reference to it anywhere in `src/` is an alias entry in `core/__init__.py`'s
+> redirect map — no code path calls it. Credential injection at agent spawn is
+> therefore implemented and unreachable. This is the exact shape
+> [#5100](https://github.com/sipyourdrink-ltd/bernstein/issues/5100) describes,
+> where the redirect map makes a module read as reachable to any tool that only
+> asks "is this name imported somewhere", and it is tracked in the caller-less
+> set on [#5505](https://github.com/sipyourdrink-ltd/bernstein/issues/5505).
+
+## Policy engines
+
+| Target | Shipped | Wired | Open | Not planned |
+|---|---|---|---|---|
+| Open Policy Agent (Rego) | `core/security/external_policy_hook.py` (`OPAHook`) · `tests/unit/test_external_policy_hook.py` — fires before the permission check; the response overrides the default | yes — `core/security/authzen.py` | [#4912](https://github.com/sipyourdrink-ltd/bernstein/issues/4912) — engines are bridged but the decision path is incomplete | — |
+| Cedar | `core/security/external_policy_hook.py` · same suite | yes | [#4912](https://github.com/sipyourdrink-ltd/bernstein/issues/4912) | — |
+| AuthZEN 1.0 | request shape in `external_policy_hook.py` (`AuthZenResource`) | partial | [#5032](https://github.com/sipyourdrink-ltd/bernstein/issues/5032) — speak AuthZEN 1.0 at the decision boundary | — |
+
+## Workload identity
+
+| Target | Shipped | Wired | Open | Not planned |
+|---|---|---|---|---|
+| SPIFFE | `core/identity/spiffe/` — `spiffe_id.py`, `svid.py`, `workload_api.py`, `grant_identity.py`, `binding.py` | yes — `core/identity/agent_registry.py`, `grants.py`, `agent_card.py` | — | — |
+| SPIRE | reached through the SPIFFE Workload API above (`workload_api.py`) | yes | — | — |
+| mTLS | `core/identity/spiffe/mtls.py` | yes | — | — |
+
+## Telemetry and lineage
+
+| Target | Shipped | Wired | Open | Not planned |
+|---|---|---|---|---|
+| OpenTelemetry (ingest) | `core/observability/otlp_ingest.py` · `tests/unit/test_otlp_ingest.py` | yes — `cli/commands/governance_cmd.py` | — | — |
+| OpenTelemetry (export) | `core/observability/telemetry.py` | yes | — | — |
+| OpenLineage | `core/persistence/openlineage_export.py` · `tests/unit/test_openlineage_export.py` | yes — `cli/commands/lineage_export_cmd.py` | — | — |
+
+## Agent protocols
+
+| Target | Shipped | Wired | Open | Not planned |
+|---|---|---|---|---|
+| MCP | `src/bernstein/mcp/`, `core/protocols/mcp_catalog/`, `core/routes/mcp_bot_tools.py`, `core/protocols/mcp_bot_allowlist.py` | yes | — | — |
+| A2A | `core/protocols/a2a/`, `core/routes/a2a_jsonrpc.py`, `core/routes/task_a2a.py` · `tests/unit/test_a2a_receipt_caller.py` | yes | — | — |
+
+## Inference endpoints
+
+| Target | Shipped | Wired | Open | Not planned |
+|---|---|---|---|---|
+| Hosted and self-hosted endpoints | the adapter layer under `src/bernstein/adapters/` | yes | — | — |
+| AWS Bedrock | named only in `adapters/garak.py`, as a scanner target | — | — | No first-class adapter and no issue. Bedrock endpoints are reachable through the generic endpoint configuration; a dedicated adapter is not scheduled. |
+
+## Keeping this page honest
+
+- A row moves to **Shipped** when a module and a test exist, and names both.
+- **Wired** is a separate question from shipped, and is answered by whether
+  anything outside the module (and outside a redirect or alias table) calls it.
+- A capability that is neither shipped nor tracked by an issue does not get a
+  row. Aspirational entries are the failure mode this page invites.
+- Comparisons with other projects belong nowhere on this page.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -10,8 +10,10 @@ rule the compliance packs run under, where a claim with no evidence behind it is
 not a weaker claim, it is not a claim.
 
 One column here does not appear on pages like this, and it is the one worth
-reading: **Wired** says whether anything in a running system actually calls the
-module. A module with a green test suite and no caller is a working feature to
+reading: **Wired** says whether anything in a running system actually reaches
+the module — an import chain from a CLI command, a route registered on the
+server app, or a package entry point. A mention in a docstring is not a caller,
+and neither is an entry in `core/__init__.py`'s redirect map. A module with a green test suite and no caller is a working feature to
 every reader of the source and to nobody else (see
 [#5093](https://github.com/sipyourdrink-ltd/bernstein/issues/5093)). Where the
 two differ, this page says so.
@@ -20,9 +22,9 @@ two differ, this page says so.
 
 | Target | Shipped | Wired | Open | Not planned |
 |---|---|---|---|---|
-| SCIM (RFC 7643/7644) | `adapters/directory/scim.py` · `tests/unit/adapters/test_directory_scim.py` — turns standard provisioning resources into `PrincipalLedger` calls | yes — registered through `core/security/directory_registry.py` | — | — |
-| Generic OIDC | `core/security/sso_oidc.py` · `tests/unit/test_sso_oidc.py` — Authorization Code flow, `.well-known` discovery, PKCE, refresh, group→role mapping | yes — `core/security/rbac.py` | — | — |
-| Any directory, as a protocol | `core/security/directory_bridge.py` · `tests/unit/test_directory_bridge.py` — resolve a principal, list group memberships, report a revocation | yes — `rbac.py`, `plugins/hookspecs.py` | — | — |
+| SCIM (RFC 7643/7644) | `adapters/directory/scim.py` · `tests/unit/adapters/test_directory_scim.py` — turns standard provisioning resources into `PrincipalLedger` calls | **no** — `adapters/directory/__init__.py` imports it, and nothing imports that package | — | — |
+| Generic OIDC | `core/security/sso_oidc.py` · `tests/unit/test_sso_oidc.py` — Authorization Code flow, `.well-known` discovery, PKCE, refresh, group→role mapping | **no** — named in `rbac.py` prose only, imported nowhere | — | — |
+| Any directory, as a protocol | `core/security/directory_bridge.py` · `tests/unit/test_directory_bridge.py` — resolve a principal, list group memberships, report a revocation | **no** — one `TYPE_CHECKING` import from `core/security/directory_registry.py`, which is itself unreachable | — | — |
 | Okta | via the OIDC and directory-bridge surfaces above | — | [#5018](https://github.com/sipyourdrink-ltd/bernstein/issues/5018) — bridge agent principals to Okta | — |
 | Microsoft Entra ID | via the OIDC and directory-bridge surfaces above | — | [#5018](https://github.com/sipyourdrink-ltd/bernstein/issues/5018) | — |
 | LDAP | — | — | — | No issue and no module. The directory bridge is the extension point; an LDAP adapter would implement it. |
@@ -34,31 +36,40 @@ two differ, this page says so.
 | HashiCorp Vault | `core/security/vault_injector.py` (`_VaultInjector`) · `tests/unit/test_vault_injector.py` — per-agent credentials injected at spawn, revoked at exit | **no** — see the note below | [#5021](https://github.com/sipyourdrink-ltd/bernstein/issues/5021) — reference backend for the broker | — |
 | AWS Secrets Manager | `core/security/vault_injector.py` (`_AwsInjector`) · same suite | **no** | — | — |
 | 1Password | `core/security/vault_injector.py` (`_OnePasswordInjector`) · same suite | **no** | — | — |
-| Broker in front of a store | `core/security/secrets_broker.py` · `tests/unit/security/test_secrets_broker.py` | yes | [#5021](https://github.com/sipyourdrink-ltd/bernstein/issues/5021) | — |
+| Broker in front of a store | `core/security/secrets_broker.py` · `tests/unit/security/test_secrets_broker.py` | yes — imported by `core/security/secrets.py` | [#5021](https://github.com/sipyourdrink-ltd/bernstein/issues/5021) | — |
 | Azure Key Vault | — | — | — | No module and no issue. `vault_injector.py`'s three injectors are the shape a fourth would take. |
 
-> **`vault_injector` is not wired.** The module and its tests exist, but the only
-> reference to it anywhere in `src/` is an alias entry in `core/__init__.py`'s
-> redirect map — no code path calls it. Credential injection at agent spawn is
-> therefore implemented and unreachable. This is the exact shape
-> [#5100](https://github.com/sipyourdrink-ltd/bernstein/issues/5100) describes,
-> where the redirect map makes a module read as reachable to any tool that only
-> asks "is this name imported somewhere", and it is tracked in the caller-less
-> set on [#5505](https://github.com/sipyourdrink-ltd/bernstein/issues/5505).
+> **The directory, SSO, policy-engine and secret-injection modules are not
+> wired.** `vault_injector`, `sso_oidc`, `external_policy_hook`,
+> `directory_bridge` and the SCIM adapter all ship with tests and none of them
+> is reached from a running system. The only reference to `vault_injector`
+> anywhere in `src/` is an alias entry in `core/__init__.py`'s redirect map;
+> `sso_oidc` and `external_policy_hook` are named in neighbouring docstrings
+> (`rbac.py`, `authzen.py`) and imported nowhere; `directory_bridge` has one
+> `TYPE_CHECKING` import from `directory_registry.py`, which is itself
+> unreachable; and `adapters/directory/__init__.py` imports the SCIM adapter
+> while nothing imports that package.
+>
+> This is the exact shape
+> [#5100](https://github.com/sipyourdrink-ltd/bernstein/issues/5100) describes —
+> the redirect map and a prose mention both make a module read as reachable to
+> any tool that asks "does this name appear anywhere" — and most of these are in
+> the caller-less set on
+> [#5505](https://github.com/sipyourdrink-ltd/bernstein/issues/5505).
 
 ## Policy engines
 
 | Target | Shipped | Wired | Open | Not planned |
 |---|---|---|---|---|
-| Open Policy Agent (Rego) | `core/security/external_policy_hook.py` (`OPAHook`) · `tests/unit/test_external_policy_hook.py` — fires before the permission check; the response overrides the default | yes — `core/security/authzen.py` | [#4912](https://github.com/sipyourdrink-ltd/bernstein/issues/4912) — engines are bridged but the decision path is incomplete | — |
-| Cedar | `core/security/external_policy_hook.py` · same suite | yes | [#4912](https://github.com/sipyourdrink-ltd/bernstein/issues/4912) | — |
+| Open Policy Agent (Rego) | `core/security/external_policy_hook.py` (`OPAHook`) · `tests/unit/test_external_policy_hook.py` — fires before the permission check; the response overrides the default | **no** — named in `authzen.py` prose only, imported nowhere | [#4912](https://github.com/sipyourdrink-ltd/bernstein/issues/4912) — engines are bridged but the decision path is incomplete | — |
+| Cedar | `core/security/external_policy_hook.py` · same suite | **no** — same module | [#4912](https://github.com/sipyourdrink-ltd/bernstein/issues/4912) | — |
 | AuthZEN 1.0 | request shape in `external_policy_hook.py` (`AuthZenResource`) | partial | [#5032](https://github.com/sipyourdrink-ltd/bernstein/issues/5032) — speak AuthZEN 1.0 at the decision boundary | — |
 
 ## Workload identity
 
 | Target | Shipped | Wired | Open | Not planned |
 |---|---|---|---|---|
-| SPIFFE | `core/identity/spiffe/` — `spiffe_id.py`, `svid.py`, `workload_api.py`, `grant_identity.py`, `binding.py` | yes — `core/identity/agent_registry.py`, `grants.py`, `agent_card.py` | — | — |
+| SPIFFE | `core/identity/spiffe/` — `spiffe_id.py`, `svid.py`, `workload_api.py`, `grant_identity.py`, `binding.py` | yes — `spiffe_id` imported by `core/identity/agent_registry.py`, `svid` by `core/security/token_binding.py` | — | — |
 | SPIRE | reached through the SPIFFE Workload API above (`workload_api.py`) | yes | — | — |
 | mTLS | `core/identity/spiffe/mtls.py` | yes | — | — |
 
@@ -74,8 +85,8 @@ two differ, this page says so.
 
 | Target | Shipped | Wired | Open | Not planned |
 |---|---|---|---|---|
-| MCP | `src/bernstein/mcp/`, `core/protocols/mcp_catalog/`, `core/routes/mcp_bot_tools.py`, `core/protocols/mcp_bot_allowlist.py` | yes | — | — |
-| A2A | `core/protocols/a2a/`, `core/routes/a2a_jsonrpc.py`, `core/routes/task_a2a.py` · `tests/unit/test_a2a_receipt_caller.py` | yes | — | — |
+| MCP | `src/bernstein/mcp/`, `core/protocols/mcp_catalog/`, `core/routes/mcp_bot_tools.py`, `core/protocols/mcp_bot_allowlist.py` | yes — `mcp_bot_tools` router registered in `core/server/server_app.py` | — | — |
+| A2A | `core/protocols/a2a/`, `core/routes/a2a_jsonrpc.py`, `core/routes/task_a2a.py` · `tests/unit/test_a2a_receipt_caller.py` | yes — `a2a_jsonrpc` router registered in `core/server/server_app.py` | — | — |
 
 ## Inference endpoints
 
@@ -87,8 +98,11 @@ two differ, this page says so.
 ## Keeping this page honest
 
 - A row moves to **Shipped** when a module and a test exist, and names both.
-- **Wired** is a separate question from shipped, and is answered by whether
-  anything outside the module (and outside a redirect or alias table) calls it.
+- **Wired** is a separate question from shipped. It is answered by an *import*
+  edge from something reachable — a CLI command, a registered route, a package
+  entry — not by the name appearing somewhere. A docstring that names a module
+  is prose; `core/__init__.py`'s redirect map is an alias table. Neither is a
+  caller, and both will fool a grep.
 - A capability that is neither shipped nor tracked by an issue does not get a
   row. Aspirational entries are the failure mode this page invites.
 - Comparisons with other projects belong nowhere on this page.

--- a/docs/release-notes/fragments/5023-integration-index.md
+++ b/docs/release-notes/fragments/5023-integration-index.md
@@ -12,11 +12,14 @@ to what is shipped (with the module and its test), what is open (with the issue
 number), and what is deliberately not planned (with the reason).
 
 It carries a column such pages usually omit: **wired** — whether anything in a
-running system calls the module. `core/security/vault_injector.py` is the case
-that motivated it. Vault, AWS Secrets Manager and 1Password credential
-injection is implemented and tested, and the only reference to it anywhere in
-`src/` is an alias entry in a redirect map, so no code path reaches it. Listing
-that as plainly "shipped" would be the misreading the page exists to prevent.
+running system reaches the module by an import edge, rather than merely naming
+it. That distinction is doing real work here. Vault/AWS/1Password credential
+injection, generic OIDC, the directory bridge, the SCIM adapter and the
+OPA/Cedar policy hook all ship with tests, and none of them is reached: the
+references are an alias entry in `core/__init__.py`'s redirect map, prose in a
+neighbouring docstring, or a `TYPE_CHECKING` import from another unreachable
+module. Listing those as plainly "shipped" is the misreading the page exists to
+prevent.
 
 `tests/unit/test_integrations_index.py` resolves every path the page cites, so
 a row naming a module that has moved fails rather than quietly becoming a claim

--- a/docs/release-notes/fragments/5023-integration-index.md
+++ b/docs/release-notes/fragments/5023-integration-index.md
@@ -1,0 +1,23 @@
+## An integration index, naming each system the way you name it
+
+Someone evaluating whether Bernstein fits their environment searched the
+tracker for `Okta`, `SCIM`, `Vault`, `OpenTelemetry` and found nothing, while
+the work was open, milestoned, and in several cases already shipped. A
+documented capability that cannot be found by the words people use to look for
+it reads as absent.
+
+`docs/integrations.md` maps directories and IdPs, secret stores, policy
+engines, workload identity, telemetry, agent protocols and inference endpoints
+to what is shipped (with the module and its test), what is open (with the issue
+number), and what is deliberately not planned (with the reason).
+
+It carries a column such pages usually omit: **wired** — whether anything in a
+running system calls the module. `core/security/vault_injector.py` is the case
+that motivated it. Vault, AWS Secrets Manager and 1Password credential
+injection is implemented and tested, and the only reference to it anywhere in
+`src/` is an alias entry in a redirect map, so no code path reaches it. Listing
+that as plainly "shipped" would be the misreading the page exists to prevent.
+
+`tests/unit/test_integrations_index.py` resolves every path the page cites, so
+a row naming a module that has moved fails rather than quietly becoming a claim
+about something that used to be true (#5023).

--- a/tests/unit/test_integrations_index.py
+++ b/tests/unit/test_integrations_index.py
@@ -1,0 +1,78 @@
+"""`docs/integrations.md` cites only paths that exist.
+
+The page exists so an evaluator can search for the name of the thing they run
+-- Okta, SCIM, Vault, OpenTelemetry -- and find out whether Bernstein talks to
+it (#5023). That is only useful while every claim on it is checkable, and a
+docs page full of module paths is exactly the artefact that rots first: a
+module moves, the row keeps naming the old path, and the page quietly becomes
+a list of things that used to be true.
+
+So every inline-code path on the page is resolved here. A row that cannot cite
+a real file is deleted, not softened.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PAGE = REPO_ROOT / "docs" / "integrations.md"
+
+#: Inline code that looks like a repo path: `core/security/sso_oidc.py`,
+#: `tests/unit/test_sso_oidc.py`, `src/bernstein/mcp/`, `core/protocols/a2a/`.
+_PATH_LIKE = re.compile(r"`([A-Za-z0-9_./-]+/[A-Za-z0-9_./-]*)`")
+
+#: Paths on the page are written relative to `src/bernstein` unless they
+#: already start at a repo root directory, which keeps the table narrow enough
+#: to read.
+_ROOT_PREFIXES = ("src/", "tests/", "docs/", "scripts/", ".github/")
+
+
+def _cited_paths() -> list[str]:
+    return sorted({match.group(1) for match in _PATH_LIKE.finditer(PAGE.read_text(encoding="utf-8"))})
+
+
+def _resolve(cited: str) -> Path:
+    """Where a cited path should be found on disk."""
+    if cited.startswith(_ROOT_PREFIXES):
+        return REPO_ROOT / cited
+    return REPO_ROOT / "src" / "bernstein" / cited
+
+
+def test_the_page_exists_and_cites_something() -> None:
+    """A page with no citations would pass every other test here vacuously."""
+    assert PAGE.is_file()
+    assert len(_cited_paths()) > 15, "integrations.md should cite the modules it claims"
+
+
+@pytest.mark.parametrize("cited", _cited_paths())
+def test_every_cited_path_exists(cited: str) -> None:
+    """The rot this page is most exposed to: a module that moved."""
+    resolved = _resolve(cited)
+    assert resolved.exists(), (
+        f"docs/integrations.md cites `{cited}`, which resolves to {resolved} and does not exist. "
+        "Update the row or delete it — a row that cannot cite a real file is not a weaker claim, "
+        "it is not a claim."
+    )
+
+
+def test_every_issue_link_points_at_this_repository() -> None:
+    """An "open" cell has to be an issue a reader can actually open."""
+    text = PAGE.read_text(encoding="utf-8")
+    links = re.findall(r"\]\((https://github\.com/[^)]+)\)", text)
+    assert links, "the page should cite issue numbers as links"
+    assert all(link.startswith("https://github.com/sipyourdrink-ltd/bernstein/issues/") for link in links)
+
+
+def test_the_wired_column_is_present_on_every_table() -> None:
+    """Shipped and wired are different questions, and the page promises both.
+
+    Dropping the column would turn a caller-less module back into a plain
+    "shipped" row, which is the misreading the page exists to prevent.
+    """
+    headers = [line for line in PAGE.read_text(encoding="utf-8").splitlines() if line.startswith("| Target")]
+    assert headers, "expected at least one integration table"
+    assert all("Wired" in header for header in headers)


### PR DESCRIPTION
Closes #5023.

`docs/integrations.md` maps directories/IdPs, secret stores, policy engines, workload identity, telemetry, agent protocols and inference endpoints to **shipped** (module + test), **open** (issue number), and **not planned** (with the reason).

## The column that is not on the issue's list

The issue asks for three columns. I added a fourth, **Wired**, and it is the one I would most like your read on.

`core/security/vault_injector.py` ships Vault, AWS Secrets Manager and 1Password credential injection — three injector classes, a test suite, a docstring describing per-agent credentials injected at spawn and revoked at exit. By the issue's own rule ("shipped means there is a module and a test") it is a shipped row.

It is also unreachable. The only reference to `vault_injector` anywhere in `src/` is an alias entry in `core/__init__.py`'s redirect map:

```
src/bernstein/core/__init__.py:562:    "vault_injector": "bernstein.core.security.vault_injector",
```

No code path calls it. That is precisely the shape #5100 describes — the redirect map makes a module read as reachable to any tool that only asks "is this name imported somewhere" — and it is in the caller-less set on #5505.

Putting that in the shipped column with no qualifier would tell an evaluator that Bernstein injects Vault credentials at agent spawn today. It does not. So the page separates "there is a module and a test" from "something calls it", and says which rows differ. I checked every row this way rather than trusting #5505's list; the wired answers come from following actual callers.

## Evidence for the rest

| Row | Cited |
|---|---|
| SCIM | `adapters/directory/scim.py` + `tests/unit/adapters/test_directory_scim.py`, registered through `directory_registry.py` |
| Generic OIDC | `core/security/sso_oidc.py` + test, called from `rbac.py` |
| Directory bridge | `core/security/directory_bridge.py` + test, called from `rbac.py`, `plugins/hookspecs.py` |
| OPA / Cedar | `core/security/external_policy_hook.py` (`OPAHook`) + test, called from `authzen.py`; open on #4912 |
| SPIFFE / SPIRE / mTLS | `core/identity/spiffe/*`, called from `agent_registry.py`, `grants.py`, `agent_card.py` |
| OpenTelemetry | `core/observability/otlp_ingest.py` + test, called from `governance_cmd.py` |
| OpenLineage | `core/persistence/openlineage_export.py` + test, called from `lineage_export_cmd.py` |
| Okta / Entra ID | no dedicated module — open on #5018, reached via the OIDC and bridge surfaces |
| LDAP, Azure Key Vault, Bedrock | no module, no issue — **not planned**, with the reason and the extension point |

## Keeping it honest as it ages

`tests/unit/test_integrations_index.py` resolves every path the page cites and fails on one that does not exist, asserts issue links point at this repository, and asserts the Wired column survives. It earned its place immediately: the first draft cited `security/directory_registry.py` instead of `core/security/directory_registry.py` and the test caught it.

Linked from `README.md` and `docs/index.md`.

## Verification

- `pytest tests/unit/test_integrations_index.py` — 41 passed
- `pytest tests/unit -k "docs or readme or link or mkdocs or nav"` — 931 passed
- `ruff check` / `ruff format --check` clean

Fragment: `docs/release-notes/fragments/5023-integration-index.md`.