### PR TITLE
fix(mutation): record an untrusted module when the baseline times out

### DIFF
--- a/scripts/mutmut_critical.py
+++ b/scripts/mutmut_critical.py
@@ -28,7 +28,8 @@ Exit codes:
 
     0 - every module met its threshold
     1 - at least one module below threshold (gate failed)
-    2 - baseline tests fail (cannot trust mutation results)
+    2 - baseline tests fail (cannot trust mutation results); a timed-out
+        baseline exits the same way with ``baseline_timeout`` in the JSON
 """
 
 from __future__ import annotations
@@ -42,6 +43,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
+
+#: Per-mutant pytest cap. The baseline run gets a share of the module's
+#: own ``budget_seconds`` (see :func:`_mutate_module`) instead of this
+#: constant: a baseline is one run, a mutant run is one of many, and one
+#: constant for both is what made a slow suite fatal (issue #5570).
+_MUTANT_RUN_TIMEOUT = 180
 
 
 @dataclass(frozen=True)
@@ -215,6 +222,7 @@ class ModuleResult:
     elapsed_seconds: float = 0.0
     threshold: float = 0.0
     baseline_ok: bool = True
+    baseline_timeout: bool = False  # baseline run exceeded its budget (distinct from a failing baseline)
     timed_out: bool = False  # wall-clock budget exceeded mid-run
 
     @property
@@ -236,12 +244,13 @@ class ModuleResult:
             "threshold": self.threshold,
             "passed": self.passed,
             "baseline_ok": self.baseline_ok,
+            "baseline_timeout": self.baseline_timeout,
             "elapsed_seconds": round(self.elapsed_seconds, 1),
             "budget_exceeded": self.timed_out,
         }
 
 
-def _run_tests(test_paths: tuple[str, ...]) -> bool:
+def _run_tests(test_paths: tuple[str, ...], timeout: int = _MUTANT_RUN_TIMEOUT) -> bool:
     """Return True iff tests pass (i.e. mutation NOT killed)."""
     res = subprocess.run(
         [
@@ -258,9 +267,21 @@ def _run_tests(test_paths: tuple[str, ...]) -> bool:
         cwd=str(REPO),
         capture_output=True,
         text=True,
-        timeout=180,
+        timeout=timeout,
     )
     return res.returncode == 0
+
+
+def _baseline_timeout_seconds(mod: Module) -> int:
+    """Wall-clock budget for a module's baseline pytest run.
+
+    A quarter of the module's own ``budget_seconds`` - a baseline is one
+    run of the suite, while a mutant run is one of many inside the same
+    budget - floored at the per-mutant cap so the baseline never gets a
+    smaller allowance than a single mutant (issue #5570).
+    """
+
+    return max(mod.budget_seconds // 4, _MUTANT_RUN_TIMEOUT)
 
 
 def _candidates(target: Path, limit: int) -> list[tuple[int, str, str, str]]:
@@ -298,7 +319,14 @@ def _mutate_module(mod: Module, *, verbose: bool = True) -> ModuleResult:
 
     if verbose:
         print(f"[{mod.key}] baseline tests: {mod.tests}", flush=True)
-    if not _run_tests(mod.tests):
+    try:
+        baseline_passed = _run_tests(mod.tests, timeout=_baseline_timeout_seconds(mod))
+    except subprocess.TimeoutExpired:
+        print(f"[{mod.key}] baseline timed out - cannot trust mutation run", file=sys.stderr)
+        res.baseline_ok = False
+        res.baseline_timeout = True
+        return res
+    if not baseline_passed:
         print(f"[{mod.key}] baseline fails - cannot trust mutation run", file=sys.stderr)
         res.baseline_ok = False
         return res
@@ -347,7 +375,7 @@ def _print_summary(results: list[ModuleResult]) -> None:
         status = "PASS" if r.passed else ("BASE-FAIL" if not r.baseline_ok else "FAIL")
         rate = f"{100 * r.kill_rate:5.1f}%" if r.total else "  n/a"
         thr = f"{100 * r.threshold:4.0f}%"
-        suffix = " (budget exceeded)" if r.timed_out else ""
+        suffix = " (baseline timed out)" if r.baseline_timeout else (" (budget exceeded)" if r.timed_out else "")
         print(f"{r.key:<20} {rate:>10} {thr:>6} {status:>8}  {r.killed}/{r.total} killed{suffix}")
     for r in results:
         if r.survivors:

--- a/tests/unit/test_mutmut_critical_baseline_timeout.py
+++ b/tests/unit/test_mutmut_critical_baseline_timeout.py
@@ -1,0 +1,88 @@
+"""Regression tests for a baseline run that times out (issue #5570).
+
+``scripts/mutmut_critical.py`` guards the *mutant* pytest call against
+``subprocess.TimeoutExpired`` but its baseline call was bare, so a suite
+that crossed the timeout limit killed the whole nightly job with a
+traceback instead of recording one untrusted module. These tests pin the
+guarded behaviour; no test actually waits three minutes - the timeout is
+injected by monkeypatching ``subprocess.run`` to raise, per the issue's
+reproduction brief.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from scripts import mutmut_critical
+from scripts.mutmut_critical import (
+    Module,
+    _mutate_module,  # pyright: ignore[reportPrivateUsage]
+)
+
+# The real lineage_tips entry from MODULES: same source and suite as the
+# nightly job that crashed, so the missing-source guard is satisfied and
+# the baseline path under test is the production one.
+LINEAGE_TIPS = Module(
+    key="lineage_tips",
+    source="src/bernstein/core/lineage/tips.py",
+    tests=("tests/unit/lineage/",),
+    threshold=0.75,
+    budget_seconds=600,
+    max_candidates=60,
+    note="Lineage v1 tip tracker.",
+)
+
+
+def _raise_timeout(cmd: list[str], timeout: int | None = None, **_: Any) -> None:
+    raise subprocess.TimeoutExpired(cmd, timeout=timeout if timeout is not None else 180.0)
+
+
+def _failing_run(cmd: list[str], timeout: int | None = None, **_: Any) -> SimpleNamespace:
+    return SimpleNamespace(returncode=1)
+
+
+def test_baseline_timeout_records_an_untrusted_module(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(subprocess, "run", _raise_timeout)
+    res = _mutate_module(LINEAGE_TIPS, verbose=False)
+    assert res.baseline_ok is False
+    assert res.baseline_timeout is True
+    assert res.total == 0
+    # The stderr line must name the timeout, not just "baseline fails".
+    err = capsys.readouterr().err
+    assert "timed out" in err
+
+
+def test_baseline_timeout_still_writes_the_module_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+    monkeypatch.setattr(subprocess, "run", _raise_timeout)
+    exit_code = mutmut_critical.main(["--only", "lineage_tips", "--quiet", "--json", str(tmp_path / "out.json")])
+    assert exit_code == 2
+    data = json.loads((tmp_path / "out.json").read_text())
+    assert len(data) == 1
+    assert data[0]["module"] == "lineage_tips"
+    assert data[0]["baseline_ok"] is False
+    assert data[0]["baseline_timeout"] is True
+
+
+def test_baseline_timeout_is_distinct_from_baseline_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(subprocess, "run", _raise_timeout)
+    timed_out = _mutate_module(LINEAGE_TIPS, verbose=False)
+    timeout_err = capsys.readouterr().err
+
+    monkeypatch.setattr(subprocess, "run", _failing_run)
+    failed = _mutate_module(LINEAGE_TIPS, verbose=False)
+    failure_err = capsys.readouterr().err
+
+    assert timed_out.baseline_ok is False and failed.baseline_ok is False
+    assert timed_out.baseline_timeout is True
+    assert failed.baseline_timeout is False
+    assert "timed out" in timeout_err
+    assert "baseline fails" in failure_err
+    assert timed_out.to_dict() != failed.to_dict()


### PR DESCRIPTION
## What

Guards the baseline pytest call in `scripts/mutmut_critical.py` against `subprocess.TimeoutExpired`, so a suite that crosses its timeout budget records one untrusted module instead of crashing the nightly job with a traceback and uploading no artifact.

## Why

Since the 2026-09-06 08:39 nightly run, `lineage_tips` dies with `subprocess.TimeoutExpired` from the baseline call at `scripts/mutmut_critical.py:301`. The mutant loop already treats a timeout as a normal outcome (records it, counts the mutant killed, moves on), but the baseline call twelve lines earlier is bare, so the exception escapes, `main` never reaches its JSON write, and the module's result file is never uploaded. `ModuleResult` already carries `baseline_ok` for exactly this; the baseline path just could not reach it. Fixes #5570.

## How

- Wrapped the baseline `_run_tests` call in `try/except subprocess.TimeoutExpired`, mirroring the mutant-loop handler: set `baseline_ok = False`, set the new `baseline_timeout = True`, print a distinct stderr line (`baseline timed out` vs `baseline fails`), and `return res` so the JSON artifact still writes and the exit code stays 2.
- Added `baseline_timeout: bool` to `ModuleResult` and `to_dict`, so "too slow to measure" is not read as "the suite is failing" in the uploaded summary.
- Gave the baseline its own budget: `max(budget_seconds // 4, 180)` per module. On the decision the issue leaves open, I went with a slice of `budget_seconds` over a multiple of the per-mutant timeout: a baseline is one run of the suite, a mutant run is one of many inside the same module budget, so the module's own sizing is the right base. The 180s floor keeps the baseline from ever getting a smaller allowance than a single mutant run.
- The shared per-mutant cap is unchanged (now the named `_MUTANT_RUN_TIMEOUT`), and mutant-timeout semantics are untouched.
- The console summary marks the case as `BASE-FAIL (baseline timed out)`.

For `lineage_tips` (600s budget) the derived baseline budget is still 180s, so that module keeps failing until the lineage suite gets its own timing work. That is deliberate per the issue: this change makes the failure legible, not invisible.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes for the affected files (`pyright scripts/mutmut_critical.py tests/unit/test_mutmut_critical_baseline_timeout.py` is clean apart from the pre-existing `survivors` partial-unknown on `main`; the repo-wide advisory job is unchanged from `main` at 24983 pre-existing errors and gates nothing)
- [x] `uv run python scripts/run_tests.py -x` passes for the affected suites (new file plus the neighbouring mutation harness tests, 127 passed locally; CI `Test` shards and `Integration tests` green on this head)
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (N/A, internal-only harness)
- [x] `docs/operations/<area>.md` updated (N/A)
- [x] `docs/api/` schema regenerated if a public surface changed (N/A)
- [x] `uv run bernstein agents-md sync` run (N/A, no new module)
- [x] Tests cover the documented behaviour

## Verification

- before, on current `main` (`0f56c53`): `uv run pytest tests/unit/test_mutmut_critical_baseline_timeout.py -q --no-cov`: all 3 tests fail with `subprocess.TimeoutExpired` escaping `_mutate_module`, the reported crash
- after (`53a69f17`): same command, 3 passed; the result carries `baseline_ok: false, baseline_timeout: true`, `main --json` still writes the module JSON and exits 2, and a failing baseline keeps `baseline_timeout: false`
- `uv run ruff check scripts/mutmut_critical.py tests/unit/test_mutmut_critical_baseline_timeout.py` and `ruff format --check`: clean
- `uv run pyright scripts/mutmut_critical.py tests/unit/test_mutmut_critical_baseline_timeout.py`: only the pre-existing `survivors` partial-unknown on `main` remains
- `uv run python scripts/mutmut_critical.py --list`: unchanged module table
- `uv run pytest tests/unit/test_mutation_fixed_workflow_yaml.py tests/unit/test_seed_parser_mutation_kill.py -q --no-cov`: 124 passed, mutation-workflow and neighbouring harness tests unaffected

Internal-only harness change, so the documentation duty items are N/A.

