### PR TITLE
fix(security): the loopback exemption skipped strict mode entirely

### DIFF
--- a/src/bernstein/core/security/url_allowlist.py
+++ b/src/bernstein/core/security/url_allowlist.py
@@ -70,16 +70,27 @@ def ensure_http_url(
         allow_http: When True, accept ``http://`` URLs in addition to
             ``https://``. Even when False, plain ``http://`` is still accepted
             for localhost / loopback hosts so developers can hit local mock
-            servers without flipping the flag globally.
+            servers without flipping the flag globally. That exemption applies
+            to the scheme rule only - a loopback host is still rejected under
+            ``strict``, which is the flag that exists to reject it.
         source: Optional human-readable label used in the error message
             (e.g. ``"jira webhook"``) for easier debugging.
+        strict: When True, resolve the host and reject the URL if *any*
+            address it answers with is loopback, private, link-local,
+            reserved, multicast or unspecified. Resolution failure is a
+            rejection. Use it for a URL whose destination was chosen by
+            someone other than the operator; :func:`ensure_public_http_url`
+            is the same check with the flag already set.
+        resolver: Optional hostname resolver, for tests. Defaults to
+            :func:`socket.getaddrinfo`.
 
     Returns:
         ``url`` if it passes validation.
 
     Raises:
-        UrlSchemeError: If the URL is empty, unparseable, or uses any scheme
-            other than the permitted ones.
+        UrlSchemeError: If the URL is empty, unparseable, uses any scheme
+            other than the permitted ones, or - under ``strict`` - has a host
+            that is missing, unresolvable, or resolves to an internal address.
     """
     if not url or not isinstance(url, str):
         raise UrlSchemeError(_msg(source, "URL is empty or not a string"))
@@ -91,11 +102,15 @@ def ensure_http_url(
 
     allowed = _HTTP_AND_HTTPS if allow_http else _HTTPS_ONLY
     host = (parsed.hostname or "").lower()
-    if scheme == "http" and host in _LOCAL_HOSTS:
-        # Loopback hosts are always permitted on plain HTTP - most operator
-        # toolchains expect to be able to point Bernstein at a local mock.
-        return url
-    if scheme not in allowed:
+    # Loopback hosts are always permitted on plain HTTP - most operator
+    # toolchains expect to be able to point Bernstein at a local mock. This
+    # exempts the *scheme* rule and nothing else: it must not return early,
+    # because ``strict`` exists to reject internal destinations and loopback
+    # is the most internal destination there is. Skipping the check for the
+    # one host it most wants to see is the opposite of what the flag asks
+    # for, and it is silent - the caller gets the URL back looking validated.
+    loopback_http = scheme == "http" and host in _LOCAL_HOSTS
+    if scheme not in allowed and not loopback_http:
         raise UrlSchemeError(
             _msg(
                 source,
@@ -104,7 +119,6 @@ def ensure_http_url(
         )
     # Strict mode: reject internal destinations after hostname resolution.
     if strict:
-        host = (parsed.hostname or "").lower()
         if not host:
             raise UrlSchemeError(_msg(source, f"URL has no host: {url!r}"))
         resolve = resolver or _default_resolver

--- a/tests/unit/security/test_url_allowlist.py
+++ b/tests/unit/security/test_url_allowlist.py
@@ -137,6 +137,68 @@ def test_strict_unresolvable_host_is_rejected() -> None:
         ensure_http_url("https://nx.example/entry.json", strict=True, resolver=_fails)
 
 
+@pytest.mark.parametrize("host", ["localhost", "127.0.0.1", "[::1]"])
+def test_strict_mode_rejects_the_loopback_host_the_scheme_rule_exempts(host: str) -> None:
+    """The plain-HTTP exemption is a scheme exemption, not a strict-mode one.
+
+    Every other strict test on this function uses ``https://``, which never
+    reaches the loopback branch - so the branch returned ``url`` before the
+    strict block ran, and ``strict=True`` was a no-op for the exact host it
+    exists to reject. ``test_loopback_http_exemption_does_not_leak_into_strict_mode``
+    below asserts this same invariant, but against ``ensure_public_http_url``,
+    where it cannot leak: that function calls this one *without* ``strict``
+    and does its own resolution afterwards.
+    """
+    with pytest.raises(UrlSchemeError, match="internal address"):
+        ensure_http_url(
+            f"http://{host}:8052/entry.json",
+            allow_http=True,
+            strict=True,
+            resolver=_resolves_to("127.0.0.1"),
+        )
+
+
+def test_strict_mode_rejects_loopback_even_without_allow_http() -> None:
+    """``allow_http=False`` was the shape that reached the early return."""
+    with pytest.raises(UrlSchemeError, match="internal address"):
+        ensure_http_url(
+            "http://localhost:8052/entry.json",
+            strict=True,
+            resolver=_resolves_to("127.0.0.1"),
+        )
+
+
+def test_a_loopback_name_answering_with_a_public_address_is_still_judged_on_that() -> None:
+    """Strict mode judges resolved addresses, not the spelling of the host.
+
+    The fix must not degrade into "the string 'localhost' is banned" - the
+    check is on where the name points.
+    """
+    url = "http://localhost:8052/entry.json"
+    assert ensure_http_url(url, allow_http=True, strict=True, resolver=_resolves_to("93.184.216.34")) == url
+
+
+def test_loopback_http_is_still_exempt_from_the_scheme_rule() -> None:
+    """The exemption itself is intact: no strict flag, no resolution, accepted.
+
+    This is the developer-pointing-at-a-local-mock case the exemption is for,
+    and it is what makes the fix a narrowing of ``strict`` rather than a
+    removal of the exemption.
+    """
+    url = "http://127.0.0.1:8052/health"
+    assert ensure_http_url(url) == url
+
+
+def test_a_non_loopback_http_url_is_still_rejected_on_scheme_before_resolving() -> None:
+    """Reordering the branches must not let plain HTTP in through the side."""
+
+    def _must_not_be_called(_host: str) -> list[str]:  # pragma: no cover - asserted by not raising
+        raise AssertionError("resolved a URL that should have failed the scheme rule")
+
+    with pytest.raises(UrlSchemeError, match="not permitted"):
+        ensure_http_url("http://example.com/x", strict=True, resolver=_must_not_be_called)
+
+
 def test_strict_source_label_appears_in_error() -> None:
     with pytest.raises(UrlSchemeError, match="skills_catalog.fetcher"):
         ensure_http_url(


### PR DESCRIPTION
## The bug

`ensure_http_url` grants plain `http://` to loopback hosts so a developer can point Bernstein at a local mock without flipping `allow_http` globally. It granted it with a `return url`, ahead of the strict block:

```python
if scheme == "http" and host in _LOCAL_HOSTS:
    # Loopback hosts are always permitted on plain HTTP ...
    return url
if scheme not in allowed:
    raise UrlSchemeError(...)
# Strict mode: reject internal destinations after hostname resolution.
if strict:
    ...
```

So:

```python
>>> ensure_http_url("http://127.0.0.1/admin", allow_http=True, strict=True,
...                 resolver=lambda h: ["127.0.0.1"])
'http://127.0.0.1/admin'
```

`strict` exists to reject internal destinations. Loopback is the most internal destination there is. The flag was a no-op for exactly the host it most wants to see — and silently: the caller gets its URL back looking validated.

## The fix

The exemption is a **scheme** exemption. It now reads as one — it suppresses the scheme rule and falls through to the strict block instead of returning:

```python
loopback_http = scheme == "http" and host in _LOCAL_HOSTS
if scheme not in allowed and not loopback_http:
    raise UrlSchemeError(...)
if strict:
    ...
```

## Blast radius

No production call site passes `strict=True` today. `ensure_public_http_url` is the strict entry point and is unaffected — it calls this function *without* `strict` and resolves separately, so it was never exposed.

This is a trap set for the next caller, in a primitive whose entire job is to be trustworthy at a glance. The docstring now also documents `strict` and `resolver`, which were undocumented.

## Why the existing suite missed it

`tests/unit/security/test_url_allowlist.py` already asserts this invariant by name:

```python
def test_loopback_http_exemption_does_not_leak_into_strict_mode() -> None:
    # ensure_http_url lets plain http through for localhost; strict mode must not.
    with pytest.raises(UrlSchemeError, match="internal address"):
        ensure_public_http_url(...)
```

— but against `ensure_public_http_url`, where it *cannot* leak. Every strict-mode test on `ensure_http_url` itself uses `https://`, which never reaches the loopback branch. The invariant was named in the file and untested on the one function that violated it.

## Non-vacuity

On `main`, with the new tests applied:

```
FAILED ...::test_strict_mode_rejects_the_loopback_host_the_scheme_rule_exempts[localhost]
FAILED ...::test_strict_mode_rejects_the_loopback_host_the_scheme_rule_exempts[127.0.0.1]
FAILED ...::test_strict_mode_rejects_the_loopback_host_the_scheme_rule_exempts[[::1]]
FAILED ...::test_strict_mode_rejects_loopback_even_without_allow_http
4 failed, 52 passed
```

The controls pass both ways, which is the point of them:

- a loopback *name* resolving to a public address is still accepted — the check is on where the name points, not on the spelling of the host, so the fix cannot degrade into "the string `localhost` is banned";
- the plain-HTTP exemption still works when `strict` is off;
- a non-loopback `http://` URL is still refused on the scheme *before* any resolution (the resolver raises `AssertionError` if reached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)