### PR TITLE
feat(verify): add bernstein verify coverage subcommand (#5400)

### DIFF
--- a/docs/operations/verification-tracking.md
+++ b/docs/operations/verification-tracking.md
@@ -165,14 +165,41 @@ or wait for the unverified ones to age out.
 
 ---
 
+---
+
+## Coarse nudge signal vs. Recomputable receipt coverage
+
+It is important to distinguish the coarse operator nudge tracked here from the fine-grained, cryptographically verifiable merge admission coverage:
+
+| Property | `VerificationNudgeTracker` (this page) | Merge Admission Coverage (`MergeAdmissionReceipt`) |
+|---|---|---|
+| **Nature** | Coarse operational heuristic / nudge | Fine-grained, content-addressed cryptographic record |
+| **Source** | **Self-reported** log summary flags (`OR` over 3 booleans) | Deterministic set diff of changed paths against oracle scopes |
+| **Verification** | In-memory count / metric alert | Offline recomputable via `bernstein verify coverage <sha>` |
+| **Artifact** | `.sdd/metrics/verification_nudges.jsonl` | Signed receipt at `.sdd/merges/receipts/<hash>.json` |
+| **Granularity** | Task-level binary flag (`verified: bool`) | Per-path `verified`, `unverified`, and `skipped` sets |
+
+While `VerificationNudgeTracker` alerts operators when tasks finish without any reported verification activity, the merge admission gate binds exact path coverage into signed receipts that can be verified and recomputed offline at any time via:
+
+```bash
+bernstein verify coverage <head-sha>
+```
+
+For the complete command-line interface and exit codes, see [`bernstein verify coverage`](../reference/cli/verify.md#merge-admission-receipt-coverage-verify-coverage).
+
+---
+
 ## Code pointers
 
 | File                                                       | What it does |
 |------------------------------------------------------------|--------------|
 | `src/bernstein/core/quality/verification_nudge.py`         | `VerificationNudgeTracker`, `VerificationRecord`, `NudgeSummary`, `load_nudge_summary()` |
+| `src/bernstein/core/quality/merge_receipt.py`              | `MergeAdmissionReceipt`, `compute_coverage_sets()`, `read_merge_receipt()` |
+| `src/bernstein/cli/commands/verify_cmd.py`                 | `bernstein verify coverage` subcommand |
 | `src/bernstein/core/models.py`                             | `Task.verification_count`, `Task.flagged_unverified` fields |
 | `src/bernstein/core/quality/janitor.py`                    | `verify_task()` - supplies the `completion_signals_checked` evidence |
 | `tests/unit/test_verification_nudge.py`                    | 44 tests across 8 classes (record, persistence, summary, alert thresholds) |
+| `tests/unit/test_verify_coverage_cmd.py`                   | Unit tests for CLI coverage verification |
 
 JSONL ledger schema (one object per line):
 
@@ -192,6 +219,8 @@ JSONL ledger schema (one object per line):
 
 ## Related
 
+- [Merge Admission Receipt Coverage](../reference/cli/verify.md#merge-admission-receipt-coverage-verify-coverage) - offline verification of structured coverage sets.
 - [Permission modes](../architecture/permission-modes.md) - how the
   approval gate decides whether a completion needs human signoff.
 - [Runbooks](runbooks.md) - automated remediation for failing tasks.
+

--- a/docs/reference/cli/verify.md
+++ b/docs/reference/cli/verify.md
@@ -3,12 +3,13 @@
 `bernstein verify` is a command group: two run-receipt subcommands
 (`run` and `receipt`, issue #2924), the verifier-ladder subcommand
 (`ladder`, issue #2927), the plugin/skill pin subcommand (`pins`,
-issue #5089), plus five legacy verification modes —
+issue #5089), the merge admission receipt coverage subcommand (`coverage`,
+issue #5400), plus five legacy verification modes —
 air-gap wheelhouse signatures, WAL hash-chain integrity,
 execution-determinism fingerprints, lesson-memory provenance, and formal
 property checks. The legacy modes live on the default `legacy` subcommand:
 any invocation whose first token is not `run` / `receipt` / `ladder` /
-`pins` / `legacy` routes there, so pre-group invocations keep their exact
+`pins` / `coverage` / `legacy` routes there, so pre-group invocations keep their exact
 behaviour and exit codes.
 Each legacy mode is selected by its own flag (or a positional argument for
 wheelhouse mode); passing more than one runs all of them and combines their
@@ -24,6 +25,7 @@ bernstein verify run <run-id> --signing-key-path key.pem    # build the signed r
 bernstein verify receipt <path> [--public-key pub.pem]      # verify a receipt offline (0/1/2)
 bernstein verify ladder <receipt-hash>                      # re-derive a verifier-ladder receipt (0/1/2)
 bernstein verify pins --manifest pins.yaml --loaded loaded.json  # check the loaded set against the pins (0/1/2)
+bernstein verify coverage <head-sha> [--sha <head-sha>]     # inspect and recompute merge receipt coverage (0/1/2)
 bernstein verify <wheelhouse-path>                          # air-gap wheelhouse signatures
 bernstein verify --wal-integrity <run-id>                   # WAL hash-chain check
 bernstein verify --determinism <run-id>                     # print execution fingerprint
@@ -37,7 +39,7 @@ Running the bare command with no arguments prints a usage hint and returns
 without error.
 
 One routing edge: a wheelhouse directory literally named `run`, `receipt`,
-`ladder`, `pins`, or `legacy` shadows the positional mode — spell it `./run`
+`ladder`, `pins`, `coverage`, or `legacy` shadows the positional mode — spell it `./run`
 or use `bernstein verify legacy <path>`.
 
 ## Run receipts
@@ -184,6 +186,30 @@ the pin exactly.
 | 1 | The manifest or the loaded set could not be read or failed validation. |
 | 2 | At least one entry drifted. |
 
+## Merge admission receipt coverage (`verify coverage`)
+
+Inspects and verifies the structured coverage sets (`verified`, `unverified`,
+`skipped`) on a merge admission receipt (`MergeAdmissionReceipt`, issue #5400).
+
+```bash
+bernstein verify coverage <head-sha>
+bernstein verify coverage --sha <head-sha> --workdir . --json
+```
+
+The command loads the merge admission receipt covering `head_sha` from
+`.sdd/merges/receipts/<sha256(head_sha)>.json`, recomputes the
+`coverage_set_hash` from the receipt's own verified paths, unverified remainder,
+and skipped `(path, reason)` pairs, and verifies that the digest matches the
+signed `coverage_set_hash` on the receipt byte-for-byte.
+
+| Exit code | Meaning |
+|---|---|
+| 0 | Coverage sets are internally consistent and `coverage_set_hash` matches byte-for-byte. |
+| 1 | No readable merge receipt for the SHA, missing SHA, or receipt was signed under schema v1 (no coverage data). |
+| 2 | `coverage_set_hash` mismatch (tamper or scope divergence). |
+
+Architecture and operation: [Verification tracking](../../operations/verification-tracking.md).
+
 ## Legacy modes
 
 ### Wheelhouse signature verification
@@ -257,6 +283,9 @@ Every verification command in Bernstein follows a strict exit-code contract. The
 | | `2` | `TAMPER DETECTED` | Step divergence, spine/audit head mismatch, signature or pinned-key mismatch |
 | | `3` | `REQUIRE-PROVENANCE NOT MET` | `--require-provenance` given but only the integrity-only tier was reached |
 | | `4` | `SIGNING KEY NOT TRUSTED` | Authentic signature under a key the supplied `--key-chain` revoked, does not introduce, or introduces as a different key |
+| `verify coverage <sha>` | `0` | `Merge Coverage: VERIFIED` | Structured coverage sets recomputed and match receipt `coverage_set_hash` |
+| | `1` | `NOT FOUND` / `NO COVERAGE DATA` | Missing receipt, missing SHA, or v1 receipt lacking coverage sets |
+| | `2` | `TAMPER / DIVERGENCE DETECTED` | `coverage_set_hash` mismatch / scope divergence |
 | `lineage verify <run>` | `0` | `OK` | Lineage spine/chain intact and non-empty, all HMAC tags / signatures valid |
 | | `1` | `NO ENTRIES` / `SEAL ONLY` | Empty run emitted no lineage (1), or chain records only journal-head seal with no artifact provenance (1) |
 | | `2` | `TAMPER DETECTED` / `RECEIPT VERIFICATION FAILED` | HMAC tag mismatch, broken Merkle chain, or recovery receipt resolution failed |
@@ -271,6 +300,8 @@ Every verification command in Bernstein follows a strict exit-code contract. The
 `src/bernstein/core/replay/run_receipt.py` (receipt build + offline verify);
 `src/bernstein/core/security/receipt_key_chain.py` (key succession chain);
 `src/bernstein/core/quality/verifier_ladder.py` (ladder receipts);
+`src/bernstein/core/quality/merge_receipt.py` (merge admission receipts and coverage verification);
 `src/bernstein/core/plugins_core/plugin_pin_manifest.py` (pin manifest,
 verify, and idempotent apply).
+
 

--- a/docs/release-notes/fragments/5400-verify-coverage.md
+++ b/docs/release-notes/fragments/5400-verify-coverage.md
@@ -1,0 +1,16 @@
+## `bernstein verify coverage` subcommand for merge admission receipts
+
+Adds the `coverage` subcommand to the `bernstein verify` command group, enabling
+operators to inspect and cryptographically recompute the structured coverage sets
+(`verified`, `unverified`, and `skipped`) recorded on a merge admission receipt.
+
+Running `bernstein verify coverage <head-sha>` loads the receipt from
+`.sdd/merges/receipts/<hash>.json`, recomputes the `coverage_set_hash` from the
+receipt's own path sets, and renders a structured breakdown of what was exercised,
+what remained unverified, and which oracle scopes were skipped and why.
+The command exits 0 when the coverage sets recompute byte-for-byte, 1 when no
+receipt is found or when inspecting a legacy schema v1 receipt, and 2 on any
+divergence or tamper detected in `coverage_set_hash`. Passing `--json` emits
+a machine-readable JSON object for automated audit pipelines.
+
+(#5400)

--- a/src/bernstein/cli/commands/verify_cmd.py
+++ b/src/bernstein/cli/commands/verify_cmd.py
@@ -1,7 +1,8 @@
 """Verify CLI -- run receipts, ladder receipts, WAL integrity, determinism, memory, wheelhouse.
 
-``bernstein verify`` is a group. Two run-receipt verbs (issue #2924) and a
-ladder-receipt verb (issue #2927):
+``bernstein verify`` is a group. Two run-receipt verbs (issue #2924), a
+ladder-receipt verb (issue #2927), a pin-manifest verb (issue #5089), and
+a merge admission receipt coverage verb (issue #5400):
 
 * ``bernstein verify run <run-id>`` -- build the signed ``run-receipt.json``
   binding the run's journal head, lineage-spine head, and (opt-in) an
@@ -22,6 +23,13 @@ ladder-receipt verb (issue #2927):
   verdict`` plus the composite claim, re-checked against the
   ``verifier-ladder`` lineage spine. Exit codes: ``0`` OK, ``1`` no readable
   receipt, ``2`` re-derivation or anchor mismatch.
+* ``bernstein verify pins --manifest <path> --loaded <path>`` -- verify
+  the loaded plugin and skill set against the governed pin manifest. Exit
+  codes: ``0`` OK, ``1`` unreadable files, ``2`` drift detected.
+* ``bernstein verify coverage <head-sha> [--sha SHA] [--workdir PATH] [--json]``
+  -- inspect and recompute structured coverage sets on a merge admission
+  receipt. Exit codes: ``0`` OK, ``1`` missing receipt or v1 schema, ``2``
+  coverage_set_hash mismatch.
 
 The five legacy flag/positional modes are preserved verbatim under the
 default ``legacy`` subcommand -- any invocation whose first token is not a
@@ -42,8 +50,9 @@ behaviour and exit codes:
   binaries must be installed separately on PATH (no bundled extra).
 
 One routing edge: a wheelhouse directory literally named ``run``,
-``receipt``, ``ladder``, or ``legacy`` shadows the positional mode -- spell
-it ``./run`` (or use ``bernstein verify legacy run``) in that case.
+``receipt``, ``ladder``, ``pins``, ``coverage``, or ``legacy`` shadows
+the positional mode -- spell it ``./run`` (or use ``bernstein verify legacy run``)
+in that case.
 """
 
 from __future__ import annotations
@@ -97,6 +106,8 @@ def verify_cmd() -> None:
       bernstein verify run <run-id>               Build the signed run receipt
       bernstein verify receipt <path>             Verify a receipt offline (0/1/2)
       bernstein verify ladder <receipt-hash>      Re-derive a verifier-ladder receipt (0/1/2)
+      bernstein verify pins --manifest ...        Check loaded set against pin manifest (0/1/2)
+      bernstein verify coverage <head-sha>        Inspect merge receipt coverage (0/1/2)
       bernstein verify <wheelhouse-path>          Verify air-gap wheelhouse signatures
       bernstein verify --wal-integrity <run-id>   Validate hash chain
       bernstein verify --determinism  <run-id>    Show execution fingerprint
@@ -1748,3 +1759,219 @@ def verify_pins_cmd(
     )
     console.print()
     raise SystemExit(result.exit_code)
+
+
+# ---------------------------------------------------------------------------
+# Merge admission receipt coverage (issue #5400)
+# ---------------------------------------------------------------------------
+
+
+@verify_cmd.command("coverage")
+@click.argument("head_sha", required=False, default=None)
+@click.option(
+    "--sha",
+    "sha_option",
+    default=None,
+    metavar="HEAD_SHA",
+    help="Commit SHA whose merge admission receipt coverage to inspect.",
+)
+@click.option(
+    "--workdir",
+    "-w",
+    type=click.Path(file_okay=False, exists=True),
+    default=".",
+    show_default=True,
+    help="Project root containing .sdd/.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit coverage sets and hash recomputation as machine-readable JSON.",
+)
+def verify_coverage_cmd(
+    head_sha: str | None,
+    sha_option: str | None,
+    workdir: str,
+    as_json: bool,
+) -> None:
+    """Inspect and verify structured coverage on a merge admission receipt.
+
+    Loads the merge admission receipt for HEAD_SHA, recomputes the
+    coverage set hash from the receipt's own verified, unverified, and skipped
+    sets, and prints the breakdown: what was exercised, what was not, and
+    which oracles were skipped and why.
+
+    \b
+    Exit codes:
+      0  receipt coverage sets are consistent and hash recomputes byte-for-byte
+      1  no readable merge receipt, missing SHA, or receipt has no coverage sets (v1)
+      2  coverage_set_hash mismatch (tamper / divergence)
+    """
+    from bernstein.core.quality.merge_receipt import (
+        _canonical_bytes,
+        _sha256_hex,
+        read_merge_receipt,
+    )
+
+    target_sha = head_sha or sha_option
+    if not target_sha:
+        if as_json:
+            console.print_json(
+                data={
+                    "ok": False,
+                    "status": "missing_sha",
+                    "reason": "Commit SHA is required (pass as argument or via --sha).",
+                }
+            )
+        else:
+            console.print("[red]Error: Commit SHA is required (pass as argument or via --sha).[/red]")
+        raise SystemExit(1)
+
+    root = Path(workdir).resolve()
+    receipt = read_merge_receipt(root, target_sha)
+
+    if receipt is None:
+        if as_json:
+            console.print_json(
+                data={
+                    "ok": False,
+                    "status": "missing",
+                    "reason": f"No merge admission receipt found for {target_sha}.",
+                    "head_sha": target_sha,
+                }
+            )
+        else:
+            console.print()
+            console.print(
+                Panel(
+                    "[bold red]Merge Coverage: NOT FOUND[/bold red]",
+                    border_style="red",
+                    expand=False,
+                )
+            )
+            console.print(f"  [red]![/red] No merge admission receipt found for {target_sha}.")
+            console.print()
+        raise SystemExit(1)
+
+    if receipt.schema_version < 2 or not receipt.coverage_set_hash:
+        reason = (
+            f"Merge receipt for {target_sha} was signed under schema v{receipt.schema_version} "
+            "without structured coverage sets."
+        )
+        if as_json:
+            console.print_json(
+                data={
+                    "ok": False,
+                    "status": "no_coverage_sets",
+                    "reason": reason,
+                    "head_sha": target_sha,
+                    "schema_version": receipt.schema_version,
+                }
+            )
+        else:
+            console.print()
+            console.print(
+                Panel(
+                    "[bold red]Merge Coverage: NO COVERAGE DATA[/bold red]",
+                    border_style="red",
+                    expand=False,
+                )
+            )
+            console.print(f"  [red]![/red] {reason}")
+            console.print()
+        raise SystemExit(1)
+
+    payload = {
+        "verified": list(receipt.verified),
+        "unverified": list(receipt.unverified),
+        "skipped": [list(pair) for pair in receipt.skipped],
+    }
+    recomputed_hash = _sha256_hex(_canonical_bytes(payload))
+
+    if recomputed_hash != receipt.coverage_set_hash:
+        if as_json:
+            console.print_json(
+                data={
+                    "ok": False,
+                    "status": "mismatch",
+                    "reason": "coverage_set_hash mismatch",
+                    "head_sha": receipt.head_sha,
+                    "expected": receipt.coverage_set_hash,
+                    "recomputed": recomputed_hash,
+                    "verified": list(receipt.verified),
+                    "unverified": list(receipt.unverified),
+                    "skipped": [list(pair) for pair in receipt.skipped],
+                }
+            )
+        else:
+            console.print()
+            console.print(
+                Panel(
+                    "[bold red]Merge Coverage: TAMPER / DIVERGENCE DETECTED[/bold red]",
+                    border_style="red",
+                    expand=False,
+                )
+            )
+            console.print(f"  [red]![/red] Stored coverage_set_hash:     {receipt.coverage_set_hash}")
+            console.print(f"  [red]![/red] Recomputed coverage_set_hash: {recomputed_hash}")
+            console.print()
+        raise SystemExit(2)
+
+    if as_json:
+        console.print_json(
+            data={
+                "ok": True,
+                "status": "verified",
+                "head_sha": receipt.head_sha,
+                "merge_base_sha": receipt.merge_base_sha,
+                "decision": receipt.decision,
+                "authority": receipt.authority,
+                "coverage_set_hash": receipt.coverage_set_hash,
+                "recomputed_hash": recomputed_hash,
+                "verified": list(receipt.verified),
+                "unverified": list(receipt.unverified),
+                "skipped": [list(pair) for pair in receipt.skipped],
+            }
+        )
+        raise SystemExit(0)
+
+    console.print()
+    table = Table(show_header=True, box=None, padding=(0, 2))
+    table.add_column("Category", style="bold", no_wrap=True, min_width=14)
+    table.add_column("Count", justify="right", no_wrap=True)
+    table.add_column("Details", no_wrap=False)
+
+    table.add_row(
+        "[green]Verified[/green]",
+        str(len(receipt.verified)),
+        ", ".join(receipt.verified) if receipt.verified else "[dim](none)[/dim]",
+    )
+    table.add_row(
+        "[yellow]Unverified[/yellow]" if receipt.unverified else "Unverified",
+        str(len(receipt.unverified)),
+        ", ".join(receipt.unverified) if receipt.unverified else "[dim](none)[/dim]",
+    )
+    skipped_str = ", ".join(f"{p} ({r})" for p, r in receipt.skipped) if receipt.skipped else "[dim](none)[/dim]"
+    table.add_row(
+        "[cyan]Skipped[/cyan]" if receipt.skipped else "Skipped",
+        str(len(receipt.skipped)),
+        skipped_str,
+    )
+    console.print(table)
+    console.print()
+    console.print(f"  Head SHA:          {receipt.head_sha}")
+    console.print(f"  Decision:          {receipt.decision} (Authority: {receipt.authority})")
+    console.print(f"  Coverage set hash: {receipt.coverage_set_hash}")
+    console.print()
+    console.print(
+        Panel(
+            "[bold green]Merge Coverage: VERIFIED[/bold green]",
+            border_style="green",
+            expand=False,
+        )
+    )
+    console.print("  [dim]Structured coverage sets recomputed and matched the signed receipt byte-for-byte.[/dim]")
+    console.print()
+    raise SystemExit(0)

--- a/tests/unit/test_verify_coverage_cmd.py
+++ b/tests/unit/test_verify_coverage_cmd.py
@@ -1,0 +1,282 @@
+"""Unit tests for the `bernstein verify coverage` subcommand (Issue #5400).
+
+Tests the command line interface for reading merge admission receipts,
+recomputing coverage set hashes, and verifying structured coverage sets
+(verified, unverified, and skipped paths).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.verify_cmd import verify_cmd
+from bernstein.core.quality.merge_receipt import (
+    VerificationScope,
+    emit_merge_receipt,
+    load_or_create_merge_identity,
+)
+
+
+@pytest.fixture(scope="function")
+def workdir(tmp_path: Path) -> Path:
+    """Create a temporary project root with .sdd directory."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / ".sdd").mkdir(parents=True)
+    (root / ".sdd" / "identity").mkdir(parents=True)
+    (root / ".sdd" / "lineage").mkdir(parents=True)
+    (root / ".sdd" / "merges" / "receipts").mkdir(parents=True)
+    return root
+
+
+@pytest.fixture(scope="function")
+def populated_workdir(workdir: Path) -> Path:
+    """Create a working directory with signed merge identity."""
+    root = workdir
+    private_pem, public_pem = load_or_create_merge_identity(root)
+    identity_dir = root / ".sdd" / "identity"
+    (identity_dir / "merge-identity-key.pem").write_text(private_pem, encoding="ascii")
+    (identity_dir / "merge-identity-public.pem").write_text(public_pem, encoding="ascii")
+    return root
+
+
+def _emit_receipt(root: Path, head_sha: str, merge_base_sha: str = "base_123", **kwargs) -> None:
+    """Helper to emit a merge admission receipt."""
+    hmac_key = b"x" * 32
+    lineage_root = root / ".sdd" / "lineage"
+    private_key_pem = (root / ".sdd" / "identity" / "merge-identity-key.pem").read_text(encoding="ascii")
+    public_key_pem = (root / ".sdd" / "identity" / "merge-identity-public.pem").read_text(encoding="ascii")
+
+    defaults = dict(
+        required_context_ids=("ci/green",),
+        blast_radius={
+            "score": 0.1,
+            "hard_one_way": False,
+            "components": [],
+            "hits": [],
+            "rationale": "clean",
+            "files_touched": 2,
+            "files": ["src/a.py", "src/b.py"],
+        },
+        review_verdict="pass",
+        ruleset_bytes=b"",
+        decision="admit",
+        authority="autonomous",
+        timestamp=1000,
+        change_set=("src/a.py", "src/b.py"),
+        scopes=(
+            VerificationScope(
+                oracle="test",
+                checked=("src/a.py", "src/b.py"),
+                skipped=(),
+            ),
+        ),
+    )
+    defaults.update(kwargs)
+    emit_merge_receipt(
+        workdir=root,
+        lineage_root=lineage_root,
+        hmac_key=hmac_key,
+        private_key_pem=private_key_pem,
+        public_key_pem=public_key_pem,
+        head_sha=head_sha,
+        merge_base_sha=merge_base_sha,
+        **defaults,
+    )
+
+
+def test_verify_help_shows_coverage_subcommand() -> None:
+    """The verify group help text lists the coverage subcommand."""
+    runner = CliRunner()
+    result = runner.invoke(verify_cmd, ["--help"])
+    assert result.exit_code == 0
+    assert "coverage" in result.output
+    assert "Inspect merge receipt coverage" in result.output
+
+
+def test_verify_coverage_help() -> None:
+    """The verify coverage help text documents options and exit codes."""
+    runner = CliRunner()
+    result = runner.invoke(verify_cmd, ["coverage", "--help"])
+    assert result.exit_code == 0
+    assert "--sha" in result.output
+    assert "--workdir" in result.output
+    assert "--json" in result.output
+    assert "Exit codes:" in result.output
+
+
+def test_verify_coverage_success_human(populated_workdir: Path) -> None:
+    """Running against a valid receipt recomputes hash and exits 0 with table."""
+    root = populated_workdir
+    head_sha = "sha_success_123"
+    _emit_receipt(
+        root,
+        head_sha,
+        change_set=("src/a.py", "src/b.py", "docs/c.md"),
+        scopes=(
+            VerificationScope(
+                oracle="unit-tests",
+                checked=("src/a.py",),
+                skipped=(("docs/c.md", "docs change"),),
+            ),
+        ),
+        unverified_threshold=1.0,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(verify_cmd, ["coverage", head_sha, "-w", str(root)])
+    assert result.exit_code == 0, result.output
+    assert "Merge Coverage: VERIFIED" in result.output
+    assert "src/a.py" in result.output
+    assert "docs/c.md (docs change)" in result.output
+    assert "src/b.py" in result.output
+    assert head_sha in result.output
+
+
+def test_verify_coverage_success_json(populated_workdir: Path) -> None:
+    """Running with --json emits machine-readable JSON object and exits 0."""
+    root = populated_workdir
+    head_sha = "sha_json_456"
+    _emit_receipt(
+        root,
+        head_sha,
+        change_set=("src/a.py", "src/b.py"),
+        scopes=(
+            VerificationScope(
+                oracle="linter",
+                checked=("src/a.py", "src/b.py"),
+                skipped=(),
+            ),
+        ),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(verify_cmd, ["coverage", head_sha, "-w", str(root), "--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert data["status"] == "verified"
+    assert data["head_sha"] == head_sha
+    assert data["verified"] == ["src/a.py", "src/b.py"]
+    assert data["unverified"] == []
+    assert data["skipped"] == []
+    assert data["coverage_set_hash"].startswith("sha256:")
+    assert data["recomputed_hash"] == data["coverage_set_hash"]
+
+
+def test_verify_coverage_via_sha_option(populated_workdir: Path) -> None:
+    """The --sha option is accepted in place of the positional argument."""
+    root = populated_workdir
+    head_sha = "sha_flag_789"
+    _emit_receipt(root, head_sha)
+
+    runner = CliRunner()
+    result = runner.invoke(verify_cmd, ["coverage", "--sha", head_sha, "-w", str(root), "--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert data["head_sha"] == head_sha
+
+
+def test_verify_coverage_missing_sha_fails() -> None:
+    """Invoking verify coverage with no SHA exits 1."""
+    runner = CliRunner()
+    result = runner.invoke(verify_cmd, ["coverage"])
+    assert result.exit_code == 1
+    assert "Commit SHA is required" in result.output
+
+    result_json = runner.invoke(verify_cmd, ["coverage", "--json"])
+    assert result_json.exit_code == 1
+    data = json.loads(result_json.output)
+    assert data["ok"] is False
+    assert data["status"] == "missing_sha"
+
+
+def test_verify_coverage_missing_receipt_fails(populated_workdir: Path) -> None:
+    """Invoking verify coverage for a non-existent receipt exits 1."""
+    root = populated_workdir
+    runner = CliRunner()
+    result = runner.invoke(verify_cmd, ["coverage", "nonexistent_sha", "-w", str(root)])
+    assert result.exit_code == 1
+    assert "NOT FOUND" in result.output
+    assert "No merge admission receipt found" in result.output
+
+    result_json = runner.invoke(verify_cmd, ["coverage", "nonexistent_sha", "-w", str(root), "--json"])
+    assert result_json.exit_code == 1
+    data = json.loads(result_json.output)
+    assert data["ok"] is False
+    assert data["status"] == "missing"
+
+
+def test_verify_coverage_v1_receipt_no_coverage_fails(populated_workdir: Path) -> None:
+    """A v1 receipt with no coverage sets exits 1 and names the reason."""
+    root = populated_workdir
+    head_sha = "v1_sha_123"
+    safe = hashlib.sha256(head_sha.encode("utf-8")).hexdigest()
+    receipt_path = root / ".sdd" / "merges" / "receipts" / f"{safe}.json"
+
+    # Write a v1 receipt without coverage fields
+    v1_payload = {
+        "v": 1,
+        "head_sha": head_sha,
+        "merge_base_sha": "base_v1",
+        "required_context_ids": ["ci/green"],
+        "gate_results_hash": "sha256:abc",
+        "ruleset_hash": "sha256:def",
+        "review_receipt_id": "",
+        "journal_head": "",
+        "decision": "admit",
+        "authority": "autonomous",
+        "timestamp": 1000,
+        "signer_public_key_pem": "pub",
+        "signature": "sig",
+        "journal_entry_hash": "entry",
+        "advisory": "",
+    }
+    receipt_path.write_text(json.dumps(v1_payload), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(verify_cmd, ["coverage", head_sha, "-w", str(root)])
+    assert result.exit_code == 1
+    assert "NO COVERAGE DATA" in result.output
+    assert "schema v1" in result.output
+
+    result_json = runner.invoke(verify_cmd, ["coverage", head_sha, "-w", str(root), "--json"])
+    assert result_json.exit_code == 1
+    data = json.loads(result_json.output)
+    assert data["ok"] is False
+    assert data["status"] == "no_coverage_sets"
+    assert "schema v1" in data["reason"]
+
+
+def test_verify_coverage_tamper_mismatch_exits_2(populated_workdir: Path) -> None:
+    """A receipt whose coverage_set_hash diverges from its sets exits 2."""
+    root = populated_workdir
+    head_sha = "tamper_sha_456"
+    _emit_receipt(root, head_sha)
+
+    # Tamper with the stored coverage_set_hash
+    safe = hashlib.sha256(head_sha.encode("utf-8")).hexdigest()
+    receipt_path = root / ".sdd" / "merges" / "receipts" / f"{safe}.json"
+    data = json.loads(receipt_path.read_text(encoding="utf-8"))
+    data["coverage_set_hash"] = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    receipt_path.write_text(json.dumps(data), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(verify_cmd, ["coverage", head_sha, "-w", str(root)])
+    assert result.exit_code == 2
+    assert "TAMPER / DIVERGENCE DETECTED" in result.output
+    assert "Stored coverage_set_hash" in result.output
+    assert "Recomputed coverage_set_hash" in result.output
+
+    result_json = runner.invoke(verify_cmd, ["coverage", head_sha, "-w", str(root), "--json"])
+    assert result_json.exit_code == 2
+    data_json = json.loads(result_json.output)
+    assert data_json["ok"] is False
+    assert data_json["status"] == "mismatch"
+    assert data_json["expected"] != data_json["recomputed"]


### PR DESCRIPTION
Closes #5400

## Problem
`bernstein verify` is an existing command group at `src/bernstein/cli/commands/verify_cmd.py` (`run`, `receipt`, `ladder`, `pins`, and `legacy` modes). However, no subcommand loaded or verified merge admission receipts (`MergeAdmissionReceipt`), leaving the structured coverage sets (`verified`, `unverified`, `skipped`, and `coverage_set_hash`) unreachable from the command line.

## Solution
1. **Added `bernstein verify coverage` subcommand**:
   - Reads the merge admission receipt for a target commit SHA (positional `HEAD_SHA` or `--sha`) using `read_merge_receipt`.
   - Recomputes `coverage_set_hash` from the receipt's own `verified`, `unverified`, and `skipped` path sets.
   - Outputs a Rich table breakdown (`Verified`, `Unverified`, `Skipped` with reasons) or `--json` machine-readable output.
   - Strictly enforces exit codes:
     - `0`: Coverage sets recompute byte-for-byte matching `coverage_set_hash`.
     - `1`: Missing commit SHA, receipt not found, or schema v1 receipt lacking coverage fields.
     - `2`: `coverage_set_hash` mismatch (tamper / scope divergence).
2. **Comprehensive CLI unit tests**:
   - Added `tests/unit/test_verify_coverage_cmd.py` testing `--help`, human-readable table, `--json`, `--sha` option, missing receipt, v1 receipt, and tampered `coverage_set_hash` via Click `CliRunner`.
3. **Documentation**:
   - Updated `docs/reference/cli/verify.md` with usage examples and exit-code table entries.
   - Updated `docs/operations/verification-tracking.md` cross-linking to `verify coverage` and clearly explaining the contrast between self-reported nudge tracker flags and recomputable receipt coverage.
   - Added release notes fragment `docs/release-notes/fragments/5400-verify-coverage.md`.

## Verification
- Unit tests: `pytest tests/unit/test_verify_coverage_cmd.py tests/unit/test_feature_matrix_drift.py tests/unit/test_merge_receipt_cli.py` (45/45 passed).
- Lint & formatting: `ruff check` and `ruff format` passed cleanly.
- 0 UTF-8 BOMs across all files.
