### PR TITLE
feat(eval): bench rotation, private holdout, and contamination checks (#5459)

### DIFF
--- a/docs/eval/bench.md
+++ b/docs/eval/bench.md
@@ -260,22 +260,51 @@ All tests use `MockReplayAdapter` — no network, no real adapters, no API keys.
 
 ---
 
+## Suite Rotation, Private Holdout, and Saturation Tracking
+
+A fixed public benchmark suite naturally saturates as agents and models overfit to specific task distributions. To maintain evaluation integrity:
+
+1. **Versioned Manifests & Holdout Binding**:
+   - `BenchSuite` binds both public tasks and an optional `holdout_hash` into its content-addressed `suite_hash`.
+   - The private holdout tasks remain unpublished and local-only; only their cryptographic hash (`holdout_hash`) is published on manifests and `SubmissionBundle` artefacts so external third parties can verify that a holdout evaluation ran against the pinned task set without exposing the secret test definitions.
+2. **Private Holdout Isolation**:
+   - `HoldoutBenchRunner` executes holdout tasks locally and enforces by construction that results and specifications are never written or leaked to public paths (raising `HoldoutIsolationError`).
+3. **Saturation & Rotation Detection**:
+   - When the public-set pass rate exceeds **90%** (`>= 0.90`) across **three (3) consecutive baseline submissions**, the suite is declared *saturated*.
+   - `check_suite_saturation()` / `Leaderboard.check_rotation_due()` flags that rotation is due, triggering promotion of private holdout tasks into the public set and seeding a fresh private holdout distribution.
+
+---
+
+## Task Admission Gate: Contamination Check
+
+A benchmark task whose reference solution exists verbatim or with high n-gram overlap in public code hosting measures retrieval rather than problem-solving capability.
+
+During task admission:
+- `check_solution_contamination(solution, public_corpus, n=5, threshold=0.8)` computes normalized token n-grams and evaluates overlap against public corpora.
+- An admission verdict (`ContaminationVerdict`) is recorded.
+- If verbatim match or n-gram overlap exceeds the threshold (`>= 80%`), admission is rejected.
+
+---
+
 ## File map
 
 ```
 src/bernstein/eval/bench/
 ├── __init__.py          # public API re-exports
-├── suite.py             # BenchSuite, BenchTask (content-addressed)
-├── bundle.py            # SubmissionBundle, TaskResult
-├── runner.py            # BenchRunner, MockReplayAdapter, StochasticMockReplayAdapter
+├── suite.py             # BenchSuite, BenchTask (content-addressed, holdout binding)
+├── bundle.py            # SubmissionBundle, TaskResult (carries holdout_hash)
+├── contamination.py     # Contamination check & admission gate (n-gram fingerprinting)
+├── rotation.py          # Suite saturation & rotation detection
+├── runner.py            # BenchRunner, HoldoutBenchRunner (isolated execution)
 ├── verifier.py          # BenchVerifier, VerificationStatus
-├── leaderboard.py       # Leaderboard, LeaderboardEntry, Markdown render
+├── leaderboard.py       # Leaderboard, LeaderboardEntry, Markdown render & rotation alert
 ├── reliability.py       # pass^k reliability floor (see reliability.md)
 ├── tool_surface_suite.py# tool-surface risk evaluation suite (tool-surface-v1)
 └── golden_suite.py      # starter golden-v1 task suite
 
 tests/unit/eval/bench/
-├── test_bench.py                   # TDD suite — all acceptance criteria
+├── test_bench.py                   # TDD suite — core acceptance criteria
+├── test_rotation_contamination.py  # Rotation, private holdout, and contamination tests (#5459)
 ├── test_reliability.py             # pass^k reliability floor tests
 └── test_tool_surface_risk_suite.py # tool surface risk suite tests
 

--- a/docs/release-notes/fragments/5459-bench-rotation-holdout.md
+++ b/docs/release-notes/fragments/5459-bench-rotation-holdout.md
@@ -1,0 +1,7 @@
+# Release notes fragment: Bench suite rotation, private holdout, and contamination check (#5459)
+
+### Features
+- **Versioned Manifests & Holdout Binding**: Added `holdout_hash` binding to `BenchSuite` and `SubmissionBundle`, allowing benchmark suites to cryptographically bind private holdout evaluation sets without publishing secret task specifications.
+- **Private Holdout Runner & Isolation**: Introduced `HoldoutBenchRunner` with `HoldoutIsolationError` enforcing local-only execution and preventing public emission of holdout datasets and results by construction.
+- **Contamination Check & Admission Gate**: Added n-gram fingerprinting (`check_solution_contamination`, `admit_task`) to detect and reject benchmark tasks whose reference solutions exist verbatim or with high n-gram overlap in public corpora.
+- **Suite Saturation & Rotation Detection**: Added `check_suite_saturation` and `Leaderboard.check_rotation_due` to track baseline trajectory and trigger rotation alerts when public pass rate exceeds 90% across 3 consecutive baselines.

--- a/src/bernstein/eval/bench/__init__.py
+++ b/src/bernstein/eval/bench/__init__.py
@@ -1,6 +1,12 @@
 """bernstein-bench: runnable, reproducibility-gated evaluation harness."""
 
 from bernstein.eval.bench.bundle import SubmissionBundle, TaskResult
+from bernstein.eval.bench.contamination import (
+    ContaminationVerdict,
+    admit_task,
+    check_solution_contamination,
+    extract_ngrams,
+)
 from bernstein.eval.bench.golden_suite import build_golden_suite_v1
 from bernstein.eval.bench.leaderboard import Leaderboard, LeaderboardEntry
 from bernstein.eval.bench.reliability import (
@@ -20,8 +26,14 @@ from bernstein.eval.bench.reliability import (
     reliability_check,
     validate_run_receipt,
 )
+from bernstein.eval.bench.rotation import (
+    RotationStatus,
+    check_suite_saturation,
+)
 from bernstein.eval.bench.runner import (
     BenchRunner,
+    HoldoutBenchRunner,
+    HoldoutIsolationError,
     MockReplayAdapter,
     ReplayAdapter,
     StochasticMockReplayAdapter,
@@ -44,6 +56,9 @@ __all__ = [
     "BenchTask",
     "BenchVerifier",
     "BundleVerificationResult",
+    "ContaminationVerdict",
+    "HoldoutBenchRunner",
+    "HoldoutIsolationError",
     "InstallIdentityReliabilitySigner",
     "Leaderboard",
     "LeaderboardEntry",
@@ -55,6 +70,7 @@ __all__ = [
     "ReliabilityVerificationStatus",
     "ReliabilityVerifier",
     "ReplayAdapter",
+    "RotationStatus",
     "StochasticMockReplayAdapter",
     "StubReliabilitySigner",
     "SubmissionBundle",
@@ -64,10 +80,14 @@ __all__ = [
     "TaskVerificationResult",
     "ToolSurfaceReplayAdapter",
     "VerificationStatus",
+    "admit_task",
     "build_golden_suite_v1",
     "build_tool_surface_suite",
+    "check_solution_contamination",
+    "check_suite_saturation",
     "coordination_hash",
     "coordination_projection",
+    "extract_ngrams",
     "first_divergent_coordination_field",
     "reliability_check",
     "validate_run_receipt",

--- a/src/bernstein/eval/bench/bundle.py
+++ b/src/bernstein/eval/bench/bundle.py
@@ -107,6 +107,7 @@ class SubmissionBundle:
     signature: str = ""
     # Install identity fingerprint (public-key fingerprint of the signer).
     signer_fingerprint: str = ""
+    holdout_hash: str = ""
 
     # Computed lazily.
     _bundle_hash: str | None = field(default=None, init=False, repr=False, compare=False)
@@ -137,14 +138,17 @@ class SubmissionBundle:
         return self._bundle_hash
 
     def _compute_hash(self) -> str:
+        payload_dict: dict[str, Any] = {
+            "suite_hash": self.suite_hash,
+            "suite_version": self.suite_version,
+            "submitted_at": self.submitted_at,
+            "scheduler_config": self.scheduler_config,
+            "task_results": [r.to_dict() for r in self.task_results],
+        }
+        if self.holdout_hash:
+            payload_dict["holdout_hash"] = self.holdout_hash
         payload = json.dumps(
-            {
-                "suite_hash": self.suite_hash,
-                "suite_version": self.suite_version,
-                "submitted_at": self.submitted_at,
-                "scheduler_config": self.scheduler_config,
-                "task_results": [r.to_dict() for r in self.task_results],
-            },
+            payload_dict,
             sort_keys=True,
             separators=(",", ":"),
         ).encode()
@@ -155,7 +159,7 @@ class SubmissionBundle:
     # ------------------------------------------------------------------
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        d: dict[str, Any] = {
             "bundle_hash": self.bundle_hash(),
             "suite_hash": self.suite_hash,
             "suite_version": self.suite_version,
@@ -167,6 +171,9 @@ class SubmissionBundle:
             "signature": self.signature,
             "signer_fingerprint": self.signer_fingerprint,
         }
+        if self.holdout_hash:
+            d["holdout_hash"] = self.holdout_hash
+        return d
 
     def save(self, path: Path) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -209,6 +216,7 @@ class SubmissionBundle:
             submitted_at=raw["submitted_at"],
             signature=raw.get("signature", ""),
             signer_fingerprint=raw.get("signer_fingerprint", ""),
+            holdout_hash=raw.get("holdout_hash", ""),
         )
         # Integrity guard: recompute hash and compare.
         if bundle.bundle_hash() != raw["bundle_hash"]:

--- a/src/bernstein/eval/bench/contamination.py
+++ b/src/bernstein/eval/bench/contamination.py
@@ -1,0 +1,166 @@
+"""
+bernstein-bench: task admission and contamination detection.
+
+A task whose reference solution exists verbatim in public code hosting
+measures retrieval, not capability.  During task admission, the reference
+solution is fingerprinted (n-gram overlap analysis) against public corpora
+and rejected when found contaminated.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Collection, Sequence
+
+    from bernstein.eval.bench.suite import BenchTask
+
+
+# ---------------------------------------------------------------------------
+# Contamination Verdict
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ContaminationVerdict:
+    """The outcome of an admission-time contamination check."""
+
+    is_contaminated: bool
+    overlap_score: float  # [0.0, 1.0] fraction of n-grams found in public corpus
+    matched_ngrams: tuple[str, ...]
+    threshold: float = 0.8
+    n: int = 5
+    detail: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Fingerprinting & N-Gram Extraction
+# ---------------------------------------------------------------------------
+
+
+_TOKEN_SPLIT_RE = re.compile(r"[^\w]+", re.UNICODE)
+
+
+def _tokenize(text: str) -> list[str]:
+    """Tokenize code or text into normalized lowercase tokens."""
+    tokens = [t.lower() for t in _TOKEN_SPLIT_RE.split(text) if t]
+    return tokens
+
+
+def extract_ngrams(text: str, n: int = 5) -> set[tuple[str, ...]]:
+    """Extract a set of n-grams (as tuples of strings) from *text*."""
+    tokens = _tokenize(text)
+    if not tokens:
+        return set()
+    if len(tokens) < n:
+        # If text is shorter than n, return the entire token sequence as a single gram
+        return {tuple(tokens)}
+    return {tuple(tokens[i : i + n]) for i in range(len(tokens) - n + 1)}
+
+
+# ---------------------------------------------------------------------------
+# Contamination Checking
+# ---------------------------------------------------------------------------
+
+
+def check_solution_contamination(
+    solution_text: str,
+    public_corpus: Collection[str] | Sequence[str],
+    n: int = 5,
+    threshold: float = 0.8,
+) -> ContaminationVerdict:
+    """
+    Check *solution_text* against *public_corpus* using n-gram fingerprinting.
+
+    Returns a :class:`ContaminationVerdict` with the overlap score, matched
+    n-grams, and whether the verdict exceeds *threshold*.
+    """
+    cleaned_solution = solution_text.strip()
+    if not cleaned_solution:
+        return ContaminationVerdict(
+            is_contaminated=False,
+            overlap_score=0.0,
+            matched_ngrams=(),
+            threshold=threshold,
+            n=n,
+            detail="Empty reference solution; no contamination detected.",
+        )
+
+    # Check verbatim inclusion first
+    for doc in public_corpus:
+        doc_clean = doc.strip()
+        if not doc_clean:
+            continue
+        if cleaned_solution == doc_clean or cleaned_solution in doc:
+            return ContaminationVerdict(
+                is_contaminated=True,
+                overlap_score=1.0,
+                matched_ngrams=(cleaned_solution[:80] + ("..." if len(cleaned_solution) > 80 else ""),),
+                threshold=threshold,
+                n=n,
+                detail="Exact verbatim match found in public corpus.",
+            )
+
+    solution_ngrams = extract_ngrams(solution_text, n=n)
+    if not solution_ngrams:
+        return ContaminationVerdict(
+            is_contaminated=False,
+            overlap_score=0.0,
+            matched_ngrams=(),
+            threshold=threshold,
+            n=n,
+            detail="No n-grams extracted from solution.",
+        )
+
+    # Build corpus n-grams
+    corpus_ngrams: set[tuple[str, ...]] = set()
+    for doc in public_corpus:
+        corpus_ngrams.update(extract_ngrams(doc, n=n))
+
+    matched = solution_ngrams.intersection(corpus_ngrams)
+    overlap_score = len(matched) / len(solution_ngrams)
+
+    is_contaminated = overlap_score >= threshold
+    matched_strings = tuple(sorted(" ".join(g) for g in matched))
+
+    detail = (
+        f"Contamination overlap {overlap_score:.2%} >= threshold {threshold:.2%} "
+        f"({len(matched)}/{len(solution_ngrams)} n-grams matched)."
+        if is_contaminated
+        else f"Clean overlap {overlap_score:.2%} < threshold {threshold:.2%}."
+    )
+
+    return ContaminationVerdict(
+        is_contaminated=is_contaminated,
+        overlap_score=overlap_score,
+        matched_ngrams=matched_strings,
+        threshold=threshold,
+        n=n,
+        detail=detail,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task Admission Gate
+# ---------------------------------------------------------------------------
+
+
+def admit_task(
+    task: BenchTask,
+    reference_solution: str,
+    public_corpus: Collection[str] | Sequence[str],
+    n: int = 5,
+    threshold: float = 0.8,
+) -> tuple[bool, ContaminationVerdict]:
+    """
+    Admission gate for a task into a benchmark suite.
+
+    The task's reference solution is checked for contamination. Returns
+    ``(admitted, verdict)``. If admitted is False, the task must be rejected.
+    """
+    verdict = check_solution_contamination(reference_solution, public_corpus, n=n, threshold=threshold)
+    admitted = not verdict.is_contaminated
+    return admitted, verdict

--- a/src/bernstein/eval/bench/leaderboard.py
+++ b/src/bernstein/eval/bench/leaderboard.py
@@ -19,6 +19,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from bernstein.eval.bench.rotation import RotationStatus
+
 # ---------------------------------------------------------------------------
 # Leaderboard entry
 # ---------------------------------------------------------------------------
@@ -123,6 +125,12 @@ class Leaderboard:
             entries=entries,
         )
 
+    def check_rotation_due(self, threshold: float = 0.9, consecutive_required: int = 3) -> RotationStatus:
+        """Check if rotation is due based on saturation of baseline submissions."""
+        from bernstein.eval.bench.rotation import check_suite_saturation
+
+        return check_suite_saturation(self.entries, threshold=threshold, consecutive_required=consecutive_required)
+
     # ------------------------------------------------------------------
     # Markdown rendering
     # ------------------------------------------------------------------
@@ -135,11 +143,23 @@ class Leaderboard:
         ensuring entries were added only after ``BenchVerifier.verify()``
         returned MATCH).
         """
+        rotation_status = self.check_rotation_due()
         lines = [
             "# bernstein-bench leaderboard",
             "",
             "> Every row has passed `bernstein bench verify <bundle>`.  Click the bundle hash to re-verify.",
             "",
+        ]
+
+        if rotation_status.rotation_due:
+            lines += [
+                "> ⚠️ **ROTATION DUE**: Public suite has saturated "
+                "(pass rate exceeded 90% across 3 consecutive baselines). "
+                "Rotate to new task distribution or promote private holdout.",
+                "",
+            ]
+
+        lines += [
             f"Suite version: **{self.suite_version}**  ",
             f"Suite hash: `{self.suite_hash}`",
             "",

--- a/src/bernstein/eval/bench/rotation.py
+++ b/src/bernstein/eval/bench/rotation.py
@@ -1,0 +1,101 @@
+"""
+bernstein-bench: suite saturation tracking and rotation detection.
+
+A fixed public suite saturates over time; after saturation, scores reflect
+overfitting or benchmark-specific tuning rather than general capability.
+When the public-set pass rate exceeds 0.9 across three consecutive baselines,
+rotation is due.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from bernstein.eval.bench.bundle import SubmissionBundle
+    from bernstein.eval.bench.leaderboard import LeaderboardEntry
+
+
+# ---------------------------------------------------------------------------
+# Rotation Status
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RotationStatus:
+    """The saturation and rotation status for a benchmark suite."""
+
+    rotation_due: bool
+    consecutive_count: int
+    threshold: float
+    recent_pass_rates: tuple[float, ...]
+    reason: str
+
+
+# ---------------------------------------------------------------------------
+# Saturation & Rotation Check
+# ---------------------------------------------------------------------------
+
+
+def check_suite_saturation(
+    baselines: Sequence[SubmissionBundle | LeaderboardEntry | Any],
+    threshold: float = 0.9,
+    consecutive_required: int = 3,
+) -> RotationStatus:
+    """
+    Check if a suite has saturated across consecutive baselines.
+
+    When the pass rate exceeds *threshold* across *consecutive_required* (default 3)
+    consecutive baseline submissions, rotation is flagged as due.
+    """
+    if not baselines:
+        return RotationStatus(
+            rotation_due=False,
+            consecutive_count=0,
+            threshold=threshold,
+            recent_pass_rates=(),
+            reason="No baseline runs available to assess saturation.",
+        )
+
+    # Sort baselines by submitted_at ascending to analyze chronological progression
+    sorted_baselines = sorted(baselines, key=lambda b: getattr(b, "submitted_at", 0.0))
+
+    # Extract pass rates
+    pass_rates: list[float] = []
+    for b in sorted_baselines:
+        rate = getattr(b, "pass_rate", getattr(b, "overall_score", 0.0))
+        pass_rates.append(float(rate))
+
+    # Count trailing consecutive baselines that exceed the threshold
+    consecutive_count = 0
+    for rate in reversed(pass_rates):
+        if rate >= threshold:
+            consecutive_count += 1
+        else:
+            break
+
+    recent_slice = tuple(pass_rates[-consecutive_count:]) if consecutive_count > 0 else ()
+    rotation_due = consecutive_count >= consecutive_required
+
+    if rotation_due:
+        reason = (
+            f"Suite saturated: pass rate exceeded {threshold:.0%} across "
+            f"{consecutive_count} consecutive baselines (threshold: {consecutive_required}). "
+            "Suite rotation to new task distribution or holdout promotion is due."
+        )
+    else:
+        reason = (
+            f"Public suite not saturated: {consecutive_count}/{consecutive_required} "
+            f"recent baselines exceed {threshold:.0%} pass rate."
+        )
+
+    return RotationStatus(
+        rotation_due=rotation_due,
+        consecutive_count=consecutive_count,
+        threshold=threshold,
+        recent_pass_rates=recent_slice,
+        reason=reason,
+    )

--- a/src/bernstein/eval/bench/runner.py
+++ b/src/bernstein/eval/bench/runner.py
@@ -19,6 +19,8 @@ from typing import TYPE_CHECKING, Any, Protocol
 from bernstein.eval.bench.bundle import SubmissionBundle, TaskResult
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from bernstein.eval.bench.suite import BenchSuite, BenchTask
 
 # ---------------------------------------------------------------------------
@@ -159,6 +161,10 @@ class StochasticMockReplayAdapter:
 # ---------------------------------------------------------------------------
 
 
+class HoldoutIsolationError(ValueError):
+    """Raised when holdout specifications or results are exposed to a public location."""
+
+
 @dataclass
 class BenchRunner:
     """
@@ -192,7 +198,59 @@ class BenchRunner:
         return SubmissionBundle(
             suite_hash=self.suite.suite_hash,
             suite_version=self.suite.version,
+            holdout_hash=self.suite.holdout_hash,
             task_results=task_results,
             scheduler_config=self.scheduler_config,
             submitted_at=time.time(),
         )
+
+
+@dataclass
+class HoldoutBenchRunner:
+    """
+    Runs a :class:`BenchSuite`'s private holdout set end-to-end.
+
+    The holdout runner must refuse to write results or task specifications
+    anywhere public by construction.
+    """
+
+    suite: BenchSuite
+    adapter: ReplayAdapter
+    scheduler_config: dict[str, Any]
+
+    def run(self) -> SubmissionBundle:
+        """Execute holdout tasks; return the private submission bundle."""
+        if not self.suite.holdout_tasks:
+            raise ValueError("No holdout tasks defined in suite.")
+
+        task_results: list[TaskResult] = []
+        for task in self.suite.holdout_tasks:
+            receipt = self.adapter.run_task(task, self.scheduler_config)
+            passed, score, harness_output = self.adapter.score_task(task, receipt)
+            task_results.append(
+                TaskResult(
+                    task_id=task.id,
+                    task_hash=task.content_hash(),
+                    receipt=receipt,
+                    passed=passed,
+                    score=score,
+                    harness_output=harness_output,
+                )
+            )
+
+        return SubmissionBundle(
+            suite_hash=self.suite.suite_hash,
+            suite_version=self.suite.version,
+            holdout_hash=self.suite.compute_holdout_hash(),
+            task_results=task_results,
+            scheduler_config=self.scheduler_config,
+            submitted_at=time.time(),
+        )
+
+    def save_result(self, bundle: SubmissionBundle, path: Path, is_public: bool = False) -> None:
+        """Save a holdout bundle locally, refusing public export."""
+        if is_public or "public" in str(path).lower():
+            raise HoldoutIsolationError(
+                f"Holdout runner refuses to write holdout results to public location {path!r} by construction."
+            )
+        bundle.save(path)

--- a/src/bernstein/eval/bench/suite.py
+++ b/src/bernstein/eval/bench/suite.py
@@ -64,13 +64,33 @@ class BenchSuite:
 
     ``suite_hash`` is derived from the *ordered* sequence of per-task hashes,
     so adding, removing, or reordering any task changes the suite identity.
+    If private holdout tasks are configured, ``holdout_hash`` is bound to
+    the manifest without publishing the private task specifications.
     """
 
     version: str
     tasks: list[BenchTask] = field(default_factory=list)
+    holdout_hash: str = ""
+    holdout_tasks: list[BenchTask] = field(default_factory=list, repr=False)
 
     # Computed lazily and cached.
     _suite_hash: str | None = field(default=None, init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if not self.holdout_hash and self.holdout_tasks:
+            self.holdout_hash = self.compute_holdout_hash()
+
+    def compute_holdout_hash(self) -> str:
+        """Deterministic SHA-256 of the canonical holdout task hashes."""
+        if not self.holdout_tasks:
+            return self.holdout_hash
+        task_hashes = [t.content_hash() for t in self.holdout_tasks]
+        payload = json.dumps(
+            {"task_hashes": task_hashes},
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+        return hashlib.sha256(payload).hexdigest()
 
     @property
     def suite_hash(self) -> str:
@@ -80,8 +100,12 @@ class BenchSuite:
 
     def _compute_hash(self) -> str:
         task_hashes = [t.content_hash() for t in self.tasks]
+        payload_dict: dict[str, Any] = {"task_hashes": task_hashes, "version": self.version}
+        effective_holdout = self.holdout_hash or (self.compute_holdout_hash() if self.holdout_tasks else "")
+        if effective_holdout:
+            payload_dict["holdout_hash"] = effective_holdout
         payload = json.dumps(
-            {"version": self.version, "task_hashes": task_hashes},
+            payload_dict,
             sort_keys=True,
             separators=(",", ":"),
         ).encode()
@@ -92,7 +116,7 @@ class BenchSuite:
     # ------------------------------------------------------------------
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        d: dict[str, Any] = {
             "version": self.version,
             "suite_hash": self.suite_hash,
             "tasks": [
@@ -107,6 +131,10 @@ class BenchSuite:
                 for t in self.tasks
             ],
         }
+        effective_holdout = self.holdout_hash or (self.compute_holdout_hash() if self.holdout_tasks else "")
+        if effective_holdout:
+            d["holdout_hash"] = effective_holdout
+        return d
 
     def save(self, path: Path) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -128,7 +156,8 @@ class BenchSuite:
             )
             for t in raw["tasks"]
         ]
-        suite = cls(version=raw["version"], tasks=tasks)
+        holdout_hash = raw.get("holdout_hash", "")
+        suite = cls(version=raw["version"], tasks=tasks, holdout_hash=holdout_hash)
         # Integrity check: stored hash must match recomputed hash.
         if suite.suite_hash != raw["suite_hash"]:
             raise ValueError(

--- a/tests/unit/eval/bench/test_bench.py
+++ b/tests/unit/eval/bench/test_bench.py
@@ -510,7 +510,7 @@ class TestDocs:
         docs_path = repo_root / "docs" / "eval" / "bench.md"
         if not docs_path.exists():
             pytest.skip("docs file missing — caught by test_docs_file_exists")
-        content = docs_path.read_text()
+        content = docs_path.read_text(encoding="utf-8")
         assert "bernstein bench run" in content
         assert "bernstein bench verify" in content
 

--- a/tests/unit/eval/bench/test_reliability.py
+++ b/tests/unit/eval/bench/test_reliability.py
@@ -659,7 +659,7 @@ class TestDocs:
         repo_root = Path(__file__).parents[4]
         bench_docs = repo_root / "docs" / "eval" / "bench.md"
         assert bench_docs.exists()
-        assert "reliability" in bench_docs.read_text()
+        assert "reliability" in bench_docs.read_text(encoding="utf-8")
 
 
 # ===========================================================================

--- a/tests/unit/eval/bench/test_rotation_contamination.py
+++ b/tests/unit/eval/bench/test_rotation_contamination.py
@@ -1,0 +1,347 @@
+"""
+TDD tests for bernstein-bench rotation, private holdout, and contamination check (Issue #5459).
+
+Acceptance criteria covered:
+1. Versioned manifests with content hash; bundles carry version and holdout hash.
+2. Private holdout set is never published; its hash is published so results can be pinned;
+   the holdout runner refuses to write results anywhere public by construction.
+3. Task admission gate: reference solution is fingerprinted (n-gram) and rejected when
+   found verbatim/overlapping in public code hosting; verdict is recorded.
+4. Rotation: when the public-set pass rate exceeds 0.9 across three consecutive baselines,
+   rotation is due; saturation is tracked across baselines.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from bernstein.eval.bench.bundle import SubmissionBundle
+from bernstein.eval.bench.contamination import (
+    ContaminationVerdict,
+    admit_task,
+    check_solution_contamination,
+)
+from bernstein.eval.bench.leaderboard import Leaderboard, LeaderboardEntry
+from bernstein.eval.bench.rotation import RotationStatus, check_suite_saturation
+from bernstein.eval.bench.runner import (
+    BenchRunner,
+    HoldoutBenchRunner,
+    HoldoutIsolationError,
+    MockReplayAdapter,
+)
+from bernstein.eval.bench.suite import BenchSuite, BenchTask
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sample_public_tasks() -> list[BenchTask]:
+    return [
+        BenchTask(
+            id="pub_task_1",
+            description="Public Task 1",
+            steps=("step 1",),
+            assertions=({"kind": "file_exists"},),
+            category="io",
+        ),
+        BenchTask(
+            id="pub_task_2",
+            description="Public Task 2",
+            steps=("step 1", "step 2"),
+            assertions=({"kind": "syntax_valid"},),
+            category="refactor",
+        ),
+    ]
+
+
+@pytest.fixture()
+def sample_holdout_tasks() -> list[BenchTask]:
+    return [
+        BenchTask(
+            id="holdout_task_1",
+            description="Private Holdout Task 1",
+            steps=("private step 1",),
+            assertions=({"kind": "secret_verified"},),
+            category="security",
+        ),
+        BenchTask(
+            id="holdout_task_2",
+            description="Private Holdout Task 2",
+            steps=("private step 2",),
+            assertions=({"kind": "tamper_detected"},),
+            category="security",
+        ),
+    ]
+
+
+# ===========================================================================
+# 1. Versioned manifests and holdout hash binding
+# ===========================================================================
+
+
+class TestVersionedManifestsAndHoldoutBinding:
+    """AC-1: Versioned manifests; bundles carry version and holdout hash."""
+
+    def test_suite_with_holdout_computes_deterministic_holdout_hash(
+        self, sample_public_tasks: list[BenchTask], sample_holdout_tasks: list[BenchTask]
+    ) -> None:
+        suite1 = BenchSuite(
+            version="golden-v2",
+            tasks=sample_public_tasks,
+            holdout_tasks=sample_holdout_tasks,
+        )
+        suite2 = BenchSuite(
+            version="golden-v2",
+            tasks=sample_public_tasks,
+            holdout_tasks=sample_holdout_tasks,
+        )
+        assert suite1.holdout_hash != ""
+        assert suite1.holdout_hash == suite2.holdout_hash
+        assert suite1.suite_hash == suite2.suite_hash
+
+    def test_changing_holdout_task_changes_holdout_hash_and_suite_hash(
+        self, sample_public_tasks: list[BenchTask], sample_holdout_tasks: list[BenchTask]
+    ) -> None:
+        suite = BenchSuite(
+            version="golden-v2",
+            tasks=sample_public_tasks,
+            holdout_tasks=sample_holdout_tasks,
+        )
+        mutated_holdout = [
+            sample_holdout_tasks[0],
+            BenchTask(
+                id="holdout_task_2_mod",
+                description="Modified Holdout",
+                steps=("new step",),
+                assertions=(),
+            ),
+        ]
+        suite_mod = BenchSuite(
+            version="golden-v2",
+            tasks=sample_public_tasks,
+            holdout_tasks=mutated_holdout,
+        )
+        assert suite_mod.holdout_hash != suite.holdout_hash
+        assert suite_mod.suite_hash != suite.suite_hash
+
+    def test_suite_manifest_serialisation_never_exposes_holdout_tasks(
+        self, sample_public_tasks: list[BenchTask], sample_holdout_tasks: list[BenchTask]
+    ) -> None:
+        suite = BenchSuite(
+            version="golden-v2",
+            tasks=sample_public_tasks,
+            holdout_tasks=sample_holdout_tasks,
+        )
+        d = suite.to_dict()
+        assert d["holdout_hash"] == suite.holdout_hash
+        assert len(d["tasks"]) == len(sample_public_tasks)
+        # Ensure holdout task IDs or descriptions are NOT serialized to the public manifest dict
+        for task_dict in d["tasks"]:
+            assert "holdout" not in task_dict["id"]
+        assert "holdout_tasks" not in d
+
+    def test_bundle_carries_version_and_holdout_hash(
+        self, sample_public_tasks: list[BenchTask], sample_holdout_tasks: list[BenchTask]
+    ) -> None:
+        suite = BenchSuite(
+            version="golden-v2",
+            tasks=sample_public_tasks,
+            holdout_tasks=sample_holdout_tasks,
+        )
+        adapter = MockReplayAdapter()
+        runner = BenchRunner(suite=suite, adapter=adapter, scheduler_config={"scheduler": "deterministic"})
+        bundle = runner.run()
+
+        assert bundle.suite_version == "golden-v2"
+        assert bundle.holdout_hash == suite.holdout_hash
+
+        # Check serialization round-trip
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "bundle.json"
+            bundle.save(p)
+            loaded = SubmissionBundle.load(p)
+            assert loaded.suite_version == "golden-v2"
+            assert loaded.holdout_hash == suite.holdout_hash
+            assert loaded.bundle_hash() == bundle.bundle_hash()
+
+
+# ===========================================================================
+# 2. Private holdout runner and isolation enforcement
+# ===========================================================================
+
+
+class TestPrivateHoldoutIsolation:
+    """AC-2: Local-only runner path for holdout; refuses public emission by construction."""
+
+    def test_holdout_runner_executes_private_tasks(
+        self, sample_public_tasks: list[BenchTask], sample_holdout_tasks: list[BenchTask]
+    ) -> None:
+        suite = BenchSuite(
+            version="golden-v2",
+            tasks=sample_public_tasks,
+            holdout_tasks=sample_holdout_tasks,
+        )
+        adapter = MockReplayAdapter()
+        runner = HoldoutBenchRunner(suite=suite, adapter=adapter, scheduler_config={})
+        bundle = runner.run()
+
+        assert bundle.suite_version == "golden-v2"
+        assert bundle.holdout_hash == suite.holdout_hash
+        assert len(bundle.task_results) == len(sample_holdout_tasks)
+        task_ids = {r.task_id for r in bundle.task_results}
+        assert task_ids == {"holdout_task_1", "holdout_task_2"}
+
+    def test_holdout_runner_refuses_public_emission_by_construction(
+        self, sample_public_tasks: list[BenchTask], sample_holdout_tasks: list[BenchTask]
+    ) -> None:
+        suite = BenchSuite(
+            version="golden-v2",
+            tasks=sample_public_tasks,
+            holdout_tasks=sample_holdout_tasks,
+        )
+        adapter = MockReplayAdapter()
+        runner = HoldoutBenchRunner(suite=suite, adapter=adapter, scheduler_config={})
+
+        with tempfile.TemporaryDirectory() as tmp:
+            public_path = Path(tmp) / "public_export" / "holdout_bundle.json"
+            # Attempting to export to a public path or with publish=True must raise HoldoutIsolationError
+            with pytest.raises(HoldoutIsolationError, match="refuse.*public"):
+                runner.save_result(runner.run(), public_path, is_public=True)
+
+    def test_holdout_runner_fails_if_no_holdout_tasks(self, sample_public_tasks: list[BenchTask]) -> None:
+        suite = BenchSuite(version="golden-v1", tasks=sample_public_tasks)
+        adapter = MockReplayAdapter()
+        runner = HoldoutBenchRunner(suite=suite, adapter=adapter, scheduler_config={})
+        with pytest.raises(ValueError, match="No holdout tasks"):
+            runner.run()
+
+
+# ===========================================================================
+# 3. Admission gate: Contamination check (n-gram fingerprinting)
+# ===========================================================================
+
+
+class TestContaminationCheckAdmission:
+    """AC-3: Contamination check runs at admission with a recorded verdict."""
+
+    def test_verbatim_public_solution_is_rejected_as_contaminated(self) -> None:
+        public_corpus = [
+            "def solve_problem():\n    return sum(x for x in range(10) if x % 2 == 0)",
+            "import os\ndef read_config(path):\n    with open(path) as f:\n        return f.read()",
+        ]
+
+        solution = "def solve_problem():\n    return sum(x for x in range(10) if x % 2 == 0)"
+        verdict = check_solution_contamination(solution, public_corpus, n=5, threshold=0.8)
+
+        assert isinstance(verdict, ContaminationVerdict)
+        assert verdict.is_contaminated is True
+        assert verdict.overlap_score >= 0.8
+        assert len(verdict.matched_ngrams) > 0
+
+    def test_novel_solution_passes_contamination_check(self) -> None:
+        public_corpus = [
+            "def calculate_tax(income, rate):\n    return income * rate",
+            "class AgentManager:\n    def __init__(self):\n        self.agents = []",
+        ]
+
+        novel_solution = """
+        def deterministic_receipt_validator(journal_bytes, spine_hash, threshold=0.95):
+            computed = hashlib.sha256(journal_bytes + spine_hash.encode()).hexdigest()
+            return computed.startswith("0000") and threshold > 0.5
+        """
+        verdict = check_solution_contamination(novel_solution, public_corpus, n=5, threshold=0.8)
+
+        assert verdict.is_contaminated is False
+        assert verdict.overlap_score < 0.8
+
+    def test_admit_task_records_verdict(self) -> None:
+        task = BenchTask(
+            id="novel_task",
+            description="A brand new task",
+            steps=("run novel step",),
+            assertions=({"kind": "assert_novel"},),
+        )
+        public_corpus = ["def existing_code(): pass"]
+        novel_solution = "def brand_new_unique_algorithm(data):\n    return [d * 42 for d in data]"
+
+        admitted, verdict = admit_task(task, novel_solution, public_corpus, n=5, threshold=0.8)
+        assert admitted is True
+        assert verdict.is_contaminated is False
+
+        # Now test rejected admission
+        contaminated_solution = "def existing_code(): pass"
+        admitted_bad, verdict_bad = admit_task(task, contaminated_solution, public_corpus, n=2, threshold=0.8)
+        assert admitted_bad is False
+        assert verdict_bad.is_contaminated is True
+
+
+# ===========================================================================
+# 4. Rotation tracking and saturation across baselines
+# ===========================================================================
+
+
+class TestRotationAndSaturationTracking:
+    """AC-4: When public-set pass rate exceeds 0.9 across 3 consecutive baselines, rotation is due."""
+
+    def _make_dummy_entry(self, pass_rate: float, ts: float) -> LeaderboardEntry:
+        return LeaderboardEntry(
+            bundle_hash=f"bundle_{ts}",
+            suite_hash="suite_hash_v1",
+            suite_version="golden-v1",
+            overall_score=pass_rate,
+            pass_rate=pass_rate,
+            num_tasks=10,
+            submitted_at=ts,
+        )
+
+    def test_saturation_detected_after_three_consecutive_high_pass_rates(self) -> None:
+        baselines = [
+            self._make_dummy_entry(0.85, 1000.0),
+            self._make_dummy_entry(0.92, 2000.0),
+            self._make_dummy_entry(0.95, 3000.0),
+            self._make_dummy_entry(0.91, 4000.0),
+        ]
+        status = check_suite_saturation(baselines, threshold=0.9, consecutive_required=3)
+
+        assert isinstance(status, RotationStatus)
+        assert status.rotation_due is True
+        assert status.consecutive_count == 3
+        assert status.recent_pass_rates == (0.92, 0.95, 0.91)
+        assert "saturated" in status.reason.lower() or "rotation" in status.reason.lower()
+
+    def test_rotation_not_due_when_pass_rate_drops(self) -> None:
+        baselines = [
+            self._make_dummy_entry(0.95, 1000.0),
+            self._make_dummy_entry(0.95, 2000.0),
+            self._make_dummy_entry(0.88, 3000.0),  # drop below 0.9
+            self._make_dummy_entry(0.95, 4000.0),
+        ]
+        status = check_suite_saturation(baselines, threshold=0.9, consecutive_required=3)
+
+        assert status.rotation_due is False
+        assert status.consecutive_count == 1
+
+    def test_rotation_not_due_with_insufficient_baselines(self) -> None:
+        baselines = [
+            self._make_dummy_entry(0.95, 1000.0),
+            self._make_dummy_entry(0.95, 2000.0),
+        ]
+        status = check_suite_saturation(baselines, threshold=0.9, consecutive_required=3)
+        assert status.rotation_due is False
+        assert status.consecutive_count == 2
+
+    def test_leaderboard_reports_rotation_status(self) -> None:
+        lb = Leaderboard(suite_hash="suite_hash_v1", suite_version="golden-v1")
+        lb.add_entry(self._make_dummy_entry(0.95, 1000.0))
+        lb.add_entry(self._make_dummy_entry(0.95, 2000.0))
+        lb.add_entry(self._make_dummy_entry(0.95, 3000.0))
+
+        status = lb.check_rotation_due(threshold=0.9, consecutive_required=3)
+        assert status.rotation_due is True
+        md = lb.to_markdown()
+        assert "ROTATION DUE" in md or "Rotation" in md

--- a/tests/unit/test_claude_hook_url_uses_run_port.py
+++ b/tests/unit/test_claude_hook_url_uses_run_port.py
@@ -11,6 +11,7 @@ import json
 from pathlib import Path
 
 import pytest
+
 from bernstein.adapters.claude import ClaudeCodeAdapter
 
 

--- a/tests/unit/test_task_server_url_resolution.py
+++ b/tests/unit/test_task_server_url_resolution.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+
 from bernstein.core.agents.spawner_core import _render_auth_section, _resolve_task_server_url
 from bernstein.core.defaults import SDD_SERVER_PORT
 


### PR DESCRIPTION
## Description
Closes #5459.

This PR implements the benchmark suite rotation, private holdout dataset binding, and task admission contamination checking subsystems for `bernstein-bench` (#5447).

### Key Additions & Changes
1. **Versioned Manifests & Holdout Binding**:
   - `BenchSuite` and `SubmissionBundle` bind a cryptographic `holdout_hash` to their content-addressed manifests without publishing private holdout task definitions.
   - Preserves 100% backward compatibility for suites without holdout definitions.
2. **Private Holdout Runner & Isolation**:
   - `HoldoutBenchRunner` executes private holdout evaluation sets locally and enforces by construction that holdout specifications and execution results are never written to public destinations (raising `HoldoutIsolationError`).
3. **Task Admission Gate (N-Gram Fingerprinting)**:
   - Added `check_solution_contamination` and `admit_task` in `src/bernstein/eval/bench/contamination.py` to fingerprint reference solutions using normalized token n-grams and record a `ContaminationVerdict`, rejecting verbatim and overlapping solutions found in public hosting corpora.
4. **Saturation Tracking & Suite Rotation**:
   - Added `check_suite_saturation` in `src/bernstein/eval/bench/rotation.py` and `Leaderboard.check_rotation_due` to monitor baseline trajectories, flagging when rotation is due whenever the public pass rate exceeds 90% across 3 consecutive baseline submissions.
5. **Documentation & Tests**:
   - Updated `docs/eval/bench.md` with rotation procedures, private holdout isolation, and contamination check documentation.
   - Added comprehensive unit test suite `tests/unit/eval/bench/test_rotation_contamination.py` (14/14 passed; 103/103 total bench tests passing).
   - Added release note fragment `docs/release-notes/fragments/5459-bench-rotation-holdout.md`.

### Verification
- `py -3.12 -m pytest tests/unit/eval/bench/ -v` (103 passed)
- `py -3.12 -m ruff check src tests` (All clean)
- UTF-8 BOM verification (0 BOMs)
