### PR TITLE
fix(compliance): digest evidence packs with the RFC 8785 (JCS) encoder

### DIFF
--- a/docs/release-notes/fragments/5504-evidence-pack-jcs-canonicalization.md
+++ b/docs/release-notes/fragments/5504-evidence-pack-jcs-canonicalization.md
@@ -1,0 +1,22 @@
+## Evidence packs now digest under RFC 8785 (JCS), not a local byte rule
+
+Compliance evidence packs (`bernstein audit export`) digest `manifest.json`,
+`controls.json` and `audit-chain/data_catalog.json` through the same RFC 8785
+(JCS) canonical-JSON encoder the signed evidence-envelope format already
+ships and pins with golden vectors
+(`bernstein.core.security.evidence_envelope.canonical_envelope_bytes`),
+instead of a hand-rolled `json.dumps(sort_keys=True, indent=2)` call local to
+`compliance/evidence_pack.py`. A verifier who was handed the RFC 8785
+specification, rather than this source tree, can now reproduce the same
+bytes and the same digest.
+
+**Effect on previously written packs.** JCS uses minimal separators (no
+pretty-printing) and orders object keys by UTF-16 code unit rather than by
+Unicode code point, so a pack built before this change and one built after
+it from identical input do not share the same per-artefact SHA-256 or the
+same top-level bundle `sha256` -- even though nothing about *what* is
+recorded changed. A pack already delivered to a regulator or auditor still
+verifies against the encoding rule that was in effect when it was produced
+(`json.dumps(sort_keys=True, indent=2)`); it does not retroactively become
+invalid, and nothing needs to be re-issued. Only newly generated packs use
+the RFC 8785 encoding (#5504).

--- a/docs/security/evidence-envelope.md
+++ b/docs/security/evidence-envelope.md
@@ -11,9 +11,18 @@ recorded — and what the envelope does not account for.
 ## Status
 
 **The format only.** This is the schema, the canonical encoding and one
-committed vector. There is no producer that builds an envelope from a run,
-and no verifier that checks one. Until those exist, an envelope is something
-you can validate and re-encode, not something the installation emits.
+committed vector. There is no producer that builds the six-section envelope
+from a run, and no verifier that checks one. Until those exist, an envelope
+is something you can validate and re-encode, not something the installation
+emits.
+
+The canonical encoder itself has one caller outside its own tests:
+[compliance evidence packs](../operations/compliance.md) digest their JSON
+artefacts (`manifest.json`, `controls.json`, the audit data catalog) through
+`canonical_envelope_bytes` rather than a local `json.dumps` convention, so a
+pack digest and an envelope digest are checkable the same way (#5504). That
+pack is not an evidence envelope — it carries no `principal`, `grants` or
+`signature` section — it simply reuses this module's RFC 8785 encoder.
 
 ## What an envelope proves
 

--- a/src/bernstein/compliance/evidence_pack.py
+++ b/src/bernstein/compliance/evidence_pack.py
@@ -54,7 +54,10 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal
 
+from bernstein.core.security.evidence_envelope import canonical_envelope_bytes
+
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -236,9 +239,16 @@ class EvidencePack:
 # ---------------------------------------------------------------------------
 
 
-def _canonical_json(payload: Any) -> bytes:
-    """Serialise ``payload`` as deterministic JSON (sort_keys, indent=2)."""
-    return (json.dumps(payload, sort_keys=True, indent=2) + "\n").encode("utf-8")
+def _canonical_json(payload: Mapping[str, Any]) -> bytes:
+    """Serialise ``payload`` as RFC 8785 (JCS) canonical JSON bytes.
+
+    Delegates to :func:`~bernstein.core.security.evidence_envelope.canonical_envelope_bytes`
+    so every digested artefact in the pack -- and any future signature over
+    one -- goes through the one canonicaliser the repository signs
+    interop-facing evidence with, rather than a second hand-rolled
+    ``json.dumps`` convention (#5504).
+    """
+    return canonical_envelope_bytes(payload)
 
 
 def _parse_iso(value: str) -> datetime | None:

--- a/tests/unit/test_evidence_pack.py
+++ b/tests/unit/test_evidence_pack.py
@@ -28,9 +28,11 @@ import pytest
 from bernstein.compliance.evidence_pack import (
     SUPPORTED_STANDARDS,
     EvidencePack,
+    _canonical_json,
     build_evidence_pack,
     get_standard_map,
 )
+from bernstein.core.security.evidence_envelope import canonical_envelope_bytes
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -247,6 +249,94 @@ class TestBuildEvidencePack:
                 sdd_dir=sdd_dir,
                 standard="iso-9000",
             )
+
+
+# ---------------------------------------------------------------------------
+# Canonicalisation (#5504): one encoder, and it is the RFC 8785 one
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalization:
+    def test_canonical_json_is_the_rfc8785_encoder_not_a_local_rule(self) -> None:
+        """``_canonical_json`` must not be a second, hand-configured ``json.dumps``.
+
+        Regression for #5504: the digested JSON artefacts (``manifest.json``,
+        ``controls.json``, ``audit-chain/data_catalog.json``) were previously
+        serialised with a local ``sort_keys=True, indent=2`` convention that
+        disagreed with the RFC 8785 (JCS) encoder the signed evidence-envelope
+        format already ships with golden vectors for. Both entry points must
+        now produce byte-identical output for the same payload.
+        """
+        payload = {"b": 1, "a": [1, 2, 3], "c": {"nested": True, "value": 1.0}}
+        assert _canonical_json(payload) == canonical_envelope_bytes(payload)
+
+    def test_pack_artefact_reencoded_by_canonical_envelope_bytes_matches_on_disk(
+        self,
+        sdd_dir: Path,
+    ) -> None:
+        """A pack's ``manifest.json``, re-encoded independently, is byte-identical.
+
+        This is the property a verifier who holds only the RFC 8785
+        specification (and not this source tree) relies on: re-canonicalising
+        the parsed JSON must reproduce exactly the bytes shipped in the zip.
+        """
+        pack = build_evidence_pack(sdd_dir=sdd_dir, standard="ai-act")
+        with zipfile.ZipFile(pack.archive_path) as zf:  # type: ignore[arg-type]
+            for name in ("manifest.json", "controls.json", "audit-chain/data_catalog.json"):
+                on_disk = zf.read(name)
+                assert canonical_envelope_bytes(json.loads(on_disk)) == on_disk, name
+
+    def test_non_ascii_key_round_trips_byte_for_byte(self, sdd_dir: Path) -> None:
+        """A resource id carrying non-ASCII text still round-trips exactly.
+
+        ``data_catalog.json`` keys resources by ``resource_type``/``resource_id``
+        taken straight from audit events, so a non-ASCII actor or resource id
+        exercises the encoder's UTF-8 string handling end to end, not just on
+        a hand-written fixture.
+        """
+        _write_jsonl(
+            sdd_dir / "audit" / "2026-03-01.jsonl",
+            [
+                {
+                    "timestamp": "2026-03-01T00:00:00+00:00",
+                    "event_type": "task.created",
+                    "actor": "étienne",
+                    "resource_type": "task",
+                    "resource_id": "日本-1",
+                    "details": {},
+                    "hmac": "d" * 64,
+                    "prev_hmac": "c" * 64,
+                },
+            ],
+        )
+        pack = build_evidence_pack(sdd_dir=sdd_dir, standard="ai-act")
+        with zipfile.ZipFile(pack.archive_path) as zf:  # type: ignore[arg-type]
+            on_disk = zf.read("audit-chain/data_catalog.json")
+        parsed = json.loads(on_disk)
+        assert "日本-1" in parsed["resources"]["task"]
+        assert canonical_envelope_bytes(parsed) == on_disk
+
+    def test_property_order_follows_utf16_code_units_not_code_points(self) -> None:
+        """RFC 8785 §3.2.3: property names sort as UTF-16 code units.
+
+        A name starting with a supplementary-plane character (U+10000, a
+        surrogate pair starting at U+D800) and a name in U+E000..U+FFFF sort
+        in the *opposite* order under UTF-16 code units than under Unicode
+        code points -- the one place the two orderings disagree. This proves
+        ``_canonical_json`` carries that rule through, not just code-point
+        ``sort_keys``.
+        """
+        supplementary = "\U00010000-name"  # code point U+10000
+        bmp_private_use = "-name"  # code point U+E000
+        payload = {supplementary: 1, bmp_private_use: 2}
+
+        # Code-point order: U+E000 (57344) < U+10000 (65536), so
+        # ``bmp_private_use`` would sort first.
+        # UTF-16 code-unit order (RFC 8785 3.2.3): the supplementary
+        # character encodes as a surrogate pair whose lead unit is U+D800
+        # (55296) < U+E000 (57344), so ``supplementary`` must sort first.
+        encoded = _canonical_json(payload).decode("utf-8")
+        assert encoded.index(supplementary) < encoded.index(bmp_private_use)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Compliance evidence packs (`compliance/evidence_pack.py`) digested `manifest.json`, `controls.json`, and `audit-chain/data_catalog.json` under a local, hand-rolled JSON rule (`json.dumps(sort_keys=True, indent=2)`), while the repository already ships an RFC 8785 (JCS) canonical-JSON encoder with golden vectors (`core/security/evidence_envelope.py`, `canonical_envelope_bytes`) that nothing in `src/` imported.

The two rules disagree in ways that matter to a verifier who was handed the RFC 8785 spec rather than this source tree: separators, ECMAScript number formatting, and — for a property name starting with a supplementary-plane character (U+10000) meeting one in U+E000..U+FFFF — key ordering (UTF-16 code units vs. Unicode code points). A regulator or auditor's own independent RFC 8785 implementation would not reproduce the digest the pack shipped with.

## Changes

- `src/bernstein/compliance/evidence_pack.py`: `_canonical_json` now delegates to `evidence_envelope.canonical_envelope_bytes` instead of its own `json.dumps` convention. Every digested JSON artefact in a pack now goes through the one RFC 8785 encoder the codebase signs interop-facing evidence with.
- `tests/unit/test_evidence_pack.py`: added a `TestCanonicalization` class:
  - `_canonical_json` is byte-identical to `canonical_envelope_bytes` for the same payload (regression: it must not silently drift back into a second hand-configured rule).
  - A built pack's `manifest.json` / `controls.json` / `audit-chain/data_catalog.json`, re-encoded independently by `canonical_envelope_bytes`, reproduce the on-disk bytes exactly.
  - A non-ASCII resource id (drawn from real audit-event data, not a hand-written fixture) round-trips byte for byte.
  - A supplementary-plane property name and a U+E000..U+FFFF property name sort in the RFC 8785 §3.2.3 order (UTF-16 code units), which is the one case where that disagrees with plain code-point `sort_keys`.
- `docs/security/evidence-envelope.md`: noted that the canonical encoder now has a real caller outside its own tests (evidence packs), without claiming the full six-section envelope producer exists — that remains separate, larger, unbuilt work.
- `docs/release-notes/fragments/5504-evidence-pack-jcs-canonicalization.md`: user-visible note, including the effect on previously written packs.

## Compatibility

Previously written evidence packs are unaffected and still verify under the encoding rule that produced them at the time (`json.dumps(sort_keys=True, indent=2)`); nothing needs to be re-issued. Only newly generated packs use the RFC 8785 encoding going forward. This is called out explicitly in the release-notes fragment per the issue's acceptance criteria.

## Out of scope (per the issue)

- No new export targets.
- No change to the internal audit-chain format.
- The full evidence-envelope producer (principal/grants/decisions/signature) is a separate, larger piece of unbuilt work; this PR only gives the existing canonical encoder a real caller for the JSON artefacts evidence packs already produce.

## Testing

```
uv run pytest tests/unit/test_evidence_pack.py tests/unit/test_evidence_envelope_format_vectors.py -q
uv run ruff check src/bernstein/compliance/evidence_pack.py tests/unit/test_evidence_pack.py
uv run pyright src/bernstein/compliance/evidence_pack.py
uv run lint-imports
```

All pass locally (22 evidence-pack tests + 12 envelope-format-vector tests; ruff, pyright, and the architecture-contract check clean).

Fixes #5504.
