### PR TITLE
test(conformance): add bundle-only data and endpoint vectors

### DIFF
--- a/docs/release-notes/fragments/5061.md
+++ b/docs/release-notes/fragments/5061.md
@@ -1,0 +1,7 @@
+## Bundle-only data and endpoint conformance vectors
+
+The auditor suite now checks which file sensitivity and model endpoint the
+committed export records. Both answers are already present in that fixture;
+permission at request time remains a strict expected failure linked to #5038.
+The score is 3/21 for this recorded scenario, without changing the exported
+evidence or claiming production coverage.

--- a/scripts/auditor_conformance.py
+++ b/scripts/auditor_conformance.py
@@ -32,7 +32,10 @@ if str(ROOT) not in sys.path:
 from tests.conformance.auditor import recorder  # noqa: E402
 from tests.conformance.auditor.scoreboard import REPORT_PATH_ENV, read_report  # noqa: E402
 
-VECTORS = "tests/conformance/auditor/test_vectors.py"
+VECTORS = (
+    "tests/conformance/auditor/test_vectors.py",
+    "tests/conformance/auditor/test_data_endpoint_vectors.py",
+)
 SCORE_PLUGIN = "tests.conformance.auditor.scoreboard"
 
 
@@ -59,7 +62,7 @@ def score() -> int:
                 sys.executable,
                 "-m",
                 "pytest",
-                VECTORS,
+                *VECTORS,
                 "-q",
                 "--no-cov",
                 "-p",

--- a/tests/conformance/auditor/README.md
+++ b/tests/conformance/auditor/README.md
@@ -4,8 +4,11 @@ One recorded run, one exported bundle, and 21 questions that must be
 answerable **from the bundle alone** by someone who never had access to
 the machine that produced it.
 
-The score is `n/21`. It is a progress instrument, not a claim: twenty of
-the twenty-one questions have no vector yet, and the score says so.
+The score is `n/21`. It is a progress instrument, not a claim: nine
+questions have vectors, of which three pass and six explicitly
+record missing evidence with strict expected failures. The other twelve
+have no vector yet. This describes the committed scenario, not coverage
+of every production run.
 
 ## The scenario
 
@@ -26,7 +29,8 @@ the twenty-one questions have no vector yet, and the score says so.
 | `offline.py` | Runs `verify_cli/` in a subprocess with no `bernstein` on the path and an audit hook that denies sockets. |
 | `questions.py` | The 21 questions. The score's denominator. |
 | `scoreboard.py` | Pytest plugin that records which questions the run answered. |
-| `test_vectors.py` | The vectors. One today: question 17. |
+| `test_vectors.py` | Integrity and independence vectors (15–20), with supporting controls. |
+| `test_data_endpoint_vectors.py` | Data and endpoint vectors (8–10). |
 | `test_harness.py` | Holds the instrument honest; answers no question. |
 
 ## Commands
@@ -37,7 +41,7 @@ uv run python scripts/auditor_conformance.py regenerate
 
 # Run the vectors and print the score
 uv run python scripts/auditor_conformance.py score
-#   -> auditor conformance: 1/21
+#   -> auditor conformance: 3/21
 
 # Run the whole suite, harness included
 uv run pytest tests/conformance/auditor -q
@@ -61,11 +65,16 @@ between recordings in their timestamps; those are compared structurally.
 The key material here is fixed test material. It is not, and must never
 become, operator key material.
 
-## The remaining twenty
+## Question slices
 
 Each group of questions lands in its own slice: attribution (1, 2, 7,
 14), authority (3, 4, 5, 21), policy and approval (6, 11, 12, 13), data
 and endpoints (8, 9, 10), integrity and independence (15, 16, 18, 19,
-20). A slice adds vectors to `test_vectors.py` and the score moves. A
+20). A slice adds vectors to a focused test file registered in the score command;
+only passing question-marked
+vectors move the score. Questions 8 and 9 assert the recorded restricted
+file and delegated model endpoint in both receipts. Question 10 remains
+a strict expected failure for missing admission history (#5038). No
+fixture fields were added to answer these questions. A
 weak assertion that passes is worse than an honest failure: it hides
 exactly the gap this suite exists to measure.

--- a/tests/conformance/auditor/test_data_endpoint_vectors.py
+++ b/tests/conformance/auditor/test_data_endpoint_vectors.py
@@ -1,0 +1,88 @@
+"""Data and endpoint questions answered only from the exported bundle (#5061)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.conformance.auditor import recorder
+
+if TYPE_CHECKING:
+    from tests.conformance.auditor.bundle import BundleReader
+
+
+@pytest.mark.question(8)
+def test_q8_the_record_states_the_sensitivity_of_the_file_read(bundle_reader: BundleReader) -> None:
+    """Q8: the exported read names the file and its actual classification.
+
+    Unlike the issue's initial expectation, the committed recording already
+    exports ``restricted`` in both receipts. Pin that answer, not just the
+    existence of a read. This says nothing about unrecorded production reads.
+    """
+    run = bundle_reader.read_json(recorder.RUN_RECEIPT_NAME)
+    reads = [event for event in run["journal"]["events"] if event["event"] == "file_read"]
+    assert [(event["agent_id"], event["path"], event.get("sensitivity")) for event in reads] == [
+        ("agent-b", "config/customer_records.yaml", "restricted")
+    ]
+    audit = bundle_reader.read_json(recorder.AUDIT_RECEIPT_NAME)
+    reads = [event for event in audit["events"] if event["event_type"] == "data.read"]
+    assert [(event["resource_id"], event["details"].get("sensitivity")) for event in reads] == [
+        ("config/customer_records.yaml", "restricted")
+    ]
+
+
+@pytest.mark.question(9)
+def test_q9_the_record_names_the_model_and_endpoint_that_received_content(bundle_reader: BundleReader) -> None:
+    """Q9: identify the delegated request, not the parent agent's endpoint."""
+    run = bundle_reader.read_json(recorder.RUN_RECEIPT_NAME)
+    events = run["journal"]["events"]
+    requests = [event for event in events if event["event"] == "model_request"]
+    assert [(event["agent_id"], event["model"], event["endpoint"]) for event in requests] == [
+        ("agent-b", "delegated-worker", "https://models.example.invalid/v1")
+    ]
+    spawned = {event["agent_id"]: event for event in events if event["event"] == "agent_spawned"}
+    for request in requests:
+        agent = spawned[request["agent_id"]]
+        assert (agent["endpoint_model"], agent["endpoint_base_url"]) == (request["model"], request["endpoint"])
+    audit = bundle_reader.read_json(recorder.AUDIT_RECEIPT_NAME)
+    requests = [event for event in audit["events"] if event["event_type"] == "model.request"]
+    assert [(event["details"]["model"], event["resource_id"]) for event in requests] == [
+        ("delegated-worker", "https://models.example.invalid/v1")
+    ]
+
+
+@pytest.mark.question(10)
+@pytest.mark.xfail(
+    strict=True,
+    raises=AssertionError,
+    reason=(
+        "the exported bundle has no model.admitted/withdrawn history binding the "
+        "requested model and endpoint to an unexpired permission at request time (#5038)"
+    ),
+)
+def test_q10_the_endpoint_was_permitted_when_content_was_sent(bundle_reader: BundleReader) -> None:
+    """Q10: a configured or observed endpoint is not an admission decision.
+
+    Read the exported chain only. A future permission record must identify
+    the endpoint as well as the model, name the admitting principal and be
+    live when the request occurred; a later admission cannot justify it.
+    """
+    audit = bundle_reader.read_json(recorder.AUDIT_RECEIPT_NAME)
+    events = audit["events"]
+    requests = [event for event in events if event["event_type"] == "model.request"]
+    assert requests, "the bundle must record the request being assessed"
+    for request in requests:
+        decisions = [
+            event
+            for event in events
+            if event["event_type"] in ("model.admitted", "model.withdrawn")
+            and event["timestamp"] <= request["timestamp"]
+            and event["details"].get("model") == request["details"]["model"]
+            and event["details"].get("endpoint") == request["resource_id"]
+        ]
+        assert decisions, "no exported admission history for the requested model/endpoint (#5038)"
+        latest = decisions[-1]
+        assert latest["event_type"] == "model.admitted", "permission was withdrawn before the request"
+        assert latest["details"].get("admitted_by"), "the admission does not name its principal"
+        assert latest["details"].get("expires_at", "") > request["timestamp"], "permission expired before the request"

--- a/tests/conformance/auditor/test_harness.py
+++ b/tests/conformance/auditor/test_harness.py
@@ -116,10 +116,10 @@ def test_scoreboard_target_prints_the_score_out_of_twenty_one(tmp_path: Path) ->
         check=False,
     )
     assert completed.returncode == 0, completed.stdout + completed.stderr
-    assert f"1/{TOTAL_QUESTIONS}" in completed.stdout
+    assert f"3/{TOTAL_QUESTIONS}" in completed.stdout
 
     report = json.loads((tmp_path / "score.json").read_text(encoding="utf-8"))
-    assert report["passed"] == [17]
+    assert report["passed"] == [8, 9, 17]
 
 
 def test_regenerating_the_fixture_rewrites_the_bundle(tmp_path: Path) -> None:

--- a/tests/conformance/auditor/test_vectors.py
+++ b/tests/conformance/auditor/test_vectors.py
@@ -1,7 +1,7 @@
 """The 21 auditor questions, as vectors over the recorded bundle.
 
-Six vectors are implemented: question 17, and the integrity group,
-questions 15, 16, 18, 19 and 20. The rest are named in
+Six vectors are implemented here: question 17 and the integrity group
+(15, 16, 18, 19, 20). Data/endpoint vectors live in test_data_endpoint_vectors.py. The rest are named in
 :mod:`tests.conformance.auditor.questions` and land in their own slices;
 until then the scoreboard reports them as unanswered, which is the honest
 reading of the evidence rather than a weak assertion that passes.

--- a/tests/unit/test_claude_hook_url_uses_run_port.py
+++ b/tests/unit/test_claude_hook_url_uses_run_port.py
@@ -11,6 +11,7 @@ import json
 from pathlib import Path
 
 import pytest
+
 from bernstein.adapters.claude import ClaudeCodeAdapter
 
 

--- a/tests/unit/test_task_server_url_resolution.py
+++ b/tests/unit/test_task_server_url_resolution.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+
 from bernstein.core.agents.spawner_core import _render_auth_section, _resolve_task_server_url
 from bernstein.core.defaults import SDD_SERVER_PORT
 


### PR DESCRIPTION
## What

Add the three bundle-only data/endpoint conformance vectors for questions 8, 9 and 10. Closes #5061.

## Why

The harness in #5235 left these questions unanswered. The current committed export already records the restricted file classification and delegated model endpoint, so Q8 and Q9 assert those specific values in both receipts. Q10 remains `xfail(strict=True, raises=AssertionError)` because the bundle has no admission history proving permission at request time (#5038).

## How

The vectors read only through `BundleReader`; no exporter or fixture fields change. A separate vector file keeps the existing file below the repository's size limit, and the score command collects both files. The harness and documentation now report 3/21, describing only the committed scenario. Negative controls rejected missing/wrong sensitivity, substituted requests, and invalid permissions; a synthetic live admission lets Q10 pass.

Two existing import-order violations received one blank line each so the blocking pre-push lint hook passes.

## Checklist

- [x] `uv run ruff check src/` passes (also `tests/ scripts/`); source formatting and `lint-imports` pass
- [ ] `uv run pyright src/` passes — 24,960 existing errors, 3 warnings in unchanged source. The current `docs/operations/type-check-scope.md` and CI classify this run as advisory. Blocking `uv run pyright -p pyrightconfig.strict.json`: zero errors/warnings.
- [ ] `uv run python scripts/run_tests.py -x` passes — isolated run with four workers stopped after 147 passing files on `test_compact_splash_stays_compact_on_narrow_tty`. The same test fails independently; its source, test, root fixtures and dependency configuration match the base commit.
- [x] `uv run pytest tests/conformance/auditor -q --no-cov`: 14 passed, 6 intentional strict xfails
- [x] `uv run python scripts/auditor_conformance.py score`: 3/21; 6 passed, 6 xfailed
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (suite README; product README N/A for test-only scope)
- [x] `docs/operations/<area>.md` updated (N/A)
- [x] `docs/api/` schema regenerated if a public surface changed (N/A)
- [x] `uv run bernstein agents-md sync` run so AGENTS.md, CLAUDE.md, `.goosehints`, `CONVENTIONS.md`, and `.cursor/rules/*.mdc` reflect any new module (N/A: no production module added)
- [x] Tests cover the documented behaviour; release fragment included
