### PR TITLE
docs(adapters): the capability table matches the matrix, and a test keeps it that way (#5597)

### DIFF
--- a/docs/adapters/capability_contract.md
+++ b/docs/adapters/capability_contract.md
@@ -139,7 +139,7 @@ adapters at a glance.
 | `cody` | unsupported | unsupported | text-signals |
 | `composio` | unsupported | unsupported | hooks |
 | `continue` | unsupported | unsupported | text-signals |
-| `copilot` | unsupported | unsupported | text-signals |
+| `copilot` | unsupported | cli-flag | text-signals |
 | `cursor` | unsupported | cli-flag | stream-json |
 | `devin_terminal` | unsupported | unsupported | poll-pty |
 | `droid` | unsupported | unsupported | text-signals |
@@ -151,10 +151,10 @@ adapters at a glance.
 | `hermes` | unsupported | always-on | text-signals |
 | `iac` | unsupported | unsupported | text-signals |
 | `junie` | unsupported | unsupported | text-signals |
-| `kilo` | unsupported | unsupported | text-signals |
+| `kilo` | unsupported | unsupported | acp |
 | `kimi` | unsupported | cli-flag | text-signals |
 | `kiro` | unsupported | unsupported | text-signals |
-| `letta_code` | unsupported | cli-flag | text-signals |
+| `letta_code` | unsupported | cli-flag | stream-json |
 | `mistral` | unsupported | unsupported | text-signals |
 | `mock` | unsupported | unsupported | text-signals |
 | `muse` | unsupported | cli-flag | text-signals |

--- a/docs/release-notes/fragments/5597-capability-doc-matches-matrix.md
+++ b/docs/release-notes/fragments/5597-capability-doc-matches-matrix.md
@@ -1,0 +1,17 @@
+## The adapter capability table stops drifting from the matrix it documents
+
+`docs/adapters/capability_contract.md` names itself an excerpt of
+`STRATEGY_MATRIX`, but nothing checked that claim, so three rows had gone
+stale against the declaration they were supposed to mirror: `copilot`'s
+dangerous mode read `unsupported` where the adapter passes
+`--allow-all-tools --no-ask-user` (`cli-flag`), `kilo`'s event channel read
+`text-signals` where the adapter speaks `acp`, and `letta_code`'s read
+`text-signals` where the adapter spawns with `--output-format stream-json`
+and parses each line with `json.loads`. An operator picking an adapter from
+this table was reading the wrong capability for all three.
+
+The three rows now match the matrix, and a test parses the table and
+cross-checks every adapter it lists against `strategy_table()`, so the next
+matrix correction that forgets the doc fails CI instead of sitting unnoticed.
+The table remains an excerpt — ten declared adapters are still absent from it,
+which is a separate question from whether the rows it does carry are true.

--- a/tests/unit/adapters/test_capability_doc_matches_matrix.py
+++ b/tests/unit/adapters/test_capability_doc_matches_matrix.py
@@ -1,0 +1,84 @@
+"""The capability-contract doc table must agree with ``STRATEGY_MATRIX``.
+
+``docs/adapters/capability_contract.md`` carries an operator-facing adapter
+table (adapter, resume, dangerous mode, event channel). The authoritative
+declaration is :data:`bernstein.adapters._contract.STRATEGY_MATRIX`, rendered
+by :func:`strategy_table`. The doc table is hand-maintained, so correcting a
+matrix row without editing the doc silently drifts the two apart -- which is
+what happened to ``copilot``, ``kilo`` and ``letta_code`` (#5597).
+
+These tests make that class of drift a CI failure instead of a discovery.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from bernstein.adapters._contract import strategy_table
+
+#: The doc table's row shape: ``| `name` | resume | dangerous | channel |``.
+_ROW = re.compile(
+    r"^\|\s*`(?P<adapter>[a-z0-9_]+)`"
+    r"\s*\|\s*(?P<resume>[^|]+?)"
+    r"\s*\|\s*(?P<dangerous_mode>[^|]+?)"
+    r"\s*\|\s*(?P<event_channel>[^|]+?)\s*\|\s*$"
+)
+
+_DOC = Path(__file__).resolve().parents[3] / "docs" / "adapters" / "capability_contract.md"
+
+
+def _doc_rows() -> dict[str, dict[str, str]]:
+    """Return the doc table's adapter rows, keyed by adapter name."""
+    rows: dict[str, dict[str, str]] = {}
+    for line in _DOC.read_text(encoding="utf-8").splitlines():
+        match = _ROW.match(line)
+        if match is None:
+            continue
+        rows[match.group("adapter")] = {
+            axis: match.group(axis) for axis in ("resume", "dangerous_mode", "event_channel")
+        }
+    return rows
+
+
+def _matrix_rows() -> dict[str, dict[str, str]]:
+    """Return the authoritative matrix rows, keyed by adapter name."""
+    return {row["adapter"]: dict(row) for row in strategy_table()}
+
+
+def test_doc_table_is_parsed_at_all() -> None:
+    """A regex that matches nothing would make every other check vacuous."""
+    rows = _doc_rows()
+    assert len(rows) > 20, f"parsed only {len(rows)} adapter rows from {_DOC}"
+
+
+def test_every_doc_row_names_a_declared_adapter() -> None:
+    """A doc row for an adapter with no matrix entry is stale by definition."""
+    unknown = sorted(set(_doc_rows()) - set(_matrix_rows()))
+    assert not unknown, (
+        f"{_DOC.name} documents adapters absent from STRATEGY_MATRIX: {unknown}. "
+        "Remove the row, or declare the adapter in the matrix."
+    )
+
+
+def test_doc_table_agrees_with_the_strategy_matrix() -> None:
+    """Every adapter present in both must carry identical axis values.
+
+    Adapters declared in the matrix but not yet listed in the doc are not
+    failures here -- the doc is an operator-facing excerpt, and completing it
+    is a separate question from keeping the rows it does carry truthful.
+    """
+    doc, matrix = _doc_rows(), _matrix_rows()
+    drift = {
+        adapter: {
+            axis: (doc[adapter][axis], matrix[adapter][axis])
+            for axis in ("resume", "dangerous_mode", "event_channel")
+            if doc[adapter][axis] != matrix[adapter][axis]
+        }
+        for adapter in sorted(doc.keys() & matrix.keys())
+    }
+    drift = {adapter: axes for adapter, axes in drift.items() if axes}
+    assert not drift, (
+        f"{_DOC.name} disagrees with STRATEGY_MATRIX (doc value, matrix value): {drift}. "
+        "The matrix is authoritative; update the doc table."
+    )


### PR DESCRIPTION
Closes #5597.

## What was wrong

`docs/adapters/capability_contract.md` calls itself an excerpt of `STRATEGY_MATRIX`, but nothing checked that, so three rows had gone stale. I re-verified each one against the adapter source rather than trusting the issue:

| Adapter | Axis | Doc said | Matrix says | Evidence in the adapter |
|---|---|---|---|---|
| `copilot` | dangerous mode | `unsupported` | `cli-flag` | `adapters/copilot.py` passes `--allow-all-tools --no-ask-user` |
| `kilo` | event channel | `text-signals` | `acp` | the module docstring names ACP/MCP headless mode |
| `letta_code` | event channel | `text-signals` | `stream-json` | spawns with `--output-format stream-json`, parses each line with `json.loads` |

The matrix is right in all three cases, so this corrects the doc, not the declarations. A script comparison over the whole table found exactly these three and no others.

## What this changes

1. The three doc rows now read the matrix values.
2. `tests/unit/adapters/test_capability_doc_matches_matrix.py` parses the table and asserts:
   - every adapter row equals `strategy_table()`'s row for that adapter on all three axes, reporting `(doc value, matrix value)` per drifting axis;
   - every documented adapter is actually declared in the matrix, so a removed or misspelled adapter is caught too;
   - the parse found rows at all — a regex that silently matched nothing would make the other two checks vacuous.

I verified the guard bites by re-staling the `kilo` row locally; the comparison fails and names the axis and both values.

## A decision worth stating

Ten adapters are declared in the matrix but absent from the doc table (`agy`, `antigravity`, `claude_routine`, `computer_use`, `garak`, `holmesgpt`, `kimchi`, `pydantic_ai`, `python_runtime`, `skyvern`). The test deliberately does **not** fail on those. The table reads as an operator-facing excerpt, and whether it should be exhaustive is a different question from whether the rows it carries are true — folding it in here would turn a drift guard into a completeness mandate the issue did not ask for. Happy to file it separately if you want the table exhaustive.

## Verification

```
uv run pytest tests/unit/adapters/test_capability_doc_matches_matrix.py -q   # 3 passed
uv run ruff check tests/unit/adapters/test_capability_doc_matches_matrix.py  # clean
uv run ruff format --check tests/unit/adapters/                              # clean
```

## Out of scope

No adapter behaviour changes — this is documentation accuracy plus the guard that keeps it accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)