### PR TITLE
test(spawner): skip the subreaper liveness test off Linux

### DIFF
--- a/docs/release-notes/fragments/spawner-prctl-macos-skip.md
+++ b/docs/release-notes/fragments/spawner-prctl-macos-skip.md
@@ -1,0 +1,3 @@
+## The surviving-group-member spawner test no longer breaks the macOS lane
+
+`test_check_alive_process_waits_for_surviving_group_member` marks the test process as a child subreaper with `prctl(PR_SET_CHILD_SUBREAPER)` so the grandchild it spawns reparents to the test rather than to an unreaping PID 1. That option is Linux-only, and `dlsym` cannot resolve `prctl` at all on macOS, so the call raised `AttributeError` before the test body ran and failed the `macos-latest` shard holding that file on every pull request whose allocation included it. The test is now skipped off Linux, because without the subreaper the liveness read it performs never settles and it cannot run unguarded either (#5272).

--- a/tests/unit/test_spawner.py
+++ b/tests/unit/test_spawner.py
@@ -220,6 +220,15 @@ class TestLifecycle:
         sys.platform != "linux",
         reason="PR_SET_CHILD_SUBREAPER is a Linux prctl flag; darwin has no prctl symbol at all",
     )
+    @pytest.mark.skipif(
+        sys.platform != "linux",
+        reason=(
+            "PR_SET_CHILD_SUBREAPER is a Linux prctl option; dlsym cannot resolve "
+            "prctl at all on macOS. Without the subreaper the grandchild reparents "
+            "to an unreaping PID 1 and the liveness read below never settles, so "
+            "the test cannot run unguarded either."
+        ),
+    )
     def test_check_alive_process_waits_for_surviving_group_member(self, tmp_path: Path, mock_adapter_factory) -> None:
         """Issue #5272: a grandchild in the wrapper's process group must keep
         the session alive after the wrapper itself exits.


### PR DESCRIPTION
## What

Skips `test_check_alive_process_waits_for_surviving_group_member` off Linux.

## Why

The test marks the test process as a child subreaper so the grandchild it spawns reparents to it rather than to an unreaping PID 1:

```python
_PR_SET_CHILD_SUBREAPER = 36
ctypes.CDLL(None, use_errno=True).prctl(_PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0)
```

`PR_SET_CHILD_SUBREAPER` is a Linux `prctl` option, and on macOS `dlsym` cannot resolve `prctl` at all:

```
tests/unit/test_spawner.py::TestLifecycle::test_check_alive_process_waits_for_surviving_group_member
AttributeError: dlsym(RTLD_DEFAULT, prctl): symbol not found
```

The lookup raises before the test body runs, so `Test (macos-latest, Python 3.13, shard 2)` fails on every pull request whose shard allocation includes this file. The other three macOS shards pass. I hit it on an unrelated PR ([#5513](https://github.com/sipyourdrink-ltd/bernstein/pull/5513), which touches `atomic_write.py` and six writers and nothing near the spawner) and traced it back here.

## How

A `skipif` rather than a guard around the `prctl` call. The test's own docstring explains why it cannot simply run without the subreaper:

> Mark this test process as a child subreaper so the grandchild below reparents here instead of to the unreaping test-runner PID 1, **or the liveness read below never settles.**

So dropping the call on macOS would trade a fast `AttributeError` for a hang or a flake. The behaviour under test — a group member keeping the session alive after the wrapper exits — is worth covering on macOS too, but that needs a different mechanism than subreaping, which is more than a lane fix should carry.

## Tests

```
uv run pytest tests/unit/test_spawner.py -q
126 passed, 1 skipped
```

The skip is the target test; it still runs on Linux, where CI's other shards and the Linux matrix exercise it.

## Checklist

- [x] `ruff check` and `ruff format` clean on the changed file
- [x] Release note fragment added: `docs/release-notes/fragments/spawner-prctl-macos-skip.md`

### Documentation duty

- [x] N/A for README, `docs/operations/`, `docs/api/` and `agents-md sync`: no production code change, no new module, no public API or schema change.
