### PR TITLE
feat(discovery): adapter selection is a registry, not a dispatch branch (#5081)

### DIFF
--- a/docs/release-notes/fragments/5081-detector-registry.md
+++ b/docs/release-notes/fragments/5081-detector-registry.md
@@ -1,0 +1,24 @@
+## Deep-collection adapter selection is a registry, not a dispatch branch
+
+`agent_discovery` chose its deep collectors from `_RICH_DETECTOR_NAMES`, a
+table mapping a registry name to the *name of a module-level function*, which
+the dispatch loop then resolved through `globals()`. Adding an entity class
+meant editing that table and adding a `_detect_*` function beside nine others —
+a code change and a release for something that is data, and a review surface
+every other detector runs through.
+
+Selection is now `(matcher, adapter)` pairs. `register_detector` adds one,
+`resolve_detector` returns the first that matches, and the dispatch loop asks
+the registry rather than branching. The nine built-ins are registered as exact
+-name matchers and behave exactly as before.
+
+Two properties are pinned by tests because they are easy to lose in a migration
+like this. A built-in's function is resolved on every call, not captured at
+registration, so the unit tests that monkeypatch `_detect_claude` still work.
+And first match wins, so a pair registered later cannot take over an entity a
+built-in already claims; a matcher that raises is treated as no match rather
+than aborting the pass, since one bad third-party pair must not fail discovery
+for everything else.
+
+Slice 2 of #5081. The probe-record format, jitter and per-probe timeouts, and
+the per-run journal entry are the other slices.

--- a/src/bernstein/core/agents/agent_discovery.py
+++ b/src/bernstein/core/agents/agent_discovery.py
@@ -16,7 +16,10 @@ import time
 from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Final, cast
+from typing import TYPE_CHECKING, Final, Protocol, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 _CONFIG_TOML_FILENAME = "config.toml"
 
@@ -685,6 +688,10 @@ def _detect_aider() -> tuple[AgentCapabilities | None, list[str]]:
 # Adapters with a dedicated detector above, keyed by registry name. Values
 # are module attribute names resolved at call time (not captured at import
 # time) so tests can monkeypatch the individual ``_detect_*`` functions.
+#
+# Kept as the seed for :data:`_DETECTOR_REGISTRY` rather than as the dispatch
+# table: the loop asks the registry, so a new entity class is added by
+# registering a pair and never by editing a branch here.
 _RICH_DETECTOR_NAMES: dict[str, str] = {
     "aider": "_detect_aider",
     "claude": "_detect_claude",
@@ -696,6 +703,130 @@ _RICH_DETECTOR_NAMES: dict[str, str] = {
     "opencode": "_detect_opencode",
     "qwen": "_detect_qwen",
 }
+
+
+class DetectorMatcher(Protocol):
+    """Decides whether a registration handles a registry entry."""
+
+    def __call__(self, name: str) -> bool:
+        """Return True when *name* is this registration's to collect."""
+        ...
+
+
+class DetectorAdapter(Protocol):
+    """Performs deep collection for a matched registry entry."""
+
+    def __call__(self, name: str) -> tuple[AgentCapabilities | None, list[str]]:
+        """Return the collected capabilities and any warnings."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class DetectorRegistration:
+    """One ``(matcher, adapter)`` pair in the deep-collection registry.
+
+    ``source`` names where the pair came from, so a run can report which
+    registration answered for an entity without the caller reconstructing it
+    from the adapter's identity.
+    """
+
+    matcher: DetectorMatcher
+    adapter: DetectorAdapter
+    source: str
+
+
+def _module_attr_adapter(attr: str) -> DetectorAdapter:
+    """Adapt a module-level ``_detect_*`` function into the registry shape.
+
+    The attribute is resolved on every call rather than captured here, which
+    is the property the old name-keyed table existed to preserve: the unit
+    tests monkeypatch the individual ``_detect_*`` functions, and a captured
+    reference would make the patch invisible.
+    """
+
+    def _call(name: str) -> tuple[AgentCapabilities | None, list[str]]:
+        del name  # a built-in detector knows the entity it collects
+        detector = cast("Callable[[], tuple[AgentCapabilities | None, list[str]]]", globals()[attr])
+        return detector()
+
+    return _call
+
+
+def _exact_name(expected: str) -> DetectorMatcher:
+    """Match one registry name exactly."""
+
+    def _match(name: str) -> bool:
+        return name == expected
+
+    return _match
+
+
+#: Deep-collection registrations, in resolution order. The first matcher that
+#: answers owns the entry, so a later registration cannot silently take an
+#: entity a built-in already claims.
+_DETECTOR_REGISTRY: list[DetectorRegistration] = [
+    DetectorRegistration(
+        matcher=_exact_name(_name),
+        adapter=_module_attr_adapter(_attr),
+        source=f"builtin:{_attr}",
+    )
+    for _name, _attr in sorted(_RICH_DETECTOR_NAMES.items())
+]
+
+
+def register_detector(
+    matcher: DetectorMatcher,
+    adapter: DetectorAdapter,
+    *,
+    source: str,
+) -> DetectorRegistration:
+    """Register a ``(matcher, adapter)`` pair for deep collection.
+
+    Adding an entity class is a registration, never an edit to the dispatch
+    loop. Registrations are consulted in order and the first match wins, so a
+    pair registered later cannot take over an entity a built-in already
+    claims.
+
+    Args:
+        matcher: Returns True for the registry names this pair collects.
+        adapter: Performs the collection for a matched name.
+        source: Where the pair came from, for reporting.
+
+    Returns:
+        The registration, so a caller can pass it to
+        :func:`unregister_detector`.
+    """
+    registration = DetectorRegistration(matcher=matcher, adapter=adapter, source=source)
+    _DETECTOR_REGISTRY.append(registration)
+    return registration
+
+
+def unregister_detector(registration: DetectorRegistration) -> None:
+    """Remove a registration. A registration already gone is not an error."""
+    with suppress(ValueError):
+        _DETECTOR_REGISTRY.remove(registration)
+
+
+def resolve_detector(name: str) -> DetectorRegistration | None:
+    """Return the registration that owns *name*, or None for the sweep path.
+
+    A matcher that raises is treated as not matching and never aborts
+    resolution: one bad third-party pair must not make the whole discovery
+    pass fail.
+    """
+    for registration in _DETECTOR_REGISTRY:
+        try:
+            if registration.matcher(name):
+                return registration
+        except Exception:
+            logger.warning(
+                "detector matcher from %s raised for %r; treating as no match",
+                registration.source,
+                name,
+                exc_info=True,
+            )
+    return None
+
 
 # Registry entries that never resolve to a probeable dedicated CLI binary:
 # internal test/wrapper adapters, and SDK adapters that ride a shared host
@@ -789,15 +920,14 @@ def discover_agents() -> DiscoveryResult:
     start = time.monotonic()
     agents: list[AgentCapabilities] = []
     warnings: list[str] = []
-    module_globals = globals()
 
     for name, _entry in iter_adapter_specs():
-        detector_name = _RICH_DETECTOR_NAMES.get(name)
-        if detector_name is None and name in _SWEEP_EXCLUDED:
+        registration = resolve_detector(name)
+        if registration is None and name in _SWEEP_EXCLUDED:
             continue
         try:
-            if detector_name is not None:
-                agent, agent_warnings = module_globals[detector_name]()
+            if registration is not None:
+                agent, agent_warnings = registration.adapter(name)
             else:
                 agent, agent_warnings = _detect_registry_cli(name)
             if agent is not None:

--- a/tests/unit/test_agent_discovery_registry.py
+++ b/tests/unit/test_agent_discovery_registry.py
@@ -1,0 +1,146 @@
+"""Deep-collection adapter selection is a registry, not a dispatch branch.
+
+`_RICH_DETECTOR_NAMES` mapped a registry name to the *name of a module-level
+function*, and the dispatch loop resolved it through `globals()`. Adding an
+entity class meant editing that table and adding a `_detect_*` function — a
+code change and a release for something that is data, and a review surface
+nine other detectors run through (#5081, slice 2).
+
+Selection is now `(matcher, adapter)` pairs. The load-bearing test below plants
+a class and asserts it is collected with no edit outside the registry.
+
+Slice 2 only. The probe-record format, jitter and timeouts, and the per-run
+journal entry are the other slices and are not here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.agents import agent_discovery
+from bernstein.core.agents.agent_discovery import (
+    DetectorRegistration,
+    register_detector,
+    resolve_detector,
+    unregister_detector,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from bernstein.core.agents.agent_discovery import AgentCapabilities
+
+
+@pytest.fixture
+def clean_registry() -> Iterator[list[DetectorRegistration]]:
+    """Restore the registry, so a registration cannot leak between tests."""
+    original = list(agent_discovery._DETECTOR_REGISTRY)
+    yield original
+    agent_discovery._DETECTOR_REGISTRY[:] = original
+
+
+# ---------------------------------------------------------------------------
+# The named, load-bearing test
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_selection_resolves_new_class_with_zero_dispatch_changes(
+    clean_registry: list[DetectorRegistration],
+) -> None:
+    """A planted class is collected without touching the dispatch loop.
+
+    Fails on main: there is no registry, and the only way to reach deep
+    collection is an entry in `_RICH_DETECTOR_NAMES` plus a new `_detect_*`
+    function in this module.
+    """
+    collected: list[str] = []
+
+    def _matches(name: str) -> bool:
+        return name.startswith("planted-")
+
+    def _collect(name: str) -> tuple[AgentCapabilities | None, list[str]]:
+        collected.append(name)
+        return None, [f"collected {name}"]
+
+    register_detector(_matches, _collect, source="test:planted")
+
+    registration = resolve_detector("planted-thing")
+    assert registration is not None
+    assert registration.source == "test:planted"
+
+    agent, warnings = registration.adapter("planted-thing")
+    assert agent is None
+    assert warnings == ["collected planted-thing"]
+    assert collected == ["planted-thing"]
+
+
+# ---------------------------------------------------------------------------
+# What the migration must not change
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["aider", "claude", "codex", "cursor", "gemini", "kilo", "kiro", "opencode", "qwen"],
+)
+def test_every_builtin_detector_still_resolves(name: str) -> None:
+    """The nine that had a table entry are the nine that resolve."""
+    registration = resolve_detector(name)
+    assert registration is not None
+    assert registration.source == f"builtin:{agent_discovery._RICH_DETECTOR_NAMES[name]}"
+
+
+def test_an_entry_with_no_registration_falls_through_to_the_sweep() -> None:
+    """The other half of the old branch: `_detect_registry_cli` still owns it."""
+    assert resolve_detector("definitely-not-registered") is None
+
+
+def test_a_builtin_detector_is_resolved_at_call_time(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The property the name-keyed table existed to preserve.
+
+    The unit tests monkeypatch the individual `_detect_*` functions. If the
+    registry captured the function object at import time the patch would be
+    invisible, and the migration would quietly break every one of them.
+    """
+    sentinel = (None, ["patched claude"])
+    monkeypatch.setattr(agent_discovery, "_detect_claude", lambda: sentinel)
+    registration = resolve_detector("claude")
+    assert registration is not None
+    assert registration.adapter("claude") == sentinel
+
+
+def test_a_builtin_claims_its_entity_before_a_later_registration(
+    clean_registry: list[DetectorRegistration],
+) -> None:
+    """First match wins, so a third-party pair cannot take over `claude`."""
+    register_detector(lambda name: True, lambda name: (None, ["hijacked"]), source="test:greedy")
+    registration = resolve_detector("claude")
+    assert registration is not None
+    assert registration.source == "builtin:_detect_claude"
+
+
+def test_a_matcher_that_raises_does_not_abort_resolution(
+    clean_registry: list[DetectorRegistration],
+) -> None:
+    """One bad third-party pair must not fail the whole discovery pass."""
+
+    def _explodes(name: str) -> bool:
+        raise RuntimeError("bad matcher")
+
+    agent_discovery._DETECTOR_REGISTRY.insert(
+        0, DetectorRegistration(matcher=_explodes, adapter=lambda name: (None, []), source="test:bad")
+    )
+    registration = resolve_detector("claude")
+    assert registration is not None
+    assert registration.source == "builtin:_detect_claude"
+
+
+def test_unregistering_removes_the_pair(clean_registry: list[DetectorRegistration]) -> None:
+    """A registration can be withdrawn, and withdrawing twice is not an error."""
+    registration = register_detector(lambda name: name == "ephemeral", lambda name: (None, []), source="test:ephemeral")
+    assert resolve_detector("ephemeral") is not None
+    unregister_detector(registration)
+    assert resolve_detector("ephemeral") is None
+    unregister_detector(registration)


### PR DESCRIPTION
Slice 2 of #5081. Slices 1, 3 and 4 — the probe record, jitter/timeouts, and the per-run journal entry — are not here.

## What changes

`_RICH_DETECTOR_NAMES` mapped a registry name to the *name of a module-level function*, which the dispatch loop resolved through `globals()`:

```python
detector_name = _RICH_DETECTOR_NAMES.get(name)
if detector_name is not None:
    agent, agent_warnings = module_globals[detector_name]()
```

Adding an entity class meant editing that table and adding a `_detect_*` beside nine others: a code change and a release for something that is data, and a review surface every other detector runs through.

Selection is now `(matcher, adapter)` pairs. `register_detector` adds one, `resolve_detector` returns the first that matches, and the loop asks the registry instead of branching. The nine built-ins are registered as exact-name matchers.

`test_adapter_selection_resolves_new_class_with_zero_dispatch_changes` — the load-bearing test the issue names — plants a class and collects it with no edit outside the registry. It cannot pass on `main`: there is no registry, and the only route to deep collection is a table entry plus a new module-level function.

## Two things this migration could quietly have broken

Both are pinned by tests, because neither would show up as a failure until much later.

**Late binding.** The old table's own comment says the values are "module attribute names resolved at call time (not captured at import time) so tests can monkeypatch the individual `_detect_*` functions." A registry that captured the function object would silently make every one of those patches invisible — the tests would still pass, against the wrong function. `_module_attr_adapter` resolves `globals()[attr]` on each call, and `test_a_builtin_detector_is_resolved_at_call_time` asserts a `monkeypatch.setattr` on `_detect_claude` is honoured through the registry.

**Precedence.** First match wins, so a pair registered later cannot take over an entity a built-in already claims (`test_a_builtin_claims_its_entity_before_a_later_registration` registers a greedy `lambda name: True` and asserts `claude` still resolves to its built-in). And a matcher that raises is treated as no match rather than aborting resolution — one bad third-party pair must not fail discovery for everything else.

`_RICH_DETECTOR_NAMES` survives as the seed for the registry rather than as the dispatch table, so the nine names stay in one readable place.

## Verification

- `pytest tests/unit/test_agent_discovery_registry.py` — 15 passed
- `pytest tests/unit/test_agent_discovery.py` — 51 passed, unchanged
- `pytest tests/unit -k "discovery or agent_discovery or doctor or adapter_registry"` — 573 passed
- `mypy --config-file mypy.gate.ini` clean; `ruff check` / `format --check` clean; `lint-imports` 3 contracts kept

Fragment: `docs/release-notes/fragments/5081-detector-registry.md`.