### PR TITLE
docs(compliance): separate a declared posture from a verified control (#5056)

### DIFF
--- a/docs/operations/compliance.md
+++ b/docs/operations/compliance.md
@@ -27,14 +27,45 @@ evidence specifically, read `security/AUDIT.md`.
 Two distinct surfaces, both reachable through the `bernstein
 compliance` group:
 
-| Framework        | Surface                                                              | Status                                |
-| ---------------- | -------------------------------------------------------------------- | ------------------------------------- |
-| **EU AI Act**    | `compliance assess` / `eu-ai-act` / `report` (Annex III + Annex IV)  | Shipped (Regulation (EU) 2024/1689)   |
-| **HIPAA**        | `compliance: hipaa` mode (`core/security/hipaa.py`) + PHI detection  | Shipped (45 CFR §164.514(b))          |
-| **SOC 2**        | Policy library + `security/AUDIT.md` (HMAC-chained audit log)        | Shipped                               |
-| **ISO 27001**    | Policy library                                                       | Shipped                               |
-| **PCI-DSS**      | Policy library                                                       | Shipped                               |
-| **NIST 800-53**  | Policy library                                                       | Shipped                               |
+| Framework        | Surface                                                              | Status                                | What a pass asserts   |
+| ---------------- | -------------------------------------------------------------------- | ------------------------------------- | --------------------- |
+| **EU AI Act**    | `compliance assess` / `eu-ai-act` / `report` (Annex III + Annex IV)  | Shipped (Regulation (EU) 2024/1689)   | Verified from evidence |
+| **HIPAA**        | `compliance: hipaa` mode (`core/security/hipaa.py`) + PHI detection  | Shipped (45 CFR §164.514(b))          | Verified from evidence |
+| **SOC 2**        | Policy library + `security/AUDIT.md` (HMAC-chained audit log)        | Shipped                               | Declared posture      |
+| **ISO 27001**    | Policy library                                                       | Shipped                               | Declared posture      |
+| **PCI-DSS**      | Policy library                                                       | Shipped                               | Declared posture      |
+| **NIST 800-53**  | Policy library                                                       | Shipped                               | Declared posture      |
+
+### What the two values mean
+
+**Verified from evidence** means the check reads a record the system produced
+and re-derives the property from it. `core/security/article12_bundle.py` walks
+every HMAC link in the chain and aborts on a break: a pass is a statement about
+what happened.
+
+**Declared posture** means the check reads configuration and reports what the
+operator declared. A pass is a statement about intent, and it is the honest
+ceiling for a lint that never observes a run. The checks themselves say so —
+the evidence string for `check_auth_configured` is "Auth section found in
+config", not "authentication verified" — but a table that puts both under one
+"Shipped" sets the same expectation for both, and only one of them survives a
+reviewer asking what the check proves.
+
+Concretely: **14 of the 23 policy-library checks pass on a configuration whose
+keys are all present but empty.** `check_auth_configured` is
+`"auth" in config`, so an empty `auth:` section passes it.
+`tests/unit/test_compliance_assertion_classes.py` measures that rather than
+restating it, so this section cannot drift from the code.
+
+The remaining nine read a file's existence or a truthy flag —
+`check_privacy_policy` wants a document, `check_tls_enforced` wants the setting
+enabled. That is stronger than key presence and still a declaration: a file
+named `PRIVACY.md` is not a privacy programme.
+
+None of this makes the policy library less useful. A declared-posture lint
+catches the common real failure — nobody configured it at all — and it is the
+right tool for that. It is not evidence, and this column is where the
+difference is written down.
 
 The four framework values accepted by the policy commands are exactly
 the members of `ComplianceFramework`

--- a/docs/release-notes/fragments/5056-declared-vs-verified.md
+++ b/docs/release-notes/fragments/5056-declared-vs-verified.md
@@ -1,0 +1,22 @@
+## Compliance docs separate a declared posture from a verified control
+
+`docs/operations/compliance.md` listed SOC 2, ISO 27001, PCI-DSS and NIST
+800-53 as "Shipped" in the same column as the EU AI Act, whose check walks
+every HMAC link in a recorded chain and aborts on a break. The checks behind
+the other four read configuration, and most are satisfied by a key being
+present at all — `check_auth_configured` is `"auth" in config`, so an empty
+`auth:` section passes it.
+
+The table gains a **What a pass asserts** column: *verified from evidence* for
+the EU AI Act and HIPAA surfaces, *declared posture* for the policy library. The
+library's module docstring says the same thing where a caller rendering its
+results will read it.
+
+The distinction is measured, not asserted: 14 of the 23 policy-library checks
+pass on a configuration that declares every key and configures none of them,
+and `tests/unit/test_compliance_assertion_classes.py` pins that count. Strengthen
+a check and the count moves, which forces the prose to be rewritten with it.
+
+No check changed behaviour — Option B in the issue is a separate change. A
+declared-posture lint still catches the common real failure, which is that
+nobody configured it at all (#5056).

--- a/src/bernstein/core/security/compliance_library.py
+++ b/src/bernstein/core/security/compliance_library.py
@@ -1,9 +1,28 @@
 """Compliance-as-code policy library with pre-built rules.
 
 Provides a library of pure-Python compliance checks that inspect the
-filesystem state of a Bernstein project (``project_root``).  Each check
-verifies a concrete control requirement - audit logging directories exist,
-auth is configured, encryption settings are present, etc.
+filesystem state of a Bernstein project (``project_root``).
+
+**What a pass here asserts.** Every check in this module reads configuration
+or looks for a file. A pass is therefore a statement about *declared posture* -
+what the operator wrote down - and never about what a run actually did. That is
+the honest ceiling for a lint that observes no execution, and it is a different
+class of claim from the EU AI Act surface in
+:mod:`bernstein.core.security.article12_bundle`, which walks every HMAC link in
+a recorded chain and aborts on a break.
+
+Fourteen of the twenty-three checks below are satisfied by key *presence*
+alone: ``check_auth_configured`` is ``"auth" in config``, so an empty ``auth:``
+section passes it. The other nine want a file to exist or a flag to be truthy,
+which is stronger and still a declaration - a file named ``PRIVACY.md`` is not a
+privacy programme.
+
+This is not a defect in the checks; their own evidence strings say "Auth
+section found in config", not "authentication verified". It is written here so
+that a caller rendering these results does not present them as evidence.
+``docs/operations/compliance.md`` carries the same distinction per framework,
+and ``tests/unit/test_compliance_assertion_classes.py`` measures it rather than
+restating it (#5056).
 
 Six compliance frameworks are supported:
 

--- a/tests/unit/test_compliance_assertion_classes.py
+++ b/tests/unit/test_compliance_assertion_classes.py
@@ -1,0 +1,154 @@
+"""What a policy-library pass actually asserts, measured rather than described.
+
+`docs/operations/compliance.md` used to list SOC 2, ISO 27001, PCI-DSS and
+NIST 800-53 as "Shipped" in the same column as the EU AI Act, whose check walks
+every HMAC link in a recorded chain. The checks behind the other four read
+configuration, and most of them are satisfied by a key being present at all --
+`check_auth_configured` is `"auth" in config`, so an empty `auth:` section
+passes. Both claims under one "Shipped" set the same expectation, and only one
+survives a reviewer asking what the check proves (#5056).
+
+The docs now separate the two. These tests measure the property the docs
+assert, so the page cannot drift from the code: if someone strengthens
+`check_auth_configured` to resolve the section, the count here moves and the
+paragraph naming it has to be rewritten.
+
+This pins what the checks *do*, not what they should do. Option B of the issue
+-- making the checks assert something about the resolved configuration -- is a
+separate change, deliberately not made here.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from bernstein.core.security import compliance_library
+
+if TYPE_CHECKING:
+    from bernstein.core.security.compliance_library import PolicyResult
+
+DOCS = Path(__file__).resolve().parents[2] / "docs" / "operations" / "compliance.md"
+
+#: Config keys the library looks for, all present and all empty. A check that
+#: passes against this is satisfied by presence alone.
+_PRESENT_BUT_EMPTY = (
+    "auth",
+    "state_encryption",
+    "rbac",
+    "audit",
+    "logging",
+    "retention",
+    "backup",
+    "tls",
+    "incident_response",
+    "secrets",
+    "vulnerability_scanning",
+    "change_management",
+    "network_isolation",
+    "logging_integrity",
+    "session",
+    "password_policy",
+    "mfa",
+    "rate_limit",
+    "rate_limiting",
+    "dependencies",
+    "privacy",
+    "data_classification",
+    "phi_detection",
+    "consent",
+    "compliance",
+    "security",
+)
+
+#: The count the docs paragraph states. Pinned so the prose and the code move
+#: together: a check that gains a real assertion lowers this number.
+PRESENCE_SATISFIED_COUNT = 14
+
+
+def _checks() -> dict[str, Callable[[Path], PolicyResult]]:
+    return {
+        name: value for name, value in vars(compliance_library).items() if name.startswith("check_") and callable(value)
+    }
+
+
+@pytest.fixture(scope="module")
+def hollow_project() -> Path:
+    """A project whose config declares every key and configures nothing."""
+    root = Path(tempfile.mkdtemp())
+    hollow = {key: {} for key in _PRESENT_BUT_EMPTY}
+    (root / "bernstein.yaml").write_text(yaml.safe_dump(hollow), encoding="utf-8")
+    (root / ".sdd").mkdir()
+    (root / ".sdd" / "config.yaml").write_text(yaml.safe_dump(hollow), encoding="utf-8")
+    return root
+
+
+def _passing_on(project: Path) -> set[str]:
+    passing: set[str] = set()
+    for name, check in _checks().items():
+        try:
+            if check(project).passed:
+                passing.add(name)
+        except Exception:
+            continue
+    return passing
+
+
+def test_the_library_has_the_checks_this_measures() -> None:
+    """A vacuous pass here would make every count below meaningless."""
+    assert len(_checks()) > 20
+
+
+def test_most_checks_are_satisfied_by_key_presence_alone(hollow_project: Path) -> None:
+    """The measurement the docs paragraph cites.
+
+    A configuration that declares every key and configures none of them is the
+    clearest case of declared posture there is, and it passes most of the
+    library.
+    """
+    passing = _passing_on(hollow_project)
+    assert len(passing) == PRESENCE_SATISFIED_COUNT, (
+        f"{len(passing)} checks pass on a present-but-empty config, docs say "
+        f"{PRESENCE_SATISFIED_COUNT}. Update the count in "
+        "docs/operations/compliance.md and in compliance_library's module "
+        f"docstring.\nPassing: {sorted(passing)}"
+    )
+
+
+def test_the_named_example_still_passes_on_an_empty_section(hollow_project: Path) -> None:
+    """The docs name `check_auth_configured` specifically; keep that true."""
+    assert compliance_library.check_auth_configured(hollow_project).passed is True
+
+
+def test_a_project_that_declares_nothing_fails_the_library() -> None:
+    """The failure the library is genuinely good at catching.
+
+    A declared-posture lint is the right tool for "nobody configured it at
+    all", and saying what it does not prove is not a reason to stop trusting
+    what it does.
+    """
+    root = Path(tempfile.mkdtemp())
+    (root / "bernstein.yaml").write_text("{}\n", encoding="utf-8")
+    assert compliance_library.check_auth_configured(root).passed is False
+    assert compliance_library.check_encryption_at_rest(root).passed is False
+
+
+def test_the_docs_table_separates_the_two_classes() -> None:
+    """The column exists and puts the policy-library frameworks on one side."""
+    text = DOCS.read_text(encoding="utf-8")
+    assert "What a pass asserts" in text
+    for framework in ("SOC 2", "ISO 27001", "PCI-DSS", "NIST 800-53"):
+        row = next(line for line in text.splitlines() if f"**{framework}**" in line)
+        assert "Declared posture" in row, f"{framework} should be marked declared posture"
+    eu_row = next(line for line in text.splitlines() if "**EU AI Act**" in line)
+    assert "Verified from evidence" in eu_row
+
+
+def test_the_docs_count_matches_the_measurement() -> None:
+    """The prose cites a number; the number is measured above."""
+    assert f"{PRESENCE_SATISFIED_COUNT} of the 23 policy-library checks" in DOCS.read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #5056, taking **Option A** — and only Option A, since the issue says not to do both in one PR. No check changed behaviour.

## What the sweep found

The issue names one example, `check_auth_configured` being `"auth" in config`. I measured the whole library against a configuration that declares every key the checks look for and configures none of them:

**14 of the 23 policy-library checks pass on a present-but-empty config.**

```
check_access_controls        check_encryption_at_rest    check_secrets_management
check_auth_configured        check_network_isolation     check_session_management
check_backup_configured      check_rate_limiting         check_vulnerability_scanning
check_change_management      check_sdd_state_directory
check_consent_management     check_data_classification
check_data_retention
```

The other nine want a file to exist or a flag to be truthy — `check_privacy_policy` wants a document, `check_tls_enforced` wants the setting enabled. Stronger than key presence, and still a declaration: a file named `PRIVACY.md` is not a privacy programme. So the honest split is not *within* the library; the whole library is declared posture, and the EU AI Act surface (`article12_bundle.py`, which walks every HMAC link and aborts on a break) is what verifies from evidence.

## The change

- **`docs/operations/compliance.md`** gains a `What a pass asserts` column — *Verified from evidence* for EU AI Act and HIPAA, *Declared posture* for the four policy-library frameworks — with a section explaining what each value means and citing the measurement.
- **`compliance_library.py`'s module docstring** says the same thing where a caller rendering these results will actually read it.
- The page is explicit that this is not a criticism of the checks: a declared-posture lint catches the common real failure, which is that nobody configured it at all, and their own evidence strings already say "Auth section found in config", not "authentication verified".

## Keeping it honest

`tests/unit/test_compliance_assertion_classes.py` **measures** the property the docs assert rather than restating it:

- builds the present-but-empty project and counts what passes, pinned at 14
- asserts the docs paragraph cites that same number
- asserts the table marks the four frameworks declared posture and the EU AI Act verified
- asserts a project declaring nothing still fails, so the library's real value is pinned too

If someone takes Option B and strengthens `check_auth_configured` to resolve the section, the count moves, this test fails, and the prose has to be rewritten with the code. That is the drift the issue is about.

## Verification

- `pytest tests/unit/test_compliance_assertion_classes.py` — 6 passed
- `pytest tests/unit -k compliance` — 761 passed
- `mypy --config-file mypy.gate.ini` clean; `ruff check` / `ruff format --check` clean

Fragment: `docs/release-notes/fragments/5056-declared-vs-verified.md`.