### PR TITLE
fix(adapters): declare opencode's event channel as stream-json

### DIFF
--- a/docs/adapters/capability_contract.md
+++ b/docs/adapters/capability_contract.md
@@ -161,7 +161,7 @@ adapters at a glance.
 | `ollama` | unsupported | unsupported | text-signals |
 | `open_interpreter` | unsupported | unsupported | text-signals |
 | `openai_agents` | flag | always-on | hooks |
-| `opencode` | flag | cli-flag | text-signals |
+| `opencode` | flag | cli-flag | stream-json |
 | `openhands` | unsupported | unsupported | text-signals |
 | `pi` | unsupported | unsupported | text-signals |
 | `plandex` | unsupported | unsupported | text-signals |

--- a/docs/release-notes/fragments/3676-opencode-event-channel.md
+++ b/docs/release-notes/fragments/3676-opencode-event-channel.md
@@ -1,0 +1,13 @@
+## OpenCode's declared event channel now matches what it emits
+
+The OpenCode adapter's capability declaration named its event channel
+`text-signals`, even though `opencode.py` has passed `--format json` on
+every spawn since #4099 and the CLI emits NDJSON lifecycle events under
+that flag. `event_channel` names a property of what the *upstream CLI*
+emits (per the axis's own definition in
+`docs/adapters/capability_contract.md` and the `EventChannel` docstring in
+`_contract.py`) — the same reading the `cursor` adapter is already declared
+under despite having no dedicated stream parser either. OpenCode now
+declares `stream-json` to match. Nothing changes in what Bernstein actually
+parses today: NDJSON consumption for this adapter remains separate,
+unbuilt follow-up work (#3676).

--- a/src/bernstein/adapters/_contract.py
+++ b/src/bernstein/adapters/_contract.py
@@ -819,13 +819,19 @@ STRATEGY_MATRIX: dict[str, AdapterStrategy] = {
     "ollama": AdapterStrategy(),
     "open_interpreter": AdapterStrategy(),
     # Resume and dangerous mode are backed by flags ``opencode.py`` passes:
-    # ``--continue`` and ``--auto`` plus an explicit permission policy. The
-    # event channel stays ``text-signals``: the CLI does emit NDJSON under
-    # ``--format json``, but nothing consumes it yet, and declaring a channel
-    # no parser reads would claim a surface that does not exist.
+    # ``--continue`` and ``--auto`` plus an explicit permission policy.
+    # ``event_channel`` names what the upstream CLI emits (see the enum's own
+    # docstring and docs/adapters/capability_contract.md), not what Bernstein
+    # currently parses -- the same reading ``cursor`` above is declared under
+    # despite having no dedicated stream parser either (#3676). ``opencode.py``
+    # already passes ``--format json``, under which the CLI emits NDJSON, so
+    # this is ``stream-json`` today even though nothing consumes those events
+    # yet; that consumption is separate follow-up work, not a reason to
+    # misdeclare the upstream surface.
     "opencode": AdapterStrategy(
         resume=ResumeStrategy.FLAG,
         dangerous_mode=DangerousModeStrategy.CLI_FLAG,
+        event_channel=EventChannel.STREAM_JSON,
     ),
     "openhands": AdapterStrategy(),
     "pi": AdapterStrategy(),

--- a/src/bernstein/adapters/capability_profile.py
+++ b/src/bernstein/adapters/capability_profile.py
@@ -1357,7 +1357,9 @@ _PROFILE_LIST: tuple[AdapterCapabilityProfile, ...] = (
         local_models=True,
         resume=ResumeStrategy.FLAG,
         dangerous_mode=DangerousModeStrategy.CLI_FLAG,
-        notes="Structured JSON output via --format json. --continue re-enters the prior session; "
+        event_channel=EventChannel.STREAM_JSON,
+        notes="Structured JSON output via --format json: upstream emits NDJSON under this flag, "
+        "though nothing consumes it yet (#3676). --continue re-enters the prior session; "
         "--auto plus an explicit OPENCODE_PERMISSION policy pins tool permissions per spawn.",
     ),
     AdapterCapabilityProfile(

--- a/tests/unit/adapters/test_capability_enums.py
+++ b/tests/unit/adapters/test_capability_enums.py
@@ -175,16 +175,22 @@ def test_stream_json_adapters_declared() -> None:
 
 
 def test_text_signal_default_for_plain_adapters() -> None:
-    for name in ("aider", "droid", "opencode"):
+    for name in ("aider", "droid"):
         assert strategy_for(name).event_channel is EventChannel.TEXT_SIGNALS
 
 
 def test_opencode_declares_native_resume_and_a_dangerous_mode_flag() -> None:
-    """Both axes are backed by flags the adapter passes; the event channel is not yet."""
+    """All three axes are backed by flags the adapter passes on every spawn.
+
+    ``event_channel`` names what the upstream CLI emits, not what Bernstein
+    currently parses (#3676): ``opencode.py`` passes ``--format json``, under
+    which the CLI emits NDJSON, so the declared channel is ``stream-json``
+    even though nothing consumes those events yet.
+    """
     strategy = strategy_for("opencode")
     assert strategy.resume is ResumeStrategy.FLAG
     assert strategy.dangerous_mode is DangerousModeStrategy.CLI_FLAG
-    assert strategy.event_channel is EventChannel.TEXT_SIGNALS
+    assert strategy.event_channel is EventChannel.STREAM_JSON
 
 
 def test_opencode_resume_declaration_drives_the_retry_surface() -> None:

--- a/tests/unit/test_adapter_opencode.py
+++ b/tests/unit/test_adapter_opencode.py
@@ -233,6 +233,33 @@ def test_contract_pins_the_flags_the_adapter_now_depends_on() -> None:
     assert "--continue" in spec.required_flags
 
 
+class TestEventChannelDeclaration:
+    """Regression for #3676: the declared channel must match the spawn command.
+
+    ``event_channel`` names what the upstream CLI *emits* (see the
+    ``EventChannel`` docstring and ``docs/adapters/capability_contract.md``),
+    not what Bernstein currently parses -- the same reading ``cursor`` is
+    declared under with no dedicated stream parser either. ``opencode.py``
+    passes ``--format json``, under which the CLI emits NDJSON, so the
+    declared channel is ``stream-json``. This test fails first if a future
+    change either drops ``--format json`` from the spawn command (the
+    declaration would then overclaim) or the declaration drifts back to
+    ``text-signals`` while the flag stays (the declaration would then
+    underclaim) -- either direction breaks the tie this test pins.
+    """
+
+    def test_declared_channel_is_stream_json(self) -> None:
+        from bernstein.adapters._contract import STRATEGY_MATRIX, EventChannel
+
+        assert STRATEGY_MATRIX["opencode"].event_channel is EventChannel.STREAM_JSON
+
+    def test_spawn_command_requests_the_structured_output_the_declaration_names(self) -> None:
+        adapter = OpenCodeAdapter()
+        cmd = adapter._build_command(model="openai/gpt-5.4-mini", prompt="fix the bug")
+        assert "--format" in cmd
+        assert cmd[cmd.index("--format") + 1] == "json"
+
+
 class TestSessionContinuation:
     """``resume=flag`` has to describe a flag the adapter actually passes."""
 


### PR DESCRIPTION
## Summary

`opencode`'s adapter contract declared its `event_channel` as `text-signals`, justified by a comment stating that `event_channel` means "what Bernstein currently parses" — but that reading contradicts the axis's own written definition in two places:

- `EventChannel.STREAM_JSON`'s own docstring in `_contract.py`: *"Upstream emits newline-delimited JSON events (Claude/Cursor/Gemini)."*
- `docs/adapters/capability_contract.md`: *"Newline-delimited JSON events from the upstream CLI."*

Both say `event_channel` names a property of what the **upstream CLI emits**, not what Bernstein currently consumes. Under that (already-written) definition, `opencode` should be `stream-json`: `opencode.py` has passed `--format json` on every spawn since #4099, and the CLI emits NDJSON under that flag. `cursor` is already declared `stream-json` under this exact reading despite having no dedicated stream parser either (checked: only `claude_stream_parser.py` and `goose_stream_parser.py` exist).

## Why this is safe to flip

`event_channel` has exactly one runtime reader outside its own doc/table rendering: `acp_channel.py`, which only checks `is EventChannel.ACP` (unrelated to `STREAM_JSON` vs `TEXT_SIGNALS`). So this is a pure declaration correction — nothing about what Bernstein actually parses for `opencode` changes. NDJSON consumption for this adapter remains separate, unbuilt follow-up work, same as before.

I also checked whether `docs/adapters/capability_contract.md` and `STRATEGY_MATRIX` agree everywhere else before touching anything wider than this one row — they agree for 41 of 44 comparable rows; `copilot`, `kilo`, and `letta_code` already disagree, unrelated to this issue and out of scope here.

## Changes

- `src/bernstein/adapters/_contract.py`: `opencode`'s `STRATEGY_MATRIX` row now declares `event_channel=EventChannel.STREAM_JSON`; the justifying comment now states the upstream-emits reading explicitly and cites `cursor` as the adapter already declared the same way.
- `docs/adapters/capability_contract.md`: the `opencode` row now reads `flag | cli-flag | stream-json`.
- `tests/unit/test_adapter_opencode.py`: added `TestEventChannelDeclaration` — one test pins the declared enum value, the other ties it directly to the spawn command (`--format json` must be present), so either a future flag removal or a re-flip of the declaration alone fails immediately.
- `tests/unit/adapters/test_capability_enums.py`: the two tests that had pinned the old `text-signals` value for `opencode` are updated to `stream-json`, with a docstring on the second explaining why.
- `docs/release-notes/fragments/3676-opencode-event-channel.md`: user-visible note.

## Out of scope (per the issue and the maintainer's latest comment on it)

- NDJSON event consumption, the permission strategy, and `--session` wiring are explicitly out of scope for this PR — the permission-pinning and `--continue` wiring were already shipped in #4099, and NDJSON consumption is separate unbuilt work.
- The `copilot` / `kilo` / `letta_code` doc-vs-matrix mismatches found while checking this are a separate, pre-existing issue, not touched here.

## Testing

```
uv run pytest tests/unit/test_adapter_opencode.py tests/unit/adapters/test_capability_enums.py -q
uv run ruff check src/bernstein/adapters/_contract.py tests/unit/test_adapter_opencode.py tests/unit/adapters/test_capability_enums.py
uv run pyright src/bernstein/adapters/_contract.py
uv run lint-imports
```

All pass locally (73 tests across the two files; ruff, pyright, and the architecture-contract check clean).

Fixes #3676.
