### PR TITLE
test(agents): scope the subreaper liveness test to Linux

### DIFF
--- a/tests/unit/test_spawner.py
+++ b/tests/unit/test_spawner.py
@@ -6,6 +6,7 @@ import ctypes
 import os
 import re
 import subprocess
+import sys
 import threading
 import time
 from typing import TYPE_CHECKING, Any
@@ -215,6 +216,11 @@ class TestLifecycle:
         session = AgentSession(id="test-1", role="backend", pid=99)
         assert spawner.check_alive(session) is False
 
+    @pytest.mark.skipif(
+        sys.platform != "linux",
+        reason="PR_SET_CHILD_SUBREAPER is Linux-only; without it the grandchild "
+        "reparents to the unreaping test-runner and the liveness read never settles",
+    )
     def test_check_alive_process_waits_for_surviving_group_member(self, tmp_path: Path, mock_adapter_factory) -> None:
         """Issue #5272: a grandchild in the wrapper's process group must keep
         the session alive after the wrapper itself exits.


### PR DESCRIPTION
main is red on `Test (macos-latest, Python 3.13, shard 1)` with every other job green:

```
FAILED tests/unit/test_spawner.py::TestLifecycle::test_check_alive_process_waits_for_surviving_group_member
AttributeError: dlsym(RTLD_DEFAULT, prctl): symbol not found
```

`PR_SET_CHILD_SUBREAPER` is a Linux-only prctl, and the test calls it unconditionally, so the ctypes lookup fails on macOS. The bisect-on-red comment ranks candidates by files touched and named a different commit; the call was introduced with the process-group liveness fix.

The test cannot simply run unguarded on other platforms: without a subreaper the grandchild reparents to the unreaping test runner and, as the test's own docstring notes, the liveness read never settles. Scoping it to Linux keeps the invariant covered where the semantics it depends on exist.

Verified on macOS: the named test fails before this change and skips after it; the file is 126 passed, 1 skipped.