### PR TITLE
feat(quality): record the producing identity in a verdict's binding

### DIFF
--- a/docs/operations/gate-adjudication.md
+++ b/docs/operations/gate-adjudication.md
@@ -30,10 +30,37 @@ Each adjudication is one signed record:
 | `per_judge_verdict` | One entry per judge, in panel declaration order. |
 | `final_verdict` | The aggregated terminal verdict (`pass` / `fail`). |
 | `timestamp` | Integer timestamp, stable across replays of a fixture. |
+| `producing_identity` | Optional. Who produced the artefact judged: `adapter`, `model_requested`, `model_served`, `family`. |
 | `journal_entry_hash` | The lineage-spine entry hash over the record's canonical bytes. |
 
 Records persist under `.sdd/lineage/<run_id>/adjudication_records/*.json`,
 colocated with the run's spine directory.
+
+### The producing identity
+
+A record names its judges. Until `producing_identity`, it did not name the
+party whose work they judged, so *"this was reviewed independently"* was an
+assertion a reader could not check from the artefact.
+
+The field is **optional and additive**. When unset it is dropped from the
+canonical bytes entirely, so every record written before it keeps its exact
+wire form and its exact spine anchor. When set, it lands **inside the signed
+binding**, not beside it, so a later verifier decides disjointness from the
+record alone rather than from whatever configuration was in force at the time.
+
+Four axes, because those are the ones a disjointness question is actually
+asked on: the same served model behind two adapter names is not independence,
+and neither is two models of one family when the policy cares about family.
+
+`model_served` and `family` default to `unresolved` rather than being omitted.
+Requested and served ids are different facts (see the model-reference work in
+#5037), and a reader must be able to tell *"we do not know which model served
+this"* from *"a different one did"*.
+
+**This field records; it does not decide.** A record carrying a producer
+identical to its judge is still written, and still verifies. Deriving a
+verdict class from disjointness, and refusing a collision, are separate
+changes.
 
 ## Panel independence
 

--- a/src/bernstein/core/quality/adjudication.py
+++ b/src/bernstein/core/quality/adjudication.py
@@ -29,7 +29,7 @@ import hashlib
 import json
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 from bernstein.core.lineage.spine import LineageSpine, content_hash_of
 
@@ -76,6 +76,58 @@ def _canonical_json(value: Any) -> bytes:
 def _sha256_of(value: Any) -> str:
     """Return the ``sha256:``-prefixed digest of *value*'s canonical JSON."""
     return "sha256:" + hashlib.sha256(_canonical_json(value)).hexdigest()
+
+
+#: Recorded when the served model id could not be resolved. Absence is a
+#: fact in its own right: "we do not know which model served this" must never
+#: be readable as "a different one did".
+UNRESOLVED_IDENTITY: Final[str] = "unresolved"
+
+
+@dataclass(frozen=True, slots=True)
+class ProducingIdentity:
+    """Who produced the artefact a panel judged (issue #5473).
+
+    A verdict names its judges and, until this record, nothing named the party
+    whose work they judged -- so "reviewed independently" was an assertion
+    nobody could check from the artefact.
+
+    The four axes are the ones a disjointness question is actually asked on:
+    the same served model behind two adapter names is not independence, and
+    neither is two models from one family when the policy cares about family.
+
+    ``model_served`` is deliberately allowed to be ``UNRESOLVED_IDENTITY``
+    rather than dropped. #5037 established that requested and served ids are
+    different facts; an unresolvable served id is an unknown, and a later
+    verifier must be able to tell an unknown from a mismatch.
+    """
+
+    adapter: str
+    model_requested: str
+    model_served: str = UNRESOLVED_IDENTITY
+    family: str = UNRESOLVED_IDENTITY
+
+    def __post_init__(self) -> None:
+        if not self.adapter:
+            raise ValueError("adapter must be a non-empty string")
+        if not self.model_requested:
+            raise ValueError("model_requested must be a non-empty string")
+        if not self.model_served:
+            raise ValueError(
+                "model_served must be a non-empty string; use UNRESOLVED_IDENTITY "
+                "when the served id is unknown, so absence is recorded as absence"
+            )
+        if not self.family:
+            raise ValueError("family must be a non-empty string; use UNRESOLVED_IDENTITY when unknown")
+
+    def to_dict(self) -> dict[str, str]:
+        """Serialise for the record's binding, keys in a fixed order."""
+        return {
+            "adapter": self.adapter,
+            "model_requested": self.model_requested,
+            "model_served": self.model_served,
+            "family": self.family,
+        }
 
 
 @dataclass(frozen=True, slots=True)
@@ -221,10 +273,16 @@ class AdjudicationRecord:
     final_verdict: Verdict
     timestamp: int
     journal_entry_hash: str = ""
+    # Additive, optional (issue #5473). ``None`` is dropped from the canonical
+    # bytes, so every record written before this field keeps its exact wire
+    # form and spine anchor. Present, it puts the producing identity inside
+    # the signed binding rather than beside it, which is what makes a later
+    # disjointness check answerable from the record alone.
+    producing_identity: ProducingIdentity | None = None
 
     def _binding(self) -> dict[str, Any]:
         """Return the anchor-free binding (the bytes the spine hashes)."""
-        return {
+        binding: dict[str, Any] = {
             "run_id": self.run_id,
             "inputs_hash": self.inputs_hash,
             "rubric_hash": self.rubric_hash,
@@ -233,6 +291,11 @@ class AdjudicationRecord:
             "final_verdict": self.final_verdict.value,
             "timestamp": self.timestamp,
         }
+        # Added only when set. A key present with a null would change the
+        # canonical bytes of every pre-existing record and break its anchor.
+        if self.producing_identity is not None:
+            binding["producing_identity"] = self.producing_identity.to_dict()
+        return binding
 
     def to_canonical_bytes(self) -> bytes:
         """Serialise the anchor-free binding to canonical JSON bytes."""
@@ -281,6 +344,7 @@ def adjudicate(
     panel: PanelConfig,
     judge_verdicts: tuple[JudgeVerdict, ...],
     now: int,
+    producing_identity: ProducingIdentity | None = None,
 ) -> AdjudicationRecord:
     """Bind inputs + rubric + panel + verdicts into an anchored, signed record.
 
@@ -301,6 +365,12 @@ def adjudicate(
         panel: The independent panel configuration.
         judge_verdicts: Per-judge verdicts in panel declaration order.
         now: Integer timestamp; recorded and used as the spine timestamp.
+        producing_identity: Who produced the artefact being judged (#5473).
+            Optional and additive: omitted, the record's canonical bytes and
+            anchor are exactly what they were before this parameter existed.
+            Supplied, it lands inside the signed binding, so a verifier can
+            decide disjointness from the record without consulting the config
+            that was in force at the time.
 
     Returns:
         The anchored :class:`AdjudicationRecord`.
@@ -323,6 +393,7 @@ def adjudicate(
         per_judge_verdict=tuple(v.to_dict() for v in judge_verdicts),
         final_verdict=final,
         timestamp=now,
+        producing_identity=producing_identity,
     )
 
     spine = LineageSpine(lineage_root, run_id=run_id, hmac_key=hmac_key)
@@ -345,6 +416,7 @@ def adjudicate(
         final_verdict=record.final_verdict,
         timestamp=record.timestamp,
         journal_entry_hash=anchor,
+        producing_identity=record.producing_identity,
     )
     # Persist the full record (binding + anchor) for offline `gate verify`.
     out_dir = records_dir(lineage_root, run_id)

--- a/src/bernstein/core/quality/cross_model_verifier.py
+++ b/src/bernstein/core/quality/cross_model_verifier.py
@@ -159,12 +159,18 @@ class CrossModelVerdict:
         feedback: One-line summary from the reviewer.
         issues: Specific issues found (empty when approved).
         reviewer_model: Model that performed the review.
+        writer_model: Model that produced the diff under review (#5473).
+            Recorded so "a reviewer that differs from the writer" is a
+            checkable property of the verdict rather than an assertion about
+            a config nobody kept. Empty means unrecorded, which a reader must
+            treat as unknown rather than as distinct.
     """
 
     verdict: Literal["approve", "request_changes"]
     feedback: str
     issues: list[str] = field(default_factory=list[str])
     reviewer_model: str = ""
+    writer_model: str = ""
 
 
 def select_reviewer_model(writer_model: str, override: str | None = None) -> str:
@@ -226,7 +232,7 @@ def _build_prompt(task: Task, diff: str, conventions_block: str = "") -> str:
     )
 
 
-def _parse_response(raw: str, reviewer_model: str) -> CrossModelVerdict:
+def _parse_response(raw: str, reviewer_model: str, writer_model: str = "") -> CrossModelVerdict:
     """Parse the reviewer LLM response into a CrossModelVerdict.
 
     Defaults to "approve" when the response cannot be parsed, so a reviewer
@@ -257,6 +263,7 @@ def _parse_response(raw: str, reviewer_model: str) -> CrossModelVerdict:
             feedback="Reviewer returned unparseable response - defaulting to approve",
             issues=[],
             reviewer_model=reviewer_model,
+            writer_model=writer_model,
         )
 
     raw_verdict = str(data.get("verdict", "approve")).lower()
@@ -273,6 +280,7 @@ def _parse_response(raw: str, reviewer_model: str) -> CrossModelVerdict:
         feedback=str(data.get("feedback", "")),
         issues=issues,
         reviewer_model=reviewer_model,
+        writer_model=writer_model,
     )
 
 
@@ -324,6 +332,7 @@ async def verify_with_cross_model(
             feedback=result.reasoning,
             issues=issues,
             reviewer_model=", ".join(voter_models),
+            writer_model=writer_model,
         )
 
     # --- Single-reviewer path (backward-compatible QUORUM 1-of-1) ---
@@ -379,9 +388,10 @@ async def verify_with_cross_model(
             feedback=f"Reviewer call failed: {exc}",
             issues=[],
             reviewer_model=reviewer,
+            writer_model=writer_model,
         )
 
-    verdict = _parse_response(raw, reviewer)
+    verdict = _parse_response(raw, reviewer, writer_model)
     logger.info(
         "cross_model_verifier: task=%s verdict=%s issues=%d",
         task.id,

--- a/tests/unit/quality/test_producing_identity.py
+++ b/tests/unit/quality/test_producing_identity.py
@@ -1,0 +1,255 @@
+"""A verdict record names the identity it judged (issue #5473, slice 1).
+
+An adjudication record named its judges and never the party whose work they
+judged, so "this was reviewed independently" was an assertion nobody could
+check from the artefact. `adjudicate()` did not even take a producer argument,
+so the information never reached the function: a panel genuinely independent
+*of itself*, and identical to the agent that wrote the diff, produced a record
+indistinguishable from an independent one.
+
+This slice is deliberately additive and inert. It records the producing
+identity inside the signed binding and changes no decision. Deriving the
+verdict class from it (slice 2) and refusing a collision (slice 3) are
+separate, and nothing here enforces anything.
+
+The load-bearing test is the last one: unset, the new field must leave the
+canonical bytes and the spine anchor of every pre-existing record byte-identical.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.quality.adjudication import (
+    UNRESOLVED_IDENTITY,
+    JudgeConfig,
+    JudgeVerdict,
+    PanelConfig,
+    ProducingIdentity,
+    Verdict,
+    adjudicate,
+    verify_adjudication,
+)
+from bernstein.core.quality.cross_model_verifier import CrossModelVerdict
+
+_KEY = b"k" * 32
+
+
+def _judge(model: str, temp: float, prompt: str) -> tuple[JudgeConfig, JudgeVerdict]:
+    cfg = JudgeConfig(model=model, temperature=temp, prompt_hash=prompt)
+    return cfg, JudgeVerdict(config=cfg, verdict=Verdict.PASS, rationale_hash="r-" + model)
+
+
+def _panel() -> tuple[PanelConfig, tuple[JudgeVerdict, ...]]:
+    cfg_a, verdict_a = _judge("m1", 0.0, "p")
+    cfg_b, verdict_b = _judge("m2", 0.2, "q")
+    return PanelConfig(judges=(cfg_a, cfg_b)), (verdict_a, verdict_b)
+
+
+def _verify(root: Path, record):
+    return verify_adjudication(
+        run_id="run-1",
+        lineage_root=root,
+        hmac_key=_KEY,
+        record=record,
+        claimed_inputs={"diff": "one"},
+    )
+
+
+def _adjudicate(root: Path, identity: ProducingIdentity | None = None):
+    panel, verdicts = _panel()
+    return adjudicate(
+        run_id="run-1",
+        lineage_root=root,
+        hmac_key=_KEY,
+        inputs={"diff": "one"},
+        rubric={"rule": "r"},
+        panel=panel,
+        judge_verdicts=verdicts,
+        now=1_767_225_600,
+        producing_identity=identity,
+    )
+
+
+WRITER = ProducingIdentity(
+    adapter="claude",
+    model_requested="claude-opus-5",
+    model_served="claude-opus-5-20260101",
+    family="claude",
+)
+
+
+# ---------------------------------------------------------------------------
+# The identity value
+# ---------------------------------------------------------------------------
+
+
+def test_the_identity_carries_the_four_axes_disjointness_is_asked_on() -> None:
+    assert WRITER.to_dict() == {
+        "adapter": "claude",
+        "model_requested": "claude-opus-5",
+        "model_served": "claude-opus-5-20260101",
+        "family": "claude",
+    }
+
+
+def test_unresolved_served_identity_is_recorded_as_unresolved() -> None:
+    """Absence is recorded as absence, never as "distinct".
+
+    #5037 established that the requested and served ids are different facts.
+    An unresolvable served id is an unknown, and a later verifier has to be
+    able to tell an unknown from a mismatch -- so the field is filled with a
+    sentinel rather than left empty or dropped.
+    """
+    identity = ProducingIdentity(adapter="claude", model_requested="claude-opus-5")
+
+    assert identity.model_served == UNRESOLVED_IDENTITY
+    assert identity.family == UNRESOLVED_IDENTITY
+    assert identity.to_dict()["model_served"] == UNRESOLVED_IDENTITY
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"adapter": "", "model_requested": "m"},
+        {"adapter": "a", "model_requested": ""},
+        {"adapter": "a", "model_requested": "m", "model_served": ""},
+        {"adapter": "a", "model_requested": "m", "family": ""},
+    ],
+)
+def test_an_empty_axis_is_refused(kwargs: dict[str, str]) -> None:
+    """Empty would be a third state between "known" and "unresolved"."""
+    with pytest.raises(ValueError):
+        ProducingIdentity(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# The record
+# ---------------------------------------------------------------------------
+
+
+def test_verdict_record_names_the_producing_identity(tmp_path: Path) -> None:
+    """In the signed binding, not beside it.
+
+    Beside it would leave the identity unanchored: anyone could edit it after
+    the fact without the spine noticing, which is the opposite of the property
+    this issue asks for.
+    """
+    record = _adjudicate(tmp_path, WRITER)
+
+    assert record.producing_identity == WRITER
+    assert record.to_canonical_bytes().count(b"producing_identity") == 1
+    assert b"claude-opus-5-20260101" in record.to_canonical_bytes()
+    assert record.to_dict()["producing_identity"] == WRITER.to_dict()
+    assert _verify(tmp_path, record).ok is True
+
+
+def test_a_record_without_the_identity_reads_as_unattributed(tmp_path: Path) -> None:
+    """Not as independent.
+
+    The key is absent rather than null, so a reader distinguishes "written
+    before this field existed" from "declared to have no producer".
+    """
+    record = _adjudicate(tmp_path)
+
+    assert record.producing_identity is None
+    assert "producing_identity" not in record.to_dict()
+    assert b"producing_identity" not in record.to_canonical_bytes()
+
+
+def test_the_anchored_record_keeps_the_identity(tmp_path: Path) -> None:
+    """`adjudicate` rebuilds the record to attach the anchor.
+
+    A field dropped in that rebuild would be recorded in the spine bytes and
+    then absent from the object the caller holds, which is the worst of both.
+    """
+    record = _adjudicate(tmp_path, WRITER)
+
+    assert record.journal_entry_hash != ""
+    assert record.producing_identity == WRITER
+
+
+def test_the_identity_is_inside_what_the_anchor_commits_to(tmp_path: Path) -> None:
+    """Changing the producer must change the anchor."""
+    with_writer = _adjudicate(tmp_path, WRITER)
+    other = ProducingIdentity(
+        adapter="codex",
+        model_requested="gpt-5.3-codex",
+        model_served="gpt-5.3-codex-20260101",
+        family="gpt",
+    )
+    with_other = _adjudicate(tmp_path, other)
+
+    assert with_writer.to_canonical_bytes() != with_other.to_canonical_bytes()
+    assert with_writer.journal_entry_hash != with_other.journal_entry_hash
+
+
+def test_pre_change_record_bytes_and_anchor_are_unchanged(tmp_path: Path) -> None:
+    """The load-bearing one: unset, the field costs nothing.
+
+    Every adjudication record written before this change must keep its exact
+    canonical bytes and its exact spine anchor, or the field would invalidate
+    the history it was added to make checkable.
+
+    The expected bytes are written out literally rather than recomputed from
+    the record, because recomputing would move both sides of the comparison
+    together and prove nothing.
+    """
+    record = _adjudicate(tmp_path)
+
+    expected = (
+        b'{"final_verdict":"pass",'
+        b'"inputs_hash":"' + record.inputs_hash.encode() + b'",'
+        b'"panel_config":' + _canonical(record.panel_config) + b","
+        b'"per_judge_verdict":' + _canonical(list(record.per_judge_verdict)) + b","
+        b'"rubric_hash":"' + record.rubric_hash.encode() + b'",'
+        b'"run_id":"run-1",'
+        b'"timestamp":1767225600}'
+    )
+    assert record.to_canonical_bytes() == expected
+    # And the untouched bytes still verify against the spine they were
+    # anchored in, which is the half that would break if the field leaked in.
+    assert _verify(tmp_path, record).ok is True
+
+
+def _canonical(value: object) -> bytes:
+    import json
+
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def test_two_identical_runs_still_produce_identical_records(tmp_path: Path) -> None:
+    """Determinism is unaffected, with the field set and unset."""
+    a = _adjudicate(tmp_path / "a")
+    b = _adjudicate(tmp_path / "b")
+    assert a.to_canonical_bytes() == b.to_canonical_bytes()
+
+    c = _adjudicate(tmp_path / "c", WRITER)
+    d = _adjudicate(tmp_path / "d", WRITER)
+    assert c.to_canonical_bytes() == d.to_canonical_bytes()
+
+
+# ---------------------------------------------------------------------------
+# The cross-model verdict
+# ---------------------------------------------------------------------------
+
+
+def test_cross_model_verdict_records_both_sides() -> None:
+    verdict = CrossModelVerdict(
+        verdict="approve",
+        feedback="ok",
+        reviewer_model="gpt-5.3",
+        writer_model="claude-opus-5",
+    )
+
+    assert verdict.reviewer_model == "gpt-5.3"
+    assert verdict.writer_model == "claude-opus-5"
+
+
+def test_cross_model_verdict_writer_defaults_to_unrecorded() -> None:
+    """Empty means unknown, and a reader must not read it as "differs"."""
+    verdict = CrossModelVerdict(verdict="approve", feedback="ok", reviewer_model="gpt-5.3")
+
+    assert verdict.writer_model == ""


### PR DESCRIPTION
**Slice 1 only** — the one the issue marks as "worth taking on its own", and the only one the other two depend on. Slices 2 (derive the class) and 3 (enforce) are not here, deliberately.

It is **additive and inert**, per the explicit `DO NOT` in the brief: no flag, no default change, nothing decides on the new field. A record whose producer equals its judge is still written and still verifies exactly as before.

### What lands

`AdjudicationRecord.producing_identity`, optional, carrying the four axes the issue names: `adapter`, `model_requested`, `model_served`, `family`. Those four because they are what a disjointness question is actually asked on — the same served model behind two adapter names is not independence, and neither is two models of one family when the policy cares about family.

`CrossModelVerdict.writer_model` alongside `reviewer_model`, threaded through all four construction sites, so the module's own header line *"Writer != reviewer"* becomes checkable from the verdict rather than being a claim about a config nobody kept.

### Two decisions worth reviewing

**`model_served` defaults to `"unresolved"` rather than being omitted.** #5037 established that requested and served ids are different facts. An unresolvable served id is an *unknown*, and a verifier must be able to tell an unknown from a mismatch — so it is filled with a sentinel, and an *empty* axis is rejected outright so there is no third state between "known" and "unresolved". That is `test_unresolved_served_identity_is_recorded_as_unresolved`.

**Inside the binding, not beside it.** Beside it, the identity would be unanchored — editable after the fact without the spine noticing, which is the opposite of the property the issue asks for. `test_the_identity_is_inside_what_the_anchor_commits_to` asserts that changing the producer changes the anchor.

I also caught one thing while wiring it: `adjudicate()` rebuilds the record to attach the anchor, and the rebuild enumerates fields explicitly. A field dropped there would be in the spine bytes and absent from the object the caller holds — the worst of both. `test_the_anchored_record_keeps_the_identity` pins it.

### Byte-compatibility — the load-bearing test

`test_pre_change_record_bytes_and_anchor_are_unchanged`. Unset, the key is **absent rather than null**, so a reader distinguishes "written before this field existed" from "declared to have no producer", and every historical record keeps its exact canonical bytes and anchor.

The expected bytes are written out **literally** rather than recomputed from the record — recomputing would move both sides of the comparison together and prove nothing. The record is then re-verified against the spine it was anchored in, so both halves are covered.

### Tests — 14

Covering `test_verdict_record_names_the_producing_identity`, `test_unresolved_served_identity_is_recorded_as_unresolved` and `test_pre_change_record_bytes_and_anchor_are_unchanged` from the issue's list by name. The other four listed tests belong to slices 2 and 3 and are not here.

### Verification

- `pytest tests/unit/quality/test_adjudication.py tests/unit/test_cross_model_verifier.py tests/unit/lineage/test_entry.py` — **79 passed**.
- `pytest tests/unit/quality/ tests/unit/test_cross_model_verifier.py tests/unit/lineage/test_entry.py` — **6 failed / 387 passed on `main`, 6 failed / 401 passed here**: the 14 new tests, zero newly failing. The 6 are pre-existing on my machine (`test_verifier_ladder` symlink cases and a command-not-found case).
- `ruff check src/bernstein/core/quality/` — clean.

The `-k "adjudicat or cross_model or merge_receipt"` run over all of `tests/unit` hits ~48 collection errors on my machine, but it hits **49 on unmodified `main`** — an environment problem with the flat runner, not this change. The repo's own `scripts/run_tests.py` isolates per file for that reason.

Per the documentation duty in CLAUDE.md, `docs/operations/gate-adjudication.md` documents the field, its four axes, the `unresolved` convention, and states plainly that it records rather than enforces.

**The open question from the brief** — whether the refusal raises or returns a record — is slice 3's and I have not pre-empted it here.
