### PR TITLE
chore(auto): nightly mirror + format drift sweep

### DIFF
--- a/tests/unit/test_claude_hook_url_uses_run_port.py
+++ b/tests/unit/test_claude_hook_url_uses_run_port.py
@@ -11,6 +11,7 @@ import json
 from pathlib import Path
 
 import pytest
+
 from bernstein.adapters.claude import ClaudeCodeAdapter
 
 

--- a/tests/unit/test_task_server_url_resolution.py
+++ b/tests/unit/test_task_server_url_resolution.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+
 from bernstein.core.agents.spawner_core import _render_auth_section, _resolve_task_server_url
 from bernstein.core.defaults import SDD_SERVER_PORT
 


### PR DESCRIPTION
Nightly sweep regenerated AGENTS.md mirrors and ran ruff format on main. Diff is mechanical and may be merged after CI passes.

Source run: https://github.com/sipyourdrink-ltd/bernstein/actions/runs/34028492637