### PR TITLE
test(cli): pin the four known receipt groups (#5102)

### DIFF
--- a/tests/unit/test_collapse_duplicate_commands.py
+++ b/tests/unit/test_collapse_duplicate_commands.py
@@ -440,6 +440,46 @@ def _commands_by_body() -> dict[tuple[str, str], list[str]]:
     return grouped
 
 
+# Exact inventory of Click groups named ``receipt`` (#5102). These are four
+# different artefacts under one name -- not duplicates -- so the set is the
+# documentation-of-known-state, and a fifth module declaring ``.group("receipt")``
+# fails this test.
+KNOWN_RECEIPT_GROUPS = frozenset(
+    {
+        "commands/receipt_cmd.py",  # bernstein receipt
+        "commands/audit_cmd.py",  # bernstein audit receipt
+        "commands/sandbox_cmd.py",  # bernstein sandbox receipt
+        "commands/eval_benchmark_cmd.py",  # bernstein benchmark receipt
+    }
+)
+
+
+def _receipt_group_modules() -> set[str]:
+    """Modules under ``cli/`` that declare ``@….group("receipt")``."""
+    root = Path(__file__).resolve().parents[2] / "src" / "bernstein" / "cli"
+    found: set[str] = set()
+    for path in root.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            for decorator in node.decorator_list:
+                if _command_name(decorator) != "receipt":
+                    continue
+                if (
+                    isinstance(decorator, ast.Call)
+                    and isinstance(decorator.func, ast.Attribute)
+                    and decorator.func.attr == "group"
+                ):
+                    found.add(path.relative_to(root).as_posix())
+    return found
+
+
+def test_known_receipt_groups_are_exactly_these_four() -> None:
+    """Documents today's four ``receipt`` groups; fails if a fifth appears."""
+    assert _receipt_group_modules() == KNOWN_RECEIPT_GROUPS
+
+
 def test_no_two_commands_named_verify_share_a_body() -> None:
     """``verify`` is the name most copied, and the one an operator most needs to be single."""
     duplicates = {


### PR DESCRIPTION
## Summary
- Completes slice 1 of #5102: `KNOWN_RECEIPT_GROUPS` + `test_known_receipt_groups_are_exactly_these_four` documents today's four Click `receipt` groups and fails if a fifth `.group(\"receipt\")` appears.
- Body-hash guard for duplicate `verify` (and any-name) command bodies already landed in #5364; this PR only adds the missing inventory. No `src/` changes, no shims (slice 2 deferred per maintainer note — the four verifies are different artefacts).

## Hashing decision
Reuse the existing guard: **docstring-stripped AST body** (not full source text). Comments never appear in the AST; dropping the docstring means reworded help cannot hide a copy, and empty Click group callbacks are skipped.

## Test plan
- [x] `uv run pytest tests/unit/test_collapse_duplicate_commands.py::test_known_receipt_groups_are_exactly_these_four tests/unit/test_collapse_duplicate_commands.py::test_no_two_commands_named_verify_share_a_body tests/unit/test_collapse_duplicate_commands.py::test_no_two_commands_of_any_name_share_a_body -x -q` — 3 passed on current main tree
- [x] Inventory equals the four modules: `receipt_cmd`, `audit_cmd`, `sandbox_cmd`, `eval_benchmark_cmd`
- [ ] CI green on this PR

Closes #5102