### PR TITLE
docs: add an integration index naming each system in its own words

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Everything deep lives on the [docs site](https://bernstein.readthedocs.io/):
 |---|---|
 | [capabilities](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/capabilities.md) | the full capability list: MCP server mode, signed agent cards, sandbox backends, artifact sinks, regulatory mappings |
 | [who this is for](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/use-cases.md) | where the value lands, and where Bernstein is the wrong tool |
+| [integrations](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/integrations.md) | what we bridge to under its own name - Okta, SCIM, Vault, OPA, SPIFFE, OpenTelemetry - and what is deliberately not planned |
 | [workflows](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/operations/workflow-manifests.md) | declarative YAML DAGs of agent / command / loop nodes |
 | [web UI](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/gui/index.md) | browser dashboard on the same API the TUI uses |
 | [cloud execution](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/cloudflare/cloudflare-overview.md) | experimental: run agents on Cloudflare Workers with R2 workspace sync against your own account. The hosted `api.bernstein.run` service is not yet available |

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,97 @@
+# Integrations
+
+The systems Bernstein bridges to, under the names those systems use for
+themselves.
+
+This page exists because a capability that cannot be found by the words people
+search for reads as absent. If you run Okta, Vault or OpenTelemetry, this is
+the page that tells you whether we meet you there — and, where we do not,
+whether that is a gap or a decision.
+
+## How to read the table
+
+Every cell has to be checkable, and
+[`tests/unit/docs/test_integrations_index.py`](https://github.com/sipyourdrink-ltd/bernstein/blob/main/tests/unit/docs/test_integrations_index.py)
+parses this page and asserts it:
+
+- **Shipped** names a module that exists at `HEAD`. If the path stops
+  resolving, the test fails.
+- **Open** names an issue number. If the issue is closed, the row is stale and
+  gets rewritten — not softened.
+- **Not planned** carries one line of why. This is the column most such pages
+  omit, and the one that saves an evaluator the most time.
+
+A row that can cite none of the three is deleted rather than reworded. That is
+the same constraint the compliance packs run under: a claim with no evidence
+behind it is not a weaker claim, it is not a claim.
+
+There is no "partially shipped" column. A row that has both a module and an
+open issue expresses exactly that, and a fourth column would only hide which
+half is which.
+
+## Directories and identity providers
+
+| Target | Shipped | Open | Not planned |
+| --- | --- | --- | --- |
+| SCIM 2.0 (RFC 7643/7644) | `src/bernstein/adapters/directory/scim.py` — provisioning resources mapped onto agent principals | [#5040](https://github.com/sipyourdrink-ltd/bernstein/issues/5040) — serve SCIM over HTTP so a directory can drive it | |
+| Generic OIDC | `src/bernstein/core/security/auth.py` — `OIDCConfig`, dashboard and API login | | |
+| SAML | `src/bernstein/core/security/auth.py` — alongside the OIDC flow | | |
+| Okta | | [#5018](https://github.com/sipyourdrink-ltd/bernstein/issues/5018) — bridge agent principals to Okta groups | |
+| Microsoft Entra ID | | [#5018](https://github.com/sipyourdrink-ltd/bernstein/issues/5018) — same bridge, same issue | |
+| LDAP | | | No open issue and no module. SCIM is the provisioning path we invested in; an LDAP bind would be a second one. Worth an issue if you need it — this is a gap, not a decision. |
+
+## Authorization and policy engines
+
+| Target | Shipped | Open | Not planned |
+| --- | --- | --- | --- |
+| Open Policy Agent (Rego) | `src/bernstein/core/security/external_policy_hook.py` — `OPAHook`, REST API or CLI | [#4912](https://github.com/sipyourdrink-ltd/bernstein/issues/4912) — the hooks exist but no decision path consults them | |
+| Cedar | `src/bernstein/core/security/external_policy_hook.py` — `CedarHook` | [#4912](https://github.com/sipyourdrink-ltd/bernstein/issues/4912) — same gap | |
+| AuthZEN 1.0 | `src/bernstein/core/security/authzen.py` — the shape both hooks normalise through | [#5032](https://github.com/sipyourdrink-ltd/bernstein/issues/5032) — speak it at the decision boundary | |
+
+## Secret stores
+
+| Target | Shipped | Open | Not planned |
+| --- | --- | --- | --- |
+| HashiCorp Vault | `src/bernstein/core/security/secrets_broker.py` — `VaultBackend`, KV v2 | [#5021](https://github.com/sipyourdrink-ltd/bernstein/issues/5021) — leases and renewal against the broker contract | |
+| AWS Secrets Manager | `src/bernstein/core/security/secrets_broker.py` — `AwsSecretsManagerBackend` | | |
+| GCP Secret Manager | `src/bernstein/core/security/secrets_broker.py` — `GcpSecretManagerBackend` | | |
+| macOS Keychain | `src/bernstein/core/security/secrets_broker.py` — `MacosKeychainBackend` | | |
+| Linux keyring | `src/bernstein/core/security/secrets_broker.py` — `LinuxKeyringBackend` | | |
+| Azure Key Vault | | | No backend and no open issue. The broker takes a backend in about eighty lines — see the five above — so this is a gap anyone can close, not a boundary. |
+| 1Password | | | As above. The `external` backend already shells out to an arbitrary command, which covers the `op` CLI today without a dedicated module. |
+
+## Workload identity
+
+| Target | Shipped | Open | Not planned |
+| --- | --- | --- | --- |
+| SPIFFE / SPIRE | `src/bernstein/core/identity/spiffe/workload_api.py` — Workload API, SVIDs, IDs | [#5030](https://github.com/sipyourdrink-ltd/bernstein/issues/5030) — bind a token to a proof of possession | |
+| mTLS | `src/bernstein/core/identity/spiffe/mtls.py` | | |
+
+## Telemetry and lineage
+
+| Target | Shipped | Open | Not planned |
+| --- | --- | --- | --- |
+| OpenTelemetry | `src/bernstein/core/observability/otel_bridge.py` — spans; `otel_projection.py` projects the audit chain | | |
+| OpenLineage | `src/bernstein/core/persistence/lineage.py`; `bernstein lineage export` | [#4914](https://github.com/sipyourdrink-ltd/bernstein/issues/4914) — emit into a lineage stack an operator already runs | |
+
+## Agent protocols
+
+| Target | Shipped | Open | Not planned |
+| --- | --- | --- | --- |
+| MCP | `src/bernstein/mcp/` — server, OAuth, approval gate, cost meter | | |
+| A2A | `src/bernstein/cli/commands/a2a_cmd.py`; agent cards under `core/identity/` | | |
+
+## Inference endpoints
+
+Adapters live under `src/bernstein/adapters/`, one module per CLI, and the
+[adapter index](adapters/index.md) is the list. Hosted and self-hosted
+endpoints are reached through whichever adapter you run rather than through a
+provider integration here, which is why they are not enumerated in this table —
+adding a provider is an adapter change, not a change to this page.
+
+## Not on this page, deliberately
+
+- **Comparisons with other projects.** This page says what we connect to. It
+  never says what anyone else does or does not.
+- **Aspirational rows.** Not shipped and no issue means no row. If you want
+  something here, the way in is to open the issue — then it has a cell.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -152,6 +152,7 @@ nav:
       - index.md
       - Use cases: use-cases.md
       - Scope (what this does not do): scope.md
+      - Integrations: integrations.md
       - What's new: whats-new.md
       - Mentions: mentions.md
       - Benchmarks: benchmarks/BENCHMARKS.md

--- a/tests/unit/docs/test_integrations_index.py
+++ b/tests/unit/docs/test_integrations_index.py
@@ -1,0 +1,144 @@
+"""Keep ``docs/integrations.md`` from rotting into a claim nobody checked.
+
+The page maps systems Bernstein bridges to -- Okta, Vault, OpenTelemetry --
+onto three columns: shipped, open, not planned. Its whole value is that a
+reader can trust a cell without opening the source, so every cell has to be
+verifiable from the repository:
+
+* a **shipped** cell names a module path, and the module has to exist at
+  ``HEAD``;
+* an **open** cell names an issue number, in a link a reader can follow;
+* a **not planned** cell carries a reason, because a bare "no" is the thing
+  that sends people to the tracker to ask anyway.
+
+A rotted integration index is worse than none, so these are assertions rather
+than a style guide.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DOC = REPO_ROOT / "docs" / "integrations.md"
+README = REPO_ROOT / "README.md"
+
+#: ``src/bernstein/...`` or ``src/bernstein/...py`` inside backticks. Trailing
+#: prose after an em dash is the human description and is not part of the path.
+_MODULE_RE = re.compile(r"`(src/bernstein/[A-Za-z0-9_/]+(?:\.py)?)`")
+
+#: A tracker link, which is the only form an "open" cell may take -- a bare
+#: ``#5040`` renders as a fragment and is not followable from the docs site.
+_ISSUE_LINK_RE = re.compile(
+    r"\[#(\d+)\]\(https://github\.com/sipyourdrink-ltd/bernstein/issues/(\d+)\)"
+)
+
+
+def _rows() -> list[tuple[str, list[str]]]:
+    """Return ``(section, cells)`` for every data row in every table."""
+    section = ""
+    rows: list[tuple[str, list[str]]] = []
+    for line in DOC.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            section = stripped[3:]
+            continue
+        if not stripped.startswith("|"):
+            continue
+        cells = [c.strip() for c in stripped.strip("|").split("|")]
+        if len(cells) != 4:
+            continue
+        if cells[0] == "Target" or set(cells[0]) <= {"-", ":"}:
+            continue
+        rows.append((section, cells))
+    return rows
+
+
+def test_the_page_exists() -> None:
+    assert DOC.is_file()
+
+
+def test_the_page_has_rows() -> None:
+    """A parser that silently matches nothing would make every test below pass."""
+    assert len(_rows()) >= 15, "the index should cover the named targets in #5023"
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        "Directories and identity providers",
+        "Authorization and policy engines",
+        "Secret stores",
+        "Workload identity",
+        "Telemetry and lineage",
+        "Agent protocols",
+    ],
+)
+def test_every_required_kind_has_a_section(kind: str) -> None:
+    assert f"\n## {kind}\n" in DOC.read_text(encoding="utf-8")
+
+
+def test_no_row_claims_shipped_without_a_module_path() -> None:
+    """The acceptance criterion from #5023, stated directly."""
+    for section, cells in _rows():
+        shipped = cells[1]
+        if not shipped:
+            continue
+        assert _MODULE_RE.search(shipped), (
+            f"{section}: {cells[0]!r} claims shipped but names no module path: {shipped!r}"
+        )
+
+
+def test_every_shipped_module_exists_at_head() -> None:
+    checked = 0
+    for section, cells in _rows():
+        for path in _MODULE_RE.findall(cells[1]):
+            target = REPO_ROOT / path
+            assert target.exists(), (
+                f"{section}: {cells[0]!r} cites {path}, which does not exist at HEAD"
+            )
+            checked += 1
+    assert checked >= 10, "expected the index to cite real modules, not just prose"
+
+
+def test_every_open_cell_links_an_issue() -> None:
+    for section, cells in _rows():
+        open_cell = cells[2]
+        if not open_cell:
+            continue
+        matches = _ISSUE_LINK_RE.findall(open_cell)
+        assert matches, (
+            f"{section}: {cells[0]!r} has an 'open' cell that links no issue: {open_cell!r}"
+        )
+        for shown, linked in matches:
+            assert shown == linked, (
+                f"{section}: {cells[0]!r} shows #{shown} but links to issue {linked}"
+            )
+
+
+def test_every_not_planned_cell_gives_a_reason() -> None:
+    """A bare 'no' sends the reader to the tracker to ask anyway."""
+    for section, cells in _rows():
+        reason = cells[3]
+        if not reason:
+            continue
+        assert len(reason.split()) >= 8, (
+            f"{section}: {cells[0]!r} declines without saying why: {reason!r}"
+        )
+
+
+def test_no_row_is_entirely_empty() -> None:
+    """Shipped, open, or not planned -- a row citing none of the three is deleted."""
+    for section, cells in _rows():
+        assert any(cells[1:]), f"{section}: {cells[0]!r} cites no evidence in any column"
+
+
+def test_the_readme_links_the_index() -> None:
+    assert "docs/integrations.md" in README.read_text(encoding="utf-8")
+
+
+def test_the_docs_nav_lists_the_index() -> None:
+    assert "integrations.md" in (REPO_ROOT / "mkdocs.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
Adds `docs/integrations.md`, per #5023.

**Every claim was checked against the tree, not inferred from the tracker.** Grepping for these names is noisy — `cedar` matches a run-name word list, `1password` matches `password` — so each shipped cell was confirmed by opening the module:

| Target | Verified at |
| --- | --- |
| SCIM 2.0 | `adapters/directory/scim.py` — RFC 7643 resources onto `PrincipalLedger` |
| OIDC / SAML | `core/security/auth.py` — `OIDCConfig`, both flows |
| OPA (Rego), Cedar | `core/security/external_policy_hook.py` — `OPAHook`, `CedarHook` |
| AuthZEN 1.0 | `core/security/authzen.py` — the shape both hooks normalise through |
| Vault, AWS SM, GCP SM, macOS Keychain, Linux keyring | `core/security/secrets_broker.py` — five `SecretsBackend` subclasses |
| SPIFFE/SPIRE, mTLS | `core/identity/spiffe/workload_api.py`, `mtls.py` |
| OpenTelemetry | `core/observability/otel_bridge.py`, `otel_projection.py` |
| OpenLineage | `core/persistence/lineage.py` |
| MCP, A2A | `src/bernstein/mcp/`, `cli/commands/a2a_cmd.py` |

Open cells link #5040, #5018, #4912, #5032, #5021, #5030 and #4914.

**Three rows have no module and no issue**, and rather than dropping them silently they carry a reason — LDAP, Azure Key Vault, 1Password. All three say *gap, not decision*, because that is what they are: the broker takes a new backend in about eighty lines, and `external` already shells out to the `op` CLI. Claiming these as boundaries would have been the easy way to fill the column and the dishonest one.

**The decision you flagged.** No fourth "partially shipped" column. A row with both a module and an open issue already expresses that — SCIM is the clearest case, shipped as a mapping layer with #5040 open to serve it over HTTP — and a fourth column would only obscure which half is which.

**Test** — `tests/unit/docs/test_integrations_index.py`, including `test_no_row_claims_shipped_without_a_module_path` by name. It also asserts every cited module resolves at `HEAD`, every open cell links a followable issue URL (a bare `#5040` renders as a fragment on the docs site) with the shown number matching the linked one, and every not-planned cell carries a real reason rather than a bare "no".

It also asserts the row parser matched at least 15 rows and at least 10 module paths — without that, a parser that silently matched nothing would make every other assertion pass.

Mutation-checked:

```
# breaking one cited module path
FAILED test_every_shipped_module_exists_at_head

# softening LDAP's reason to "Not planned."
FAILED test_every_not_planned_cell_gives_a_reason
```

15 passed on the real tree. Linked from `README.md`'s docs table and the mkdocs nav under Home, next to Scope.
