### PR TITLE
fix(security): JWTManager signed SHA-256 whatever its header said

### DIFF
--- a/src/bernstein/core/preview/token_issuer.py
+++ b/src/bernstein/core/preview/token_issuer.py
@@ -92,6 +92,11 @@ class PreviewTokenIssuer:
     def __init__(self, secret: str, *, algorithm: str = "HS256") -> None:
         if not secret:
             raise ValueError("PreviewTokenIssuer requires a non-empty secret")
+        # The manager is built per-issue, so an algorithm it cannot sign with
+        # would otherwise surface on the first link an operator tries to
+        # create rather than when the issuer is configured. Constructing one
+        # here is the cheapest way to apply exactly the manager's own rule.
+        JWTManager(secret, algorithm=algorithm)
         self._secret = secret
         self._algorithm = algorithm
 

--- a/src/bernstein/core/security/jwt_tokens.py
+++ b/src/bernstein/core/security/jwt_tokens.py
@@ -9,12 +9,29 @@ import logging
 import time
 from dataclasses import dataclass, field
 from threading import Lock
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 
 _REFRESH_BUFFER_SECONDS: float = 300.0  # 5 minutes
 _MAX_REFRESH_FAILURES: int = 3
+
+#: The HMAC family this manager can sign and verify, mapped to the digest each
+#: one names. Kept in step with ``auth.create_jwt`` / ``auth.verify_jwt``, which
+#: accept the same three: ``BERNSTEIN_AUTH_JWT_ALGORITHM`` selects one for both
+#: sides, so a token this manager issues has to be one that verifier accepts.
+#:
+#: An algorithm outside this set is refused at construction rather than
+#: defaulted. The header is a claim about how the signature was produced, and
+#: a manager that cannot honour the claim must not make it.
+_DIGESTS: dict[str, Callable[[], Any]] = {
+    "HS256": hashlib.sha256,
+    "HS384": hashlib.sha384,
+    "HS512": hashlib.sha512,
+}
 
 
 @dataclass
@@ -42,11 +59,24 @@ class JWTManager:
         Args:
             secret: Secret key for signing tokens.
             expiry_hours: Token expiry in hours (default 24).
-            algorithm: Signing algorithm (default HS256).
+            algorithm: Signing algorithm. One of ``HS256``, ``HS384`` or
+                ``HS512`` - the same three ``auth.create_jwt`` accepts.
+
+        Raises:
+            ValueError: If *algorithm* is not one this manager can sign with.
+                Refused here rather than silently downgraded: the value ends
+                up in the token header as a claim about how the signature was
+                made, and a manager that cannot honour that claim must not
+                issue it.
         """
+        digest = _DIGESTS.get(algorithm)
+        if digest is None:
+            msg = f"Unsupported algorithm: {algorithm!r} (supported: {sorted(_DIGESTS)})"
+            raise ValueError(msg)
         self._secret = secret.encode("utf-8")
         self._expiry_seconds = expiry_hours * 3600
         self._algorithm = algorithm
+        self._digest = digest
 
     def create_token(
         self,
@@ -119,7 +149,7 @@ class JWTManager:
 
         # Create signature
         message = f"{header_b64}.{payload_b64}"
-        signature = hmac.new(self._secret, message.encode(), hashlib.sha256).digest()
+        signature = hmac.new(self._secret, message.encode(), self._digest).digest()
         signature_b64 = self._base64url_encode(signature)
 
         return f"{header_b64}.{payload_b64}.{signature_b64}"
@@ -165,10 +195,11 @@ class JWTManager:
         if not hmac.compare_digest(alg_obj.encode("utf-8"), self._algorithm.encode("utf-8")):
             raise ValueError(f"Unexpected alg {alg_obj!r}; expected {self._algorithm!r}")
 
-        # Verify signature (HMAC-SHA256 is the only algorithm this manager
-        # supports today; _algorithm is validated above).
+        # Verify with the digest the configured algorithm names. The header
+        # was compared against ``self._algorithm`` above, so this is the
+        # digest that header claims - never one chosen by the token.
         message = f"{header_b64}.{payload_b64}"
-        expected_signature = hmac.new(self._secret, message.encode(), hashlib.sha256).digest()
+        expected_signature = hmac.new(self._secret, message.encode(), self._digest).digest()
         actual_signature = self._base64url_decode(signature_b64)
 
         if not hmac.compare_digest(expected_signature, actual_signature):

--- a/tests/unit/security/test_jwt_algorithm_is_honoured.py
+++ b/tests/unit/security/test_jwt_algorithm_is_honoured.py
@@ -1,0 +1,142 @@
+"""The ``alg`` header is a claim about the signature; it has to be true.
+
+``JWTManager`` took an ``algorithm``, wrote it into the token header, and
+compared it on the way back in - but signed with SHA-256 unconditionally. The
+manager therefore agreed with itself for any value, so nothing inside it could
+notice, while the header told every other reader something false.
+
+``auth.verify_jwt`` is the reader that matters: it selects its digest from the
+``algorithm`` argument, and ``BERNSTEIN_AUTH_JWT_ALGORITHM`` feeds the same
+value to both sides. Configure ``HS384`` and the issuer signs SHA-256 under an
+``HS384`` header while the verifier computes SHA-384 - every token the system
+issues is rejected by the system's own verifier.
+
+``auth.create_jwt`` next door has always honoured all three and raised on
+anything else. These tests pin the manager to that behaviour.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+
+import pytest
+
+from bernstein.core.preview.token_issuer import PreviewTokenIssuer
+from bernstein.core.security.auth import verify_jwt
+from bernstein.core.security.jwt_tokens import JWTManager
+
+_SECRET = "shared-secret"
+
+_DIGESTS = {"HS256": hashlib.sha256, "HS384": hashlib.sha384, "HS512": hashlib.sha512}
+
+
+def _b64url_decode(data: str) -> bytes:
+    return base64.urlsafe_b64decode(data + "=" * (-len(data) % 4))
+
+
+def _header(token: str) -> dict[str, str]:
+    return json.loads(_b64url_decode(token.split(".")[0]))
+
+
+def _signature(token: str) -> bytes:
+    return _b64url_decode(token.split(".")[2])
+
+
+@pytest.mark.parametrize("algorithm", sorted(_DIGESTS))
+def test_the_signature_uses_the_digest_the_header_names(algorithm: str) -> None:
+    """The bug, stated directly: recompute the HMAC the header claims."""
+    token = JWTManager(secret=_SECRET, algorithm=algorithm).create_token("s-1")
+    signing_input = ".".join(token.split(".")[:2])
+
+    expected = hmac.new(_SECRET.encode(), signing_input.encode(), _DIGESTS[algorithm]).digest()
+
+    assert _header(token)["alg"] == algorithm
+    assert _signature(token) == expected
+
+
+@pytest.mark.parametrize("algorithm", sorted(_DIGESTS))
+def test_a_token_this_manager_issues_is_one_auth_verify_jwt_accepts(algorithm: str) -> None:
+    """Both sides read ``BERNSTEIN_AUTH_JWT_ALGORITHM``; they have to agree.
+
+    On main this returns ``None`` for HS384 and HS512: the manager signed
+    SHA-256 and the verifier computed the digest the header named.
+    """
+    token = JWTManager(secret=_SECRET, algorithm=algorithm).create_token("s-1")
+
+    assert verify_jwt(token, _SECRET, algorithm) is not None
+
+
+@pytest.mark.parametrize("algorithm", sorted(_DIGESTS))
+def test_signature_length_matches_the_named_digest(algorithm: str) -> None:
+    """A cheap, independent read on the same fact: SHA-384 is 48 bytes."""
+    token = JWTManager(secret=_SECRET, algorithm=algorithm).create_token("s-1")
+
+    assert len(_signature(token)) == _DIGESTS[algorithm]().digest_size
+
+
+@pytest.mark.parametrize("algorithm", sorted(_DIGESTS))
+def test_the_manager_still_round_trips_its_own_token(algorithm: str) -> None:
+    """Sign and verify move together, so this passed before the fix too.
+
+    It is here as the control: it is what made the defect invisible from
+    inside the class, and it must keep passing.
+    """
+    manager = JWTManager(secret=_SECRET, algorithm=algorithm)
+    payload = manager.verify_token(manager.create_token("s-1", scopes=["a"]))
+
+    assert payload is not None
+    assert payload.session_id == "s-1"
+    assert payload.scopes == ["a"]
+
+
+def test_a_token_signed_under_one_algorithm_is_rejected_by_a_manager_on_another() -> None:
+    """The alg-confusion guard still holds once the digests actually differ."""
+    token = JWTManager(secret=_SECRET, algorithm="HS512").create_token("s-1")
+
+    assert JWTManager(secret=_SECRET, algorithm="HS256").verify_token(token) is None
+
+
+@pytest.mark.parametrize("algorithm", ["RS256", "ES256", "none", "HS255", "hs256", ""])
+def test_an_algorithm_the_manager_cannot_sign_with_is_refused(algorithm: str) -> None:
+    """Refused, not silently downgraded to HS256.
+
+    ``RS256`` is the case that matters: it names asymmetric signing, and a
+    token labelled ``RS256`` but signed with an HMAC invites a verifier to
+    treat the shared secret as a public key. Never issuing that header is the
+    only guarantee available here. ``auth.create_jwt`` already raises on the
+    same input.
+    """
+    with pytest.raises(ValueError, match="Unsupported algorithm"):
+        JWTManager(secret=_SECRET, algorithm=algorithm)
+
+
+def test_the_default_algorithm_is_unchanged() -> None:
+    assert _header(JWTManager(secret=_SECRET).create_token("s-1"))["alg"] == "HS256"
+
+
+class TestPreviewTokenIssuer:
+    """The one caller that threads an operator-supplied algorithm through."""
+
+    def test_a_bad_algorithm_is_refused_when_the_issuer_is_built(self) -> None:
+        """Not on the first preview link somebody tries to create.
+
+        The issuer constructs its manager inside ``issue()``, so without this
+        the misconfiguration surfaces arbitrarily far from its cause.
+        """
+        with pytest.raises(ValueError, match="Unsupported algorithm"):
+            PreviewTokenIssuer(_SECRET, algorithm="RS256")
+
+    @pytest.mark.parametrize("algorithm", sorted(_DIGESTS))
+    def test_a_supported_algorithm_issues_a_verifiable_token(self, algorithm: str) -> None:
+        issued = PreviewTokenIssuer(_SECRET, algorithm=algorithm).issue(
+            preview_id="p-1",
+            mode="token",
+            expires_in_seconds=600,
+        )
+
+        assert issued.token is not None
+        assert _header(issued.token)["alg"] == algorithm
+        assert verify_jwt(issued.token, _SECRET, algorithm) is not None


### PR DESCRIPTION
## The bug

`JWTManager` takes an `algorithm`, writes it into the token header, and compares it against the header on the way back in. It never signed with it:

```python
header = {"alg": self._algorithm, "typ": "JWT"}
...
signature = hmac.new(self._secret, message.encode(), hashlib.sha256).digest()
```

Both `_encode` and `_decode` hard-coded SHA-256, so the manager agreed with itself for *any* value and nothing inside the class could notice. The header meanwhile told every other reader something false.

## Why it is not self-contained

`auth.verify_jwt` is the reader that matters. It selects its digest from the `algorithm` argument and supports HS256/HS384/HS512 — and `BERNSTEIN_AUTH_JWT_ALGORITHM` (`SSOConfig.jwt_algorithm`) feeds the same value to both sides:

```python
create_jwt(..., algorithm=self.config.jwt_algorithm)      # issue
verify_jwt(token, self.config.jwt_secret, self.config.jwt_algorithm)   # validate
```

Set it to `HS384` and you get an issuer signing SHA-256 under an `HS384` header and a verifier computing SHA-384:

```python
>>> m = JWTManager(secret="s", algorithm="HS384")
>>> verify_jwt(m.create_token("sess-1"), "s", "HS384")
None
```

Authentication fails closed, but it fails *completely*, and the cause is invisible from either end — the token looks well-formed and the header looks right.

## The fix

`auth.create_jwt`, in the same package, has always honoured all three algorithms and raised `ValueError` on anything else. The manager now matches it: the digest is selected from the configured algorithm, and an algorithm it cannot sign with is refused at construction rather than silently downgraded.

**Refused rather than downgraded** because of `RS256` specifically. That header names asymmetric signing, and a token labelled `RS256` but signed with an HMAC is the classic setup for a verifier that treats the shared secret as a public key. Never issuing that header is the only guarantee available from this side.

`PreviewTokenIssuer` builds its manager inside `issue()`, so it validates the algorithm at construction too — otherwise a misconfigured issuer first fails on whatever preview link an operator happens to create, arbitrarily far from the cause.

## Non-vacuity

15 of the 24 new tests fail on `main`:

```
FAILED ...::test_the_signature_uses_the_digest_the_header_names[HS384]
FAILED ...::test_the_signature_uses_the_digest_the_header_names[HS512]
FAILED ...::test_a_token_this_manager_issues_is_one_auth_verify_jwt_accepts[HS384]
FAILED ...::test_a_token_this_manager_issues_is_one_auth_verify_jwt_accepts[HS512]
FAILED ...::test_signature_length_matches_the_named_digest[HS384]
FAILED ...::test_signature_length_matches_the_named_digest[HS512]
FAILED ...::test_an_algorithm_the_manager_cannot_sign_with_is_refused[RS256|ES256|none|HS255|hs256|]
FAILED ...::TestPreviewTokenIssuer::test_a_bad_algorithm_is_refused_when_the_issuer_is_built
FAILED ...::TestPreviewTokenIssuer::test_a_supported_algorithm_issues_a_verifiable_token[HS384|HS512]
15 failed, 9 passed
```

The 9 that pass are the HS256 cases and `test_the_manager_still_round_trips_its_own_token` — that one is the control. It passed before the fix too, and it is precisely what hid the defect: sign and verify moved together, so the class was self-consistently wrong.

Existing suites unaffected: `test_jwt_refresh.py` (18), `test_security_modules.py` (19), `tests/unit/preview` (46) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)