### PR TITLE
fix(contracts): a completion claiming a verification must name its receipt (#5001)

### DIFF
--- a/docs/operations/worker-contracts.md
+++ b/docs/operations/worker-contracts.md
@@ -43,8 +43,19 @@ A successful terminal payload:
 | `summary` | yes | Non-empty string, capped at 2000 characters. |
 | `files_changed` | no | List of non-empty path strings. |
 | `exports` | no | Content-addressed outputs as `{path, content_hash}` objects. Hashes use canonical `sha256:<64 lowercase hex>` form. |
-| `verification` | no | `{command, exit_code}` - a step the worker ran before completing. |
-| `receipt_ref` | no | Optional lineage/receipt reference. |
+| `verification` | no | `{command, exit_code}` - a step the worker ran before completing. Requires `receipt_ref`. |
+| `receipt_ref` | no | Lineage/receipt reference. **Required whenever `verification` is present.** |
+
+The last two are validated together. A completion may carry neither - not
+every task runs a verification - and it may carry `receipt_ref` alone. What it
+may not do is claim a verification ran without naming where the outcome was
+recorded: a payload with `verification` and no `receipt_ref` is rejected with
+`path == "$.receipt_ref"`.
+
+The reason is what a later reader can do with the record. A claim backed by a
+receipt and one the worker simply asserted used to serialize identically, so
+the orchestrator deciding whether a dependent task may start, and an operator
+reading the ledger, had no way to tell them apart (#5001).
 
 ### Refusal
 

--- a/docs/release-notes/fragments/5001-verification-needs-a-receipt.md
+++ b/docs/release-notes/fragments/5001-verification-needs-a-receipt.md
@@ -1,0 +1,24 @@
+## A completion that claims a verification ran must name where it was recorded
+
+`verification` and `receipt_ref` were validated as two independent optional
+fields on `worker-completion/v1`, so a completion could assert that a command
+ran and exited 0 while pointing at no receipt at all:
+
+```python
+parse_terminal_payload({
+    "contract": "worker-completion/v1",
+    "summary": "ran the suite, all green",
+    "verification": {"command": "pytest -q", "exit_code": 0},
+})   # parsed, receipt_ref=None
+```
+
+A claim backed by a receipt and one the worker simply asserted serialized
+identically, so nothing reading the record later — the orchestrator deciding
+whether a dependent task may start, an operator reading the ledger — could tell
+them apart.
+
+The two are now dependent at the boundary: a payload carrying `verification`
+with no `receipt_ref` raises `ContractViolation` with `path == "$.receipt_ref"`,
+naming the half that has to be supplied so the failure is diagnosable from the
+ledger without the original payload. A completion carrying neither field is
+still valid, and so is `receipt_ref` alone (#5001).

--- a/src/bernstein/core/tasks/contracts.py
+++ b/src/bernstein/core/tasks/contracts.py
@@ -284,6 +284,10 @@ def parse_completion(payload: dict[str, Any]) -> WorkerCompletion:
     Returns:
         The validated :class:`WorkerCompletion`.
 
+    ``verification`` and ``receipt_ref`` are validated together: a payload that
+    claims a verification ran must name where the outcome was recorded. A
+    completion carrying neither is valid - not every task runs one.
+
     Raises:
         ContractViolation: On any schema mismatch, carrying the field path.
     """
@@ -299,6 +303,21 @@ def parse_completion(payload: dict[str, Any]) -> WorkerCompletion:
         if not isinstance(receipt_ref_raw, str) or not receipt_ref_raw.strip():
             raise ContractViolation("$.receipt_ref", "must be a non-empty string or null")
         receipt_ref = receipt_ref_raw
+    if verification is not None and receipt_ref is None:
+        # The two fields were independent, so a completion could assert that a
+        # command ran and exited 0 while naming nowhere the outcome was
+        # recorded. A claim backed by a receipt and one the worker simply
+        # asserted then serialized identically, and every later reader - the
+        # orchestrator releasing a dependent task, an operator reading the
+        # ledger - had to treat them the same.
+        #
+        # The path is `$.receipt_ref` rather than `$.verification` because the
+        # missing half is what has to be supplied, and the path is what makes
+        # the failure diagnosable from the ledger without the original payload.
+        raise ContractViolation(
+            "$.receipt_ref",
+            "required when `verification` is present: a verification that ran must name where it was recorded",
+        )
     return WorkerCompletion(
         summary=summary,
         files_changed=files_changed,

--- a/tests/unit/test_completion_contract_api.py
+++ b/tests/unit/test_completion_contract_api.py
@@ -100,6 +100,9 @@ def _completion_payload(**overrides: Any) -> dict[str, Any]:
         "summary": "Implemented and verified.",
         "files_changed": ["src/foo.py"],
         "verification": {"command": "pytest -q", "exit_code": 0},
+        # A verification names where its outcome was recorded (#5001); a
+        # payload carrying one without a receipt is refused at the boundary.
+        "receipt_ref": "lineage:task-9f3a",
     }
     base.update(overrides)
     return base

--- a/tests/unit/test_worker_contracts.py
+++ b/tests/unit/test_worker_contracts.py
@@ -108,6 +108,49 @@ class TestParseCompletion:
             parse_terminal_payload(_completion_payload(files_changed=["src/foo.py", ""]))
         assert exc_info.value.path == "$.files_changed[1]"
 
+    def test_a_verification_with_no_receipt_is_refused(self) -> None:
+        """The defect: a claim that a command ran and passed, recorded nowhere.
+
+        Before the cross-field rule, this parsed. A completion asserting
+        `pytest -q` exited 0 and a completion backed by a receipt serialized
+        identically, so the orchestrator releasing a dependent task could not
+        tell them apart.
+        """
+        payload = _completion_payload()
+        del payload["receipt_ref"]
+        with pytest.raises(ContractViolation) as exc_info:
+            parse_terminal_payload(payload)
+        assert exc_info.value.path == "$.receipt_ref"
+
+    def test_an_explicit_null_receipt_is_refused_the_same_way(self) -> None:
+        """Omission and an explicit null are the same claim."""
+        with pytest.raises(ContractViolation) as exc_info:
+            parse_terminal_payload(_completion_payload(receipt_ref=None))
+        assert exc_info.value.path == "$.receipt_ref"
+
+    def test_a_verification_with_a_receipt_parses(self) -> None:
+        """The shape the rule exists to admit."""
+        result = parse_terminal_payload(_completion_payload())
+        assert result.verification is not None
+        assert result.receipt_ref == "sha256:abc123"
+
+    def test_a_completion_with_neither_field_parses(self) -> None:
+        """Not every task runs a verification, and that stays valid."""
+        payload = _completion_payload()
+        del payload["verification"]
+        del payload["receipt_ref"]
+        result = parse_terminal_payload(payload)
+        assert result.verification is None
+        assert result.receipt_ref is None
+
+    def test_a_receipt_without_a_verification_parses(self) -> None:
+        """The rule is one-directional: a receipt may name work of another shape."""
+        payload = _completion_payload()
+        del payload["verification"]
+        result = parse_terminal_payload(payload)
+        assert result.verification is None
+        assert result.receipt_ref == "sha256:abc123"
+
     def test_verification_requires_command(self) -> None:
         with pytest.raises(ContractViolation) as exc_info:
             parse_terminal_payload(_completion_payload(verification={"exit_code": 0}))


### PR DESCRIPTION
Closes #5001.

## The defect, reproduced on current `main`

```python
parse_terminal_payload({
    "contract": "worker-completion/v1",
    "summary": "ran the suite, all green",
    "files_changed": ["src/a.py"],
    "verification": {"command": "pytest -q", "exit_code": 0},
})
# WorkerCompletion(..., verification=VerificationEvidence(command='pytest -q', exit_code=0),
#                  receipt_ref=None, exports=())
```

The payload claims a command ran and passed and names nowhere the outcome was recorded. A claim backed by a receipt and one the worker simply asserted serialize identically, so nothing reading the record later — the orchestrator deciding whether a dependent task may start, an operator reading the ledger — can separate them.

## The change

`verification` and `receipt_ref` are validated together in `parse_completion`. The violation carries `path == "$.receipt_ref"`, as the issue specifies: the missing half is what has to be supplied, and the path is what makes the failure diagnosable from the ledger without the original payload.

The rule is one-directional on purpose. A completion carrying neither field stays valid — not every task runs a verification — and `receipt_ref` alone stays valid, since a receipt may name work of another shape.

## Tests

The four the issue asks for, plus one it does not: an **explicit `"receipt_ref": null`** is refused the same way as omission, since they are the same claim and only one of them was obviously covered.

## One thing beyond the issue's scope that I think belongs in the same PR

This tightens a contract that **agents produce**, so the shape has to be documented where the producer reads it — otherwise the first symptom is workers failing rather than a contract being enforced. `docs/operations/worker-contracts.md` now marks `receipt_ref` required when `verification` is present, and says why.

Three fixtures in `tests/unit/test_completion_contract_api.py` were emitting the now-refused shape through the HTTP surface. None of them asserts anything about a missing receipt — they assert a valid completion is accepted — so the shared `_completion_payload` helper gained a `receipt_ref`. Flagging it explicitly since "the fix made tests fail so I changed the tests" deserves to be visible rather than buried in the diff.

## Verification

- `pytest tests/unit/test_worker_contracts.py` — 49 passed (5 new)
- `pytest tests/unit/test_completion_contract_api.py` — 12 passed
- `pytest tests/unit -k contract` — **1329 passed, 14 skipped**, no failures (3 failed before the fixture update)
- `mypy` clean on the module; `mypy --config-file mypy.gate.ini` clean
- `ruff check` / `ruff format --check` clean

Fragment: `docs/release-notes/fragments/5001-verification-needs-a-receipt.md`.