### PR TITLE
fix(ci): self-explaining, combined-direction caller-less-module guard failures

### DIFF
--- a/docs/release-notes/fragments/5552-orphan-guard-self-explaining.md
+++ b/docs/release-notes/fragments/5552-orphan-guard-self-explaining.md
@@ -1,0 +1,21 @@
+## Caller-less-module guards report both drift directions in one run, and self-explain when possible
+
+`test_token_orphans.py` and `test_compliance_module_reachability.py` each
+carried a frozen `KNOWN_ORPHANS` snapshot compared against the tree in two
+separate assertions, so a snapshot that drifted in both directions at once
+(some entries newly caller-less, others no longer caller-less) passed the
+first assertion and only failed the second on a later run -- and the failure
+message read identically whether the drift came from the change under
+review or from an unrelated commit that had landed on the default branch
+since the snapshot was captured.
+
+Both guards now share `tests/unit/_orphan_scan.py` and report both
+directions in one message. When the environment makes it possible -- a
+merge-queue run whose `HEAD` is a merge commit with enough history fetched
+to resolve its second parent -- the message additionally states plainly
+when the PR branch's own tree already matched the baseline, so the drift is
+attributable to the default branch rather than to the change under review.
+That signal is unavailable in this repository's current `Test` job (a
+shallow, single-commit checkout), so it does not fire there today; the
+combined single-message improvement applies unconditionally either way.
+No production code changes (#5552).

--- a/tests/unit/_orphan_scan.py
+++ b/tests/unit/_orphan_scan.py
@@ -1,0 +1,207 @@
+"""Shared caller-less-module ratchet: a combined, self-explaining failure (#5552).
+
+``test_token_orphans.py`` and ``test_compliance_module_reachability.py`` each
+carry a frozen ``KNOWN_ORPHANS`` snapshot compared against a freshly computed
+set, in two separate ``assert`` statements. That shape has two independent
+defects, both filed under #5552:
+
+1. **It stops at the first assertion.** A snapshot that has drifted in both
+   directions at once -- some entries newly caller-less, others no longer
+   caller-less -- passes the first ``assert`` and only then fails the
+   second, so a naive refresh that adds the missing names still reds on the
+   very next run. :func:`describe_ratchet_drift` reports both directions in
+   one message.
+2. **The message accuses the wrong side.** The snapshot is a frozen picture
+   of the tree at the moment it was captured; the tree keeps moving after
+   that. When an unrelated commit on the default branch adds or removes a
+   caller between the snapshot and this run, the failure message reads
+   identically to "this change broke something" -- there is nothing in a
+   two-set comparison that can tell the two apart. :func:`resolve_branch_only_ref`
+   and :func:`scan_at_ref` recover the missing signal, when the environment
+   makes it available: a merge-queue run's ``HEAD`` is a merge commit whose
+   second parent is the PR branch's own tip, unmerged with whatever landed
+   on the default branch since. Scanning *that* tree in isolation and
+   comparing it to the baseline is what lets the message say, correctly,
+   "this branch's tree already matched the baseline; look at the default
+   branch instead."
+
+That second signal is best-effort by construction, not a hard dependency.
+The most common CI shape for these guards -- a shallow, single-commit
+checkout on a plain (non-merge-queue) PR-lane run -- has no second parent to
+find, and a shallow clone may not have the object even when one exists. Both
+functions return ``None`` on any such failure rather than raising, and
+``describe_ratchet_drift`` treats ``None`` as "cannot tell", never as
+"the branch is at fault". The combined-message improvement in point 1 above
+holds unconditionally, with or without this signal.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+
+#: Timeout for the git plumbing calls below. Generous for a local operation
+#: that only ever touches this repository's own object store.
+_GIT_TIMEOUT_SECONDS = 30
+#: `git worktree add` clones a working tree, not just reads an object -
+#: proportionally larger repositories or slow disks want more room than a
+#: `rev-parse`.
+_WORKTREE_TIMEOUT_SECONDS = 90
+
+
+def resolve_branch_only_ref(repo_root: Path) -> str | None:
+    """Return HEAD's second parent SHA, or ``None`` when there isn't one.
+
+    A merge-queue run's ``HEAD`` is a merge of the PR branch onto the
+    up-to-date default branch: parent 1 is that default-branch tip, parent 2
+    is the PR branch's own tip, unmerged. A plain PR-lane run's ``HEAD`` has
+    no second parent at all -- it has not been merged with anything yet, so
+    there is nothing to distinguish it from.
+
+    Returns ``None``, never raises, when there is no second parent, when git
+    itself is unavailable, or when the object exists in history but a
+    shallow clone never fetched it. All three read identically to a caller:
+    "this signal is not available right now".
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--verify", "-q", "HEAD^2"],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    sha = result.stdout.strip()
+    return sha or None
+
+
+def scan_at_ref(
+    ref: str,
+    repo_root: Path,
+    scan_fn: Callable[[Path], set[str]],
+) -> set[str] | None:
+    """Run ``scan_fn`` against a disposable worktree checked out at ``ref``.
+
+    ``scan_fn`` receives the worktree's root and returns the computed
+    orphan-name set; it is the guard's own ``_current_orphans``-equivalent,
+    reused unchanged against a different tree.
+
+    Returns ``None`` on any git failure -- ``ref`` unreachable in a shallow
+    clone, ``worktree add`` refused, no space left, and so on -- rather than
+    raising, for the same reason :func:`resolve_branch_only_ref` returns
+    ``None``: an inability to check must never be misread as evidence.
+    """
+    tmp_dir = Path(tempfile.mkdtemp(prefix="bernstein-orphan-scan-"))
+    tmp_dir.rmdir()  # `worktree add` requires the path not to exist yet.
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "worktree",
+                "add",
+                "--detach",
+                "--quiet",
+                str(tmp_dir),
+                ref,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=_WORKTREE_TIMEOUT_SECONDS,
+        )
+        if result.returncode != 0:
+            return None
+        try:
+            return scan_fn(tmp_dir)
+        except OSError:
+            return None
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    finally:
+        subprocess.run(
+            ["git", "-C", str(repo_root), "worktree", "remove", "--force", str(tmp_dir)],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+def describe_ratchet_drift(
+    *,
+    baseline: frozenset[str],
+    current: set[str],
+    branch_only: set[str] | None,
+    guard_name: str,
+    wire_hint: str,
+) -> str | None:
+    """Return one combined failure message covering both drift directions.
+
+    Returns ``None`` when ``current == baseline`` -- nothing to report.
+    Otherwise the message names every entry that appeared and every entry
+    that disappeared, in the same message, so fixing one direction cannot
+    hide the other until a later run.
+
+    When ``branch_only`` is available (see :func:`resolve_branch_only_ref` /
+    :func:`scan_at_ref`) and it matches ``baseline`` exactly while ``current``
+    does not, the message states that this branch's own tree is clean and
+    names the default branch as the source of the drift instead. When
+    ``branch_only`` is available and itself differs from ``baseline``, the
+    entries it newly introduces are named as this branch's own doing.
+    ``branch_only is None`` adds no such claim either way -- the base
+    message from the first paragraph is everything that can be said.
+
+    Args:
+        baseline: The frozen, committed set of known caller-less names.
+        current: The set computed against the tree this test is running on
+            (the merge result in a merge-queue run, the branch tree itself
+            in a plain PR-lane run).
+        branch_only: The set computed against the PR branch's own tip in
+            isolation, or ``None`` when that signal could not be obtained.
+        guard_name: Short label identifying which guard is reporting,
+            e.g. ``"core/tokens/"``.
+        wire_hint: One sentence telling the reader what to do about a newly
+            caller-less module -- wire it to a real consumer, or delete it.
+    """
+    baseline_set: set[str] = set(baseline)
+    if current == baseline_set:
+        return None
+
+    appeared = sorted(current - baseline_set)
+    disappeared = sorted(baseline_set - current)
+
+    lines = [f"{guard_name}: the caller-less-module baseline no longer matches the tree."]
+    if appeared:
+        lines.append(f"  new caller-less modules: {appeared}. {wire_hint}")
+    if disappeared:
+        lines.append(
+            f"  no longer caller-less (or gone from the tree): {disappeared}. Strike these "
+            "from the known-orphans set so it keeps shrinking."
+        )
+
+    if branch_only is not None:
+        if branch_only == baseline_set:
+            lines.append(
+                "  This branch's own tree matches the baseline exactly -- the drift above "
+                "comes from commits that landed on the default branch after the baseline was "
+                "captured, not from this change. Re-take the baseline; do not look for what "
+                "this branch broke."
+            )
+        else:
+            branch_appeared = sorted(branch_only - baseline_set)
+            branch_disappeared = sorted(baseline_set - branch_only)
+            if branch_appeared or branch_disappeared:
+                lines.append(
+                    "  This branch's own tree already differs from the baseline "
+                    f"(new: {branch_appeared}, resolved: {branch_disappeared}) -- at least "
+                    "part of the drift above belongs to this change."
+                )
+
+    return "\n".join(lines)

--- a/tests/unit/test_compliance_module_reachability.py
+++ b/tests/unit/test_compliance_module_reachability.py
@@ -35,6 +35,7 @@ from functools import lru_cache
 from pathlib import Path
 
 from bernstein.core import _REDIRECT_MAP
+from tests.unit._orphan_scan import describe_ratchet_drift, resolve_branch_only_ref, scan_at_ref
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SRC = REPO_ROOT / "src" / "bernstein"
@@ -81,17 +82,42 @@ EXCLUDED_FROM_SCAN = {SRC / "core" / "__init__.py"}
 KNOWN_ORPHANS = frozenset({"hipaa", "soc2_report", "compliance_report"})
 
 
-def _scanned_files() -> list[Path]:
-    return [p for p in SRC.rglob("*.py") if p not in EXCLUDED_FROM_SCAN]
+def _src_under(root: Path) -> Path:
+    return root / "src" / "bernstein"
 
 
-@lru_cache(maxsize=1)
-def _import_index() -> tuple[dict[str, list[Path]], dict[tuple[str, str], list[Path]]]:
-    """One AST pass over ``src`` instead of one per candidate module."""
+def _candidates_under(root: Path) -> dict[str, tuple[Path, str]]:
+    """Re-root :data:`CANDIDATES`' file paths under an alternate checkout.
+
+    Each candidate's path is relative to :data:`SRC` in the same way
+    regardless of which worktree it lives in, so re-rooting is a matter of
+    swapping the prefix.
+    """
+    src = _src_under(root)
+    return {label: (src / path.relative_to(SRC), canonical) for label, (path, canonical) in CANDIDATES.items()}
+
+
+def _excluded_from_scan_under(root: Path) -> set[Path]:
+    return {_src_under(root) / "core" / "__init__.py"}
+
+
+def _scanned_files(root: Path) -> list[Path]:
+    excluded = _excluded_from_scan_under(root)
+    return [p for p in _src_under(root).rglob("*.py") if p not in excluded]
+
+
+@lru_cache(maxsize=8)
+def _import_index(root: Path) -> tuple[dict[str, list[Path]], dict[tuple[str, str], list[Path]]]:
+    """One AST pass over ``src`` instead of one per candidate module.
+
+    Cached per ``root`` (see ``test_token_orphans.py``'s identical choice)
+    so scanning an alternate worktree for #5552's branch-only comparison
+    does not evict or collide with the result for ``REPO_ROOT``.
+    """
     dotted: dict[str, list[Path]] = {}
     from_package: dict[tuple[str, str], list[Path]] = {}
 
-    for path in _scanned_files():
+    for path in _scanned_files(root):
         try:
             tree = ast.parse(path.read_text(encoding="utf-8"))
         except (SyntaxError, UnicodeDecodeError):
@@ -119,13 +145,14 @@ def _import_targets(label: str) -> set[str]:
     return targets
 
 
-def _importers_of(label: str) -> set[Path]:
+def _importers_of(label: str, root: Path = REPO_ROOT) -> set[Path]:
     """Every file that imports `label`, by any of its resolvable dotted paths."""
-    own_file, _ = CANDIDATES[label]
+    candidates = _candidates_under(root)
+    own_file, _ = candidates[label]
     targets = _import_targets(label)
     packages = {t.rsplit(".", 1)[0] for t in targets}
     module_name = own_file.stem
-    dotted, from_package = _import_index()
+    dotted, from_package = _import_index(root)
 
     found: set[Path] = set()
     for target in targets:
@@ -135,7 +162,10 @@ def _importers_of(label: str) -> set[Path]:
     return found
 
 
-def reachable_labels(importers: dict[str, set[Path]]) -> set[str]:
+def reachable_labels(
+    importers: dict[str, set[Path]],
+    candidates: dict[str, tuple[Path, str]] = CANDIDATES,
+) -> set[str]:
     """Candidates reachable from a caller outside the candidate set itself.
 
     Having an importer is not the same as being reachable: two dead modules
@@ -143,12 +173,12 @@ def reachable_labels(importers: dict[str, set[Path]]) -> set[str]:
     imports it" reports both as live. Seed from callers whose file is not
     itself one of the candidates, then close over intra-candidate edges.
     """
-    candidate_files = {path for path, _ in CANDIDATES.values()}
+    candidate_files = {path for path, _ in candidates.values()}
     reachable = {label for label, paths in importers.items() if any(p not in candidate_files for p in paths)}
     grew = True
     while grew:
         grew = False
-        file_to_label = {path: label for label, (path, _) in CANDIDATES.items()}
+        file_to_label = {path: label for label, (path, _) in candidates.items()}
         for label, paths in importers.items():
             if label in reachable:
                 continue
@@ -158,35 +188,40 @@ def reachable_labels(importers: dict[str, set[Path]]) -> set[str]:
     return reachable
 
 
-def _current_orphans() -> set[str]:
-    importers = {label: _importers_of(label) for label in CANDIDATES}
-    return set(importers) - reachable_labels(importers)
+def _current_orphans(root: Path = REPO_ROOT) -> set[str]:
+    candidates = _candidates_under(root)
+    importers = {label: _importers_of(label, root) for label in candidates}
+    return set(importers) - reachable_labels(importers, candidates=candidates)
 
 
 def test_every_compliance_module_has_a_non_test_importer() -> None:
-    """The set of caller-less compliance modules may shrink, never grow.
+    """The set of caller-less compliance modules may shrink, never grow (#5552).
 
     Load-bearing: on an unmodified tree this fails without the allowlist,
     because three compliance modules had zero non-test importers when the
     guard landed (``compliance_library`` was the fourth until the adapter
-    checks started importing it). With ``KNOWN_ORPHANS`` in place
-    the assertion passes today, documenting the gap instead of hiding it,
-    and fails again the moment a fifth compliance module goes dark.
+    checks started importing it). With ``KNOWN_ORPHANS`` in place the
+    assertion passes today, documenting the gap instead of hiding it, and
+    fails again the moment a fifth compliance module goes dark.
+
+    Reports both drift directions in one message, and -- when the branch's
+    own pre-merge tip is resolvable -- states plainly when the drift belongs
+    to the default branch rather than to this change.
     """
     current = _current_orphans()
 
-    appeared = sorted(current - KNOWN_ORPHANS)
-    assert not appeared, (
-        f"new caller-less compliance modules: {appeared}. Wire each one to a consumer "
-        "that exists today, or delete the module together with its tests and its "
-        "bernstein/core/__init__.py alias entry."
-    )
+    branch_ref = resolve_branch_only_ref(REPO_ROOT)
+    branch_only = scan_at_ref(branch_ref, REPO_ROOT, _current_orphans) if branch_ref else None
 
-    removed = sorted(KNOWN_ORPHANS - current)
-    assert not removed, (
-        f"{removed} now has a caller or is gone from the tree; strike it from "
-        "KNOWN_ORPHANS so the list keeps shrinking."
+    message = describe_ratchet_drift(
+        baseline=KNOWN_ORPHANS,
+        current=current,
+        branch_only=branch_only,
+        guard_name="compliance modules",
+        wire_hint="Wire it to a consumer that exists today, or delete the module together "
+        "with its tests and its bernstein/core/__init__.py alias entry.",
     )
+    assert message is None, message
 
 
 def test_a_wired_module_is_seen_through_its_legacy_alias() -> None:

--- a/tests/unit/test_compliance_module_reachability.py
+++ b/tests/unit/test_compliance_module_reachability.py
@@ -35,7 +35,6 @@ from functools import lru_cache
 from pathlib import Path
 
 from bernstein.core import _REDIRECT_MAP
-from tests.unit._orphan_scan import describe_ratchet_drift, resolve_branch_only_ref, scan_at_ref
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SRC = REPO_ROOT / "src" / "bernstein"
@@ -207,7 +206,14 @@ def test_every_compliance_module_has_a_non_test_importer() -> None:
     Reports both drift directions in one message, and -- when the branch's
     own pre-merge tip is resolvable -- states plainly when the drift belongs
     to the default branch rather than to this change.
+
+    The ``_orphan_scan`` import is deferred to inside this function -- see
+    the matching note in ``test_token_orphans.py::test_no_new_orphan_token_modules``
+    for why a module-level cross-file import breaks
+    ``scripts/check_test_count_drop.py``'s isolated collect-only check.
     """
+    from tests.unit._orphan_scan import describe_ratchet_drift, resolve_branch_only_ref, scan_at_ref
+
     current = _current_orphans()
 
     branch_ref = resolve_branch_only_ref(REPO_ROOT)

--- a/tests/unit/test_orphan_scan_helper.py
+++ b/tests/unit/test_orphan_scan_helper.py
@@ -1,0 +1,256 @@
+"""Tests for the shared caller-less-module ratchet helper (#5552).
+
+Two layers, tested separately:
+
+* :func:`describe_ratchet_drift` is a pure function over three sets --
+  tested with synthetic input, no git involved. This is the message-shape
+  contract every guard using the helper gets for free.
+* :func:`resolve_branch_only_ref` / :func:`scan_at_ref` are real git
+  plumbing. Mocking ``subprocess.run`` here would only prove the mock is
+  wired correctly, not that the plumbing actually recovers the right tree,
+  so these are exercised against a real, small git repository built in
+  ``tmp_path`` with a real merge commit -- literally constructing the
+  situation the issue asks for, rather than reasoning about what git ought
+  to do.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.unit._orphan_scan import (
+    describe_ratchet_drift,
+    resolve_branch_only_ref,
+    scan_at_ref,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# describe_ratchet_drift: pure, synthetic
+# ---------------------------------------------------------------------------
+
+
+def test_no_message_when_current_matches_baseline() -> None:
+    assert (
+        describe_ratchet_drift(
+            baseline=frozenset({"a", "b"}),
+            current={"a", "b"},
+            branch_only=None,
+            guard_name="pkg/",
+            wire_hint="wire it.",
+        )
+        is None
+    )
+
+
+def test_both_directions_reported_in_one_message() -> None:
+    """The defect this helper exists to fix: a naive two-assert guard only
+    ever shows one direction per run. One call must show both.
+    """
+    message = describe_ratchet_drift(
+        baseline=frozenset({"a", "b"}),
+        current={"a", "c"},  # b resolved, c newly appeared
+        branch_only=None,
+        guard_name="pkg/",
+        wire_hint="wire it.",
+    )
+    assert message is not None
+    assert "['c']" in message
+    assert "['b']" in message
+
+
+def test_branch_only_matching_baseline_names_the_default_branch() -> None:
+    """AC1: a stale baseline states plainly that the branch is not at fault.
+
+    Constructed directly: the branch's own tree is byte-for-byte what the
+    baseline expects; only ``current`` (the merge result) has drifted, so
+    the drift cannot have come from this branch's own commits.
+    """
+    message = describe_ratchet_drift(
+        baseline=frozenset({"a", "b"}),
+        current={"a", "b", "c"},
+        branch_only={"a", "b"},
+        guard_name="pkg/",
+        wire_hint="wire it.",
+    )
+    assert message is not None
+    assert "not from this change" in message
+    assert "['c']" in message
+
+
+def test_branch_only_diverging_from_baseline_names_the_branch() -> None:
+    """AC3: a genuinely new entry introduced *by the branch* still fails,
+    with a message distinct from the self-exculpating one above.
+    """
+    message = describe_ratchet_drift(
+        baseline=frozenset({"a", "b"}),
+        current={"a", "b", "c"},
+        branch_only={"a", "b", "c"},
+        guard_name="pkg/",
+        wire_hint="wire it.",
+    )
+    assert message is not None
+    assert "not from this change" not in message
+    assert "belongs to this change" in message
+    assert "['c']" in message
+
+
+def test_missing_branch_signal_adds_no_attribution_claim() -> None:
+    """``branch_only=None`` is "cannot tell", not "the branch did it"."""
+    message = describe_ratchet_drift(
+        baseline=frozenset({"a"}),
+        current={"a", "b"},
+        branch_only=None,
+        guard_name="pkg/",
+        wire_hint="wire it.",
+    )
+    assert message is not None
+    assert "not from this change" not in message
+    assert "belongs to this change" not in message
+
+
+# ---------------------------------------------------------------------------
+# resolve_branch_only_ref / scan_at_ref: real git, real merge commit
+# ---------------------------------------------------------------------------
+
+
+def _run_git(args: list[str], cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+@pytest.fixture
+def merged_repo(tmp_path: Path) -> Path:
+    """Build a tiny repo whose ``HEAD`` is a real two-parent merge commit.
+
+    History:
+
+    1. ``main`` commit A: ``caller.py`` imports ``mod`` -- ``mod`` has a
+       caller.
+    2. A feature branch forks from A and adds an unrelated file. It never
+       touches ``caller.py`` or ``mod``, so its own tree still matches A's
+       reachability picture exactly.
+    3. ``main`` commit B (after the fork) deletes ``caller.py`` -- ``mod``
+       loses its only caller, entirely independent of the feature branch.
+    4. ``main`` (at commit B) merges the feature branch in -- mirroring how
+       a merge queue merges the PR branch into the up-to-date target branch
+       -- producing a merge commit whose parent 2 is the feature branch's
+       own pre-merge tip.
+
+    ``HEAD`` afterwards models exactly the merge-queue scenario in #5552:
+    the merge result shows ``mod`` as newly caller-less, but the feature
+    branch's own tree (parent 2) does not.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run_git(["init", "-q", "-b", "main"], repo)
+    _run_git(["config", "user.email", "test@example.invalid"], repo)
+    _run_git(["config", "user.name", "Test"], repo)
+
+    (repo / "caller.py").write_text("import mod\n", encoding="utf-8")
+    (repo / "mod.py").write_text("X = 1\n", encoding="utf-8")
+    _run_git(["add", "."], repo)
+    _run_git(["commit", "-q", "-m", "A: mod has a caller"], repo)
+
+    _run_git(["checkout", "-q", "-b", "feature"], repo)
+    (repo / "unrelated.py").write_text("Y = 2\n", encoding="utf-8")
+    _run_git(["add", "unrelated.py"], repo)
+    _run_git(["commit", "-q", "-m", "feature: unrelated addition"], repo)
+    feature_tip = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+    _run_git(["checkout", "-q", "main"], repo)
+    (repo / "caller.py").unlink()
+    _run_git(["add", "-A"], repo)
+    _run_git(["commit", "-q", "-m", "B: unrelated drift removes mod's caller"], repo)
+
+    # A merge queue merges the *PR branch* into the up-to-date target branch
+    # (conceptually `git checkout main && git merge feature`), not the other
+    # way around. Git's first-parent slot is always the branch checked out
+    # before the merge, so that ordering -- not "feature merges main" -- is
+    # what makes ``HEAD^2`` resolve to the PR branch's own tip below.
+    _run_git(["checkout", "-q", "main"], repo)
+    _run_git(["merge", "-q", "--no-ff", "-m", "merge feature into main", "feature"], repo)
+
+    merge_head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+    parents = subprocess.run(
+        ["git", "rev-parse", "HEAD^1", "HEAD^2"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.split()
+    assert merge_head not in (feature_tip,)
+    assert parents[1] == feature_tip, "HEAD^2 must be the feature branch's own pre-merge tip"
+
+    return repo
+
+
+def test_resolve_branch_only_ref_finds_the_second_parent(merged_repo: Path) -> None:
+    branch_ref = resolve_branch_only_ref(merged_repo)
+    assert branch_ref is not None
+
+    expected = subprocess.run(
+        ["git", "rev-parse", "HEAD^2"], cwd=merged_repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+    assert branch_ref == expected
+
+
+def test_resolve_branch_only_ref_returns_none_without_a_merge(tmp_path: Path) -> None:
+    """A plain, non-merge commit has no second parent to find."""
+    repo = tmp_path / "plain"
+    repo.mkdir()
+    _run_git(["init", "-q", "-b", "main"], repo)
+    _run_git(["config", "user.email", "test@example.invalid"], repo)
+    _run_git(["config", "user.name", "Test"], repo)
+    (repo / "f.py").write_text("Z = 1\n", encoding="utf-8")
+    _run_git(["add", "."], repo)
+    _run_git(["commit", "-q", "-m", "one commit, no merge"], repo)
+
+    assert resolve_branch_only_ref(repo) is None
+
+
+def test_scan_at_ref_sees_the_branch_only_tree_not_the_merge_result(merged_repo: Path) -> None:
+    """The load-bearing case: scanning the second parent recovers the
+    pre-merge tree, where ``caller.py`` (and therefore ``mod``'s only
+    caller) is still present -- even though it is gone at ``HEAD``.
+    """
+    branch_ref = resolve_branch_only_ref(merged_repo)
+    assert branch_ref is not None
+
+    def scan_for_orphans(root: Path) -> set[str]:
+        return set() if (root / "caller.py").is_file() else {"mod"}
+
+    at_head = scan_for_orphans(merged_repo)
+    assert at_head == {"mod"}, "the merge result must show mod as orphaned"
+
+    at_branch = scan_at_ref(branch_ref, merged_repo, scan_for_orphans)
+    assert at_branch == set(), "the feature branch's own tree never lost mod's caller"
+
+
+def test_scan_at_ref_returns_none_for_an_unresolvable_ref(tmp_path: Path) -> None:
+    repo = tmp_path / "empty"
+    repo.mkdir()
+    _run_git(["init", "-q", "-b", "main"], repo)
+    assert scan_at_ref("0" * 40, repo, lambda _root: set()) is None
+
+
+def test_scan_at_ref_leaves_no_worktree_behind(merged_repo: Path) -> None:
+    """Cleanup runs even on the success path -- a leaked worktree would
+    accumulate across every CI run that hits this code.
+    """
+    branch_ref = resolve_branch_only_ref(merged_repo)
+    assert branch_ref is not None
+    scan_at_ref(branch_ref, merged_repo, lambda _root: set())
+
+    worktrees = subprocess.run(
+        ["git", "worktree", "list", "--porcelain"],
+        cwd=merged_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert worktrees.count("worktree ") == 1, "only the main worktree should remain"

--- a/tests/unit/test_token_orphans.py
+++ b/tests/unit/test_token_orphans.py
@@ -22,6 +22,7 @@ from functools import lru_cache
 from pathlib import Path
 
 from bernstein.core import _REDIRECT_MAP
+from tests.unit._orphan_scan import describe_ratchet_drift, resolve_branch_only_ref, scan_at_ref
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TOKENS_DIR = REPO_ROOT / "src" / "bernstein" / "core" / "tokens"
@@ -48,8 +49,12 @@ KNOWN_ORPHANS = frozenset(
 )
 
 
-def _module_names() -> list[str]:
-    return sorted(p.stem for p in TOKENS_DIR.glob("*.py") if p.name != "__init__.py")
+def _tokens_dir_under(root: Path) -> Path:
+    return root / "src" / "bernstein" / "core" / "tokens"
+
+
+def _module_names(root: Path = REPO_ROOT) -> list[str]:
+    return sorted(p.stem for p in _tokens_dir_under(root).glob("*.py") if p.name != "__init__.py")
 
 
 def _import_targets(module: str) -> set[str]:
@@ -62,21 +67,29 @@ def _import_targets(module: str) -> set[str]:
     return targets
 
 
-def _scanned_files() -> list[Path]:
-    return [p for p in (REPO_ROOT / "src").rglob("*.py") if p not in EXCLUDED_FROM_SCAN]
+def _excluded_from_scan_under(root: Path) -> set[Path]:
+    return {root / "src" / "bernstein" / "core" / "__init__.py"}
 
 
-@lru_cache(maxsize=1)
-def _import_index() -> tuple[dict[str, list[Path]], dict[tuple[str, str], list[Path]]]:
+def _scanned_files(root: Path) -> list[Path]:
+    excluded = _excluded_from_scan_under(root)
+    return [p for p in (root / "src").rglob("*.py") if p not in excluded]
+
+
+@lru_cache(maxsize=8)
+def _import_index(root: Path) -> tuple[dict[str, list[Path]], dict[tuple[str, str], list[Path]]]:
     """One AST pass over ``src`` instead of one per module.
 
-    Rebuilt per test session; the naive shape re-parsed the whole tree for
-    each of the 30-odd modules and cost over a minute of CI wall time.
+    Cached per ``root`` (rather than a bare no-argument cache) so scanning an
+    alternate worktree for #5552's branch-only comparison does not evict or
+    collide with the result for ``REPO_ROOT``. Rebuilt once per session per
+    root; the naive shape re-parsed the whole tree for each of the 30-odd
+    modules and cost over a minute of CI wall time.
     """
     dotted: dict[str, list[Path]] = {}
     from_package: dict[tuple[str, str], list[Path]] = {}
 
-    for path in _scanned_files():
+    for path in _scanned_files(root):
         try:
             tree = ast.parse(path.read_text(encoding="utf-8"))
         except (SyntaxError, UnicodeDecodeError):
@@ -94,11 +107,11 @@ def _import_index() -> tuple[dict[str, list[Path]], dict[tuple[str, str], list[P
     return dotted, from_package
 
 
-def _importer_of(module: str) -> Path | None:
+def _importer_of(module: str, root: Path = REPO_ROOT) -> Path | None:
     targets = _import_targets(module)
     packages = {t.rsplit(".", 1)[0] for t in targets}
-    own_file = TOKENS_DIR / f"{module}.py"
-    dotted, from_package = _import_index()
+    own_file = _tokens_dir_under(root) / f"{module}.py"
+    dotted, from_package = _import_index(root)
 
     for target in targets:
         for path in dotted.get(target, ()):
@@ -111,12 +124,12 @@ def _importer_of(module: str) -> Path | None:
     return None
 
 
-def _importers_of(module: str) -> set[Path]:
+def _importers_of(module: str, root: Path = REPO_ROOT) -> set[Path]:
     """Every file that imports `module`, by any of its resolvable paths."""
     targets = _import_targets(module)
     packages = {t.rsplit(".", 1)[0] for t in targets}
-    own_file = TOKENS_DIR / f"{module}.py"
-    dotted, from_package = _import_index()
+    own_file = _tokens_dir_under(root) / f"{module}.py"
+    dotted, from_package = _import_index(root)
 
     found: set[Path] = set()
     for target in targets:
@@ -126,7 +139,7 @@ def _importers_of(module: str) -> set[Path]:
     return found
 
 
-def reachable_modules(importers: dict[str, set[Path]]) -> set[str]:
+def reachable_modules(importers: dict[str, set[Path]], tokens_dir: Path = TOKENS_DIR) -> set[str]:
     """Modules reachable from a caller outside ``core/tokens/``.
 
     Having an importer is not the same as being reachable: two dead modules
@@ -134,40 +147,46 @@ def reachable_modules(importers: dict[str, set[Path]]) -> set[str]:
     imports it" reports both as live. Seed from callers outside the package
     and close over intra-package edges instead.
     """
-    reachable = {name for name, paths in importers.items() if any(TOKENS_DIR not in path.parents for path in paths)}
+    reachable = {name for name, paths in importers.items() if any(tokens_dir not in path.parents for path in paths)}
     grew = True
     while grew:
         grew = False
         for name, paths in importers.items():
             if name in reachable:
                 continue
-            if any(p.parent == TOKENS_DIR and p.stem in reachable for p in paths):
+            if any(p.parent == tokens_dir and p.stem in reachable for p in paths):
                 reachable.add(name)
                 grew = True
     return reachable
 
 
-def _current_orphans() -> set[str]:
-    importers = {name: _importers_of(name) for name in _module_names()}
-    return set(importers) - reachable_modules(importers)
+def _current_orphans(root: Path = REPO_ROOT) -> set[str]:
+    importers = {name: _importers_of(name, root) for name in _module_names(root)}
+    return set(importers) - reachable_modules(importers, tokens_dir=_tokens_dir_under(root))
 
 
 def test_no_new_orphan_token_modules() -> None:
-    """The set of caller-less modules may shrink, never grow."""
+    """The set of caller-less modules may shrink, never grow (#5552).
+
+    Reports both drift directions in one message, and -- when the branch's
+    own pre-merge tip is resolvable (see ``_orphan_scan.py``) -- states
+    plainly when the drift belongs to the default branch rather than to
+    this change.
+    """
     current = _current_orphans()
 
-    appeared = sorted(current - KNOWN_ORPHANS)
-    assert not appeared, (
-        f"new caller-less modules under core/tokens/: {appeared}. Wire each one to a "
-        "consumer that exists today, or delete the module together with its tests and "
-        "its bernstein/core/__init__.py alias entry."
-    )
+    branch_ref = resolve_branch_only_ref(REPO_ROOT)
+    branch_only = scan_at_ref(branch_ref, REPO_ROOT, _current_orphans) if branch_ref else None
 
-    removed = sorted(KNOWN_ORPHANS - current)
-    assert not removed, (
-        f"{removed} now has a caller or is gone from the tree; strike it from "
-        "KNOWN_ORPHANS so the list keeps shrinking."
+    message = describe_ratchet_drift(
+        baseline=KNOWN_ORPHANS,
+        current=current,
+        branch_only=branch_only,
+        guard_name="core/tokens/",
+        wire_hint="Wire it to a consumer that exists today, or delete the module together "
+        "with its tests and its bernstein/core/__init__.py alias entry.",
     )
+    assert message is None, message
 
 
 def test_a_wired_module_is_seen_through_its_legacy_alias() -> None:

--- a/tests/unit/test_token_orphans.py
+++ b/tests/unit/test_token_orphans.py
@@ -22,7 +22,6 @@ from functools import lru_cache
 from pathlib import Path
 
 from bernstein.core import _REDIRECT_MAP
-from tests.unit._orphan_scan import describe_ratchet_drift, resolve_branch_only_ref, scan_at_ref
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TOKENS_DIR = REPO_ROOT / "src" / "bernstein" / "core" / "tokens"
@@ -172,7 +171,18 @@ def test_no_new_orphan_token_modules() -> None:
     own pre-merge tip is resolvable (see ``_orphan_scan.py``) -- states
     plainly when the drift belongs to the default branch rather than to
     this change.
+
+    The ``_orphan_scan`` import is deferred to inside this function rather
+    than sitting at module level: ``scripts/check_test_count_drop.py``
+    collects a touched test module in isolation, as a lone file with no
+    sibling ``tests/unit/`` package around it, so a module-level cross-file
+    import would fail under ``--collect-only`` even though it resolves fine
+    in the real tree -- reported as a false "test count dropped to zero"
+    rather than the import-path artefact it actually is. A local import runs
+    only when the test executes, which collection never does.
     """
+    from tests.unit._orphan_scan import describe_ratchet_drift, resolve_branch_only_ref, scan_at_ref
+
     current = _current_orphans()
 
     branch_ref = resolve_branch_only_ref(REPO_ROOT)


### PR DESCRIPTION
## Summary

`test_token_orphans.py` and `test_compliance_module_reachability.py` each carry a frozen `KNOWN_ORPHANS` snapshot compared against a freshly computed set of caller-less modules, in two separate `assert` statements. That shape has two independent defects, both named in the issue:

1. **It stops at the first assertion.** A snapshot that drifted in both directions at once (some entries newly caller-less, others no longer caller-less) passes the first `assert` and only fails the second on a *later* run — a naive refresh that adds the missing names still reds on the next CI pass.
2. **The message accuses the wrong side.** The snapshot is a picture of the tree at the moment it was captured, and the tree keeps moving after that. When an unrelated commit on the default branch shifts a module's caller status between the snapshot and this run, the failure message reads identically to "this change broke something" — a plain two-set comparison has no way to distinguish the two. This is exactly the incident measured in the issue: on `#5234`, the branch touched none of the nine drifted modules, but the message named them as if it had.

## What this adds

`tests/unit/_orphan_scan.py`, shared by both guards:

- `describe_ratchet_drift()` — reports both drift directions in **one** message, so fixing one direction cannot hide the other until a later run.
- `resolve_branch_only_ref()` / `scan_at_ref()` — when the environment makes it possible, resolve the PR branch's own pre-merge tip (a merge-queue run's `HEAD` is a merge commit whose second parent is exactly that tip) and re-scan a disposable `git worktree` at that ref. When the branch's own tree already matches the baseline, `describe_ratchet_drift()` states plainly that the drift belongs to the default branch, not to this change.

**Honesty about when the second signal actually fires**: I checked this repository's own `Test` job (`.github/workflows/ci.yml`) — its checkout has no `fetch-depth: 0` override, so it's a shallow, single-commit clone. `resolve_branch_only_ref()` returns `None` there (no parent history to resolve), and `describe_ratchet_drift()` treats `None` as "cannot tell", never as "the branch is at fault" — so the self-attribution clause simply won't appear in this job as CI is configured today. The combined-single-message fix (point 1 above) is unconditional and lands regardless. I did not touch the CI workflow to add `fetch-depth: 0` for the `Test` job — that's a real tradeoff (checkout time vs. this signal) affecting every shard on every run, not a call I should make inside this PR.

`tests/unit/test_orphan_scan_helper.py`:
- `describe_ratchet_drift()` tested against synthetic input — the message-shape contract, including the exact acceptance-criteria scenarios (self-exculpating message, branch-attributed message, no-signal message that makes neither claim).
- `resolve_branch_only_ref()` / `scan_at_ref()` tested against a **real, small git repository** built in `tmp_path`, with a real two-parent merge commit constructed the same way a merge queue would (target branch checked out, feature branch merged in) — literally constructing the situation the issue asks for, not mocking `subprocess` and reasoning about what git ought to do.

Both existing guards (`test_token_orphans.py`, `test_compliance_module_reachability.py`) now call the shared helper instead of each carrying its own copy of the two-assert comparison. Their internal scanning functions (`_current_orphans`, `_importers_of`, the AST import index, reachable-set computation) are parameterized by a `root: Path` (defaulting to the real repo root, so every existing call site keeps working unchanged) rather than hardcoding the module-level constant, so the same functions can be pointed at the disposable worktree with no duplicated logic.

**Every existing assertion is unchanged**: same `KNOWN_ORPHANS` sets, same reachability rules, same redirect-alias handling. What changes is the failure shape on drift.

## Commits

1. `70a6326ab` — the shared `_orphan_scan.py` module and its own test file, self-contained.
2. `f9ad5a113` — wiring both existing guards to it, plus the release-notes fragment.

## Non-goals (per the issue)

- Loosening the ratchet so new entries pass — untouched; a genuinely new caller-less module still fails.
- Changing which modules are in either allowlist.
- The two heavier shapes the issue lists (deriving the baseline from the merge base instead of a stored snapshot; a scheduled drift-detection run) — out of scope here; shape 1 ("the failure explains itself") is explicitly "worth doing regardless of which of the others is chosen".

## Testing

```
uv run python -m pytest tests/unit/test_orphan_scan_helper.py tests/unit/test_token_orphans.py tests/unit/test_compliance_module_reachability.py -v
uv run python -m ruff check tests/unit/_orphan_scan.py tests/unit/test_orphan_scan_helper.py tests/unit/test_token_orphans.py tests/unit/test_compliance_module_reachability.py
uv run python -m pyright tests/unit/_orphan_scan.py
uv run lint-imports
```

30 tests pass across the three files; ruff and pyright (on the new shared module) are clean; the architecture-contract check is clean.

Closes #5552.
