### PR TITLE
fix(quality): select static directory guards (#5503)

### DIFF
--- a/src/bernstein/core/quality/test_impact.py
+++ b/src/bernstein/core/quality/test_impact.py
@@ -195,6 +195,30 @@ def _is_path_literal(value: str) -> bool:
     return "." in value.rsplit("/", 1)[-1]
 
 
+def _static_path_segments(node: ast.expr) -> list[str] | None:
+    """Return literal path segments from a ``Path``-style division chain.
+
+    A structural guard commonly anchors a scanned directory at ``REPO_ROOT``
+    and appends literal segments. The root is runtime-specific, but the
+    repository-relative directory is not.
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return [node.value]
+    if not isinstance(node, ast.BinOp) or not isinstance(node.op, ast.Div):
+        return None
+
+    right = _static_path_segments(node.right)
+    if right is None:
+        return None
+    left = _static_path_segments(node.left)
+    return right if left is None else [*left, *right]
+
+
+def _is_directory_literal(value: str) -> bool:
+    """Return whether a static literal names a specific repository directory."""
+    return value.count("/") >= 2 and not value.startswith(".") and "." not in value.rsplit("/", 1)[-1]
+
+
 def extract_path_literals(path: Path) -> set[str]:
     """Return the repo paths a file names as string literals.
 
@@ -225,13 +249,23 @@ def extract_path_literals(path: Path) -> set[str]:
     except (OSError, SyntaxError, UnicodeDecodeError):
         return set()
 
-    return {
+    literals = {
         stripped
         for node in ast.walk(tree)
         if isinstance(node, ast.Constant) and isinstance(node.value, str)
         for stripped in [node.value.strip().strip("/")]
         if _is_path_literal(stripped)
     }
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.BinOp):
+            continue
+        segments = _static_path_segments(node)
+        if segments is None:
+            continue
+        literal = "/".join(segment.strip("/") for segment in segments if segment.strip("/"))
+        if _is_directory_literal(literal):
+            literals.add(literal)
+    return literals
 
 
 def _string_dict_literal(node: ast.expr) -> dict[str, str]:
@@ -497,10 +531,13 @@ def _path_match_keys(rel_path: str) -> set[str]:
     ``src/bernstein/core/security/AGENTS.md`` yields the whole path, then
     ``core/security/AGENTS.md`` down to ``AGENTS.md``. A guard that globs for a
     bare file name matches on the last key; one that pins a single file matches
-    only on the longer key it wrote, so pinning stays specific.
+    only on the longer key it wrote, so pinning stays specific. Static
+    directory declarations also match their descendants.
     """
     parts = Path(rel_path).as_posix().split("/")
-    return {"/".join(parts[index:]) for index in range(len(parts))}
+    suffixes = {"/".join(parts[index:]) for index in range(len(parts))}
+    ancestors = {"/".join(parts[:index]) for index in range(1, len(parts))}
+    return suffixes | ancestors
 
 
 def _tests_reading_changed_paths(

--- a/tests/unit/test_test_impact_core.py
+++ b/tests/unit/test_test_impact_core.py
@@ -170,6 +170,45 @@ def test_workflow_change_selects_guards_that_read_workflow_yaml(tmp_path: Path) 
     ]
 
 
+def test_static_directory_guard_selects_descendants_only(tmp_path: Path) -> None:
+    """A tree scan must run on a pull request that changes its tree.
+
+    The guard imports no module below ``controls``. Its static directory is
+    still an input to the assertion, so a new module there must select it;
+    a sibling directory must not.
+    """
+    _write(tmp_path / "src" / "demo" / "__init__.py", "")
+    _write(tmp_path / "src" / "demo" / "controls" / "__init__.py", "")
+    _write(
+        tmp_path / "tests" / "unit" / "test_control_reachability.py",
+        "from pathlib import Path\n\nREPO_ROOT = Path(__file__).resolve().parents[2]\n"
+        'CONTROL_DIR = REPO_ROOT / "src" / "demo" / "controls"\n',
+    )
+
+    dep_map = build_compat_dep_map(
+        tmp_path,
+        tmp_path / "src",
+        [tmp_path / "tests" / "unit"],
+        {"demo"},
+    )
+
+    selected = compat_get_affected_tests(
+        ["src/demo/controls/added.py"],
+        dep_map,
+        root=tmp_path,
+        src_root=tmp_path / "src",
+    )
+    sibling_selected = compat_get_affected_tests(
+        ["src/demo/other.py"],
+        dep_map,
+        root=tmp_path,
+        src_root=tmp_path / "src",
+    )
+
+    assert [path.relative_to(tmp_path).as_posix() for path in selected] == ["tests/unit/test_control_reachability.py"]
+    assert sibling_selected == []
+
+
 def test_dispatcher_workflow_change_selects_the_real_dispatcher_guard() -> None:
     """A change to post-ci-dispatcher.yml selects this repository's own guard.
 


### PR DESCRIPTION
## What

Select a tree-snapshot guard when a pull request changes a descendant of the static directory it scans.

## Why

The impact selector previously indexed only file-like string literals. A guard that constructs a scanned directory from `REPO_ROOT / "src" / ...` has no import edge to newly added modules, so it can miss the pull-request lane and first fail against the merge-queue tree.

## How

Harvest static `Path` division chains as repository-relative directory paths, then match a changed path against its ancestors. File-specific path selection remains specific.

## Checklist

- [x] `uv run ruff check src/bernstein/core/quality/test_impact.py tests/unit/test_test_impact_core.py` passes
- [x] `uv run pyright src/bernstein/core/quality/test_impact.py` passes
- [x] `uv run lint-imports` passes
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (N/A: internal test selection)
- [x] `docs/operations/<area>.md` updated (N/A: internal test selection)
- [x] `docs/api/` schema regenerated if a public surface changed (N/A)
- [x] `uv run bernstein agents-md sync` run so AGENTS.md, CLAUDE.md, `.goosehints`, `CONVENTIONS.md`, and `.cursor/rules/*.mdc` reflect any new module (N/A)
- [x] Tests cover the documented behaviour

## Verification

- Before: `uv run python scripts/run_tests.py -x tests/unit/test_test_impact_core.py::test_static_directory_guard_selects_descendants_only` failed because `src/demo/controls/added.py` selected no guard.
- After: `uv run python scripts/run_tests.py -x tests/unit/test_test_impact_core.py` passes (37 tests).
- `uv run python scripts/test_impact.py --files src/bernstein/core/security/zz_probe.py --print-paths` selects structural reachability guards for the changed tree.

Fixes #5503
