### PR TITLE
docs(getting-started): correct two fabricated sample outputs (#3619)

### DIFF
--- a/docs/getting-started/first-run.md
+++ b/docs/getting-started/first-run.md
@@ -116,13 +116,10 @@ bernstein live       # full TUI dashboard (attach to a running session)
 bernstein gui serve  # opens http://127.0.0.1:8052/ui/ in your browser
 ```
 
-`bernstein status` output looks like:
-
-```
-Tasks: 0 open · 1 in-progress · 0 done · 0 failed
-Agents: 1 running (agent/abc12345 - backend)
-Spend:  $0.04 so far
-```
+`bernstein status` prints a banner, the task counts, and a **Bernstein Agents**
+table with one row per running session — session, role, CLI, model, worker,
+skills, worker PID, agent PID and runtime — followed by the spend so far. Use
+`bernstein status --json` when you want a shape to parse rather than to read.
 
 ---
 

--- a/docs/getting-started/quickstart-tutorial.md
+++ b/docs/getting-started/quickstart-tutorial.md
@@ -38,7 +38,7 @@ bernstein --version
 You should see something like:
 
 ```
-bernstein 3.5.0
+bernstein, version 3.17.0
 ```
 
 > **If you see "command not found"**: Make sure your tool bin directory is on `$PATH`.

--- a/docs/release-notes/fragments/3619-getting-started-sample-output.md
+++ b/docs/release-notes/fragments/3619-getting-started-sample-output.md
@@ -1,0 +1,16 @@
+## Two fabricated sample outputs in getting-started corrected
+
+`quickstart-tutorial.md` showed `bernstein --version` printing `bernstein 3.5.0`.
+The real output is `bernstein, version 3.17.0` — the format was wrong as well as
+the number, so a reader comparing their terminal to the page saw a mismatch on
+their first command.
+
+`first-run.md` showed `bernstein status` printing a three-line text block
+(`Tasks: 0 open · 1 in-progress · …`). No such format string exists anywhere in
+the CLI; the command prints a banner, task counts, and a Rich **Bernstein
+Agents** table. The page now describes what the command renders and points at
+`bernstein status --json` for a parseable shape, rather than quoting output that
+was never produced.
+
+Found by running every command invocation in the narrative getting-started
+pages against the current CLI rather than reading them (#3619).


### PR DESCRIPTION
Slice 1 of #3527. Prose only — no gate, no extractor, no test infrastructure, as the issue specifies.

## What I ran

The issue asks for the invocations to be **executed, not read**, and for the result to be recorded per page as input to slice 2's extractor. I extracted every `bernstein …` invocation from the narrative pages a new reader follows, then walked each subcommand path against the real CLI and checked every flag against that command's `--help`.

**56 invocations across 8 pages. Every command path resolves. Every flag named in prose is accepted today.** The corpus is in better shape than the issue expects — which is the useful finding for slice 2, since the gate has something clean to hold.

| Page | Invocations | Result |
|---|---|---|
| `docs/index.md` | 8 | all resolve |
| `docs/getting-started/install.md` | 2 | all resolve |
| `docs/getting-started/first-run.md` | 6 | all resolve — **sample output wrong**, below |
| `docs/getting-started/quickstart-demo.md` | 8 | all resolve |
| `docs/getting-started/quickstart-tutorial.md` | 13 | all resolve — **sample output wrong**, below |
| `docs/getting-started/install-linux.md` | 1 | resolves |
| `docs/getting-started/remote.md` | 5 | all resolve |
| `README.md` | 14 | all resolve |

Two things the probe flagged that turned out to be fine, recorded so slice 2's extractor does not re-flag them: `bernstein agents discover` (`first-run.md:193`) **does** exist — it is simply absent from the `agents` group's own help listing, which is generated-reference territory (#3465), not prose. And the `-g "…"` forms take the goal as an argument, which a naive extractor reads as a subcommand.

## What was actually wrong

Both are sample **outputs**, and both are on pages a reader hits in their first five minutes.

**1. `quickstart-tutorial.md:41`** — claimed `bernstein --version` prints:

```
bernstein 3.5.0
```

It prints `bernstein, version 3.17.0`. The *format* is wrong as well as the number, so the mismatch shows up on the reader's very first command.

**2. `first-run.md:119`** — quoted this for `bernstein status`:

```
Tasks: 0 open · 1 in-progress · 0 done · 0 failed
Agents: 1 running (agent/abc12345 - backend)
Spend:  $0.04 so far
```

No such format string exists anywhere in `src/` — I grepped for `open ·`, `in-progress ·`, `so far` and `running (agent/`. The command prints a banner, task counts, and a Rich table titled **Bernstein Agents** whose columns I read off `status_cmd.py:468-477`. I could not reproduce the real output verbatim without standing up a task server, so rather than invent a second block I described what it renders and pointed at `bernstein status --json`, which I did verify.

## The agents/adapters rename

Already propagated. The remaining uses of "agent" on these pages refer to the CLI coding agents themselves — Claude Code, Codex — which is the correct word; "adapter" is our wrapper around one. `first-run.md:189` gets this exactly right: "`bernstein doctor` shows every `Adapter:` row red. Install at least one CLI agent", and `doctor` does print `Adapter:` rows. No page uses the old term for the current concept.

## Verification

- `pytest tests/unit -k "docs or readme or link"` — 804 passed
- No change to `docs/reference/` (#3465's territory)

Fragment: `docs/release-notes/fragments/3619-getting-started-sample-output.md`.