### PR TITLE
fix(quality): fix AttributeError crash in the dead-code gate

### DIFF
--- a/docs/release-notes/fragments/5572-dead-code-gate-crash-fix.md
+++ b/docs/release-notes/fragments/5572-dead-code-gate-crash-fix.md
@@ -1,0 +1,15 @@
+## Fixed a crash in the dead-code quality gate
+
+`GateRunner._run_dead_code_gate_sync` called `self._build_dead_code_result`,
+a method `GateRunner` never defines or inherits. `GateRunnerCommandsMixin`
+(`core/quality/gate_commands.py`) defines it, but nothing composes that
+mixin into `GateRunner` — confirmed empirically: `GateRunner.__mro__` is
+just `(GateRunner, object)`. The gate is disabled by default
+(`dead_code_check=False`), which is why this went unnoticed: any operator
+who enabled it would have hit `AttributeError` on the very first run.
+`_build_dead_code_result` is a `@staticmethod` with no dependency on
+instance state, so the fix qualifies the call directly
+(`GateRunnerCommandsMixin._build_dead_code_result(...)`) — the same
+pattern the file already uses for two other cross-mixin static calls
+(`_check_alembic_migrations`, `_check_sql_migrations`). No change to what
+the gate reports; it now reports something instead of crashing (#5572).

--- a/src/bernstein/core/quality/gate_runner.py
+++ b/src/bernstein/core/quality/gate_runner.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 from bernstein.core.quality.gate_commands import (
+    GateRunnerCommandsMixin,
     _module_name_from_path,
     _resolve_import_from,
 )
@@ -686,7 +687,7 @@ class GateRunner:
             logger.warning("dead_code_detector.analyse failed: %s", exc)
             report = dead_code_detector.DeadCodeReport()
 
-        return self._build_dead_code_result(step, command, ok, vulture_detail, report)
+        return GateRunnerCommandsMixin._build_dead_code_result(step, command, ok, vulture_detail, report)
 
     def _run_comment_quality_gate_sync(
         self,

--- a/tests/unit/test_gate_runner.py
+++ b/tests/unit/test_gate_runner.py
@@ -428,3 +428,37 @@ def test_type_check_command_no_extra_files_when_no_importers(tmp_path: Path) -> 
     assert "utils.py" in cmd
     # other.py does not import utils.py - it must not be included
     assert "other.py" not in cmd
+
+
+def test_dead_code_gate_runs_to_completion_instead_of_crashing(tmp_path: Path) -> None:
+    """Regression for #5572: the dead-code gate must not raise AttributeError.
+
+    ``GateRunner._run_dead_code_gate_sync`` called ``self._build_dead_code_result``,
+    a method ``GateRunner`` never defined or inherited -- ``GateRunnerCommandsMixin``
+    defines it, but nothing composes that mixin into ``GateRunner`` (confirmed:
+    ``GateRunner.__mro__`` is just ``(GateRunner, object)``). The gate is disabled
+    by default (``dead_code_check=False``), which is why this went unnoticed: any
+    operator who turned it on would have hit this on the very first run. This test
+    fails before the fix (an unhandled ``AttributeError`` propagates out of
+    ``run_all``) and passes after.
+    """
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "module.py").write_text("def f() -> int:\n    return 1\n", encoding="utf-8")
+
+    config = QualityGatesConfig(
+        pipeline=[GatePipelineStep(name="dead_code", required=False, condition="python_changed")],
+        cache_enabled=False,
+    )
+    runner = GateRunner(config, tmp_path)
+    task = _make_task(owned_files=["src/module.py"])
+
+    def fake_run(_command: str, _cwd: Path, _timeout_s: int) -> tuple[bool, str, int]:
+        return True, "(no output)", 0
+
+    with patch("bernstein.core.quality.quality_gates._run_command", side_effect=fake_run):
+        report = asyncio.run(runner.run_all(task, tmp_path))
+
+    assert report.gates_run == ["dead_code"]
+    (result,) = report.results
+    assert result.status in ("pass", "fail", "warn")


### PR DESCRIPTION
## Summary

`GateRunner._run_dead_code_gate_sync` (`gate_runner.py:690`) called `self._build_dead_code_result`, which `GateRunner` never defines. `GateRunnerCommandsMixin` (`gate_commands.py`) defines it, and its own docstring claims it "is combined with `GateRunner` at runtime" — but **that composition does not exist**. I verified this empirically before writing any fix:

```python
>>> from bernstein.core.quality.gate_runner import GateRunner
>>> hasattr(GateRunner, '_build_dead_code_result')
False
>>> GateRunner.__mro__
(<class 'bernstein.core.quality.gate_runner.GateRunner'>, <class 'object'>)
```

A repo-wide search found no class statement, decorator, or dynamic injection mechanism anywhere that combines the two classes. This is a stronger finding than the issue's framing ("at runtime today the attribute resolves and the gate works") — the coupling doesn't just lack a declaration, it doesn't work at all. The gate is disabled by default (`dead_code_check: bool = False` in `quality_gates.py:232`), which is exactly why nobody has hit this: it only fires the first time an operator turns the gate on.

I reproduced the crash directly by reverting the fix locally and running the new test:

```
AttributeError: 'GateRunner' object has no attribute '_build_dead_code_result'
```

## Why not the issue's suggested Protocol, and why not inheriting the mixin

The issue offers two options: declare a `Protocol` on `self`, or relocate the method to a shared base. I checked a third option first — since `GateRunnerCommandsMixin` is a *mixin*, the obvious "correct" fix looked like making `GateRunner` inherit it. I checked the overlap before doing that:

```python
overlap = method_names('gate_runner.py') & method_names('gate_commands.py')
# {'_run_dead_code_gate_sync', '_run_tests_gate', '_run_complexity_gate_sync',
#  '_run_auto_format_gate_sync', '_run_import_cycle_gate_sync', ... 23 total}
```

**23 method names are independently defined in both files**, and `GateRunnerCommandsMixin` is never inherited by anything in `src/` today. Inheriting it into `GateRunner` would silently swap in 22 *other* gates' duplicate implementations for reasons nobody has investigated — a far larger and riskier change than this bug warrants, and it would violate the issue's own scope ("any behaviour change to the dead code gate — the result this builds must stay byte-identical," which a wholesale mixin merge cannot promise for the other 22 methods). I did **not** attempt that here. I flagged it as a separate follow-up investigation (chip visible in my session; can open a tracking issue on request) since it needs its own decision about which of the two duplicate implementations is meant to ship, or whether `gate_commands.py`'s copy is dead code from an abandoned refactor.

`_build_dead_code_result` is a `@staticmethod` with no dependency on instance state, so the minimal, actually-correct fix is to qualify the call directly: `GateRunnerCommandsMixin._build_dead_code_result(...)`. This exact pattern already exists in the same file for two other cross-mixin static calls — `GateRunnerCommandsMixin._check_alembic_migrations` / `_check_sql_migrations` at lines 961-962 — so this isn't a new idiom, it's applying the file's own established convention to the one call site that was missed.

## Verification

- Confirmed the AttributeError before the fix, confirmed it's gone after (see commit message for the exact revert-and-reproduce steps).
- Confirmed pyright's residual complaint on the fixed line (`reportPrivateUsage`) is byte-for-byte the same, already-tolerated warning the two existing precedent call sites produce — not a new class of pyright noise.
- Added `test_dead_code_gate_runs_to_completion_instead_of_crashing`, which fails with the real `AttributeError` before the fix and passes after, running the gate through the actual public `GateRunner.run_all` entry point (not a mocked/isolated call).

## Testing

```
uv run python -m pytest tests/unit/test_gate_runner.py -v
uv run python -m ruff check src/bernstein/core/quality/gate_runner.py tests/unit/test_gate_runner.py
uv run lint-imports
```

18/18 pass (including the one pre-existing timing-sensitive test in the file, confirmed flaky/unrelated by running it in isolation). Ruff and the architecture-contract check are clean.

Fixes #5572.
