### PR TITLE
docs: add ADOPTERS.md so an evaluator can see who depends on this

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,80 @@
+# Adopters
+
+Who runs Bernstein, on what, and since when.
+
+This page exists so three questions have an answer that is not a guess:
+
+- **Can I calibrate the risk?** Someone deciding whether to put a governance
+  layer in front of regulated workloads asks who else depends on it, and for
+  what. Absent evidence reads as absent adopters.
+- **Where did my work land?** A contributor who fixed something in the identity
+  plane cannot otherwise learn that it mattered to an air-gapped deployment.
+- **Which surfaces are load-bearing?** Prioritisation should not run on the
+  maintainer's intuition about what people use.
+
+## How this list stays honest
+
+- **Self-reported, by pull request.** You add yourself. A list a maintainer
+  writes about their own users is a claim; a list adopters sign is evidence.
+  Nobody is listed on someone else's behalf — including anyone whose usage
+  could be inferred from public activity. **Inference is not consent.**
+- **A contact handle is required.** An entry nobody will stand behind does not
+  go in. A GitHub handle is enough; it does not have to be an email address.
+- **The use case is specific.** "Uses Bernstein" is not a row. "Deterministic
+  replay for regulated evidence in an air-gapped environment" is. The column
+  has to tell a reader something they could not have guessed from the project's
+  own README.
+- **Individuals and projects are welcome**, not only companies. Most real usage
+  here is not corporate, and a list that accepted only logos would be both
+  empty and dishonest.
+- **Stale entries are pruned.** If an entry's contact does not respond to a
+  maintainer's check-in within **60 days**, the row moves to
+  [Former adopters](#former-adopters) with the date it was last confirmed. It
+  is not deleted — a project that stopped being used is a fact about the
+  project, and quietly erasing it would make this page a marketing document.
+  Re-confirming at any time moves it back.
+
+An empty table with clear instructions is a correct starting state. A padded
+one is worse than none.
+
+## Adding yourself
+
+Open a pull request that adds one row to the table below. In the pull request
+description, say which of the two sections you belong in and confirm you are
+adding your own entry.
+
+Nothing else is required — no issue first, no maintainer approval of the
+wording, no logo.
+
+## Production
+
+Bernstein is a dependency of something you run for real.
+
+| Organization or project | Domain | What they use it for | Since | Contact |
+| --- | --- | --- | --- | --- |
+| _No entries yet._ | | | | |
+
+## Evaluation / Pilot
+
+You are trying Bernstein against a real workload, but nothing depends on it
+yet. This is a different claim from the one above and is kept separate so the
+two do not need a squint to tell apart.
+
+| Organization or project | Domain | What they use it for | Since | Contact |
+| --- | --- | --- | --- | --- |
+| _No entries yet._ | | | | |
+
+## Former adopters
+
+Entries that were not re-confirmed, kept with the date they were last known
+good.
+
+| Organization or project | Domain | What they used it for | Last confirmed | Contact |
+| --- | --- | --- | --- | --- |
+| _No entries yet._ | | | | |
+
+## What this page is not
+
+- No claims about scale, revenue, or growth.
+- No logos, testimonials, or case-study prose. Rows and links.
+- No entry for anyone who has not opted in.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -358,6 +358,17 @@ bernstein stop
 pkill -f bernstein   # kills everything including your own shell session
 ```
 
+## Telling us you use it
+
+If you run Bernstein — in production, or as a pilot against a real workload —
+add yourself to [ADOPTERS.md](ADOPTERS.md). Open a pull request with one row in
+whichever of the two tables fits; there is no issue to file first and no
+approval step.
+
+Entries are self-reported, so nobody is added on anyone else's behalf. That
+also means the list is only as complete as the people who write themselves
+into it, which is the trade the page deliberately makes.
+
 ## Recognition
 
 All contributors are listed in [CONTRIBUTORS.md](CONTRIBUTORS.md).

--- a/tests/unit/test_adopters_file.py
+++ b/tests/unit/test_adopters_file.py
@@ -1,0 +1,139 @@
+"""Keep ``ADOPTERS.md`` from decaying into a marketing page.
+
+The list is self-reported and added to by pull request, so the only thing
+standing between it and the usual failure modes is review. Two fields decay
+first and are the ones worth pinning:
+
+* **Contact.** An entry nobody will stand behind is not evidence that anyone
+  uses this. The page says a handle is required; this asserts it.
+* **Use case.** "Uses Bernstein" is not a row. A row that could have been
+  guessed from the README tells an evaluator nothing, which is the whole
+  reason the page exists.
+
+The tests below check the shape of the tables rather than their contents, so
+an empty list passes -- an empty ``ADOPTERS.md`` with clear instructions is a
+correct starting state, and a padded one is the failure this page invites.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ADOPTERS = REPO_ROOT / "ADOPTERS.md"
+CONTRIBUTING = REPO_ROOT / "CONTRIBUTING.md"
+
+#: The three tables the page is required to carry, by heading.
+REQUIRED_SECTIONS = ("Production", "Evaluation / Pilot", "Former adopters")
+
+#: Placeholder rows that stand in for an empty table. These are the one kind of
+#: row allowed to skip the field checks below.
+_EMPTY_ROW = re.compile(r"^\|\s*_No entries yet\._\s*\|")
+
+#: Phrases too generic to be a use case. Anything that merely restates the
+#: project's own name is not telling a reader something new.
+_VAGUE_USE_CASES = frozenset(
+    {"uses bernstein", "bernstein", "governance", "n/a", "tbd", "-", "various"}
+)
+
+
+def _adopters_text() -> str:
+    return ADOPTERS.read_text(encoding="utf-8")
+
+
+def _rows(section: str) -> list[list[str]]:
+    """Return the data rows of one section's table, as stripped cell lists.
+
+    Header and separator rows are dropped; so are the ``_No entries yet._``
+    placeholders, which exist so an empty table still renders.
+    """
+    text = _adopters_text()
+    start = text.index(f"\n## {section}\n")
+    rest = text[start + 1 :]
+    end = rest.find("\n## ")
+    body = rest if end == -1 else rest[:end]
+
+    rows = []
+    for line in body.splitlines():
+        line = line.strip()
+        if not line.startswith("|") or _EMPTY_ROW.match(line):
+            continue
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        # Skip the header row and the `| --- |` separator beneath it.
+        if cells[0].lower().startswith("organization") or set(cells[0]) <= {"-", ":"}:
+            continue
+        rows.append(cells)
+    return rows
+
+
+def test_the_file_exists() -> None:
+    assert ADOPTERS.is_file(), "ADOPTERS.md must live at the repository root"
+
+
+@pytest.mark.parametrize("section", REQUIRED_SECTIONS)
+def test_every_required_section_is_present(section: str) -> None:
+    """A pilot and a production dependency are different claims.
+
+    They are kept in separate tables so the difference does not need a squint,
+    and ``Former adopters`` exists so a lapsed entry is demoted rather than
+    quietly deleted.
+    """
+    assert f"\n## {section}\n" in _adopters_text()
+
+
+@pytest.mark.parametrize("section", REQUIRED_SECTIONS)
+def test_every_table_declares_the_full_column_set(section: str) -> None:
+    text = _adopters_text()
+    start = text.index(f"\n## {section}\n")
+    body = text[start:]
+    header = next(line for line in body.splitlines() if line.strip().startswith("| Organization"))
+    columns = [c.strip().lower() for c in header.strip().strip("|").split("|")]
+
+    assert columns[0].startswith("organization")
+    assert columns[1] == "domain"
+    assert columns[2].startswith("what they use")
+    # "Since" for current adopters, "Last confirmed" for former ones.
+    assert columns[3] in {"since", "last confirmed"}
+    assert columns[4] == "contact"
+
+
+@pytest.mark.parametrize("section", REQUIRED_SECTIONS)
+def test_every_row_names_a_contact(section: str) -> None:
+    """A row nobody will stand behind is not evidence."""
+    for row in _rows(section):
+        assert row[4], f"{section}: {row[0]!r} has no contact handle"
+
+
+@pytest.mark.parametrize("section", REQUIRED_SECTIONS)
+def test_every_row_states_a_specific_use_case(section: str) -> None:
+    for row in _rows(section):
+        use_case = row[2]
+        assert use_case, f"{section}: {row[0]!r} has no use case"
+        assert use_case.lower().rstrip(".") not in _VAGUE_USE_CASES, (
+            f"{section}: {row[0]!r} has a use case that restates the project "
+            f"rather than describing a deployment: {use_case!r}"
+        )
+
+
+def test_the_page_states_the_rule_that_keeps_it_honest() -> None:
+    """The rules are the artefact. Losing them turns this into a logo wall."""
+    text = _adopters_text().lower()
+    assert "self-reported" in text
+    assert "inference is not consent" in text
+    assert "contact handle is required" in text
+
+
+def test_the_pruning_rule_names_a_period() -> None:
+    """"Stale entries get pruned" is not a rule until it says when."""
+    section = _adopters_text().split("## Production")[0]
+    assert re.search(r"\b\d+\s+days\b", section), (
+        "the pruning rule must name a concrete period, not just promise pruning"
+    )
+
+
+def test_contributing_tells_people_how_to_add_themselves() -> None:
+    text = CONTRIBUTING.read_text(encoding="utf-8")
+    assert "ADOPTERS.md" in text, "CONTRIBUTING.md must link to the adopters list"


### PR DESCRIPTION
Adds `ADOPTERS.md` at the repository root, per the acceptance criteria in #5027.

**Two tables, not one with a status column.** The issue left this open and recommended two sections; I agree, and the reason is the one given there — a pilot and a production dependency are different claims, and a status column makes the reader do work to tell them apart.

**A third table: `Former adopters`.** The issue says stale entries get pruned and that the rule goes on the page. Deleting a row makes the page a marketing document — a project that stopped being used is a fact about the project. Lapsed entries move here with the date they were last confirmed, and re-confirming moves them back. The rule names a concrete period (60 days without a response from the contact) rather than promising pruning in the abstract.

**Both tables start empty.** Nothing is seeded, including from contributors whose deployments are visible in the tracker — the issue is explicit that inference is not consent, and that line is on the page.

**Test.** `tests/unit/test_adopters_file.py` pins the two fields the issue names as first to decay:

- every row names a contact handle;
- every use case says something specific — a small denylist rejects `Uses Bernstein`, `governance`, `N/A` and friends, which are the rows that would otherwise pass a "non-empty" check while telling an evaluator nothing.

Plus the section/column shape, and that the honesty rules and the pruning period are still on the page. The checks are on table *shape*, so an empty `ADOPTERS.md` passes — that is the correct starting state, not a failure.

I checked the tests actually bite rather than passing vacuously:

```
# adding `| Acme Corp | Fintech | Uses Bernstein | 2026-01 | |`
FAILED test_every_row_names_a_contact[Production]
FAILED test_every_row_states_a_specific_use_case[Production]

# softening "60 days" to "promptly"
FAILED test_the_pruning_rule_names_a_period
```

16 passed on the unmutated tree.

`CONTRIBUTING.md` gains a short "Telling us you use it" section above Recognition, saying to open a PR with one row and that there is no issue to file first — and stating the trade the page makes, that a self-reported list is only as complete as the people who write themselves into it.

Acceptance criterion 4 ("zero rows added by a maintainer on someone else's behalf") is social rather than testable, so it is stated on the page rather than asserted.
