### PR TITLE
docs: add ADOPTERS.md, self-reported and pruned (#5027)

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,78 @@
+# Adopters
+
+Who runs Bernstein, on what, and since when.
+
+This page exists for three reasons, none of them promotion:
+
+- **An evaluator cannot calibrate risk without it.** Someone deciding whether to
+  put a governance layer in front of regulated workloads asks who else depends
+  on it and for what. Absent evidence reads as absent adopters, which is a
+  stronger negative signal than a short list.
+- **Contributors cannot see where their work lands.** Someone who fixed
+  something in the identity plane has no way to learn that it mattered to an
+  air-gapped install. That feedback is most of what keeps unpaid contributors
+  returning.
+- **We cannot tell which surfaces are load-bearing.** Prioritisation runs on
+  intuition about what people use. A use-case column turns that into something
+  readable.
+
+## Production
+
+Systems people depend on.
+
+| Organization or project | Domain | What they use it for | Since | Contact |
+|---|---|---|---|---|
+<!-- Add your row here. Keep the table sorted by the first column. -->
+
+## Evaluation / Pilot
+
+Trials, proofs of concept, and installs not yet depended on. A pilot and a
+production dependency are different claims and should not need a squint to tell
+apart.
+
+| Organization or project | Domain | What they use it for | Since | Contact |
+|---|---|---|---|---|
+<!-- Add your row here. Keep the table sorted by the first column. -->
+
+## How to add yourself
+
+Open a pull request adding one row to the section that describes your install.
+That is the whole process — no form, no approval queue.
+
+The rules that keep this page worth reading:
+
+- **Self-reported, by pull request.** An entry is added by the adopter, never by
+  a maintainer on someone's behalf. A list a maintainer writes about their own
+  users is a claim; a list adopters sign is evidence. Usage that could be
+  inferred from public activity is not listed: **inference is not consent.**
+- **A contact handle is required.** A GitHub handle, an email, or a project
+  URL — something a reader could follow up with. An entry nobody will stand
+  behind does not go in.
+- **The use case is specific.** "Uses Bernstein" is not a row. "Deterministic
+  replay for regulated evidence in an air-gapped environment" is a row. The
+  column is what makes the page useful to the next evaluator, and to us when we
+  are deciding what to work on.
+- **Individuals and projects are welcome**, not only companies. Most real usage
+  here is not corporate, and a list that accepted only logos would be both empty
+  and dishonest.
+- **`Since` is a month and year** (`2026-03`), the point you started depending
+  on it — not the day you first cloned it.
+
+Nothing about scale, revenue, or growth belongs on this page, and neither do
+logos, testimonials, or case-study prose. Rows and links.
+
+## Pruning
+
+An entry is removed when it stops being true. In practice:
+
+- The contact has been unreachable for two release cycles and the row cannot be
+  confirmed.
+- The adopter asks for removal — always, immediately, no discussion.
+- The described use case no longer exists.
+
+Anyone may open a pull request removing their own row for any reason or none.
+Removal is never treated as a signal about the project, and no one is asked to
+justify it.
+
+An empty section is a correct state for this page. A padded one is worse than
+none, and it is the failure mode a page like this invites.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,17 @@ without anyone having to fetch anything.
 Include what a PR would carry: what changed, the tests that prove it, and the
 commit the diff applies to.
 
+### Telling us you use it
+
+If you depend on Bernstein, add yourself to
+[ADOPTERS.md](ADOPTERS.md) — one row, in your own pull request. Nobody is
+listed by a maintainer on their behalf, and usage that could be inferred from
+public activity is not listed either: inference is not consent.
+
+It is worth doing for a reason that is not promotion. It is how a contributor
+finds out that the thing they fixed mattered to an air-gapped install, and how
+we learn which surfaces are load-bearing rather than guessing.
+
 ### Docs alongside code
 
 Every PR that adds or changes a feature MUST update docs in the same PR:

--- a/docs/release-notes/fragments/5027-adopters.md
+++ b/docs/release-notes/fragments/5027-adopters.md
@@ -1,0 +1,18 @@
+## `ADOPTERS.md`: who runs this, on what, and since when
+
+Nothing in the repository said who depends on Bernstein. An evaluator deciding
+whether to put a governance layer in front of regulated workloads had to read
+the issue tracker and guess from usernames, and absent evidence reads as absent
+adopters — a stronger negative signal than a short list would be.
+
+`ADOPTERS.md` carries two sections, Production and Evaluation / Pilot, because a
+pilot and a production dependency are different claims and should not need a
+squint to tell apart. Both start empty, which is the correct state: a padded
+list is worse than none.
+
+Entries are self-reported by pull request. Nobody is added by a maintainer on
+someone else's behalf, and usage that could be inferred from public activity is
+not listed — inference is not consent. A contact handle is required and the use
+case has to be specific; `tests/unit/test_adopters_page.py` enforces both, plus
+the `Since` month format, since those are the fields that decay first and that
+nobody can reconstruct later. `CONTRIBUTING.md` says how to add yourself (#5027).

--- a/tests/unit/test_adopters_page.py
+++ b/tests/unit/test_adopters_page.py
@@ -1,0 +1,106 @@
+"""`ADOPTERS.md` rows carry the two fields that decay first.
+
+The page is self-reported, so its integrity cannot come from review alone: a
+row is added by the adopter, in their own pull request, and nobody else is in a
+position to know whether the use case is still true. What *can* be enforced
+mechanically is that a row was written to be checkable in the first place --
+that somebody is named who will stand behind it, and that the use case says
+something more than "uses Bernstein" (#5027).
+
+An empty table passes every assertion here, deliberately. An empty
+`ADOPTERS.md` is a correct state; a padded one is the failure mode.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PAGE = REPO_ROOT / "ADOPTERS.md"
+
+#: The column set both tables carry.
+COLUMNS = ("Organization or project", "Domain", "What they use it for", "Since", "Contact")
+
+#: Section headings that must exist. A pilot and a production dependency are
+#: different claims; collapsing them into a status column would let one read as
+#: the other at a glance.
+SECTIONS = ("## Production", "## Evaluation / Pilot")
+
+#: Placeholder use cases -- the shape the "specific use case" rule exists to
+#: refuse. Matched case-insensitively against the whole cell.
+_VAGUE = frozenset({"uses bernstein", "uses it", "various", "tbd", "n/a", "-", ""})
+
+
+def _text() -> str:
+    return PAGE.read_text(encoding="utf-8")
+
+
+def _data_rows() -> list[list[str]]:
+    """Every table row that is not a header or separator."""
+    rows: list[list[str]] = []
+    for line in _text().splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        if cells[0] == COLUMNS[0]:
+            continue
+        if all(set(cell) <= {"-", ":"} and cell for cell in cells):
+            continue
+        rows.append(cells)
+    return rows
+
+
+def test_the_page_exists_with_both_sections() -> None:
+    """Two sections, not one table with a status column."""
+    assert PAGE.is_file()
+    text = _text()
+    for section in SECTIONS:
+        assert section in text, f"ADOPTERS.md is missing the `{section}` section"
+
+
+def test_both_tables_carry_the_agreed_columns() -> None:
+    """A row is only comparable to another row if the columns are the same."""
+    headers = [line for line in _text().splitlines() if line.strip().startswith(f"| {COLUMNS[0]}")]
+    assert len(headers) == 2, "expected one header row per section"
+    for header in headers:
+        cells = [cell.strip() for cell in header.strip().strip("|").split("|")]
+        assert tuple(cells) == COLUMNS
+
+
+def test_the_contribution_rule_is_stated_on_the_page() -> None:
+    """The rule is enforced socially, so it has to be legible where rows are added."""
+    text = _text().lower()
+    assert "inference is not consent" in text
+    assert "self-reported" in text
+
+
+def test_the_pruning_rule_is_stated_on_the_page() -> None:
+    """A list with no removal rule becomes a list of things that used to be true."""
+    assert "## Pruning" in _text()
+
+
+@pytest.mark.parametrize("row", _data_rows() or [None])
+def test_every_row_names_a_contact_and_a_specific_use_case(row: list[str] | None) -> None:
+    """The two fields that decay first, and the two nobody can reconstruct later.
+
+    An entry nobody will stand behind does not go in, and a use case that says
+    nothing makes the page unreadable to the next evaluator.
+    """
+    if row is None:
+        pytest.skip("no adopters listed yet — an empty page is a correct state")
+    assert len(row) == len(COLUMNS), f"row has {len(row)} cells, expected {len(COLUMNS)}: {row}"
+    organization, _domain, use_case, since, contact = row
+    assert organization, "every row needs an organization or project name"
+    assert contact, f"{organization}: a row needs a contact handle nobody has to guess at"
+    assert use_case.lower() not in _VAGUE, (
+        f"{organization}: '{use_case}' is not a use case. "
+        "Name what it does for you, e.g. 'deterministic replay for regulated "
+        "evidence in an air-gapped environment'."
+    )
+    assert re.fullmatch(r"\d{4}-\d{2}", since), (
+        f"{organization}: `Since` should be a month, like 2026-03, not {since!r}"
+    )


### PR DESCRIPTION
Closes #5027.

## The page

`ADOPTERS.md` at the repository root, with **two sections** rather than a status column — taking the recommendation in the issue, for the reason it gives: a pilot and a production dependency are different claims and should not need a squint to tell apart.

Both tables start **empty**. That is the correct state per the issue, and the tests are written so it stays a green one.

Columns as specified: `Organization or project | Domain | What they use it for | Since | Contact`.

## The rules, stated on the page

- Self-reported by pull request; nobody is added by a maintainer on someone else's behalf.
- Inferred usage is not listed — **inference is not consent**, stated in those words.
- A contact handle is required.
- The use case must be specific; "Uses Bernstein" is not a row.
- Individuals and projects welcome, not only companies.
- A `## Pruning` section, including that anyone may remove their own row for any reason or none, that removal is never treated as a signal about the project, and that a removal request is honoured immediately without discussion.

## The test

`tests/unit/test_adopters_page.py` covers acceptance criterion 3 and the structure around it. It enforces what review cannot, since the page is self-reported and no reviewer is in a position to know whether a use case is still true:

- every row has a contact and a use case that is not a placeholder
- `Since` is a month (`2026-03`), not a free-text date
- both sections exist with the agreed columns
- the contribution rule and the pruning rule are present in the text

Checked that it actually fires — with three rows added temporarily:

```
AssertionError: Vague Co: 'Uses Bernstein' is not a use case. Name what it does for you, e.g.
  'deterministic replay for regulated evidence in an air-gapped environment'.
AssertionError: Nameless Co: a row needs a contact handle nobody has to guess at
```

...while the well-formed row passed. With the tables empty, the row test **skips** rather than fails, so the page's correct starting state is not a red build.

## Criterion 4

"Zero rows added by a maintainer on someone else's behalf" is social, and I have added none — both tables ship empty. It is stated on the page and repeated in `CONTRIBUTING.md`.

## Verification

- `pytest tests/unit/test_adopters_page.py` — 4 passed, 1 skipped (the empty-table skip)
- `ruff check` clean

Fragment: `docs/release-notes/fragments/5027-adopters.md`.