### PR TITLE
fix(security): an IP allowlist that parses to nothing is a refusal, not an absence

### DIFF
--- a/docs/security/security-hardening.md
+++ b/docs/security/security-hardening.md
@@ -526,6 +526,14 @@ network:
 Localhost (127.0.0.1, ::1) is always allowed. Health check endpoints (`/healthz`) are
 exempt from IP restrictions.
 
+A range that does not parse is dropped with a warning, so the rest of the list still
+applies. If *every* configured range is dropped the allowlist cannot be enforced at all,
+and the server answers `500` on non-exempt paths rather than serving them unrestricted -
+a typo in a CIDR must not silently turn the allowlist off. Health endpoints stay
+reachable in that state so the container is not killed before the log line naming the bad
+range can be read. An empty or omitted `allowed_ips` is unchanged: it means no
+restriction was asked for.
+
 ## API authentication
 
 ### JWT authentication (recommended for single-tenant)

--- a/src/bernstein/core/security/ip_allowlist.py
+++ b/src/bernstein/core/security/ip_allowlist.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Any, cast
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
 
+from bernstein.core.security.sanitize import sanitize_log
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
@@ -23,14 +25,39 @@ _Network = ipaddress.IPv4Network | ipaddress.IPv6Network
 
 
 def _parse_allowed_networks(allowed_ips: Sequence[str]) -> tuple[_Network, ...]:
-    """Parse a sequence of CIDR strings into IP network objects."""
+    """Parse a sequence of CIDR strings into IP network objects.
+
+    An entry that does not parse is dropped with a warning rather than
+    raising: one bad range in a list of five should narrow the allowlist,
+    not take the server down. Dropping narrows, so it errs towards denial -
+    but only while at least one range survives. Callers must therefore
+    distinguish "nothing was configured" from "everything configured was
+    dropped"; see :func:`allowlist_is_unusable`.
+    """
     networks: list[_Network] = []
     for ip_range in allowed_ips:
         try:
             networks.append(ipaddress.ip_network(ip_range, strict=False))
         except ValueError as exc:
-            logger.warning("Invalid IP range %s: %s", ip_range, exc)
+            logger.warning("Invalid IP range %s: %s", sanitize_log(ip_range), sanitize_log(str(exc)))
     return tuple(networks)
+
+
+def allowlist_is_unusable(configured: Sequence[str], parsed: Sequence[_Network]) -> bool:
+    """Is this an allowlist that was asked for but cannot be enforced?
+
+    The middleware treats an empty set of networks as "no allowlist", which
+    is right for an operator who configured none and wrong for an operator
+    who configured only ranges that fail to parse. The two states are
+    identical downstream - an empty tuple either way - so they have to be
+    told apart here, before the request is judged.
+
+    ``configured`` empty is the first state: nothing was asked for, the
+    middleware is inert, every request passes. ``configured`` non-empty with
+    ``parsed`` empty is the second: an operator asked for a restriction and
+    a typo silently removed it. That must not resolve to "allow everyone".
+    """
+    return bool(configured) and not parsed
 
 
 class IPAllowlistMiddleware(BaseHTTPMiddleware):
@@ -39,6 +66,13 @@ class IPAllowlistMiddleware(BaseHTTPMiddleware):
     When configured, all requests must originate from an allowed IP range.
     Localhost (127.0.0.1) is always allowed. Health and discovery endpoints
     are exempt.
+
+    A configured allowlist in which *no* range parses is refused rather than
+    ignored. Dropping unparseable ranges narrows the allowlist, which is safe
+    while one survives; when none does, the same drop widens it to everything,
+    and an allowlist that silently stops restricting is worse than one that
+    stops the server. ``check_ip_allowed`` has always denied in that state -
+    this is the middleware agreeing with it.
 
     Args:
         app: ASGI application.
@@ -96,7 +130,22 @@ class IPAllowlistMiddleware(BaseHTTPMiddleware):
         if path in self._active_public_paths:
             return await call_next(request)
 
-        allowed_networks = self._resolve_allowed_networks(request)
+        configured, allowed_networks = self._resolve_allowed_networks(request)
+
+        # An allowlist that was configured but parsed to nothing is a
+        # misconfiguration, not an absence. Passing through here is how a
+        # single typo turns "only the office range may reach this server"
+        # into "anyone may", with nothing in the response to show it.
+        if allowlist_is_unusable(configured, allowed_networks):
+            logger.error(
+                "IP allowlist configured with %d range(s), none of them parseable; refusing %s",
+                len(configured),
+                sanitize_log(path),
+            )
+            return JSONResponse(
+                status_code=500,
+                content={"detail": "IP allowlist is configured but unusable; no range parsed"},
+            )
 
         # If no allowlist configured, pass through
         if not allowed_networks:
@@ -115,27 +164,35 @@ class IPAllowlistMiddleware(BaseHTTPMiddleware):
             if any(client_addr in network for network in allowed_networks):
                 return await call_next(request)
         except ValueError:
-            logger.warning("Invalid client IP: %s", client_ip)
+            logger.warning("Invalid client IP: %s", sanitize_log(client_ip))
 
         # IP not in allowlist
-        logger.warning("Blocked request from IP %s to %s", client_ip, path)
+        # Both values can come straight from the request - the IP via a
+        # forwarded header, the path from the request line - so neither
+        # reaches the log without escaping.
+        logger.warning("Blocked request from IP %s to %s", sanitize_log(client_ip), sanitize_log(path))
         return JSONResponse(
             status_code=403,
             content={"detail": f"IP {client_ip} not in allowed list"},
         )
 
-    def _resolve_allowed_networks(self, request: Request) -> tuple[_Network, ...]:
-        """Resolve the active allowlist from static config or app state."""
+    def _resolve_allowed_networks(self, request: Request) -> tuple[tuple[str, ...], tuple[_Network, ...]]:
+        """Resolve the active allowlist from static config or app state.
+
+        Returns both halves - the raw ranges the operator configured and the
+        ones that parsed - because the caller cannot tell a missing allowlist
+        from a wholly unparseable one from the parsed tuple alone.
+        """
         if self._configured_allowed_ips is not None:
-            return self._configured_networks
+            return self._configured_allowed_ips, self._configured_networks
 
         allowed_ips = self._allowed_ips_from_seed(request)
         if not allowed_ips:
-            return ()
+            return (), ()
         if allowed_ips != self._cached_dynamic_allowed_ips:
             self._cached_dynamic_allowed_ips = allowed_ips
             self._cached_dynamic_networks = _parse_allowed_networks(allowed_ips)
-        return self._cached_dynamic_networks
+        return allowed_ips, self._cached_dynamic_networks
 
     def _allowed_ips_from_seed(self, request: Request) -> tuple[str, ...]:
         """Read allowlist CIDRs from the current app seed config."""

--- a/tests/unit/test_ip_allowlist.py
+++ b/tests/unit/test_ip_allowlist.py
@@ -2,8 +2,22 @@
 
 from __future__ import annotations
 
+import logging
+
+import pytest
 from bernstein.core.ip_allowlist import (
     check_ip_allowed,
+)
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from bernstein.core.security.ip_allowlist import (
+    IPAllowlistMiddleware,
+    _parse_allowed_networks,
+    allowlist_is_unusable,
 )
 
 # ---------------------------------------------------------------------------
@@ -49,3 +63,127 @@ class TestCheckIPAllowed:
         # Invalid CIDR should not match, but valid ones still work
         assert check_ip_allowed("10.0.0.1", ["invalid", "10.0.0.0/8"])
         assert not check_ip_allowed("192.168.1.1", ["invalid"])
+
+
+# ---------------------------------------------------------------------------
+# IPAllowlistMiddleware: a configured allowlist that parses to nothing
+# ---------------------------------------------------------------------------
+#
+# ``_parse_allowed_networks`` drops a range it cannot parse. That is the right
+# call while another range survives - the allowlist gets narrower, which errs
+# towards denial. When *every* range is dropped the same behaviour inverts:
+# the middleware sees an empty tuple, reads it as "no allowlist configured",
+# and passes every request through. One typo in one CIDR is enough, and
+# nothing in the response says the restriction stopped applying.
+#
+# ``check_ip_allowed`` never had this problem - an empty parse there means no
+# network matches, so it denies (``test_invalid_cidr_ignored`` above pins it).
+# These tests pin the middleware to the same answer.
+
+
+def _client(allowed_ips: list[str] | None) -> TestClient:
+    """A one-route app behind the middleware, addressed from a public IP."""
+
+    async def handler(_request: Request) -> PlainTextResponse:
+        return PlainTextResponse("reached the handler")
+
+    app = Starlette(routes=[Route("/tasks", handler), Route("/health", handler)])
+    app.add_middleware(IPAllowlistMiddleware, allowed_ips=allowed_ips)
+    # 203.0.113.0/24 is TEST-NET-3: routable-looking, and not loopback, so the
+    # request is judged by the allowlist rather than by the loopback exemption.
+    return TestClient(app, client=("203.0.113.9", 1234))
+
+
+class TestUnusableAllowlistIsNotAnAbsentOne:
+    def test_a_sole_unparseable_range_denies_rather_than_passing_through(self) -> None:
+        """The whole bug in one call: /33 is not a prefix length."""
+        response = _client(["10.0.0.0/33"]).get("/tasks")
+        assert response.status_code == 500
+        assert "unusable" in response.json()["detail"]
+
+    def test_every_range_unparseable_denies(self) -> None:
+        response = _client(["not-an-ip", "10.0.0.0/33", ""]).get("/tasks")
+        assert response.status_code == 500
+
+    def test_one_surviving_range_still_enforces_that_range(self) -> None:
+        """Dropping narrows: the good half of a half-broken list still applies."""
+        response = _client(["10.0.0.0/33", "10.0.0.0/8"]).get("/tasks")
+        assert response.status_code == 403
+        assert "203.0.113.9" in response.json()["detail"]
+
+    def test_one_surviving_range_still_admits_a_client_inside_it(self) -> None:
+        async def handler(_request: Request) -> PlainTextResponse:
+            return PlainTextResponse("reached the handler")
+
+        app = Starlette(routes=[Route("/tasks", handler)])
+        app.add_middleware(IPAllowlistMiddleware, allowed_ips=["garbage", "10.0.0.0/8"])
+        response = TestClient(app, client=("10.1.2.3", 1234)).get("/tasks")
+        assert response.status_code == 200
+
+    def test_no_allowlist_configured_still_passes_through(self) -> None:
+        """``None`` means the operator asked for no restriction at all."""
+        assert _client(None).get("/tasks").status_code == 200
+
+    def test_an_explicitly_empty_allowlist_still_passes_through(self) -> None:
+        """``[]`` is how callers spell "feature off"; unchanged on purpose.
+
+        It is not the bug: an empty list carries no operator intent that got
+        lost. Only a non-empty list that parses to nothing does.
+        """
+        assert _client([]).get("/tasks").status_code == 200
+
+    def test_public_paths_stay_reachable_so_health_checks_survive(self) -> None:
+        """A refused allowlist must not take the liveness probe with it.
+
+        Otherwise a typo in a CIDR gets the container killed by its own
+        orchestrator before an operator can read the log line naming it.
+        """
+        assert _client(["10.0.0.0/33"]).get("/health").status_code == 200
+
+    def test_the_refusal_names_the_cause_in_the_log(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A 500 with no explanation is a worse failure than the fail-open."""
+        with caplog.at_level(logging.ERROR, logger="bernstein.core.security.ip_allowlist"):
+            _client(["10.0.0.0/33"]).get("/tasks")
+        assert "none of them parseable" in caplog.text
+
+
+class TestAllowlistIsUnusable:
+    """The predicate on its own - it is the whole distinction."""
+
+    def test_configured_and_parsed_is_usable(self) -> None:
+        assert not allowlist_is_unusable(["10.0.0.0/8"], _parse_allowed_networks(["10.0.0.0/8"]))
+
+    def test_configured_and_unparsed_is_unusable(self) -> None:
+        assert allowlist_is_unusable(["10.0.0.0/33"], _parse_allowed_networks(["10.0.0.0/33"]))
+
+    def test_unconfigured_is_not_unusable(self) -> None:
+        """Nothing was asked for, so nothing was lost."""
+        assert not allowlist_is_unusable([], ())
+
+
+# ---------------------------------------------------------------------------
+# Log injection through the forwarded-IP header
+# ---------------------------------------------------------------------------
+
+
+def test_a_forwarded_ip_cannot_forge_a_log_record(caplog: pytest.LogCaptureFixture) -> None:
+    """The blocked-request line is built from two request-controlled values.
+
+    ``X-Forwarded-For`` is trusted only when the direct peer is loopback, but
+    that is exactly the deployment this middleware is written for - a proxy on
+    the same host. The header value then reaches ``logger.warning`` verbatim,
+    so a newline in it writes the attacker's own line into the log.
+    """
+
+    async def handler(_request: Request) -> PlainTextResponse:  # pragma: no cover - never reached
+        return PlainTextResponse("reached the handler")
+
+    app = Starlette(routes=[Route("/tasks", handler)])
+    app.add_middleware(IPAllowlistMiddleware, allowed_ips=["10.0.0.0/8"])
+    client = TestClient(app, client=("127.0.0.1", 1234))
+
+    with caplog.at_level(logging.WARNING, logger="bernstein.core.security.ip_allowlist"):
+        client.get("/tasks", headers={"X-Forwarded-For": "9.9.9.9\nINFO Blocked request from IP nobody"})
+
+    assert "\nINFO" not in caplog.text
+    assert "\n" in caplog.text


### PR DESCRIPTION
## The bug

`_parse_allowed_networks` drops a CIDR it cannot parse and carries on. While another range survives that is correct — the allowlist gets *narrower*, which errs towards denial.

When every range is dropped, the same behaviour inverts. `dispatch` receives an empty tuple, and an empty tuple is how it spells *"no allowlist configured"*:

```python
allowed_networks = self._resolve_allowed_networks(request)

# If no allowlist configured, pass through
if not allowed_networks:
    return await call_next(request)
```

So this configuration is a server open to the internet:

```yaml
network:
  allowed_ips:
    - "10.0.0.0/33"   # typo: /33 is not a prefix length
```

One `WARNING` about a bad range is the only trace, and every request gets a `200`.

`check_ip_allowed` in the same module never had this problem — an empty parse means no network matches, so it denies. `test_invalid_cidr_ignored` has pinned that since ENT-011. The helper and the middleware gave opposite answers for the same input and the middleware had the dangerous half.

## The fix

"Nothing configured" and "everything configured was dropped" are indistinguishable once parsing is done, so they are told apart before it: `allowlist_is_unusable` compares the configured ranges against the surviving ones. A non-empty configuration that yields no networks now answers `500` on non-exempt paths and names the cause in the log.

Deliberately unchanged:

- **absent or empty `allowed_ips`** still passes through — no operator intent went missing there;
- **a partly-bad list** still enforces its good half, since dropping narrows;
- **public paths** stay exempt, so a liveness probe does not get the container killed before an operator can read the log line naming the bad range.

## Log injection, while in here

The blocked-request line is built from two request-controlled values:

```python
logger.warning("Blocked request from IP %s to %s", client_ip, path)
```

`X-Forwarded-For` is trusted when the direct peer is loopback — the proxy-on-the-same-host deployment this middleware exists for — so a newline in that header writes the attacker's own record into the log. Both now go through `sanitize_log`. The test asserts the forged line is absent rather than that escaping happened:

```
WARNING ... Blocked request from IP 9.9.9.9
INFO Blocked request from IP nobody to /tasks     <- attacker's line, on main
```

## Non-vacuity

Reverting only the behavioural change (keeping the new helper so the file still imports) fails four of the new tests:

```
FAILED ...::test_a_sole_unparseable_range_denies_rather_than_passing_through
FAILED ...::test_every_range_unparseable_denies
FAILED ...::test_the_refusal_names_the_cause_in_the_log
FAILED ...::test_a_forwarded_ip_cannot_forge_a_log_record
4 failed, 18 passed
```

The other new tests are the controls — a surviving range still admits and still denies, `None` and `[]` still pass through, `/health` stays reachable.

## Docs

`docs/security/security-hardening.md` gains the new failure mode next to the `allowed_ips` example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)