### PR TITLE
fix(tests): skip PR_SET_CHILD_SUBREAPER test on non-Linux

### DIFF
--- a/tests/unit/test_spawner.py
+++ b/tests/unit/test_spawner.py
@@ -6,6 +6,7 @@ import ctypes
 import os
 import re
 import subprocess
+import sys
 import threading
 import time
 from typing import TYPE_CHECKING, Any
@@ -215,6 +216,10 @@ class TestLifecycle:
         session = AgentSession(id="test-1", role="backend", pid=99)
         assert spawner.check_alive(session) is False
 
+    @pytest.mark.skipif(
+        sys.platform != "linux",
+        reason="PR_SET_CHILD_SUBREAPER is a Linux prctl flag; darwin has no prctl symbol at all",
+    )
     def test_check_alive_process_waits_for_surviving_group_member(self, tmp_path: Path, mock_adapter_factory) -> None:
         """Issue #5272: a grandchild in the wrapper's process group must keep
         the session alive after the wrapper itself exits.


### PR DESCRIPTION
#5519 merged today and immediately went red on main: bisect-on-red flagged run 33967499729, `Test (macos-latest, Python 3.13, shard 1)` failing with `AttributeError: dlsym(RTLD_DEFAULT, prctl): symbol not found`.

The new test in that PR marks the process a child subreaper with `ctypes.CDLL(None).prctl(PR_SET_CHILD_SUBREAPER, ...)` before spawning the grandchild. prctl is Linux-only, macOS has no such symbol at all. The production fix (`process_group_alive` in platform_compat.py) is already cross-platform, it's just this one test setup step that isn't.

Skipped the test on non-Linux, same marker style as test_hard_stop_group_reap.py. Ran the two spawner liveness tests on Python 3.12, both pass; ruff clean on the file.
