### PR TITLE
feat(lineage): render a run's whole plan from its journal (#4958)

### DIFF
--- a/docs/release-notes/fragments/4958-lineage-plan.md
+++ b/docs/release-notes/fragments/4958-lineage-plan.md
@@ -1,0 +1,19 @@
+## `bernstein lineage plan` renders a run's whole task graph from its journal
+
+A run's decomposition was already recorded — the orchestrator appends a
+`plan.graph.full` row carrying the goal and every task node with its role,
+title and dependencies — but nothing read it back as a plan. Every review
+surface ships per-task, so an operator approving task 7 of 20 had no rendering
+of what the other 19 add up to.
+
+`bernstein lineage plan <run-id>` prints the goal and the full graph, each task
+with its role, title and the tasks it waits on; `--json` emits the same shape
+for a machine reader. It reads through the projection
+`core/replay/review_board.py` already uses, rather than opening a second path
+to the same data.
+
+Re-rendering the same journal produces identical bytes: the projection never
+reads a row's wall-clock envelope, and ordering is a journal fact — nodes
+sorted by task id, dependencies sorted within a node — not a render-time
+choice. A journal with no `plan.graph.full` row is reported as "never
+recorded", which is not the same claim as a run that planned nothing (#4958).

--- a/src/bernstein/cli/commands/lineage_cmd.py
+++ b/src/bernstein/cli/commands/lineage_cmd.py
@@ -529,6 +529,69 @@ def export_prov_cmd(artefact_path: str, fmt: str, log_path: Path, output_path: P
         console.print(f"[green]Wrote[/green] {len(payload)} byte(s) -> {output_path} [{fmt.lower()}]")
 
 
+@lineage_cmd.command(name="plan")
+@click.argument("run_id")
+@click.option(
+    "--runs-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=Path(".sdd/runs"),
+    show_default=True,
+    help="Directory holding per-run journals.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit the plan as JSON instead of text.")
+def lineage_plan_cmd(run_id: str, runs_dir: Path, as_json: bool) -> None:
+    """Render RUN_ID's whole task graph from its journal.
+
+    Every review surface is per-task, so an operator approving task 7 of 20
+    has no rendering of what the other 19 add up to. This reads the run's
+    recorded decomposition back: the goal, every task, its role and title,
+    and the dependencies between them.
+
+    Re-rendering the same journal produces identical bytes.
+    """
+    import json as _json
+
+    from bernstein.core.lineage.plan_render import read_run_plan, render_plan_text
+    from bernstein.core.replay.journal import contained_run_journal
+
+    # RUN_ID arrives from the command line, so the path is derived through the
+    # containment barrier rather than by joining: a crafted id must not address
+    # a journal outside the runs root, and an ordinary-looking run directory
+    # that is a symlink must not redirect the read.
+    journal_path = contained_run_journal(runs_dir, run_id)
+    if journal_path is None:
+        console.print(f"[red]run id does not resolve inside[/red] {runs_dir}: {run_id}")
+        raise SystemExit(1)
+    plan = read_run_plan(journal_path)
+
+    if as_json:
+        click.echo(
+            _json.dumps(
+                {
+                    "run_id": run_id,
+                    "goal": plan.goal,
+                    "recorded": plan.recorded,
+                    "nodes": [
+                        {
+                            "id": node.task_id,
+                            "role": node.role,
+                            "title": node.title,
+                            "depends_on": list(node.depends_on),
+                        }
+                        for node in plan.nodes
+                    ],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return
+
+    # click.echo rather than the Rich console: the output is an artefact a
+    # caller may diff or hash, and Rich would wrap it to the terminal width.
+    click.echo(render_plan_text(plan, run_id=run_id), nl=False)
+
+
 @lineage_cmd.command(name="reindex")
 @click.option(
     "--log",

--- a/src/bernstein/core/lineage/plan_render.py
+++ b/src/bernstein/core/lineage/plan_render.py
@@ -1,0 +1,139 @@
+"""Render a run's whole task graph from its journal.
+
+A run's decomposition is already in the journal. The orchestrator appends a
+``plan.graph.full`` row whenever the executed graph changes, carrying the run's
+goal and every task node with its role, title and dependencies
+(:meth:`~bernstein.core.orchestration.orchestrator.Orchestrator._record_plan_graph_full`).
+Nothing read it back as a plan, so every review surface was per-task: an
+operator approving task 7 of 20 had no rendering of what the other 19 add up
+to (#4958).
+
+This module is the rendering and nothing else. It reads through
+:func:`~bernstein.core.replay.review_board.project_board`, which already folds
+those rows canonically, rather than opening a second path to the same data.
+
+Determinism is the contract. ``project_board`` never reads the wall-clock
+envelope on a row, and the ordering here is a journal fact rather than a
+render-time choice: nodes come back sorted by task id, and a task's
+dependencies are sorted within the node. Re-rendering the same journal
+therefore produces identical bytes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.replay.journal import load_events
+from bernstein.core.replay.review_board import project_board
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from pathlib import Path
+
+__all__ = [
+    "PlanNode",
+    "RunPlan",
+    "plan_from_journal",
+    "read_run_plan",
+    "render_plan_text",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class PlanNode:
+    """One task in the plan, as the journal recorded it."""
+
+    task_id: str
+    role: str
+    title: str
+    depends_on: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RunPlan:
+    """A run's goal and the whole task graph it was decomposed into.
+
+    ``recorded`` distinguishes "this run wrote no plan row" from "this run
+    planned nothing". A journal with no ``plan.graph.full`` row is not a run
+    with an empty plan: the graph may simply never have been recorded, and a
+    renderer that prints an empty graph for both says something untrue about
+    one of them.
+    """
+
+    goal: str
+    nodes: tuple[PlanNode, ...]
+    recorded: bool
+
+    @property
+    def roots(self) -> tuple[PlanNode, ...]:
+        """Nodes nothing in this plan depends on being finished first."""
+        return tuple(node for node in self.nodes if not node.depends_on)
+
+
+def plan_from_journal(events: Sequence[Mapping[str, Any]]) -> RunPlan:
+    """Project journal *events* into the plan they recorded.
+
+    Args:
+        events: Journal rows in append order, as
+            :func:`bernstein.core.replay.journal.load_events` returns them.
+
+    Returns:
+        The plan. ``recorded`` is False when no ``plan.graph.full`` row was
+        folded, in which case ``nodes`` is empty and ``goal`` is "".
+    """
+    board = project_board(events)
+    run = board.get("run", {})
+    raw_nodes = run.get("plan_nodes")
+    if not isinstance(raw_nodes, list):
+        return RunPlan(goal=str(run.get("goal", "") or ""), nodes=(), recorded=False)
+    nodes = tuple(
+        PlanNode(
+            task_id=str(node.get("id", "")),
+            role=str(node.get("role", "")),
+            title=str(node.get("title", "")),
+            depends_on=tuple(str(dep) for dep in node.get("depends_on", ())),
+        )
+        for node in raw_nodes
+    )
+    return RunPlan(goal=str(run.get("goal", "") or ""), nodes=nodes, recorded=True)
+
+
+def read_run_plan(journal_path: Path) -> RunPlan:
+    """Read *journal_path* and project the plan it recorded.
+
+    A missing journal is reported as an unrecorded plan rather than raised:
+    the caller's question is "what did this run plan", and "nothing recorded
+    it" is an answer to that.
+    """
+    if not journal_path.exists():
+        return RunPlan(goal="", nodes=(), recorded=False)
+    loaded = load_events(journal_path)
+    return plan_from_journal(loaded.events)
+
+
+def render_plan_text(plan: RunPlan, *, run_id: str) -> str:
+    """Render *plan* as the artefact an operator reads.
+
+    Every line is derived from the plan alone - no timestamps, no counts taken
+    at render time - so two renderings of one journal are byte-identical.
+    """
+    lines = [f"run: {run_id}"]
+    lines.append(f"goal: {plan.goal}" if plan.goal else "goal: (not recorded)")
+
+    if not plan.recorded:
+        lines.append("")
+        lines.append("No plan.graph.full row in this journal: the run's task graph was never recorded.")
+        lines.append("This is not the same as a run that planned nothing.")
+        return "\n".join(lines) + "\n"
+
+    lines.append(f"tasks: {len(plan.nodes)}")
+    lines.append("")
+    for node in plan.nodes:
+        title = node.title or "(untitled)"
+        lines.append(f"  {node.task_id}  [{node.role or 'unassigned'}]  {title}")
+        if node.depends_on:
+            lines.append(f"      depends on: {', '.join(node.depends_on)}")
+        else:
+            lines.append("      depends on: nothing")
+    return "\n".join(lines) + "\n"

--- a/tests/unit/test_lineage_plan_render.py
+++ b/tests/unit/test_lineage_plan_render.py
@@ -1,0 +1,186 @@
+"""`bernstein lineage plan`: a run's whole task graph, read back from its journal.
+
+The decomposition was already recorded — the orchestrator appends a
+`plan.graph.full` row carrying the goal and every task node — but nothing read
+it back as a plan. Every review surface ships per-task, so an operator
+approving task 7 of 20 had no rendering of what the other 19 add up to (#4958).
+
+The load-bearing property is byte-identity: a plan artefact that renders
+differently on two reads of one journal cannot be diffed, hashed, or cited.
+It holds because `project_board` never reads a row's wall-clock envelope and
+because ordering here is a journal fact — nodes sorted by task id, each node's
+dependencies sorted within it — rather than a render-time choice.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.lineage_cmd import lineage_cmd
+from bernstein.core.lineage.plan_render import plan_from_journal, read_run_plan, render_plan_text
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+RUN_ID = "run-4958"
+
+#: A three-task graph with a real dependency chain and one independent task.
+_NODES = [
+    {"id": "T-3", "role": "reviewer", "title": "Review the API change", "depends_on": ["T-1", "T-2"]},
+    {"id": "T-1", "role": "backend", "title": "Add the endpoint", "depends_on": []},
+    {"id": "T-2", "role": "tests", "title": "Cover the endpoint", "depends_on": ["T-1"]},
+]
+
+_GOAL = "Add a /health endpoint with tests and a review"
+
+
+def _journal_rows() -> list[dict[str, Any]]:
+    return [
+        {"event": "session_start", "ts": 1.0},
+        {"event": "plan.graph.full", "ts": 2.0, "goal": _GOAL, "nodes": _NODES},
+        {"event": "task_claimed", "ts": 3.0, "task_id": "T-1"},
+    ]
+
+
+@pytest.fixture
+def runs_dir(tmp_path: Path) -> Path:
+    """A runs directory holding one journal with a recorded plan."""
+    run_dir = tmp_path / "runs" / RUN_ID
+    run_dir.mkdir(parents=True)
+    (run_dir / "journal.jsonl").write_text(
+        "\n".join(json.dumps(row) for row in _journal_rows()) + "\n", encoding="utf-8"
+    )
+    return tmp_path / "runs"
+
+
+def _plan(runs_dir: Path, *args: str) -> tuple[int, str]:
+    result = CliRunner().invoke(lineage_cmd, ["plan", RUN_ID, "--runs-dir", str(runs_dir), *args])
+    return result.exit_code, result.output
+
+
+# ---------------------------------------------------------------------------
+# The acceptance criteria, as the issue states them
+# ---------------------------------------------------------------------------
+
+
+def test_the_command_exits_successfully(runs_dir: Path) -> None:
+    code, _ = _plan(runs_dir)
+    assert code == 0
+
+
+def test_the_output_contains_the_goal(runs_dir: Path) -> None:
+    _, output = _plan(runs_dir)
+    assert _GOAL in output
+
+
+def test_every_task_appears(runs_dir: Path) -> None:
+    _, output = _plan(runs_dir)
+    for node in _NODES:
+        assert str(node["id"]) in output, f"{node['id']} missing from the rendering"
+
+
+def test_every_declared_intent_appears(runs_dir: Path) -> None:
+    """A task's declared intent is its role and title, as the journal records them."""
+    _, output = _plan(runs_dir)
+    for node in _NODES:
+        assert str(node["role"]) in output
+        assert str(node["title"]) in output
+
+
+def test_every_dependency_appears(runs_dir: Path) -> None:
+    """The edges, not just the nodes — a graph without them is a list."""
+    _, output = _plan(runs_dir)
+    review_line = next(line for line in output.splitlines() if "depends on: T-1, T-2" in line)
+    assert review_line
+    assert "depends on: T-1" in output
+
+
+def test_rendering_the_same_journal_twice_produces_identical_bytes(runs_dir: Path) -> None:
+    """The property that makes the output an artefact rather than a report."""
+    first_code, first = _plan(runs_dir)
+    second_code, second = _plan(runs_dir)
+    assert (first_code, second_code) == (0, 0)
+    assert first == second
+
+
+def test_json_output_is_stable_too(runs_dir: Path) -> None:
+    """The machine-readable shape carries the same guarantee."""
+    _, first = _plan(runs_dir, "--json")
+    _, second = _plan(runs_dir, "--json")
+    assert first == second
+    payload = json.loads(first)
+    assert payload["goal"] == _GOAL
+    assert [node["id"] for node in payload["nodes"]] == ["T-1", "T-2", "T-3"]
+
+
+# ---------------------------------------------------------------------------
+# What the rendering must not claim
+# ---------------------------------------------------------------------------
+
+
+def test_a_journal_with_no_plan_row_is_not_a_run_that_planned_nothing(tmp_path: Path) -> None:
+    """The distinction a renderer that printed an empty graph would erase."""
+    run_dir = tmp_path / "runs" / RUN_ID
+    run_dir.mkdir(parents=True)
+    (run_dir / "journal.jsonl").write_text(json.dumps({"event": "session_start", "ts": 1.0}) + "\n", encoding="utf-8")
+    code, output = _plan(tmp_path / "runs")
+    assert code == 0
+    assert "never recorded" in output
+    assert "not the same as a run that planned nothing" in output
+
+
+def test_a_missing_journal_reports_that_rather_than_raising(tmp_path: Path) -> None:
+    """ "Nothing recorded it" is an answer to "what did this run plan"."""
+    plan = read_run_plan(tmp_path / "absent" / "journal.jsonl")
+    assert plan.recorded is False
+    assert plan.nodes == ()
+
+
+def test_a_run_id_that_escapes_the_runs_root_is_refused(tmp_path: Path) -> None:
+    """RUN_ID arrives from the command line, so the path is derived, not joined.
+
+    `tests/unit/test_path_containment.py` enforces this mechanically for every
+    journal reader; the case is pinned here too so the refusal is visible where
+    the command is read.
+    """
+    outside = tmp_path / "outside" / "journal.jsonl"
+    outside.parent.mkdir(parents=True)
+    outside.write_text(
+        json.dumps({"event": "plan.graph.full", "goal": "leaked", "nodes": []}) + "\n",
+        encoding="utf-8",
+    )
+    runs = tmp_path / "runs"
+    runs.mkdir()
+    result = CliRunner().invoke(lineage_cmd, ["plan", "../outside", "--runs-dir", str(runs)])
+    assert result.exit_code == 1
+    assert "does not resolve inside" in result.output
+    assert "leaked" not in result.output
+
+
+def test_nodes_are_ordered_by_task_id_not_journal_order() -> None:
+    """Write order is an orchestration artefact; the rendering must not inherit it."""
+    plan = plan_from_journal(_journal_rows())
+    assert [node.task_id for node in plan.nodes] == ["T-1", "T-2", "T-3"]
+
+
+def test_a_dependencyless_task_is_reported_as_a_root() -> None:
+    """Where an operator starts reading the graph."""
+    plan = plan_from_journal(_journal_rows())
+    assert [node.task_id for node in plan.roots] == ["T-1"]
+
+
+def test_the_rendering_carries_no_clock(tmp_path: Path) -> None:
+    """Two journals differing only in timestamps render identically.
+
+    This is what `project_board` not reading the wall-clock envelope buys, and
+    it is the reason the byte-identity property survives a re-run rather than
+    holding only within one process.
+    """
+    shifted = [dict(row, ts=float(row["ts"]) + 10_000) for row in _journal_rows()]
+    assert render_plan_text(plan_from_journal(_journal_rows()), run_id=RUN_ID) == render_plan_text(
+        plan_from_journal(shifted), run_id=RUN_ID
+    )


### PR DESCRIPTION
Closes #4958. Rendering only — verification and approval gating are the separate slices the issue names.

## What it renders

```
$ bernstein lineage plan run-demo
run: run-demo
goal: Add a /health endpoint with tests and a review
tasks: 3

  T-1  [backend]  Add the endpoint
      depends on: nothing
  T-2  [tests]  Cover the endpoint
      depends on: T-1
  T-3  [reviewer]  Review the API change
      depends on: T-1, T-2
```

`--json` emits the same shape for a machine reader.

## Reading through the existing path

The issue says not to add a second path to the same data, so the renderer folds through `review_board.project_board`, which already reads `plan.graph.full` rows canonically. The new module in `core/lineage/` is projection and formatting; it opens no journal path of its own beyond the contained lookup.

## Byte-identity, and why it holds structurally

The acceptance criterion is that re-rendering produces identical bytes. That is not incidental here:

- `project_board` never reads a row's wall-clock envelope, so timestamps cannot leak in. `test_the_rendering_carries_no_clock` renders two journals differing *only* in `ts` and asserts the bytes match — so the property survives a re-run on another day, not just two calls in one process.
- Ordering is a journal fact: nodes sorted by task id, dependencies sorted within a node. Write order is an orchestration artefact and the rendering does not inherit it (`test_nodes_are_ordered_by_task_id_not_journal_order`).
- Output goes through `click.echo`, not the Rich console, because an artefact a caller may diff or hash must not be wrapped to the terminal width.

## A guard caught the first version

I built the path as `runs_dir / run_id / "journal.jsonl"`, and `tests/unit/test_path_containment.py::test_no_unrouted_journal_path_construction` failed:

```
these sites build a journal path without the containment barrier:
    commands/lineage_cmd.py:556: journal_path = runs_dir / run_id / "journal.jsonl"
```

It is right, and `RUN_ID` here comes straight off the command line — the exact threat. It now routes through `contained_run_journal`, and the refusal is pinned in this command's own tests as well (`test_a_run_id_that_escapes_the_runs_root_is_refused` asserts `../outside` exits 1 and that the planted journal's goal never reaches the output).

## One distinction the rendering keeps

A journal with no `plan.graph.full` row reports *"the run's task graph was never recorded"*, not an empty graph. Those are different claims, and printing the same thing for both would say something untrue about one of them.

## Verification

- `pytest tests/unit/test_lineage_plan_render.py` — 13 passed, covering each acceptance criterion
- `pytest tests/unit -k "lineage or review_board or journal"` — 1829 passed (1 failure before the containment fix, now green)
- `pytest tests/unit/test_path_containment.py` — 189 passed
- `mypy --config-file mypy.gate.ini` clean, 101 files; `ruff check` / `format --check` clean; `lint-imports` 3 contracts kept

Fragment: `docs/release-notes/fragments/4958-lineage-plan.md`.