### PR TITLE
fix(security): HOME=/ made the redactor rewrite every string it touched

### DIFF
--- a/src/bernstein/core/security/redactor.py
+++ b/src/bernstein/core/security/redactor.py
@@ -36,7 +36,20 @@ if TYPE_CHECKING:
 
 __all__ = ["collapse_home", "mask", "redact_file", "redact_text"]
 
-_HOME_RE: re.Pattern[str] | None = None
+#: Cached ``(home value, compiled pattern)``. Keyed on the home value rather
+#: than compiled once and kept forever: ``$HOME`` is read from the environment,
+#: and a process that changes it would otherwise keep collapsing against the
+#: path it started with.
+_HOME_CACHE: tuple[str, re.Pattern[str] | None] | None = None
+
+
+def _home_prefix() -> str:
+    """Return the current home directory, without a trailing separator."""
+    home = os.environ.get("HOME") or os.path.expanduser("~")
+    # Both separators: a value can arrive from a Windows environment
+    # (``C:\\Users\\x\\``) as readily as a POSIX one, and only the POSIX
+    # spelling was being trimmed.
+    return home.rstrip("/\\")
 
 
 def _home_pattern() -> re.Pattern[str] | None:
@@ -44,16 +57,43 @@ def _home_pattern() -> re.Pattern[str] | None:
 
     Compiled lazily because ``$HOME`` can be unset in CI runners; we
     return ``None`` in that case and skip the collapse step.
+
+    ``None`` is also returned when the home directory is a filesystem root -
+    ``/`` on POSIX, ``C:\\`` on Windows. Trimming the trailing separator
+    leaves such a value empty (or a bare drive letter), and an empty pattern
+    matches at *every* position: ``re.compile("").sub("~", "abc")`` is
+    ``"~a~b~c~"``. That is not a redaction failing to fire, it is every string
+    that passes through the redactor being rewritten character by character.
+
+    ``HOME=/`` is the ordinary configuration for a container running as root,
+    and :func:`redact_text` runs on the write path of the work ledger *before*
+    each entry is hashed - so the corruption would be sealed into the chain,
+    not merely displayed. Collapsing the root to ``~`` would be wrong even if
+    it worked, since every absolute path on the host begins with it.
     """
-    global _HOME_RE
-    if _HOME_RE is not None:
-        return _HOME_RE
-    home = os.environ.get("HOME") or os.path.expanduser("~")
-    if not home or home == "~":
-        return None
-    # Match the literal home path as a path prefix.
-    _HOME_RE = re.compile(re.escape(home.rstrip("/")))
-    return _HOME_RE
+    global _HOME_CACHE
+    home = _home_prefix()
+    if _HOME_CACHE is not None and _HOME_CACHE[0] == home:
+        return _HOME_CACHE[1]
+    # ``expanduser`` returns "~" unchanged when it cannot resolve one.
+    # ``_is_filesystem_root`` covers the emptied-by-trimming cases above.
+    pattern = None if not home or home == "~" or _is_filesystem_root(home) else re.compile(re.escape(home))
+    _HOME_CACHE = (home, pattern)
+    return pattern
+
+
+def _is_filesystem_root(home: str) -> bool:
+    """Is *home* a filesystem root rather than a directory inside one?
+
+    Reached with the trailing separator already trimmed, so ``/`` arrives as
+    ``""`` and ``C:\\`` as ``"C:"``. A UNC share root (``\\\\server\\share``)
+    trims to ``\\\\server\\share`` and is left alone - it is a real directory
+    with a real prefix, unlike the two above.
+    """
+    if not home:
+        return True
+    # A bare drive designator: "C:" is what "C:\\" trims down to.
+    return len(home) == 2 and home[1] == ":" and home[0].isalpha()
 
 
 def collapse_home(text: str) -> str:

--- a/tests/unit/orchestration/test_missions_projection.py
+++ b/tests/unit/orchestration/test_missions_projection.py
@@ -1115,16 +1115,15 @@ _PINNED_HALTED_STATUS_HASH_V2 = "fd879e56b1572468c9fa2ee778e814971cc66960f61a717
 def _become_host(monkeypatch: pytest.MonkeyPatch, home: str) -> None:
     """Point the process at a different $HOME, as a second machine would.
 
-    The redactor compiles the $HOME pattern once into a module global, so
-    setting the environment variable alone leaves the first host's pattern
-    live and hides any host dependence entirely. Clearing that cache is what
-    makes this equivalent to a fresh process on another machine -- without it
-    these tests pass even against the defective code they exist to catch.
+    The redactor used to compile the $HOME pattern once into a module global,
+    so setting the environment variable alone left the first host's pattern
+    live and hid any host dependence entirely -- these tests passed even
+    against the defective code they exist to catch, until the cache was
+    cleared by hand here. The cache is now keyed on the home value it was
+    built from, so a changed $HOME recompiles on its own and the environment
+    variable is the whole of the setup again.
     """
-    from bernstein.core.security import redactor
-
     monkeypatch.setenv("HOME", home)
-    monkeypatch.setattr(redactor, "_HOME_RE", None, raising=False)
 
 
 def test_receipt_hash_is_independent_of_home(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/security/test_redactor_home_collapse.py
+++ b/tests/unit/security/test_redactor_home_collapse.py
@@ -1,0 +1,154 @@
+"""A home directory that is a filesystem root must not become an empty pattern.
+
+``collapse_home`` rewrites ``$HOME`` to ``~``. It built its pattern by
+trimming the trailing separator off the home value::
+
+    _HOME_RE = re.compile(re.escape(home.rstrip("/")))
+
+``HOME=/`` trims to ``""``, and an empty pattern matches at every position, so
+``sub`` inserts ``~`` between every character of the input. That is not a
+redaction failing to fire - it is every string passing through the redactor
+being rewritten character by character.
+
+``HOME=/`` is the ordinary configuration for a container running as root. The
+blast radius is not cosmetic: ``redact_text`` runs on the write path of the
+work ledger *before* each entry is hashed, so the mangled text is what gets
+sealed into the chain.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from bernstein.core.security import redactor
+from bernstein.core.security.redactor import collapse_home, redact_text
+
+
+@pytest.fixture(autouse=True)
+def _clear_home_cache() -> None:
+    """The pattern cache is keyed on the home value, but not across tests."""
+    redactor._HOME_CACHE = None
+
+
+@pytest.mark.parametrize("home", ["/", "//", "///"])
+def test_a_posix_root_home_leaves_text_untouched(home: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """On main this returns ``'~a~b~c~/~d~e~f~'``."""
+    monkeypatch.setenv("HOME", home)
+
+    assert collapse_home("abc/def") == "abc/def"
+
+
+@pytest.mark.parametrize("home", ["C:\\", "C:", "z:\\"])
+def test_a_windows_drive_root_home_leaves_text_untouched(home: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``rstrip("/")`` never trimmed a backslash, so ``C:\\`` stayed ``C:\\``.
+
+    That is not the empty-pattern catastrophe - it is a pattern that rewrites
+    every absolute path on the drive to ``~`` - but it is the same mistake:
+    a filesystem root is not a home prefix worth collapsing.
+    """
+    monkeypatch.setenv("HOME", home)
+
+    assert collapse_home("C:\\Windows\\System32") == "C:\\Windows\\System32"
+
+
+def test_the_mangling_reaches_redact_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``collapse_home`` is the last step of the public entry point.
+
+    This is the one that matters: ``redact_text`` is what the work ledger and
+    the task mailbox call, so a corrupted result is persisted, not just shown.
+    """
+    monkeypatch.setenv("HOME", "/")
+
+    cleaned, count = redact_text("the quick brown fox")
+
+    assert cleaned == "the quick brown fox"
+    assert count == 0
+
+
+def test_a_real_home_still_collapses(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The control: the feature has to keep working.
+
+    A fix that only ever returned ``None`` would pass every test above.
+    """
+    monkeypatch.setenv("HOME", "/home/alice")
+
+    assert collapse_home("/home/alice/src/app.py") == "~/src/app.py"
+
+
+def test_a_trailing_separator_on_a_real_home_is_still_trimmed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", "/home/alice/")
+
+    assert collapse_home("/home/alice/src/app.py") == "~/src/app.py"
+
+
+def test_a_windows_home_collapses_and_its_trailing_backslash_is_trimmed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", "C:\\Users\\alice\\")
+
+    assert collapse_home("C:\\Users\\alice\\src\\app.py") == "~\\src\\app.py"
+
+
+def test_a_unc_share_root_is_treated_as_a_real_home(monkeypatch: pytest.MonkeyPatch) -> None:
+    """It is a directory with a real prefix, unlike ``/`` and ``C:\\``.
+
+    Pinned so the root check is not widened into "anything that looks rootish".
+    """
+    monkeypatch.setenv("HOME", "\\\\server\\share")
+
+    assert collapse_home("\\\\server\\share\\notes.txt") == "~\\notes.txt"
+
+
+def test_a_home_with_regex_metacharacters_is_matched_literally(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``re.escape`` was always there; this keeps it there."""
+    monkeypatch.setenv("HOME", "/home/a+b(c)")
+
+    assert collapse_home("/home/a+b(c)/x") == "~/x"
+    assert collapse_home("/home/aXbYcZ/x") == "/home/aXbYcZ/x"
+
+
+class TestThePatternCacheFollowsHome:
+    """The cache is keyed on the home value it was built from.
+
+    It used to be compiled once into a module global and kept for the life of
+    the process, so a changed ``$HOME`` kept collapsing against the first one.
+    ``tests/unit/orchestration/test_missions_projection.py`` had to clear that
+    global by hand to make its host-independence tests meaningful at all.
+    """
+
+    def test_a_changed_home_recompiles(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HOME", "/home/alice")
+        assert collapse_home("/home/alice/x") == "~/x"
+
+        monkeypatch.setenv("HOME", "/home/bob")
+        assert collapse_home("/home/alice/x") == "/home/alice/x"
+        assert collapse_home("/home/bob/x") == "~/x"
+
+    def test_moving_to_a_root_home_recompiles_to_no_pattern(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A cached good pattern must not be what saves the root case."""
+        monkeypatch.setenv("HOME", "/home/alice")
+        assert collapse_home("/home/alice/x") == "~/x"
+
+        monkeypatch.setenv("HOME", "/")
+        assert collapse_home("abc") == "abc"
+
+    def test_an_unchanged_home_is_not_recompiled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The cache still caches - this runs on every ledger string."""
+        monkeypatch.setenv("HOME", "/home/alice")
+        collapse_home("/home/alice/x")
+
+        compiles = 0
+        real_compile = re.compile
+
+        def counting_compile(*args: object, **kwargs: object) -> re.Pattern[str]:
+            nonlocal compiles
+            compiles += 1
+            return real_compile(*args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(re, "compile", counting_compile)
+        for _ in range(10):
+            collapse_home("/home/alice/x")
+
+        assert compiles == 0


### PR DESCRIPTION
## The bug

`collapse_home` built its pattern by trimming the trailing separator off the home value:

```python
home = os.environ.get("HOME") or os.path.expanduser("~")
if not home or home == "~":
    return None
_HOME_RE = re.compile(re.escape(home.rstrip("/")))
```

`HOME=/` trims to `""`, and an empty pattern matches at **every position**:

```python
>>> collapse_home("abc/def")
'~a~b~c~/~d~e~f~'
```

The guard above does not catch it: `/` is neither empty nor `"~"` — it is only emptied by the trim that follows it.

This is not a redaction failing to fire. Every string that passes through `redact_text` comes back rewritten character by character. And `HOME=/` is the ordinary configuration for a container running as root.

## Why it is not cosmetic

The consumers are on write paths, not display paths:

- **`work_ledger._redact_value`** runs `redact_text` over every string in a payload *before* the entry is hashed. That ordering is deliberate and documented — "the hash is computed over the redacted payload, [so] the portable chain verifies everywhere without ever carrying the cleartext". It also means the mangled text is what gets sealed into the chain.
- **`task_mailbox`** stores the redacted message body.
- **`cli/debug_bundle`** writes the result to a file an operator reads.

## The fix

A filesystem root is not a home prefix worth collapsing under any circumstances — every absolute path on the host begins with it. `/` and `C:\` now return no pattern.

`rstrip` also handles backslashes, which it never did: `C:\` survived the trim intact and compiled to a pattern matching every absolute path on the drive. Different symptom, same mistake.

A UNC share root (`\server\share`) is deliberately *not* treated as a root — it is a real directory with a real prefix — and there is a test pinning that, so the check cannot be widened into "anything that looks rootish".

## The stale pattern cache, while in here

The pattern was compiled once into a module global and kept for the life of the process, so a changed `$HOME` kept collapsing against the first one. It is now keyed on the home value it was built from.

That hazard was already known. `tests/unit/orchestration/test_missions_projection.py` cleared the global by hand and said why:

> The redactor compiles the $HOME pattern once into a module global, so setting the environment variable alone leaves the first host's pattern live and hides any host dependence entirely. Clearing that cache is what makes this equivalent to a fresh process on another machine — without it these tests pass even against the defective code they exist to catch.

That workaround is removed and the docstring updated. Its 64 tests now pass on `monkeypatch.setenv` alone, which is the check that the new keying works.

## Non-vacuity

Eight of the fifteen new tests fail on `main` (with a one-line shim so the module still imports the renamed cache):

```
FAILED ...::test_a_posix_root_home_leaves_text_untouched[/]
FAILED ...::test_a_posix_root_home_leaves_text_untouched[//]
FAILED ...::test_a_posix_root_home_leaves_text_untouched[///]
FAILED ...::test_a_windows_drive_root_home_leaves_text_untouched[C:\]
FAILED ...::test_a_windows_drive_root_home_leaves_text_untouched[C:]
FAILED ...::test_the_mangling_reaches_redact_text
FAILED ...::test_a_windows_home_collapses_and_its_trailing_backslash_is_trimmed
FAILED ...::TestThePatternCacheFollowsHome::test_moving_to_a_root_home_recompiles_to_no_pattern
```

(A ninth, `test_an_unchanged_home_is_not_recompiled`, also reports — but it exercises the new cache and the shim distorts it, so I am not claiming it as a genuine `main` failure.)

The controls are what stop the fix degrading into "never collapse anything": a real home still collapses, a trailing separator on a real home is still trimmed, a UNC share root is still a real home, and regex metacharacters in a home are still escaped.

Consumers verified: `test_work_ledger` (21), `test_work_ledger_chaos` (2), `test_audit_chain_work_ledger` (2), `test_task_mailbox` (21), `test_debug_bundle` (70), `test_log_redact` (30), `test_missions_projection` (64) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)