### PR TITLE
feat(bench): bundles carry a harness fingerprint; compare refuses to rank across harnesses

### DIFF
--- a/docs/eval/bench.md
+++ b/docs/eval/bench.md
@@ -119,6 +119,34 @@ any leaderboard entry is written.
 The leaderboard (`docs/eval/leaderboard.md`) lists only verified bundles,
 each row linking its bundle hash so anyone can re-verify.
 
+### 4. Compare two bundles
+
+```bash
+bernstein bench compare a.json b.json
+```
+
+`bench compare` ranks two bundles by score, but only when they were
+produced by the **same harness settings**.  Every bundle carries a
+`harness_fingerprint` (see [Bundle format](#bundle-format)) — a SHA-256
+over the canonical JSON of the `scheduler_config` mapping that shaped
+the run.  When the fingerprints differ, `compare` prints which settings
+keys differ and **refuses to rank**, because a score gap across
+differing harness settings is a harness change, not a model change:
+
+```text
+Harness fingerprints differ: 9f1c48d0aa21… vs 5b07d39c88fe…
+Differing harness settings: prompt_template
+Refusing to rank: a score gap across differing harness settings is a
+harness change, not a model change.  Pass --allow-harness-drift to rank
+anyway.
+```
+
+Pass `--allow-harness-drift` to rank anyway (the differing keys are
+still printed).  The stored fingerprint is recomputed from the raw
+`scheduler_config` beside it before it is trusted; a bundle whose stored
+fingerprint does not match its own settings fails with an integrity
+error even with the flag.
+
 ---
 
 ## Reliability floor (`--reliability k`)
@@ -177,6 +205,7 @@ Two runners on the same `suite_hash` provably ran the same task set.
   "suite_version": "golden-v1",
   "submitted_at": 1753000000.0,
   "scheduler_config": {"...": "..."},
+  "harness_fingerprint": "<sha256 of canonical scheduler_config JSON>",
   "overall_score": 0.95,
   "pass_rate": 1.0,
   "task_results": [
@@ -203,6 +232,18 @@ Two runners on the same `suite_hash` provably ran the same task set.
 The `receipt` is the replay substrate.  The `score` only means something
 because the receipt exists to replay it.  Removing or corrupting the receipt
 makes the entire bundle fail verification.
+
+`harness_fingerprint` is a SHA-256 over the canonical JSON (sorted keys,
+no whitespace) of the full `scheduler_config` mapping.  It is a pure
+projection of the settings carried beside it — it does not participate
+in `bundle_hash` — and is recomputed by `bench compare` before it is
+trusted.  The whole mapping is hashed rather than a named-key allowlist,
+so a setting nobody thought to list still changes the fingerprint instead
+of silently drifting two runs onto one identity; wall-clock time, paths,
+and run identity are excluded because they are not harness settings.
+Bundles emitted before the field existed load unchanged (the fingerprint
+is derived on load), and comparing against one reads as drift requiring
+`--allow-harness-drift`.
 
 ---
 

--- a/src/bernstein/eval/bench/__init__.py
+++ b/src/bernstein/eval/bench/__init__.py
@@ -1,6 +1,6 @@
 """bernstein-bench: runnable, reproducibility-gated evaluation harness."""
 
-from bernstein.eval.bench.bundle import SubmissionBundle, TaskResult
+from bernstein.eval.bench.bundle import SubmissionBundle, TaskResult, harness_fingerprint
 from bernstein.eval.bench.contamination import (
     ContaminationVerdict,
     admit_task,
@@ -89,6 +89,7 @@ __all__ = [
     "coordination_projection",
     "extract_ngrams",
     "first_divergent_coordination_field",
+    "harness_fingerprint",
     "reliability_check",
     "validate_run_receipt",
 ]

--- a/src/bernstein/eval/bench/bench_cli.py
+++ b/src/bernstein/eval/bench/bench_cli.py
@@ -193,6 +193,85 @@ def bench_verify(bundle: str, suite: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# bernstein bench compare
+# ---------------------------------------------------------------------------
+
+
+@bench_group.command(name="compare")
+@click.argument("a")
+@click.argument("b")
+@click.option(
+    "--allow-harness-drift",
+    is_flag=True,
+    default=False,
+    help="Rank even when the two bundles' harness fingerprints differ.",
+)
+def bench_compare(a: str, b: str, allow_harness_drift: bool) -> None:
+    """Compare two submission bundles, ranking by score.
+
+    A and B are paths to submission bundle .json files.
+
+    The harness fingerprint is recomputed from each bundle's raw
+    scheduler_config before it is trusted.  Bundles from different
+    harnesses are not ranked against each other unless
+    --allow-harness-drift is passed: a score gap across differing
+    harness settings is a harness change, not a model change.
+
+    Exits 0 when the bundles are ranked, 1 on harness mismatch without
+    the flag or on a fingerprint integrity failure.
+    """
+    from bernstein.eval.bench.bundle import SubmissionBundle, harness_fingerprint
+
+    path_a, path_b = Path(a), Path(b)
+    for path in (path_a, path_b):
+        if not path.exists():
+            raise click.ClickException(f"Bundle file not found: {path}")
+
+    bundle_a = SubmissionBundle.load(path_a)
+    bundle_b = SubmissionBundle.load(path_b)
+
+    # Recompute before trust: a stored fingerprint that disagrees with
+    # the settings beside it is an integrity failure, not drift.
+    expected_a = harness_fingerprint(bundle_a.scheduler_config)
+    expected_b = harness_fingerprint(bundle_b.scheduler_config)
+    for path, bundle, expected in ((path_a, bundle_a, expected_a), (path_b, bundle_b, expected_b)):
+        if bundle.harness_fingerprint != expected:
+            raise click.ClickException(
+                f"Harness fingerprint integrity failure: {path} stores "
+                f"{bundle.harness_fingerprint[:12]}… but its scheduler_config "
+                f"hashes to {expected[:12]}…."
+            )
+
+    fp_a, fp_b = bundle_a.harness_fingerprint, bundle_b.harness_fingerprint
+    if fp_a != fp_b:
+        differing = sorted(
+            key
+            for key in set(bundle_a.scheduler_config) | set(bundle_b.scheduler_config)
+            if bundle_a.scheduler_config.get(key) != bundle_b.scheduler_config.get(key)
+        )
+        click.echo(f"Harness fingerprints differ: {fp_a[:12]}… vs {fp_b[:12]}…")
+        click.echo(f"Differing harness settings: {', '.join(differing)}")
+        if not allow_harness_drift:
+            click.echo(
+                "Refusing to rank: a score gap across differing harness settings "
+                "is a harness change, not a model change. "
+                "Pass --allow-harness-drift to rank anyway."
+            )
+            sys.exit(1)
+        click.echo("--allow-harness-drift: ranking anyway.")
+    else:
+        click.echo(f"Harness fingerprint: {fp_a} (match)")
+
+    ordered = sorted([(path_a, bundle_a), (path_b, bundle_b)], key=lambda p: -p[1].overall_score)
+    click.echo("")
+    for rank, (path, bundle) in enumerate(ordered, start=1):
+        click.echo(
+            f"{rank}. {path.name}: score {bundle.overall_score * 100:.1f}%, "
+            f"pass rate {bundle.pass_rate * 100:.1f}%, {len(bundle.task_results)} tasks"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Reliability: pass^k floor (issue #2933)
 # ---------------------------------------------------------------------------
 

--- a/src/bernstein/eval/bench/bundle.py
+++ b/src/bernstein/eval/bench/bundle.py
@@ -85,6 +85,37 @@ class TaskResult:
 
 
 # ---------------------------------------------------------------------------
+# Harness fingerprint
+# ---------------------------------------------------------------------------
+
+FINGERPRINT_SCHEMA_VERSION = 1
+
+
+def harness_fingerprint(scheduler_config: Mapping[str, Any]) -> str:
+    """Canonical fingerprint of the harness settings that shaped a run.
+
+    sha256 over the canonical JSON (sorted keys, no whitespace) of the
+    full ``scheduler_config`` mapping — the single settings carrier every
+    runner passes to ``adapter.run_task``: decomposition config, prompt
+    template, tool allowlist, effort/thinking budget, retry policy,
+    timeouts, sandbox type, and any key a caller adds.
+
+    The whole mapping is hashed rather than a named-key allowlist, so a
+    setting nobody thought to list still changes the fingerprint instead
+    of silently drifting two runs onto one identity.  Nothing outside the
+    mapping participates: wall-clock time, paths, and run identity are
+    not harness settings, and a fingerprint that included them would
+    never match across runs.
+    """
+    canonical = json.dumps(
+        {"schema": FINGERPRINT_SCHEMA_VERSION, "settings": scheduler_config},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    return hashlib.sha256(canonical).hexdigest()
+
+
+# ---------------------------------------------------------------------------
 # Bundle
 # ---------------------------------------------------------------------------
 
@@ -108,6 +139,17 @@ class SubmissionBundle:
     # Install identity fingerprint (public-key fingerprint of the signer).
     signer_fingerprint: str = ""
     holdout_hash: str = ""
+    # Canonical fingerprint of the harness settings (scheduler_config).
+    # Derived at construction when not supplied; from_dict passes the
+    # stored value so a tampered one survives load for compare to catch,
+    # and a pre-#5568 bundle derives it on load instead of failing.
+    harness_fingerprint: str = ""
+
+    def __post_init__(self) -> None:
+        # If caller didn't supply a fingerprint, derive it now — same
+        # emit-time contract as TaskResult.stored_receipt_hash.
+        if not self.harness_fingerprint:
+            self.harness_fingerprint = harness_fingerprint(self.scheduler_config)
 
     # Computed lazily.
     _bundle_hash: str | None = field(default=None, init=False, repr=False, compare=False)
@@ -165,6 +207,7 @@ class SubmissionBundle:
             "suite_version": self.suite_version,
             "submitted_at": self.submitted_at,
             "scheduler_config": self.scheduler_config,
+            "harness_fingerprint": self.harness_fingerprint,
             "overall_score": self.overall_score,
             "pass_rate": self.pass_rate,
             "task_results": [r.to_dict() for r in self.task_results],
@@ -217,6 +260,7 @@ class SubmissionBundle:
             signature=raw.get("signature", ""),
             signer_fingerprint=raw.get("signer_fingerprint", ""),
             holdout_hash=raw.get("holdout_hash", ""),
+            harness_fingerprint=raw.get("harness_fingerprint", ""),
         )
         # Integrity guard: recompute hash and compare.
         if bundle.bundle_hash() != raw["bundle_hash"]:

--- a/src/bernstein/eval/bench/leaderboard.py
+++ b/src/bernstein/eval/bench/leaderboard.py
@@ -36,6 +36,9 @@ class LeaderboardEntry:
     num_tasks: int
     submitted_at: float
     signer_fingerprint: str = ""
+    # Harness-settings fingerprint carried from the bundle; groups the
+    # leaderboard so rows are only ranked against like harnesses.
+    harness_fingerprint: str = ""
     # Path to the bundle file (relative to the leaderboard root).
     bundle_path: str = ""
 
@@ -55,6 +58,7 @@ class LeaderboardEntry:
             "submitted_at": self.submitted_at,
             "submitted_at_iso": self.submitted_at_iso(),
             "signer_fingerprint": self.signer_fingerprint,
+            "harness_fingerprint": self.harness_fingerprint,
             "bundle_path": self.bundle_path,
         }
 
@@ -115,6 +119,7 @@ class Leaderboard:
                 num_tasks=e["num_tasks"],
                 submitted_at=e["submitted_at"],
                 signer_fingerprint=e.get("signer_fingerprint", ""),
+                harness_fingerprint=e.get("harness_fingerprint", ""),
                 bundle_path=e.get("bundle_path", ""),
             )
             for e in raw.get("entries", [])
@@ -163,26 +168,44 @@ class Leaderboard:
             f"Suite version: **{self.suite_version}**  ",
             f"Suite hash: `{self.suite_hash}`",
             "",
-            "| Rank | Score | Pass rate | Tasks | Submitted | Bundle hash |",
-            "|------|------:|----------:|------:|-----------|-------------|",
+            "Rows are grouped by harness fingerprint: scores are only ranked "
+            "against bundles produced by the same harness settings "
+            "(`scheduler_config`).",
+            "",
         ]
 
-        for rank, entry in enumerate(self.entries, start=1):
-            score_pct = f"{entry.overall_score * 100:.1f}%"
-            pass_pct = f"{entry.pass_rate * 100:.1f}%"
-            short_hash = entry.bundle_hash[:16]
-            bundle_link = f"[`{short_hash}…`]({entry.bundle_path})" if entry.bundle_path else f"`{short_hash}…`"
-            lines.append(
-                f"| {rank} "
-                f"| {score_pct} "
-                f"| {pass_pct} "
-                f"| {entry.num_tasks} "
-                f"| {entry.submitted_at_iso()} "
-                f"| {bundle_link} |"
-            )
+        # One ranked section per harness fingerprint, best group first.
+        groups: dict[str, list[LeaderboardEntry]] = {}
+        for entry in self.entries:
+            groups.setdefault(entry.harness_fingerprint, []).append(entry)
+        ordered_groups = sorted(groups.items(), key=lambda kv: (-max(e.overall_score for e in kv[1]), kv[0]))
+
+        for fingerprint, group in ordered_groups:
+            label = f"{fingerprint[:12]}…" if fingerprint else "(unattributed — pre-fingerprint bundle)"
+            lines += [
+                f"### Harness {label}",
+                "",
+                "| Rank | Score | Pass rate | Tasks | Submitted | Bundle hash | Harness |",
+                "|------|------:|----------:|------:|-----------|-------------|---------|",
+            ]
+            for rank, entry in enumerate(group, start=1):
+                score_pct = f"{entry.overall_score * 100:.1f}%"
+                pass_pct = f"{entry.pass_rate * 100:.1f}%"
+                short_hash = entry.bundle_hash[:16]
+                bundle_link = f"[`{short_hash}…`]({entry.bundle_path})" if entry.bundle_path else f"`{short_hash}…`"
+                harness_cell = f"`{entry.harness_fingerprint[:12]}…`" if entry.harness_fingerprint else "—"
+                lines.append(
+                    f"| {rank} "
+                    f"| {score_pct} "
+                    f"| {pass_pct} "
+                    f"| {entry.num_tasks} "
+                    f"| {entry.submitted_at_iso()} "
+                    f"| {bundle_link} "
+                    f"| {harness_cell} |"
+                )
+            lines.append("")
 
         lines += [
-            "",
             "---",
             "",
             "## How to verify a row",

--- a/tests/unit/eval/bench/test_harness_fingerprint.py
+++ b/tests/unit/eval/bench/test_harness_fingerprint.py
@@ -1,0 +1,277 @@
+"""
+Harness-fingerprint tests for bernstein-bench (issue #5568).
+
+The four acceptance tests named in the issue, plus the boundary cases
+recorded in the patch matrix: save/load round trip, pre-#5568 legacy
+bundle load, stored-fingerprint integrity recompute, same-fingerprint
+ranking, and leaderboard round trip.  All hermetic (MockReplayAdapter).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.eval.bench.bench_cli import bench_group
+from bernstein.eval.bench.bundle import SubmissionBundle, harness_fingerprint
+from bernstein.eval.bench.leaderboard import Leaderboard, LeaderboardEntry
+from bernstein.eval.bench.runner import BenchRunner, MockReplayAdapter
+from bernstein.eval.bench.suite import BenchSuite, BenchTask
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+#: Harness settings shaped like a real deployment's scheduler_config: the
+#: keys the issue enumerates (decomposition, prompt template, tool
+#: allowlist, effort/thinking budget, retry policy, timeouts, sandbox).
+BASE_CFG: dict = {
+    "scheduler": "default",
+    "decomposition": {"depth": 2},
+    "prompt_template": "code-review-v1",
+    "tool_allowlist": ["read", "grep", "apply_patch"],
+    "effort": "high",
+    "thinking_budget": 4096,
+    "retry": {"max_attempts": 2, "backoff_s": 5},
+    "timeout_s": 900,
+    "sandbox": "seatbelt",
+}
+
+
+@pytest.fixture()
+def simple_suite() -> BenchSuite:
+    """A minimal two-task suite for fast tests."""
+    return BenchSuite(
+        version="test-v1",
+        tasks=[
+            BenchTask(
+                id="task_a",
+                description="Task A",
+                steps=("step 1", "step 2"),
+                assertions=({"kind": "exists"},),
+                category="cat1",
+            ),
+            BenchTask(
+                id="task_b",
+                description="Task B",
+                steps=("step 1",),
+                assertions=({"kind": "syntax_valid"},),
+                category="cat2",
+            ),
+        ],
+    )
+
+
+@pytest.fixture()
+def adapter() -> MockReplayAdapter:
+    return MockReplayAdapter()
+
+
+def _make_bundle(suite: BenchSuite, adapter: MockReplayAdapter, cfg: dict | None = None) -> SubmissionBundle:
+    runner = BenchRunner(suite=suite, adapter=adapter, scheduler_config=cfg if cfg is not None else {})
+    return runner.run()
+
+
+def _write_bundle(bundle: SubmissionBundle, directory: Path, name: str) -> Path:
+    path = directory / name
+    bundle.save(path)
+    return path
+
+
+# ===========================================================================
+# AC-1 / AC-2 — the fingerprint itself
+# ===========================================================================
+
+
+class TestHarnessFingerprint:
+    def test_fingerprint_changes_when_a_prompt_template_changes(
+        self, simple_suite: BenchSuite, adapter: MockReplayAdapter
+    ) -> None:
+        cfg_a = {**BASE_CFG, "prompt_template": "code-review-v1"}
+        cfg_b = {**BASE_CFG, "prompt_template": "code-review-v2"}
+        bundle_a = _make_bundle(simple_suite, adapter, cfg_a)
+        bundle_b = _make_bundle(simple_suite, adapter, cfg_b)
+
+        assert bundle_a.harness_fingerprint != ""
+        assert bundle_a.harness_fingerprint != bundle_b.harness_fingerprint
+
+    def test_fingerprint_is_stable_across_identical_runs(
+        self, simple_suite: BenchSuite, adapter: MockReplayAdapter, tmp_path: Path
+    ) -> None:
+        # Two separately built config dicts with shuffled key order: the
+        # canonical JSON must make insertion order irrelevant.
+        cfg_1 = {k: BASE_CFG[k] for k in reversed(list(BASE_CFG))}
+        cfg_2 = dict(BASE_CFG)
+        bundle_1 = _make_bundle(simple_suite, adapter, cfg_1)
+        bundle_2 = _make_bundle(simple_suite, adapter, cfg_2)
+
+        assert bundle_1.harness_fingerprint == bundle_2.harness_fingerprint
+
+        # The stored value is exactly the canonical function of the raw
+        # settings carried beside it.
+        assert bundle_1.harness_fingerprint == harness_fingerprint(bundle_1.scheduler_config)
+
+        # A save/load round trip preserves it byte-for-byte.
+        path = _write_bundle(bundle_1, tmp_path, "bundle.json")
+        loaded = SubmissionBundle.load(path)
+        assert loaded.harness_fingerprint == bundle_1.harness_fingerprint
+
+    def test_legacy_bundle_without_the_field_still_loads(
+        self, simple_suite: BenchSuite, adapter: MockReplayAdapter, tmp_path: Path
+    ) -> None:
+        bundle = _make_bundle(simple_suite, adapter, BASE_CFG)
+        path = _write_bundle(bundle, tmp_path, "legacy.json")
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        del raw["harness_fingerprint"]
+        path.write_text(json.dumps(raw), encoding="utf-8")
+
+        loaded = SubmissionBundle.load(path)
+        # The fingerprint is a pure function of scheduler_config, so a
+        # pre-#5568 bundle derives it on load instead of failing.
+        assert loaded.harness_fingerprint == harness_fingerprint(loaded.scheduler_config)
+
+
+# ===========================================================================
+# AC-3 — bench compare
+# ===========================================================================
+
+
+class TestBenchCompare:
+    def test_compare_refuses_different_fingerprints_without_the_flag(
+        self, simple_suite: BenchSuite, adapter: MockReplayAdapter, tmp_path: Path
+    ) -> None:
+        from click.testing import CliRunner
+
+        bundle_a = _make_bundle(simple_suite, adapter, {**BASE_CFG, "prompt_template": "code-review-v1"})
+        bundle_b = _make_bundle(simple_suite, adapter, {**BASE_CFG, "prompt_template": "code-review-v2"})
+        path_a = _write_bundle(bundle_a, tmp_path, "a.json")
+        path_b = _write_bundle(bundle_b, tmp_path, "b.json")
+
+        result = CliRunner().invoke(bench_group, ["compare", str(path_a), str(path_b)])
+        assert result.exit_code == 1
+        assert "prompt_template" in result.output
+        assert "--allow-harness-drift" in result.output
+
+        overridden = CliRunner().invoke(bench_group, ["compare", str(path_a), str(path_b), "--allow-harness-drift"])
+        assert overridden.exit_code == 0, overridden.output
+        assert "prompt_template" in overridden.output
+
+    def test_compare_ranks_same_fingerprint_bundles(
+        self, simple_suite: BenchSuite, adapter: MockReplayAdapter, tmp_path: Path
+    ) -> None:
+        from click.testing import CliRunner
+
+        bundle_a = _make_bundle(simple_suite, adapter, BASE_CFG)
+        bundle_b = _make_bundle(simple_suite, adapter, dict(BASE_CFG))
+        path_a = _write_bundle(bundle_a, tmp_path, "a.json")
+        path_b = _write_bundle(bundle_b, tmp_path, "b.json")
+
+        result = CliRunner().invoke(bench_group, ["compare", str(path_a), str(path_b)])
+        assert result.exit_code == 0, result.output
+        assert path_a.name in result.output
+        assert path_b.name in result.output
+        assert bundle_a.harness_fingerprint in result.output
+
+    def test_compare_refuses_a_stored_fingerprint_that_does_not_match_its_settings(
+        self, simple_suite: BenchSuite, adapter: MockReplayAdapter, tmp_path: Path
+    ) -> None:
+        from click.testing import CliRunner
+
+        bundle_a = _make_bundle(simple_suite, adapter, BASE_CFG)
+        bundle_b = _make_bundle(simple_suite, adapter, BASE_CFG)
+        path_a = _write_bundle(bundle_a, tmp_path, "a.json")
+        path_b = _write_bundle(bundle_b, tmp_path, "b.json")
+
+        # Edit the stored fingerprint without touching scheduler_config.
+        # It sits outside bundle_hash (a projection of settings already
+        # hashed), so load succeeds and compare's recompute must catch it.
+        raw = json.loads(path_a.read_text(encoding="utf-8"))
+        raw["harness_fingerprint"] = "f4" * 32
+        path_a.write_text(json.dumps(raw), encoding="utf-8")
+
+        result = CliRunner().invoke(bench_group, ["compare", str(path_a), str(path_b), "--allow-harness-drift"])
+        assert result.exit_code == 1
+        assert "integrity" in result.output
+
+
+# ===========================================================================
+# AC-4 — leaderboard groups rows by fingerprint
+# ===========================================================================
+
+
+class TestLeaderboardGrouping:
+    def test_leaderboard_groups_rows_by_fingerprint(self) -> None:
+        fp_1 = "1f" * 32
+        fp_2 = "2e" * 32
+
+        def entry(fp: str, score: float) -> LeaderboardEntry:
+            return LeaderboardEntry(
+                bundle_hash=f"hash-{fp[:4]}-{score}",
+                suite_hash="x",
+                suite_version="v1",
+                overall_score=score,
+                pass_rate=score,
+                num_tasks=2,
+                submitted_at=1.0,
+                harness_fingerprint=fp,
+            )
+
+        lb = Leaderboard(suite_hash="x", suite_version="v1")
+        # The fp_2 row outscores both fp_1 rows globally; grouping must
+        # still rank it inside its own section, not at the top of fp_1's.
+        lb.add_entry(entry(fp_1, 0.9))
+        lb.add_entry(entry(fp_1, 0.8))
+        lb.add_entry(entry(fp_2, 1.0))
+
+        md = lb.to_markdown()
+
+        sections = [chunk for chunk in md.split("### Harness ")[1:]]
+        assert len(sections) == 2
+        # Every row shows its fingerprint prefix.
+        assert fp_1[:12] in md
+        assert fp_2[:12] in md
+        # Ranks restart within each group (data rows only — the first
+        # two pipe lines per section are the header and its rule).
+        # The fp_2 group has the global best score, so it renders first.
+        first, second = sections
+        first_ranks = [line.split("|")[1].strip() for line in first.splitlines() if line.startswith("|")][2:]
+        second_ranks = [line.split("|")[1].strip() for line in second.splitlines() if line.startswith("|")][2:]
+        assert first_ranks == ["1"]
+        assert second_ranks == ["1", "2"]
+
+    def test_leaderboard_round_trip_preserves_fingerprint(self, tmp_path: Path) -> None:
+        lb = Leaderboard(suite_hash="x", suite_version="v1")
+        lb.add_entry(
+            LeaderboardEntry(
+                bundle_hash="hash-x",
+                suite_hash="x",
+                suite_version="v1",
+                overall_score=1.0,
+                pass_rate=1.0,
+                num_tasks=2,
+                submitted_at=1.0,
+                harness_fingerprint="ab" * 32,
+            )
+        )
+        path = tmp_path / "lb.json"
+        lb.save(path)
+        loaded = Leaderboard.load(path)
+        assert loaded.entries[0].harness_fingerprint == "ab" * 32
+
+
+# ===========================================================================
+# AC-5 — documented schema and key coverage
+# ===========================================================================
+
+
+class TestDocs:
+    def test_docs_cover_the_fingerprint_and_compare(self) -> None:
+        repo_root = Path(__file__).parents[4]  # tests/unit/eval/bench/test_harness_fingerprint.py -> repo root
+        docs_path = repo_root / "docs" / "eval" / "bench.md"
+        assert docs_path.exists(), f"docs/eval/bench.md not found at {docs_path}."
+        content = docs_path.read_text(encoding="utf-8")
+        assert "harness_fingerprint" in content
+        assert "bernstein bench compare" in content
+        assert "--allow-harness-drift" in content


### PR DESCRIPTION
## What

Every signed bench bundle now carries a `harness_fingerprint`: a SHA-256
over the canonical JSON of the `scheduler_config` mapping that shaped the
run, stored beside the raw settings. `bernstein bench compare a b` names
the differing settings keys and refuses to rank bundles from different
harnesses unless `--allow-harness-drift` is passed, and the leaderboard
markdown groups rows by fingerprint (one ranked section per harness, the
fingerprint prefix on every row). Closes #5568.

## Why

Two runs with the same model but a different decomposition depth, prompt
template, tool allowlist or effort budget produce different numbers, and
a bundle could not tell them apart, so `bench compare` ranked them as if
the model had changed and a leaderboard row attributed a harness change
to the model. The fingerprint makes the harness part of the bundle's
identity, the same way `suite_hash` already makes the task set part of
it.

## How

- One canonical function, `harness_fingerprint(scheduler_config)` in
  `bundle.py`, hashes the full settings mapping (sorted keys, no
  whitespace). `SubmissionBundle` derives it at construction, the same
  emit-time contract as `TaskResult.stored_receipt_hash`: and
  `from_dict` restores the stored value, so a tampered value survives
  load for `compare` to catch.
- The whole mapping is hashed rather than a named-key allowlist, so a
  setting nobody thought to list still changes the fingerprint instead
  of silently drifting two runs onto one identity. Wall-clock time,
  paths, and run identity are excluded: they are not harness settings,
  and a fingerprint that included them would never match across runs.
- The fingerprint does not participate in `bundle_hash` (it is a pure
  projection of `scheduler_config`, which is already hashed), so
  existing stored bundles verify unchanged.
- `bench compare` recomputes each bundle's fingerprint from its raw
  `scheduler_config` before trusting the stored value; a mismatch fails
  with an integrity error even with `--allow-harness-drift`.
- The leaderboard's markdown projection renders one ranked table per
  fingerprint; `LeaderboardEntry` carries the fingerprint and it
  round-trips through save/load.
- Bundles emitted before this change load unchanged (the fingerprint is
  derived on load); comparing against one reads as drift requiring the
  flag.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes (repo pins mypy; `uv run mypy src`
      reports only the 3 pre-existing errors also present on `main`)
- [x] `uv run python scripts/run_tests.py -x` passes (scoped:
      `uv run pytest tests/unit/eval tests/unit/test_leaderboard.py -q`
      → 361 + 22 passed; the pre-existing `I001` findings in
      `tests/unit/test_codex_worktree_gitdir_writable.py` and
      `tests/unit/test_retry_unblocks_dependents.py` are also on `main`)
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] `docs/eval/bench.md` updated: compare walkthrough section and the
      bundle schema/key-coverage documentation the issue asks for
- [ ] `docs/operations/<area>.md` updated, N/A (no operations surface)
- [ ] `docs/api/` schema regenerated, N/A (no public API schema for the
      bench bundle)
- [x] `uv run bernstein agents-md sync`: N/A (no new module; the bench
      package map entry is unchanged)
- [x] Tests cover the documented behaviour

## Tests

The four acceptance tests named in the issue, all through the real entry
points (runner → bundle save/load, `CliRunner` on the `bench compare`
command, leaderboard projection):

- `test_fingerprint_changes_when_a_prompt_template_changes`
- `test_fingerprint_is_stable_across_identical_runs` (also covers the
  save/load round trip and that the stored value equals the canonical
  function of the raw settings)
- `test_compare_refuses_different_fingerprints_without_the_flag` (refusal
  names the differing key, exit 1; `--allow-harness-drift` ranks, exit 0)
- `test_leaderboard_groups_rows_by_fingerprint` (a globally-best row
  still ranks inside its own group; ranks restart per section)

Plus the recorded boundary cases: a pre-#5568 bundle without the field
still loads and derives its fingerprint; a stored fingerprint edited
away from its settings is refused as an integrity failure even with the
flag; same-fingerprint bundles rank; leaderboard entries round-trip the
fingerprint; and the docs file covers `harness_fingerprint`, `bench
compare`, and `--allow-harness-drift`. Also exercised the standalone
`bernstein-bench` CLI end to end (run → compare match/drift/flag/
tamper) outside the suite.

## Reproduction

```bash
# Two runs of the same suite with identical settings share a fingerprint:
uv run bernstein-bench run golden-v1 --out a.json --stub-signer
uv run bernstein-bench run golden-v1 --out b.json --stub-signer
uv run bernstein-bench compare a.json b.json   # fingerprint (match), ranks

# Edit b.json's scheduler_config prompt_template and its stored
# fingerprint/bundle_hash to match (genuine harness drift):
uv run bernstein-bench compare a.json b.json
# -> exit 1: "Differing harness settings: prompt_template", refuses to rank
uv run bernstein-bench compare a.json b.json --allow-harness-drift
# -> exit 0: ranks, still prints the differing keys
```
