### PR TITLE
feat(orchestration): record run quiescence before the seal (#5272)

### DIFF
--- a/docs/release-notes/fragments/5272-run-quiescence.md
+++ b/docs/release-notes/fragments/5272-run-quiescence.md
@@ -1,0 +1,26 @@
+## The seal records whether execution had actually stopped
+
+Finalization seals the journal head into the lineage spine and writes the run
+receipt. Nothing recorded whether the processes the run started had exited
+first, so a tool process that outlived its wrapper could still write into a
+worktree or the integration branch *after* the receipt covering the run was
+produced — and the record was silent about it.
+
+A `run_quiescence` row is now appended before the seal, carrying `verified`,
+the `residual` groups by session id and pgid, the `method` used, and how many
+groups were `checked`. The sealed head and the receipt therefore cover the
+answer instead of being written over an unanswered question, and an operator
+reading the journal can tell a quiet run from one that was sealed over work
+still in flight.
+
+The distinction the row keeps is between *checked and clean* and *could not
+check*. On a platform without process groups it records
+`verified: false, method: "unsupported"` — never a silent true, because
+`process_group_alive` falls back to the lead pid there and would answer a
+narrower question than the row claims. A check that fails outright records
+`method: "check_failed"` rather than raising: a run that already completed must
+not fail because its quiescence could not be established.
+
+This records; it does not yet stop anything. Waiting out the drain timeout and
+escalating with `kill_process_group_graceful` for what remains is the rest of
+#5272.

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -6783,6 +6783,16 @@ class AgentSpawner:
             session.exit_code = container_mgr.get_exit_code(handle)
         return alive
 
+    def session_process_groups(self) -> dict[str, int | None]:
+        """Return each live session's process group id, for a quiescence check.
+
+        Adapters spawn with ``start_new_session=True``, so the stored
+        ``Popen.pid`` is the group id. A session with no stored process
+        contributes ``None``: there is nothing to probe, which is different
+        from a group that was probed and found empty (#5272).
+        """
+        return {session_id: (proc.pid if proc is not None else None) for session_id, proc in self._procs.items()}
+
     def _check_alive_process(self, session: AgentSession) -> bool | None:
         """Check liveness via stored subprocess. Returns None if no proc stored."""
         proc = self._procs.get(session.id)

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -3353,6 +3353,7 @@ class Orchestrator:
         )
         self._mark_finalization_started()
         try:
+            self._record_run_quiescence()
             self._seal_journal_into_lineage_spine()
             if self._otel_stream is not None:
                 self._otel_stream.finalize()
@@ -3364,6 +3365,45 @@ class Orchestrator:
             self._recorder.path,
             self._recorder.fingerprint()[:16] + "...",
         )
+
+    def _record_run_quiescence(self) -> None:
+        """Record whether every process the run started had exited.
+
+        Appended *before* the seal, so the sealed head and the run receipt
+        cover the answer rather than being written over an unanswered
+        question. A tool process that outlived its wrapper can still write
+        into a worktree or the integration branch after the seal; this row is
+        what makes that visible in the record instead of invisible (#5272).
+
+        Never raises: a run that already completed must not fail because its
+        quiescence could not be established. A failure to check is recorded as
+        a failure to check.
+        """
+        try:
+            from bernstein.core.orchestration.quiescence import check_quiescence
+
+            groups = self._spawner.session_process_groups() if hasattr(self._spawner, "session_process_groups") else {}
+            report = check_quiescence(groups)
+        except Exception:
+            logger.warning("run_quiescence check failed", exc_info=True)
+            self._recorder.record(
+                "run_quiescence",
+                run_id=self._run_id,
+                verified=False,
+                residual=[],
+                method="check_failed",
+                checked=0,
+            )
+            return
+
+        if report.residual:
+            logger.warning(
+                "run %s sealed with %d process group(s) still alive: %s",
+                self._run_id,
+                len(report.residual),
+                ", ".join(f"{g.session_id}:{g.pgid}" for g in report.residual),
+            )
+        self._recorder.record("run_quiescence", run_id=self._run_id, **report.to_dict())
 
     def _seal_journal_into_lineage_spine(self) -> None:
         """Wire the journal head into the f01 lineage spine (issue #2293).

--- a/src/bernstein/core/orchestration/quiescence.py
+++ b/src/bernstein/core/orchestration/quiescence.py
@@ -1,0 +1,122 @@
+"""Whether every process a run started had actually exited when it was sealed.
+
+Finalization seals the journal head into the lineage spine and writes the run
+receipt. Nothing recorded whether execution had stopped first, so a tool
+process that outlived its wrapper could still write into a worktree or the
+integration branch *after* the receipt covering the run was produced, and the
+record was silent about it (#5272).
+
+This module answers the question and produces the record. It does not stop
+anything: escalating with ``kill_process_group_graceful`` for what remains
+after the drain timeout is the other half of that issue, and a report that is
+honest about residual work is useful before anything acts on it.
+
+The distinction the record has to keep is between *checked and clean* and
+*could not check*. On a platform without process groups the answer is
+``verified=False`` with ``method="unsupported"`` — never a silent true, because
+"we did not look" and "nothing was there" are different claims and only one of
+them is evidence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.config.platform_compat import IS_WINDOWS, process_group_alive
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+__all__ = [
+    "METHOD_PROCESS_GROUP",
+    "METHOD_UNSUPPORTED",
+    "QuiescenceReport",
+    "ResidualGroup",
+    "check_quiescence",
+]
+
+#: Groups were probed with the platform's process-group primitive.
+METHOD_PROCESS_GROUP = "process_group"
+
+#: The platform has no process groups, so nothing was probed.
+METHOD_UNSUPPORTED = "unsupported"
+
+
+@dataclass(frozen=True, slots=True)
+class ResidualGroup:
+    """One session whose process group still had members at the seal."""
+
+    session_id: str
+    pgid: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical serialization."""
+        return {"session_id": self.session_id, "pgid": self.pgid}
+
+
+@dataclass(frozen=True, slots=True)
+class QuiescenceReport:
+    """What was checked, and what was still running.
+
+    ``verified`` is True only when every group was probed and none had
+    members. It is False both when something survived and when nothing could
+    be probed; ``method`` and ``residual`` say which, so a reader is never
+    left to infer it from an empty list.
+    """
+
+    verified: bool
+    residual: tuple[ResidualGroup, ...]
+    method: str
+    checked: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical serialization for the journal row."""
+        return {
+            "verified": self.verified,
+            "residual": [group.to_dict() for group in self.residual],
+            "method": self.method,
+            "checked": self.checked,
+        }
+
+
+def check_quiescence(session_pgids: Mapping[str, int | None]) -> QuiescenceReport:
+    """Report whether every session's process group has exited.
+
+    Args:
+        session_pgids: Session id to the pgid the session was started in.
+            Under ``start_new_session=True`` that is the wrapper's pid. A
+            ``None`` or non-positive value is a session with nothing to probe
+            and is skipped rather than counted as clean.
+
+    Returns:
+        The report. On a platform without process groups, ``verified`` is
+        False and ``method`` is :data:`METHOD_UNSUPPORTED`, whatever the probe
+        would have said.
+    """
+    if IS_WINDOWS:
+        # `process_group_alive` falls back to the lead pid here, which answers
+        # a narrower question than this record claims to answer. Reporting
+        # `verified=True` off that fallback would be the silent true the issue
+        # rules out.
+        return QuiescenceReport(
+            verified=False,
+            residual=(),
+            method=METHOD_UNSUPPORTED,
+            checked=0,
+        )
+
+    residual: list[ResidualGroup] = []
+    checked = 0
+    for session_id, pgid in sorted(session_pgids.items()):
+        if pgid is None or pgid <= 0:
+            continue
+        checked += 1
+        if process_group_alive(pgid):
+            residual.append(ResidualGroup(session_id=session_id, pgid=pgid))
+    return QuiescenceReport(
+        verified=not residual,
+        residual=tuple(residual),
+        method=METHOD_PROCESS_GROUP,
+        checked=checked,
+    )

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1682,6 +1682,9 @@ class TestRunStop:
             "loaded_extension_set",
             "tick_start",
             "run_completed",
+            # Appended before the seal so the sealed head and the run receipt
+            # cover whether execution had actually stopped (#5272).
+            "run_quiescence",
         ]
         stream.finalize.assert_called_once_with()
         chain = AuditChainStore(tmp_path / ".sdd" / "audit")

--- a/tests/unit/test_run_quiescence.py
+++ b/tests/unit/test_run_quiescence.py
@@ -1,0 +1,128 @@
+"""The seal records whether execution had actually stopped.
+
+Finalization seals the journal head into the lineage spine and writes the run
+receipt. Nothing recorded whether the processes the run started had exited, so
+a tool that outlived its wrapper could still write into a worktree or the
+integration branch after the receipt covering the run was produced — and the
+record said nothing (#5272).
+
+The distinction these tests defend is between *checked and clean* and *could
+not check*. Both are `verified: False` cases when they are not clean, and only
+`method` separates them; a report that collapsed them would let a platform
+that cannot probe read as a run that was quiet.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+
+import pytest
+
+from bernstein.core.config.platform_compat import IS_WINDOWS, kill_process_group, process_group_alive
+from bernstein.core.orchestration import quiescence
+from bernstein.core.orchestration.quiescence import (
+    METHOD_PROCESS_GROUP,
+    METHOD_UNSUPPORTED,
+    check_quiescence,
+)
+
+
+@pytest.fixture(autouse=True)
+def _posix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default to the POSIX path; the Windows case is asserted explicitly."""
+    monkeypatch.setattr(quiescence, "IS_WINDOWS", False)
+
+
+def test_no_sessions_is_verified_quiet() -> None:
+    """A run that started nothing has nothing outstanding."""
+    report = check_quiescence({})
+    assert report.verified is True
+    assert report.residual == ()
+    assert report.method == METHOD_PROCESS_GROUP
+    assert report.checked == 0
+
+
+def test_every_group_gone_is_verified_quiet(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(quiescence, "process_group_alive", lambda pgid: False)
+    report = check_quiescence({"s-1": 100, "s-2": 200})
+    assert report.verified is True
+    assert report.checked == 2
+
+
+def test_a_surviving_group_is_named(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The row an operator reads to find what was still running."""
+    monkeypatch.setattr(quiescence, "process_group_alive", lambda pgid: pgid == 200)
+    report = check_quiescence({"s-1": 100, "s-2": 200})
+    assert report.verified is False
+    assert [g.to_dict() for g in report.residual] == [{"session_id": "s-2", "pgid": 200}]
+    assert report.method == METHOD_PROCESS_GROUP
+
+
+def test_a_session_with_no_process_is_not_counted_as_clean(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Nothing to probe is not the same as probed and empty."""
+    monkeypatch.setattr(quiescence, "process_group_alive", lambda pgid: False)
+    report = check_quiescence({"s-1": None, "s-2": 0, "s-3": 300})
+    assert report.checked == 1
+
+
+def test_a_platform_without_process_groups_never_reports_verified(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The silent true the issue rules out.
+
+    `process_group_alive` falls back to the lead pid on Windows, which answers
+    a narrower question than this record claims. Reporting `verified: True`
+    off that fallback would make "we could not look" indistinguishable from
+    "nothing was there".
+    """
+    monkeypatch.setattr(quiescence, "IS_WINDOWS", True)
+    monkeypatch.setattr(quiescence, "process_group_alive", lambda pgid: False)
+    report = check_quiescence({"s-1": 100})
+    assert report.verified is False
+    assert report.method == METHOD_UNSUPPORTED
+    assert report.residual == ()
+    assert report.checked == 0
+
+
+def test_the_serialization_carries_the_fields_the_journal_row_needs() -> None:
+    """`verified`, `residual`, `method` — the shape #5272 specifies."""
+    report = check_quiescence({})
+    assert set(report.to_dict()) == {"verified", "residual", "method", "checked"}
+
+
+def test_residual_order_is_stable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two seals over the same state produce the same row."""
+    monkeypatch.setattr(quiescence, "process_group_alive", lambda pgid: True)
+    first = check_quiescence({"s-2": 200, "s-1": 100})
+    second = check_quiescence({"s-1": 100, "s-2": 200})
+    assert first.to_dict() == second.to_dict()
+    assert [g.session_id for g in first.residual] == ["s-1", "s-2"]
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="POSIX process groups")
+def test_a_real_surviving_group_is_reported(monkeypatch: pytest.MonkeyPatch) -> None:
+    """End to end, with a real orphan rather than a patched probe."""
+    monkeypatch.setattr(quiescence, "process_group_alive", process_group_alive)
+    wrapper = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import subprocess,sys;subprocess.Popen([sys.executable,'-c','import time;time.sleep(30)']);sys.exit(0)",
+        ],
+        start_new_session=True,
+    )
+    try:
+        wrapper.wait(timeout=30)
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and not process_group_alive(wrapper.pid):
+            time.sleep(0.05)
+
+        report = check_quiescence({"s-live": wrapper.pid})
+        assert report.verified is False
+        assert [g.pgid for g in report.residual] == [wrapper.pid]
+    finally:
+        kill_process_group(wrapper.pid, 9)


### PR DESCRIPTION
Points 3 and 5 of #5272 — the record. Builds naturally on #5543 (the liveness half) but does not depend on it; either can land first.

## What it closes

Finalization seals the journal head into the lineage spine and writes the run receipt. Nothing recorded whether the processes the run started had exited first, so a tool that outlived its wrapper could still write into a worktree or the integration branch **after** the receipt covering the run was produced — and the record was silent about it.

A `run_quiescence` row is now appended before the seal:

```json
{"event": "run_quiescence", "verified": false, "method": "process_group",
 "checked": 3, "residual": [{"session_id": "backend-1", "pgid": 48213}]}
```

The sealed head and the receipt therefore cover the answer, rather than being written over an unanswered question.

## The distinction the row exists to keep

*Checked and clean* and *could not check* are both non-quiet outcomes, and only `method` separates them. Collapsing them would let a platform that cannot probe read as a run that was quiet — which is the failure mode the issue names in point 5.

- **No process groups** → `verified: false, method: "unsupported"`, and nothing is probed. `process_group_alive` falls back to the lead pid on Windows, which answers a narrower question than this row claims, so reporting `verified: true` off that fallback would be exactly the silent true the issue rules out.
- **The check itself fails** → `method: "check_failed"`, recorded rather than raised. A run that already completed must not fail because its quiescence could not be established.
- **A session with no stored process** contributes `None` and is *not* counted as clean. Nothing to probe is not the same as probed and empty, so it does not inflate `checked`.

Residual groups are sorted by session id, so two seals over the same state produce the same row.

## One pinned test moves, deliberately

`test_orchestrator.py::TestRunStop::test_live_otel_stream_attaches_and_finalizes` asserts the exact journal event sequence, and it now ends `..., "run_completed", "run_quiescence"`. That contract is precisely what this change extends — the issue asks for the row to be appended before the seal — so the expectation moves with a comment saying why, rather than the row being placed somewhere it would not be noticed.

I checked the ordering directly rather than trusting the diff: `_record_run_quiescence()` precedes `_seal_journal_into_lineage_spine()` inside the finalization block.

## Not in this slice

This records; it does not stop anything. Waiting out the drain timeout and escalating with `kill_process_group_graceful` for what remains is the rest of #5272, and I would rather the report be honest about residual work before anything acts on it.

## Verification

- `pytest tests/unit/test_run_quiescence.py` — 8 passed, including an end-to-end case with a real orphaned process group rather than a patched probe
- `pytest tests/unit -k "orchestrator or quiescence or spawner or finaliz or seal"` — **1375 passed, 11 skipped**
- `mypy --config-file mypy.gate.ini` clean; `ruff check` / `format --check` clean

Fragment: `docs/release-notes/fragments/5272-run-quiescence.md`.