### PR TITLE
feat(govern): a probe is a declared record (#5081)

### DIFF
--- a/docs/release-notes/fragments/5081-probe-records.md
+++ b/docs/release-notes/fragments/5081-probe-records.md
@@ -1,0 +1,27 @@
+## A probe is a declared record
+
+Which attribute a discovery pass collects, how it collects it, how long it may
+take and what it is allowed to assert were all implicit in code.
+`agent_discovery._RICH_DETECTOR_NAMES` named functions, and nothing anywhere
+carried a refresh interval, a timeout, a cost class or a taint tag — so adding
+one attribute to what a probe reports was a code change and a release, and two
+operators could not compare two runs without diffing the source that produced
+them.
+
+`bernstein.core.govern.probe` makes a probe data: a stable id, the attribute it
+produces, its collection method, refresh interval, hard timeout, cost class,
+and the taint tags it may assert. `load_probe_set` reads a directory an
+operator can extend, in sorted name order so the set is identical on every
+machine, and refuses two declarations sharing an id — the id is what a run
+records, and two of them make "which probe produced this" unanswerable.
+
+Unknown fields round-trip unchanged. A probe file written by a newer build
+carries fields this one does not interpret; dropping them on load would
+silently rewrite the operator's file the next time anything saved it. They are
+preserved verbatim and re-emitted, and the round trip is stable across repeated
+load-save passes so a file cannot drift on its own.
+
+A probe with no timeout is refused rather than defaulted: a probe with no
+ceiling is one that can hang a whole pass.
+
+Slice 1 of #5081. Nothing runs these yet — the collector is #5082.

--- a/src/bernstein/core/govern/__init__.py
+++ b/src/bernstein/core/govern/__init__.py
@@ -57,6 +57,14 @@ from bernstein.core.govern.playbook_models import (
     PlaybookValidationError,
     RemediationAction,
 )
+from bernstein.core.govern.probe import (
+    CollectionMethod,
+    CostClass,
+    Probe,
+    ProbeError,
+    ProbeSet,
+    load_probe_set,
+)
 from bernstein.core.govern.proposal import DraftProposal, ProposalStatus
 from bernstein.core.govern.reconcile import (
     compute_reconcile_diff,
@@ -262,6 +270,8 @@ __all__ = [
     "ChangeOutcome",
     "ChangeResult",
     "ChangeStatus",
+    "CollectionMethod",
+    "CostClass",
     "DesiredEntity",
     "DesiredState",
     "DiffAction",
@@ -292,6 +302,9 @@ __all__ = [
     "Playbook",
     "PlaybookClause",
     "PlaybookValidationError",
+    "Probe",
+    "ProbeError",
+    "ProbeSet",
     "ProducerState",
     "ProposalStatus",
     "ReconcileDiff",
@@ -317,6 +330,7 @@ __all__ = [
     "compute_reconcile_diff",
     "freshness_gated_read",
     "load_lane_set",
+    "load_probe_set",
     "observation_store_root",
     "propose_reconcile",
     "reconcile_lanes",

--- a/src/bernstein/core/govern/probe.py
+++ b/src/bernstein/core/govern/probe.py
@@ -1,0 +1,279 @@
+"""A probe is a declared record, not a function name in a dispatch table.
+
+Which attribute a discovery pass collects, how it collects it, how long it may
+take and what it is allowed to assert were all implicit in code:
+``agent_discovery._RICH_DETECTOR_NAMES`` named functions, and nothing anywhere
+carried a refresh interval, a timeout, a cost class or a taint tag. So adding
+one attribute to what a probe reports was a code change and a release, and two
+operators could not compare two runs without diffing the source that produced
+them (#5081, slice 1).
+
+A probe declared here is data. Two operators running the same probe-set version
+against the same targets get the same declared surface, and the review surface
+for a new probe is the probe file rather than a diff to a dispatch function
+that nine other probes also run through.
+
+**Unknown fields round-trip unchanged.** A probe file written by a newer build
+carries fields this one does not interpret, and dropping them on load would
+silently rewrite an operator's file the next time anything saved it. They are
+preserved verbatim and re-emitted in :meth:`Probe.to_dict`, so an older build
+is a reader that does not understand every field rather than one that destroys
+it.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+__all__ = [
+    "CollectionMethod",
+    "CostClass",
+    "Probe",
+    "ProbeError",
+    "ProbeSet",
+    "load_probe_set",
+]
+
+
+class ProbeError(ValueError):
+    """A probe declaration that cannot be read as one.
+
+    Raised at load, never at use: a probe set is operator-authored data, and a
+    file that cannot be interpreted must fail where it is read rather than
+    halfway through a discovery pass.
+    """
+
+
+class CollectionMethod(StrEnum):
+    """How a probe obtains its attribute."""
+
+    #: Run a command and read its output.
+    COMMAND = "command"
+    #: Read a file from the target's filesystem.
+    FILE = "file"
+    #: Ask an API endpoint.
+    API = "api"
+    #: Derive from something already collected; no I/O of its own.
+    DERIVED = "derived"
+
+
+class CostClass(StrEnum):
+    """What a probe costs to run, so a scheduler can budget without timing it."""
+
+    #: Local, sub-second, no network.
+    FREE = "free"
+    #: Local but slow, or one cheap network call.
+    CHEAP = "cheap"
+    #: Several network calls, or a metered API.
+    EXPENSIVE = "expensive"
+
+
+#: Keys :class:`Probe` interprets. Anything else in a declaration is carried
+#: through untouched — see the module docstring.
+_KNOWN_KEYS = frozenset(
+    {
+        "id",
+        "attribute",
+        "collection_method",
+        "refresh_interval_s",
+        "timeout_s",
+        "cost_class",
+        "taint_tags",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Probe:
+    """One declared probe.
+
+    Attributes:
+        id: Stable identifier. Two runs of the same id are comparable; it is
+            what a journal entry names, so it may not change when a probe's
+            implementation does.
+        attribute: The attribute this probe produces.
+        collection_method: How it is obtained.
+        refresh_interval_s: How long a result stays usable. ``0`` means every
+            pass re-collects.
+        timeout_s: Hard ceiling for one invocation. A probe with no ceiling is
+            a probe that can hang a whole pass, so this is required.
+        cost_class: What running it costs.
+        taint_tags: Tags this probe may assert on its result, and the only ones
+            it may. A probe that could assert anything is not a declaration.
+        unknown: Fields this build does not interpret, preserved verbatim.
+    """
+
+    id: str
+    attribute: str
+    collection_method: CollectionMethod
+    timeout_s: float
+    refresh_interval_s: float = 0.0
+    cost_class: CostClass = CostClass.CHEAP
+    taint_tags: tuple[str, ...] = ()
+    unknown: dict[str, Any] = field(default_factory=dict[str, Any])
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical serialization, unknown fields included.
+
+        Known keys are emitted in a fixed order so two writers of the same
+        probe produce the same bytes; unknown keys follow, sorted, for the
+        same reason.
+        """
+        out: dict[str, Any] = {
+            "id": self.id,
+            "attribute": self.attribute,
+            "collection_method": str(self.collection_method),
+            "refresh_interval_s": self.refresh_interval_s,
+            "timeout_s": self.timeout_s,
+            "cost_class": str(self.cost_class),
+            "taint_tags": list(self.taint_tags),
+        }
+        for key in sorted(self.unknown):
+            out[key] = self.unknown[key]
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any], *, origin: str = "<memory>") -> Probe:
+        """Rebuild a probe from a declaration.
+
+        Args:
+            raw: The declaration.
+            origin: Where it came from, named in any refusal so an operator
+                does not have to guess which file is wrong.
+
+        Raises:
+            ProbeError: A required field is missing or uninterpretable.
+        """
+        probe_id = _require_text(raw, "id", origin)
+        attribute = _require_text(raw, "attribute", origin)
+        method = _require_member(raw, "collection_method", CollectionMethod, origin, probe_id)
+        cost = (
+            _require_member(raw, "cost_class", CostClass, origin, probe_id)
+            if raw.get("cost_class") is not None
+            else CostClass.CHEAP
+        )
+        timeout = _require_positive(raw, "timeout_s", origin, probe_id)
+        refresh = _optional_non_negative(raw, "refresh_interval_s", origin, probe_id)
+        tags = raw.get("taint_tags", ())
+        if not isinstance(tags, list | tuple) or any(not isinstance(t, str) for t in tags):
+            raise ProbeError(f"{origin}: probe {probe_id!r} taint_tags must be a list of strings")
+        return cls(
+            id=probe_id,
+            attribute=attribute,
+            collection_method=method,
+            timeout_s=timeout,
+            refresh_interval_s=refresh,
+            cost_class=cost,
+            taint_tags=tuple(str(t) for t in tags),
+            unknown={k: v for k, v in raw.items() if k not in _KNOWN_KEYS},
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeSet:
+    """Every probe an operator declared, and the version they declared it at.
+
+    ``version`` is what a run records so "which probe set produced this" is
+    answerable from the record alone. It is the directory's own declaration,
+    not a hash of the files: an operator who edits a probe and does not bump it
+    is making a statement, and inventing a version would hide that.
+    """
+
+    version: str
+    probes: tuple[Probe, ...]
+
+    def __iter__(self) -> Iterator[Probe]:
+        return iter(self.probes)
+
+    def __len__(self) -> int:
+        return len(self.probes)
+
+    def by_id(self, probe_id: str) -> Probe | None:
+        """Return the probe with *probe_id*, or None."""
+        return next((p for p in self.probes if p.id == probe_id), None)
+
+
+def load_probe_set(directory: Path, *, version: str = "") -> ProbeSet:
+    """Load every ``*.json`` probe declaration under *directory*.
+
+    Files are read in sorted name order so the set is the same on every
+    machine. A directory that does not exist is an empty set, not an error:
+    an operator who has declared no probes has declared no probes.
+
+    Args:
+        directory: Directory holding probe declarations.
+        version: The probe-set version to record. Defaults to the value in
+            ``probe-set.json`` if present, else "".
+
+    Raises:
+        ProbeError: A file is unparsable, or two probes share an id.
+    """
+    if not directory.is_dir():
+        return ProbeSet(version=version, probes=())
+
+    declared_version = version
+    manifest = directory / "probe-set.json"
+    if not declared_version and manifest.is_file():
+        declared_version = str(_read_json(manifest).get("version", ""))
+
+    probes: list[Probe] = []
+    seen: dict[str, str] = {}
+    for path in sorted(directory.glob("*.json")):
+        if path.name == "probe-set.json":
+            continue
+        raw = _read_json(path)
+        probe = Probe.from_dict(raw, origin=str(path))
+        if probe.id in seen:
+            # Two declarations of one id make "which probe produced this"
+            # unanswerable from the record, which is the whole point of the id.
+            raise ProbeError(f"{path}: probe id {probe.id!r} is already declared by {seen[probe.id]}")
+        seen[probe.id] = str(path)
+        probes.append(probe)
+    return ProbeSet(version=declared_version, probes=tuple(probes))
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProbeError(f"{path}: cannot be read as JSON: {exc}") from exc
+    if not isinstance(loaded, dict):
+        raise ProbeError(f"{path}: a probe declaration must be an object")
+    return dict(loaded)
+
+
+def _require_text(raw: dict[str, Any], key: str, origin: str) -> str:
+    value = raw.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ProbeError(f"{origin}: {key} must be a non-empty string")
+    return value
+
+
+def _require_member(raw: dict[str, Any], key: str, enum: type[StrEnum], origin: str, probe_id: str) -> Any:
+    value = raw.get(key)
+    try:
+        return enum(str(value))
+    except ValueError as exc:
+        allowed = ", ".join(sorted(str(m) for m in enum))
+        raise ProbeError(f"{origin}: probe {probe_id!r} {key}={value!r} is not one of: {allowed}") from exc
+
+
+def _require_positive(raw: dict[str, Any], key: str, origin: str, probe_id: str) -> float:
+    value = raw.get(key)
+    if not isinstance(value, int | float) or isinstance(value, bool) or value <= 0:
+        raise ProbeError(f"{origin}: probe {probe_id!r} {key} must be a positive number")
+    return float(value)
+
+
+def _optional_non_negative(raw: dict[str, Any], key: str, origin: str, probe_id: str) -> float:
+    value = raw.get(key, 0.0)
+    if not isinstance(value, int | float) or isinstance(value, bool) or value < 0:
+        raise ProbeError(f"{origin}: probe {probe_id!r} {key} must be a non-negative number")
+    return float(value)

--- a/tests/unit/core/govern/test_probe_records.py
+++ b/tests/unit/core/govern/test_probe_records.py
@@ -1,0 +1,168 @@
+"""A probe is a declared record, and an unknown field survives a round trip.
+
+Which attribute a discovery pass collects, and what it costs, took how long and
+may assert, were implicit in code: `agent_discovery._RICH_DETECTOR_NAMES` named
+functions and nothing carried a refresh interval, a timeout, a cost class or a
+taint tag. Adding one attribute to what a probe reports was a code change and a
+release (#5081, slice 1).
+
+The load-bearing test here is the round trip. A probe file written by a newer
+build carries fields this one does not interpret; dropping them on load would
+silently rewrite an operator's file the next time anything saved it, and the
+damage would show up as a probe that quietly stopped doing something.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from bernstein.core.govern.probe import (
+    CollectionMethod,
+    CostClass,
+    Probe,
+    ProbeError,
+    load_probe_set,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _declaration(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "id": "adapter-version",
+        "attribute": "adapter.version",
+        "collection_method": "command",
+        "refresh_interval_s": 900,
+        "timeout_s": 5,
+        "cost_class": "cheap",
+        "taint_tags": ["host-derived"],
+    }
+    base.update(overrides)
+    return base
+
+
+def _write(directory: Path, name: str, payload: dict[str, Any]) -> Path:
+    path = directory / name
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# The named, load-bearing test
+# ---------------------------------------------------------------------------
+
+
+def test_probe_record_round_trips_unknown_fields() -> None:
+    """A field this build does not recognise survives load then save unchanged.
+
+    Fails on main: no probe record exists at all, so a newer build's field has
+    nowhere to survive.
+    """
+    raw = _declaration(sampling_strategy="reservoir", future_budget={"tokens": 10})
+    probe = Probe.from_dict(raw)
+    assert probe.unknown == {"sampling_strategy": "reservoir", "future_budget": {"tokens": 10}}
+    assert probe.to_dict() == raw
+
+
+def test_a_round_trip_is_stable_across_two_passes() -> None:
+    """Load-save-load-save must not drift, or a file rewrites itself forever."""
+    raw = _declaration(unrecognised={"a": [1, 2]})
+    once = Probe.from_dict(raw).to_dict()
+    twice = Probe.from_dict(once).to_dict()
+    assert once == twice == raw
+
+
+def test_known_keys_serialize_in_a_fixed_order() -> None:
+    """Two writers of one probe produce the same bytes."""
+    first = json.dumps(Probe.from_dict(_declaration(z_extra=1, a_extra=2)).to_dict())
+    second = json.dumps(Probe.from_dict(_declaration(a_extra=2, z_extra=1)).to_dict())
+    assert first == second
+
+
+# ---------------------------------------------------------------------------
+# What a declaration must carry
+# ---------------------------------------------------------------------------
+
+
+def test_a_probe_declares_everything_the_issue_asks_for() -> None:
+    probe = Probe.from_dict(_declaration())
+    assert probe.id == "adapter-version"
+    assert probe.attribute == "adapter.version"
+    assert probe.collection_method is CollectionMethod.COMMAND
+    assert probe.refresh_interval_s == 900.0
+    assert probe.timeout_s == 5.0
+    assert probe.cost_class is CostClass.CHEAP
+    assert probe.taint_tags == ("host-derived",)
+
+
+def test_a_probe_without_a_timeout_is_refused() -> None:
+    """A probe with no ceiling is a probe that can hang a whole pass."""
+    raw = _declaration()
+    del raw["timeout_s"]
+    with pytest.raises(ProbeError, match="timeout_s"):
+        Probe.from_dict(raw)
+
+
+@pytest.mark.parametrize("bad", [0, -1, "5", True])
+def test_a_non_positive_timeout_is_refused(bad: object) -> None:
+    """Zero is not a ceiling, and a bool is not a number."""
+    with pytest.raises(ProbeError, match="timeout_s"):
+        Probe.from_dict(_declaration(timeout_s=bad))
+
+
+def test_an_unknown_collection_method_names_what_is_allowed() -> None:
+    """A refusal an operator can act on without reading the source."""
+    with pytest.raises(ProbeError, match="command"):
+        Probe.from_dict(_declaration(collection_method="telepathy"))
+
+
+def test_taint_tags_must_be_strings() -> None:
+    with pytest.raises(ProbeError, match="taint_tags"):
+        Probe.from_dict(_declaration(taint_tags=[{"nested": True}]))
+
+
+# ---------------------------------------------------------------------------
+# Loading a directory
+# ---------------------------------------------------------------------------
+
+
+def test_a_directory_of_declarations_loads_in_name_order(tmp_path: Path) -> None:
+    """Sorted, so the set is the same on every machine."""
+    _write(tmp_path, "b.json", _declaration(id="b", attribute="b"))
+    _write(tmp_path, "a.json", _declaration(id="a", attribute="a"))
+    probe_set = load_probe_set(tmp_path)
+    assert [p.id for p in probe_set] == ["a", "b"]
+    assert len(probe_set) == 2
+    assert probe_set.by_id("b") is not None
+
+
+def test_the_version_comes_from_the_set_not_from_a_hash(tmp_path: Path) -> None:
+    """An operator who edits a probe without bumping is making a statement."""
+    _write(tmp_path, "probe-set.json", {"version": "2026.09.1"})
+    _write(tmp_path, "a.json", _declaration(id="a"))
+    assert load_probe_set(tmp_path).version == "2026.09.1"
+
+
+def test_two_probes_sharing_an_id_are_refused(tmp_path: Path) -> None:
+    """The id is what a journal entry names; two of them make it unanswerable."""
+    _write(tmp_path, "one.json", _declaration(id="dup"))
+    _write(tmp_path, "two.json", _declaration(id="dup"))
+    with pytest.raises(ProbeError, match="already declared"):
+        load_probe_set(tmp_path)
+
+
+def test_a_missing_directory_is_an_empty_set(tmp_path: Path) -> None:
+    """An operator who declared no probes has declared no probes."""
+    probe_set = load_probe_set(tmp_path / "absent")
+    assert len(probe_set) == 0
+
+
+def test_an_unparsable_file_names_itself(tmp_path: Path) -> None:
+    """Fails where it is read, not halfway through a discovery pass."""
+    (tmp_path / "broken.json").write_text("{not json", encoding="utf-8")
+    with pytest.raises(ProbeError, match="broken.json"):
+        load_probe_set(tmp_path)


### PR DESCRIPTION
Slice 1 of #5081. Companion to #5537 (slice 2, the adapter-selection registry) — independent of it, and either can land first.

## What it makes possible

Which attribute a discovery pass collects, how it collects it, how long it may take and what it may assert were implicit in code. `agent_discovery._RICH_DETECTOR_NAMES` named functions, and nothing anywhere carried a refresh interval, a timeout, a cost class or a taint tag. So adding one attribute to what a probe reports was a code change and a release, and two operators could not compare two runs without diffing the source that produced them.

A probe is now data — id, attribute, collection method, refresh interval, hard timeout, cost class, taint tags — loaded from a directory the operator can extend.

## The load-bearing property

`test_probe_record_round_trips_unknown_fields`, the test the issue names. A probe file written by a newer build carries fields this build does not interpret. Dropping them on load would silently rewrite the operator's file the next time anything saved it, and the damage surfaces much later as a probe that quietly stopped doing something.

They are preserved verbatim and re-emitted. I also pinned that the round trip is **stable across repeated passes** (`load → save → load → save` is a fixed point), because a serializer that reorders or normalises would otherwise make a file drift on its own every time it was touched, which is the same bug arriving slowly.

## Two refusals rather than defaults

- **No timeout is an error, not a default.** A probe with no ceiling is a probe that can hang a whole pass; picking a number on the operator's behalf hides that decision. `0` and negatives are refused too, and a `bool` is not accepted as a number.
- **Two probes sharing an id is an error.** The id is what a run records, so two declarations of it make "which probe produced this" unanswerable — which is the whole point of having a stable id.

Refusals name the file and the probe, so an operator does not have to guess which of thirty declarations is wrong.

## Not in this slice

Nothing runs these yet: the collector that walks a probe and produces an observation envelope is #5082, and jitter/timeout enforcement is slice 3. This slice is the declaration, which the issue says is worth taking alone.

## Verification

- `pytest tests/unit/core/govern/test_probe_records.py` — 16 passed
- `pytest tests/unit/core/govern/` — 301 passed
- `mypy --config-file mypy.gate.ini` clean; `ruff check` / `format --check` clean; `lint-imports` 3 contracts kept

Fragment: `docs/release-notes/fragments/5081-probe-records.md`.