### PR TITLE
fix(ci): the test shards establish origin/HEAD, so the mirror guard stops flaking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1869,14 +1869,26 @@ jobs:
         with:
           persist-credentials: false
       - name: Establish origin/HEAD
-        # The same step, for the same reason, as the one in `repo-hygiene`:
-        # actions/checkout does not set `refs/remotes/origin/HEAD`, and the
-        # AGENTS.md generator's first-choice resolver reads that symbolic ref.
+        # The AGENTS.md generator's first-choice resolver reads
+        # `refs/remotes/origin/HEAD`, which actions/checkout does not set.
         # Without it `tests/unit/test_agents_md_mirror_guards.py` raises
         # DefaultBranchUnresolvedError -- but only on the runs where the
         # affected-test selector happens to pick that file up, which is why it
-        # read as an unrelated flake instead of a missing setup step.
-        run: git remote set-head origin -a
+        # read as an unrelated flake rather than a missing setup step.
+        #
+        # `repo-hygiene` runs `set-head` alone because it checks out at
+        # fetch-depth 0. These jobs check out shallow, so the remote-tracking
+        # ref does not exist yet and `set-head` fails with "Not a valid ref".
+        # The default branch is fetched at depth 1 first: that is enough for
+        # both the symbolic ref and the generator's fallback resolver, and it
+        # costs one commit rather than the whole history.
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          git fetch --no-tags --depth=1 origin \
+            "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
+          git remote set-head origin -a
       - uses: ./.github/actions/bootstrap
         with:
           python-version: ${{ matrix.python-version }}
@@ -2156,14 +2168,26 @@ jobs:
         with:
           persist-credentials: false
       - name: Establish origin/HEAD
-        # The same step, for the same reason, as the one in `repo-hygiene`:
-        # actions/checkout does not set `refs/remotes/origin/HEAD`, and the
-        # AGENTS.md generator's first-choice resolver reads that symbolic ref.
+        # The AGENTS.md generator's first-choice resolver reads
+        # `refs/remotes/origin/HEAD`, which actions/checkout does not set.
         # Without it `tests/unit/test_agents_md_mirror_guards.py` raises
         # DefaultBranchUnresolvedError -- but only on the runs where the
         # affected-test selector happens to pick that file up, which is why it
-        # read as an unrelated flake instead of a missing setup step.
-        run: git remote set-head origin -a
+        # read as an unrelated flake rather than a missing setup step.
+        #
+        # `repo-hygiene` runs `set-head` alone because it checks out at
+        # fetch-depth 0. These jobs check out shallow, so the remote-tracking
+        # ref does not exist yet and `set-head` fails with "Not a valid ref".
+        # The default branch is fetched at depth 1 first: that is enough for
+        # both the symbolic ref and the generator's fallback resolver, and it
+        # costs one commit rather than the whole history.
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          git fetch --no-tags --depth=1 origin \
+            "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
+          git remote set-head origin -a
       - uses: ./.github/actions/bootstrap
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1868,6 +1868,15 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Establish origin/HEAD
+        # The same step, for the same reason, as the one in `repo-hygiene`:
+        # actions/checkout does not set `refs/remotes/origin/HEAD`, and the
+        # AGENTS.md generator's first-choice resolver reads that symbolic ref.
+        # Without it `tests/unit/test_agents_md_mirror_guards.py` raises
+        # DefaultBranchUnresolvedError -- but only on the runs where the
+        # affected-test selector happens to pick that file up, which is why it
+        # read as an unrelated flake instead of a missing setup step.
+        run: git remote set-head origin -a
       - uses: ./.github/actions/bootstrap
         with:
           python-version: ${{ matrix.python-version }}
@@ -2146,6 +2155,15 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Establish origin/HEAD
+        # The same step, for the same reason, as the one in `repo-hygiene`:
+        # actions/checkout does not set `refs/remotes/origin/HEAD`, and the
+        # AGENTS.md generator's first-choice resolver reads that symbolic ref.
+        # Without it `tests/unit/test_agents_md_mirror_guards.py` raises
+        # DefaultBranchUnresolvedError -- but only on the runs where the
+        # affected-test selector happens to pick that file up, which is why it
+        # read as an unrelated flake instead of a missing setup step.
+        run: git remote set-head origin -a
       - uses: ./.github/actions/bootstrap
         with:
           python-version: ${{ matrix.python-version }}

--- a/docs/release-notes/fragments/ci-test-job-establishes-origin-head.md
+++ b/docs/release-notes/fragments/ci-test-job-establishes-origin-head.md
@@ -1,0 +1,21 @@
+## The test shards establish `origin/HEAD`, so the AGENTS.md mirror guard stops flaking
+
+`tests/unit/test_agents_md_mirror_guards.py` resolves the repository's default
+branch through `refs/remotes/origin/HEAD`. `actions/checkout` does not set that
+symbolic ref, which is why `repo-hygiene` runs `git remote set-head origin -a`
+right after its checkout and says so in a comment.
+
+The `test` and `test-macos` shard jobs never did. They check out shallow and
+fetch only the pull request's base commit into `origin/pr-base`, so the guard
+raised `DefaultBranchUnresolvedError` — but only on the runs where the
+affected-test selector happened to pull that file into a shard's slice. A
+failure that appears on some pull requests and not others, in a file the pull
+request never touched, reads as an unrelated flake and was re-run as one.
+
+Both jobs now run the same step, and
+`tests/unit/scripts/test_ci_establishes_origin_head.py` makes it a property of
+any job that selects tests from the diff rather than something each job has to
+remember. It is deliberately narrower than "runs pytest": `beartype` runs
+`pytest tests/unit/` but narrows to three lineage files with `-k`, and
+`integration-tests` points the runner at `tests/integration`, so neither can
+select the guard.

--- a/docs/release-notes/fragments/ci-test-job-establishes-origin-head.md
+++ b/docs/release-notes/fragments/ci-test-job-establishes-origin-head.md
@@ -12,7 +12,11 @@ affected-test selector happened to pull that file into a shard's slice. A
 failure that appears on some pull requests and not others, in a file the pull
 request never touched, reads as an unrelated flake and was re-run as one.
 
-Both jobs now run the same step, and
+Both jobs now fetch the default branch at depth 1 and then run the step.
+`repo-hygiene` gets away with `set-head` alone because it checks out at
+`fetch-depth: 0`; a shallow checkout has no `refs/remotes/origin/<default>` for
+`set-head` to resolve, and it fails with `Not a valid ref`. The depth-1 fetch is
+enough for both the symbolic ref and the generator's fallback resolver, and
 `tests/unit/scripts/test_ci_establishes_origin_head.py` makes it a property of
 any job that selects tests from the diff rather than something each job has to
 remember. It is deliberately narrower than "runs pytest": `beartype` runs

--- a/tests/unit/scripts/test_ci_establishes_origin_head.py
+++ b/tests/unit/scripts/test_ci_establishes_origin_head.py
@@ -1,0 +1,88 @@
+"""Every CI job that selects unit tests from the diff establishes ``origin/HEAD``.
+
+`tests/unit/test_agents_md_mirror_guards.py` regenerates the AGENTS.md mirrors
+and compares them to disk. The generator resolves the repository's default
+branch through `refs/remotes/origin/HEAD`, which `actions/checkout` does not
+set -- `repo-hygiene` runs `git remote set-head origin -a` for exactly that
+reason, and says so in a comment.
+
+The `test` and `test-macos` shard jobs did not. So the guard passed on a
+developer checkout and in `repo-hygiene`, and raised
+`DefaultBranchUnresolvedError` in a test shard -- but only on the runs where
+the affected-test selector happened to pick that file up. A failure that
+appears on some pull requests and not others, in a file the pull request never
+touched, reads as an unrelated flake, and was re-run as one.
+
+This test makes the setup step a property of "a job that selects tests from the
+diff" rather than something each job has to remember separately.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+#: The command that resolves the symbolic ref the generator reads.
+SET_HEAD = "git remote set-head origin -a"
+
+#: The selector that can pull any unit test into a job's slice.
+_RUNNER = "scripts/run_tests.py"
+#: Narrower than "runs pytest" on purpose. `beartype` runs `pytest tests/unit/`
+#: but narrows to three lineage files with `-k`, and `integration-tests` points
+#: `run_tests.py` at `tests/integration`. Neither can select the mirror guard.
+#: A diff-driven selection can, on any pull request, which is what made the
+#: missing step everybody's problem rather than one job's.
+_SELECTOR_FLAGS = ("--affected", "--shard")
+
+
+def _workflow() -> dict[str, Any]:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _steps(job: dict[str, Any]) -> list[dict[str, Any]]:
+    return [step for step in job.get("steps", []) if isinstance(step, dict)]
+
+
+def _selects_from_the_diff(step: dict[str, Any]) -> bool:
+    run = str(step.get("run", ""))
+    return _RUNNER in run and any(flag in run for flag in _SELECTOR_FLAGS)
+
+
+def _diff_selecting_jobs() -> list[str]:
+    return sorted(
+        name for name, job in _workflow()["jobs"].items() if any(_selects_from_the_diff(step) for step in _steps(job))
+    )
+
+
+def test_the_workflow_has_jobs_that_select_from_the_diff() -> None:
+    """A vacuous pass here would hide the whole point of the test below."""
+    assert _diff_selecting_jobs(), "expected at least one CI job to select tests from the diff"
+
+
+@pytest.mark.parametrize("job_name", _diff_selecting_jobs())
+def test_such_a_job_establishes_origin_head(job_name: str) -> None:
+    """Without it the AGENTS.md mirror guard fails on an unrelated pull request."""
+    commands = " ".join(str(step.get("run", "")) for step in _steps(_workflow()["jobs"][job_name]))
+    assert SET_HEAD in commands, (
+        f"CI job `{job_name}` selects unit tests from the diff but never runs "
+        f"`{SET_HEAD}`.\n"
+        "tests/unit/test_agents_md_mirror_guards.py resolves the default branch "
+        "through refs/remotes/origin/HEAD, which actions/checkout does not set, so "
+        "the guard fails whenever the selector picks it up. Add the step after the "
+        "checkout, as `repo-hygiene` does."
+    )
+
+
+@pytest.mark.parametrize("job_name", _diff_selecting_jobs())
+def test_the_step_runs_before_the_selection(job_name: str) -> None:
+    """A setup step that runs after the tests is not a setup step."""
+    steps = _steps(_workflow()["jobs"][job_name])
+    set_head = next(i for i, step in enumerate(steps) if SET_HEAD in str(step.get("run", "")))
+    first_selection = next(i for i, step in enumerate(steps) if _selects_from_the_diff(step))
+    assert set_head < first_selection, f"`{job_name}` establishes origin/HEAD after it has already run the tests"


### PR DESCRIPTION
Not from an issue — found while diagnosing why two unrelated pull requests of mine went red today.

## The failure

```
FAILED tests/unit/test_agents_md_mirror_guards.py::TestMirrorsInSync::test_every_generated_file_matches_disk
  - DefaultBranchUnresolvedError: cannot determine the repository's default branch
    for /home/runner/work/bernstein/bernstein; set one explicitly via --default-branch,
    configure `git remote set-head origin -a`, or fetch the default branch ref
```

Seen today on **#5434** (shard 2, ubuntu) and **#5521** (shard 1, ubuntu *and* macos). Neither goes anywhere near the AGENTS.md generator — 5434 adds a module under `core/govern/`, 5521 marks test files.

## The cause

The generator resolves the default branch through `refs/remotes/origin/HEAD`. `actions/checkout` does not set that symbolic ref, which `repo-hygiene` already knows — it runs the step right after its checkout, with a comment saying why:

```yaml
- name: Establish origin/HEAD
  # actions/checkout does not set ``refs/remotes/origin/HEAD`` even
  # with full fetch. The generator's first-choice resolver reads that
  # symbolic-ref; this step makes the result match a developer checkout
  run: git remote set-head origin -a
```

`test` and `test-macos` never got it. They check out shallow and fetch only the pull request's base commit into `origin/pr-base` — so there is no `origin/HEAD` and no `origin/main` for the fallback resolver either.

**Why it looked like a flake.** The guard only runs in a shard when the affected-test selector pulls it into that shard's slice, which depends on the diff. So it fails on some pull requests and not others, in a file the author never touched, on a different shard each time. It gets re-run rather than read.

`beartype` runs `pytest tests/unit/` on the same shallow checkout and does *not* hit this, because it narrows to three lineage files with `-k`. `integration-tests` points the runner at `tests/integration`. Neither can select the guard, which is why the gap survived.

## The fix

The same step, in both jobs, after the checkout and before the bootstrap.

`tests/unit/scripts/test_ci_establishes_origin_head.py` keeps it from regressing by making it a property of *any* job that selects tests from the diff (`run_tests.py` with `--affected` or `--shard`), rather than something each job has to remember. Against `upstream/main`'s workflow it fails and names both:

```
AssertionError: CI job `test` selects unit tests from the diff but never runs `git remote set-head origin -a`.
AssertionError: CI job `test-macos` selects unit tests from the diff but never runs `git remote set-head origin -a`.
```

It also pins the ordering — a setup step after the run is not a setup step.

## Verification

- `pytest tests/unit/scripts/test_ci_establishes_origin_head.py` — 5 passed
- The guard fails on `upstream/main`'s `ci.yml` and passes on this one
- `ci.yml` parses; `ruff check` clean
- `pytest tests/unit/test_agents_md_mirror_guards.py` — 4 passed locally, where `origin/HEAD` is set, which is the asymmetry this closes

I would expect this to unblock #5434 and #5521 once it lands.