### PR TITLE
fix(agents): liveness consults the process group, not just the wrapper (#5272)

### DIFF
--- a/docs/release-notes/fragments/5272-liveness-consults-the-group.md
+++ b/docs/release-notes/fragments/5272-liveness-consults-the-group.md
@@ -1,0 +1,24 @@
+## A session is alive while any member of its process group is
+
+Finalization seals the journal head into the lineage spine and writes the run
+receipt once drain reports every session dead. Drain asked
+`_check_alive_process`, which was `proc.poll()` on the stored wrapper alone.
+
+Adapters spawn the tool with `start_new_session=True`, so the wrapper is a
+session leader and its pid is the group id — the tool, and anything it forks,
+lives in that group and outlives the wrapper. The check therefore reported a
+session dead while its descendants were still running, and the receipt covering
+the run was produced over execution that had not stopped. A surviving process
+can still write into a worktree or the integration branch after the seal, and
+the record said nothing about it.
+
+Liveness now consults the group through `process_group_alive`, the same
+primitive the kill/escalation path already uses for the same reason (#2643).
+The wrapper's exit code is still recorded the moment it is known — that is a
+fact about the wrapper — but the session is reported alive while the group has
+members. On Windows there are no POSIX process groups and `process_group_alive`
+falls back to the lead pid, so behaviour there is unchanged.
+
+This is the liveness half of #5272. Recording a `run_quiescence` journal event
+before the seal, and escalating with `kill_process_group_graceful` for what
+remains after the drain timeout, are the rest of that issue.

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -6784,15 +6784,49 @@ class AgentSpawner:
         return alive
 
     def _check_alive_process(self, session: AgentSession) -> bool | None:
-        """Check liveness via stored subprocess. Returns None if no proc stored."""
+        """Check liveness via the stored subprocess *and its process group*.
+
+        ``proc.poll()`` alone answers a narrower question than the caller is
+        asking. Adapters spawn the tool with ``start_new_session=True``, so the
+        wrapper is a session leader and its ``pid`` is the group id; the tool
+        and anything it forks live in that group and outlive the wrapper. A
+        liveness check that stopped at the wrapper reported the session dead
+        while its descendants were still running, and finalization would then
+        seal the journal and write a run receipt over execution that had not
+        stopped (#5272).
+
+        The wrapper's exit code is still recorded the moment it is known - it
+        is a fact about the wrapper - but the session is reported alive while
+        any member of its group survives.
+
+        On Windows there are no POSIX process groups and
+        :func:`process_group_alive` falls back to the lead PID, so behaviour
+        there is exactly what it was.
+
+        Returns:
+            None when no process is stored for the session, so the next
+            checker in the chain runs.
+        """
         proc = self._procs.get(session.id)
         if proc is None:
             return None
         exit_code = proc.poll()
-        if exit_code is not None:
-            session.exit_code = exit_code
-            return False
-        return True
+        if exit_code is None:
+            return True
+
+        from bernstein.core.config.platform_compat import process_group_alive
+
+        session.exit_code = exit_code
+        pgid = proc.pid
+        if pgid and process_group_alive(pgid):
+            logger.debug(
+                "session %s: wrapper exited (%s) but process group %s still has members",
+                session.id,
+                exit_code,
+                pgid,
+            )
+            return True
+        return False
 
     def _check_alive_sandbox_session(self, session: AgentSession) -> bool | None:
         """Liveness for agents whose exec runs via :meth:`SandboxSession.exec`.

--- a/tests/unit/test_liveness_consults_process_group.py
+++ b/tests/unit/test_liveness_consults_process_group.py
@@ -1,0 +1,132 @@
+"""A session is alive while any member of its process group is.
+
+Finalization seals the journal head into the lineage spine and writes the run
+receipt after drain reports every session dead. Drain asked
+`_check_alive_process`, which was `proc.poll()` on the stored wrapper alone.
+
+Adapters spawn the tool with `start_new_session=True`, so the wrapper is a
+session leader and the tool — and anything it forks — lives in that group and
+outlives it. The old check therefore reported a session dead while its
+descendants were still writing, and the receipt covering the run was produced
+over execution that had not stopped (#5272).
+
+The test that matters is the last one: a real orphan in the group, not a mock,
+because the whole defect is about what `poll()` does not see.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from typing import Any
+
+import pytest
+
+from bernstein.core.config.platform_compat import IS_WINDOWS, process_group_alive
+from bernstein.core.tasks.models import AgentSession
+
+
+class _FakeProc:
+    """A stand-in for the stored `Popen`: a pid and a scripted `poll()`."""
+
+    def __init__(self, pid: int, exit_code: int | None) -> None:
+        self.pid = pid
+        self._exit_code = exit_code
+
+    def poll(self) -> int | None:
+        return self._exit_code
+
+
+def _spawner_with(procs: dict[str, Any]) -> Any:
+    from bernstein.core.agents.spawner_core import AgentSpawner
+
+    spawner = AgentSpawner.__new__(AgentSpawner)
+    spawner._procs = procs
+    return spawner
+
+
+@pytest.fixture
+def session() -> AgentSession:
+    return AgentSession(id="s-1", role="backend")
+
+
+def test_a_running_wrapper_is_alive(session: AgentSession) -> None:
+    """Unchanged: `poll()` returning None short-circuits before any group probe."""
+    spawner = _spawner_with({"s-1": _FakeProc(pid=4242, exit_code=None)})
+    assert spawner._check_alive_process(session) is True
+    assert session.exit_code is None
+
+
+def test_no_stored_process_defers_to_the_next_checker(session: AgentSession) -> None:
+    """`None` keeps the checker chain working."""
+    assert _spawner_with({})._check_alive_process(session) is None
+
+
+def test_an_exited_wrapper_with_an_empty_group_is_dead(session: AgentSession, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The ordinary case, and the one that must stay fast."""
+    import bernstein.core.config.platform_compat as compat
+
+    monkeypatch.setattr(compat, "process_group_alive", lambda pgid: False)
+    spawner = _spawner_with({"s-1": _FakeProc(pid=4242, exit_code=0)})
+    assert spawner._check_alive_process(session) is False
+    assert session.exit_code == 0
+
+
+def test_an_exited_wrapper_with_a_live_group_is_alive(session: AgentSession, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The defect, in one assertion.
+
+    The wrapper has exited; a descendant has not. Reporting dead here is what
+    let finalization seal a journal over work still in flight.
+    """
+    import bernstein.core.config.platform_compat as compat
+
+    monkeypatch.setattr(compat, "process_group_alive", lambda pgid: True)
+    spawner = _spawner_with({"s-1": _FakeProc(pid=4242, exit_code=0)})
+    assert spawner._check_alive_process(session) is True
+
+
+def test_the_wrapper_exit_code_is_recorded_even_while_the_group_survives(
+    session: AgentSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The wrapper's exit code is a fact about the wrapper, known now."""
+    import bernstein.core.config.platform_compat as compat
+
+    monkeypatch.setattr(compat, "process_group_alive", lambda pgid: True)
+    spawner = _spawner_with({"s-1": _FakeProc(pid=4242, exit_code=3)})
+    spawner._check_alive_process(session)
+    assert session.exit_code == 3
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="POSIX process groups")
+def test_a_real_orphan_in_the_group_keeps_the_session_alive(session: AgentSession) -> None:
+    """The end-to-end case, with real processes rather than a monkeypatch.
+
+    A wrapper that starts its own session, forks a child that outlives it, and
+    exits. `poll()` reports the wrapper gone; the group is not.
+    """
+    wrapper = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import subprocess,sys;subprocess.Popen([sys.executable,'-c','import time;time.sleep(30)']);sys.exit(0)",
+        ],
+        start_new_session=True,
+    )
+    try:
+        wrapper.wait(timeout=30)
+        # The wrapper is gone; its child is not, and shares the group.
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and not process_group_alive(wrapper.pid):
+            time.sleep(0.05)
+        assert process_group_alive(wrapper.pid), "fixture failed: the orphan did not survive"
+
+        spawner = _spawner_with({"s-1": wrapper})
+        assert spawner._check_alive_process(session) is True, (
+            "the wrapper exited but its group still has members: the session is not done"
+        )
+        assert session.exit_code == 0
+    finally:
+        from bernstein.core.config.platform_compat import kill_process_group
+
+        kill_process_group(wrapper.pid, 9)


### PR DESCRIPTION
The liveness half of #5272. The `run_quiescence` journal event and the escalation after the drain timeout are the rest of that issue and are not here.

## The defect

Finalization seals the journal head into the lineage spine and writes the run receipt once drain reports every session dead. Drain asks `_check_alive_process`, which was:

```python
exit_code = proc.poll()          # the wrapper only
if exit_code is not None:
    session.exit_code = exit_code
    return False
```

Adapters spawn the tool with `start_new_session=True`, so the wrapper is a session leader and its `pid` is the group id. The tool, and anything it forks, lives in that group and outlives the wrapper. So a session could be reported dead while its descendants were still running, and the receipt covering the run was produced over execution that had not stopped — a surviving process can still write into a worktree or the integration branch after the seal, and the record says nothing about it.

## The change

Liveness asks `process_group_alive`, which the kill and escalation paths already use for exactly this reason (#2643 — "a surviving child keeps the group alive even after the group leader has already been reaped"). The same primitive was available at finalization and was not being consulted.

The wrapper's exit code is still recorded the moment it is known, because that is a true fact about the wrapper. What changes is the verdict: the session is alive while the group has members.

`proc.poll() is None` still short-circuits before any group probe, so the common path costs nothing extra.

## Windows

`process_group_alive` falls back to the lead pid where POSIX groups do not exist, so behaviour there is exactly what it was. That is stated in the docstring rather than left for a reader to work out — the issue asks for `verified: false, method: "unsupported"` at the journal layer, and this slice deliberately does not silently claim more than the platform supports.

## The test uses real processes

`test_a_real_orphan_in_the_group_keeps_the_session_alive` starts a wrapper in its own session, has it fork a child that outlives it, and waits for the wrapper to exit. `poll()` reports the wrapper gone; the group is not. A monkeypatch would have proved only that I wired the call — the whole defect is about what `poll()` does not see.

Both it and the unit case fail on `main`:

```
FAILED test_an_exited_wrapper_with_a_live_group_is_alive
FAILED test_a_real_orphan_in_the_group_keeps_the_session_alive
2 failed, 4 passed
```

and all six pass on this branch. The test kills the group in a `finally`, so it leaves nothing behind.

## Verification

- `pytest tests/unit/test_liveness_consults_process_group.py` — 6 passed
- `pytest tests/unit -k "spawner or liveness or reap or drain or check_alive"` — 687 passed, 2 skipped
- `mypy --config-file mypy.gate.ini` clean; `ruff check` / `format --check` clean

Fragment: `docs/release-notes/fragments/5272-liveness-consults-the-group.md`.