### PR TITLE
fix(security): a torn quarantine write releases every quarantined task

### DIFF
--- a/src/bernstein/core/security/quarantine.py
+++ b/src/bernstein/core/security/quarantine.py
@@ -16,6 +16,8 @@ from dataclasses import asdict, dataclass
 from datetime import date, timedelta
 from typing import TYPE_CHECKING, Literal
 
+from bernstein.core.persistence.atomic_write import write_atomic_json
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -86,7 +88,16 @@ class QuarantineStore:
                 for item in raw
             ]
         except (json.JSONDecodeError, KeyError, TypeError) as exc:
-            logger.warning("quarantine: failed to load %s: %s", self._path, exc)
+            # Degrading to "nothing is quarantined" is the permissive answer:
+            # every repeatedly-failing task becomes eligible again. Kept, so a
+            # damaged file cannot stop the orchestrator, but logged as an
+            # error saying what was lost - a WARNING understated it.
+            logger.error(
+                "quarantine: %s is unreadable (%s); treating every task as not quarantined "
+                "until the file is repaired or removed",
+                self._path,
+                exc,
+            )
             return []
 
     def get_entry(self, task_title: str) -> QuarantineEntry | None:
@@ -139,11 +150,19 @@ class QuarantineStore:
 
         Creates parent directories as needed.
 
+        Written through :func:`write_atomic_json` rather than in place. A
+        plain write truncates the destination before it writes, so the window
+        between those two steps is one where the file on disk holds no
+        entries - and :meth:`load` reads an unparseable file as "nothing is
+        quarantined", which is the permissive answer. A crash in that window
+        therefore releases every quarantined task back into the next run's
+        schedule, silently. Writing to a temporary file and renaming means a
+        reader sees either the previous set or the new one, never neither.
+
         Args:
             entries: Full list of entries to write (replaces current file).
         """
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        self._path.write_text(json.dumps([asdict(e) for e in entries], indent=2))
+        write_atomic_json(self._path, [asdict(e) for e in entries])
 
     def record_failure(self, task_title: str, reason: str) -> None:
         """Record a failure for *task_title*, incrementing its fail count.

--- a/tests/unit/test_quarantine.py
+++ b/tests/unit/test_quarantine.py
@@ -11,10 +11,14 @@ Covers:
 
 from __future__ import annotations
 
+import builtins
 import json
+import logging
+import os
 from datetime import date, timedelta
 from typing import TYPE_CHECKING
 
+import pytest
 from bernstein.core.quarantine import QUARANTINE_THRESHOLD, QuarantineEntry, QuarantineStore
 
 if TYPE_CHECKING:
@@ -284,3 +288,124 @@ def test_get_action_returns_skip_by_default(tmp_path: Path) -> None:
 def test_get_action_returns_none_for_unknown_task(tmp_path: Path) -> None:
     store = _store(tmp_path)
     assert store.get_entry("unknown") is None
+
+
+# ---------------------------------------------------------------------------
+# The write is crash-safe
+# ---------------------------------------------------------------------------
+#
+# ``load`` reads an unparseable file as an empty list - every quarantined task
+# becomes eligible again. That is the permissive answer, and it is reachable
+# from the store's own writes: a plain ``write_text`` truncates the
+# destination before writing it, so a crash between those two steps leaves
+# zero bytes where the quarantine set used to be. The next run reschedules
+# every known-bad task, with a single log line as the only trace.
+#
+# ``write_atomic_json`` writes a temporary file, fsyncs it, and renames it
+# over the destination, so a reader sees the previous set or the new one and
+# never neither.
+
+
+def test_the_destination_is_never_opened_for_writing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The invariant that makes the write atomic, asserted directly.
+
+    An in-place write has to truncate the destination; a rename never touches
+    it. So "was the destination ever opened for writing" separates the two
+    implementations exactly, without needing to catch the crash window in the
+    act.
+    """
+    store_path = tmp_path / "quarantine.json"
+    opened_for_write: list[str] = []
+
+    real_open = os.open
+
+    def spy(path: object, flags: int, *args: object, **kwargs: object) -> int:
+        if flags & (os.O_WRONLY | os.O_RDWR):
+            opened_for_write.append(str(path))
+        return real_open(path, flags, *args, **kwargs)  # type: ignore[arg-type]
+
+    real_builtin_open = builtins.open
+
+    def builtin_spy(file: object, mode: str = "r", *args: object, **kwargs: object) -> object:
+        if any(flag in mode for flag in ("w", "a", "+", "x")):
+            opened_for_write.append(str(file))
+        return real_builtin_open(file, mode, *args, **kwargs)  # type: ignore[arg-type, call-overload]
+
+    monkeypatch.setattr(os, "open", spy)
+    monkeypatch.setattr(builtins, "open", builtin_spy)
+
+    QuarantineStore(store_path).save([QuarantineEntry("t", 1, date.today().isoformat(), "boom")])
+
+    assert str(store_path) not in opened_for_write
+    assert opened_for_write, "nothing was opened for writing at all - the spy is not wired up"
+
+
+def test_the_write_is_flushed_to_disk(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A rename that outlives its own bytes is not a crash-safe write."""
+    synced: list[int] = []
+    real_fsync = os.fsync
+
+    def spy(fd: int) -> None:
+        synced.append(fd)
+        real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", spy)
+
+    QuarantineStore(tmp_path / "quarantine.json").save([QuarantineEntry("t", 1, date.today().isoformat(), "boom")])
+
+    assert synced, "quarantine state was published without being fsynced"
+
+
+def test_a_save_leaves_no_temporary_file_behind(tmp_path: Path) -> None:
+    store_path = tmp_path / "quarantine.json"
+    store = QuarantineStore(store_path)
+    store.save([QuarantineEntry("t", 1, date.today().isoformat(), "boom")])
+    store.save([QuarantineEntry("t", 2, date.today().isoformat(), "boom again")])
+
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["quarantine.json"]
+
+
+def test_a_rewrite_replaces_the_previous_contents(tmp_path: Path) -> None:
+    """``Path.rename`` refuses an existing destination on Windows.
+
+    Delegating must not turn the second save of a run into a crash there.
+    """
+    store_path = tmp_path / "quarantine.json"
+    store = QuarantineStore(store_path)
+    today = date.today().isoformat()
+    store.save([QuarantineEntry("first", 1, today, "a")])
+    store.save([QuarantineEntry("second", 2, today, "b")])
+
+    assert [e.task_title for e in store.load()] == ["second"]
+
+
+def test_a_truncated_file_releases_every_quarantined_task(tmp_path: Path) -> None:
+    """The consequence the atomic write exists to prevent, spelled out.
+
+    This is documentation rather than a regression: it passes either way. It
+    is what a torn write costs, and it is why ``load`` degrading to ``[]``
+    makes the write path the thing that has to be safe.
+    """
+    store_path = tmp_path / "quarantine.json"
+    store = QuarantineStore(store_path)
+    for _ in range(QUARANTINE_THRESHOLD):
+        store.record_failure("known bad task", "boom")
+    assert store.is_quarantined("known bad task")
+
+    intact = store_path.read_text()
+    store_path.write_text(intact[: len(intact) // 2])
+
+    assert not QuarantineStore(store_path).is_quarantined("known bad task")
+
+
+def test_an_unreadable_file_is_logged_as_an_error_naming_what_was_lost(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A WARNING understated it: the whole quarantine set stops applying."""
+    store_path = tmp_path / "quarantine.json"
+    store_path.write_text("{ not json")
+
+    with caplog.at_level(logging.ERROR, logger="bernstein.core.security.quarantine"):
+        assert QuarantineStore(store_path).load() == []
+
+    assert "treating every task as not quarantined" in caplog.text


### PR DESCRIPTION
## The bug

`QuarantineStore.save` wrote in place:

```python
self._path.parent.mkdir(parents=True, exist_ok=True)
self._path.write_text(json.dumps([asdict(e) for e in entries], indent=2))
```

An in-place write truncates the destination *before* it writes it. And `load` reads an unparseable file as an empty list:

```python
except (json.JSONDecodeError, KeyError, TypeError) as exc:
    logger.warning("quarantine: failed to load %s: %s", self._path, exc)
    return []
```

An empty list means nothing is quarantined. So the window between truncate and write is a window in which the file on disk says every repeatedly-failing task is eligible again.

A crash in that window is not recoverable by the next run — it re-reads the same file, gets `[]`, and schedules every known-bad task. `QUARANTINE_THRESHOLD` failures' worth of evidence is gone, and a single log line is the whole trace.

The window is not rare, either: the store persists after every `record_failure`, so it is entered on each failure the orchestrator records, not once per run.

```python
>>> store.is_quarantined("known bad task")
True
>>> path.write_text(path.read_text()[:len//2])   # what a crash leaves behind
>>> QuarantineStore(path).is_quarantined("known bad task")
False
```

## The fix

Routed through `core.persistence.atomic_write.write_atomic_json` — the module that exists for exactly this: temp file, fsync, `os.replace`, fsync of the containing directory. A reader now sees the previous set or the new one, never neither.

`load` still degrades to `[]` for a file it cannot parse — a damaged file must not stop the orchestrator — but says so at `ERROR` and names the consequence. `WARNING` understated it: the whole quarantine set stops applying.

## Non-vacuity

Three of the six new tests fail on `main`:

```
FAILED tests/unit/test_quarantine.py::test_the_destination_is_never_opened_for_writing
FAILED tests/unit/test_quarantine.py::test_the_write_is_flushed_to_disk
FAILED tests/unit/test_quarantine.py::test_an_unreadable_file_is_logged_as_an_error_naming_what_was_lost
3 failed, 23 passed
```

The write-side two assert the properties that actually separate the two implementations, rather than trying to catch the crash window in the act:

- **the destination is never opened for writing** — an in-place write has to truncate it, a rename never touches it, so this is the atomicity invariant stated directly (spies on both `os.open` and `builtins.open`, and asserts the spy caught *something* so it cannot pass by being unwired);
- **the bytes are fsynced before they are published** — a rename that outlives its own bytes is not crash-safe.

`test_a_truncated_file_releases_every_quarantined_task` passes either way, on purpose. It is not a regression test; it is what the torn write costs, and the reason the write path is the half that has to be safe. Two more (no stray temp file, a rewrite replaces the previous contents) guard the delegation itself — the second because `Path.rename` refuses an existing destination on Windows, which is how these conversions have gone wrong before.

## Out of scope

`record_failure` is load-mutate-save with no lock, so two orchestrators sharing a workdir lose updates. Atomicity does not fix that and I did not try to — `core/persistence/file_locks.py` is the tool for it, and it deserves its own decision rather than being bolted onto this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)