### PR TITLE
feat(quality): a gate's scope declares its confidence, evidence and canonical bytes (#5395)

### DIFF
--- a/docs/release-notes/fragments/5395-verification-scope-confidence.md
+++ b/docs/release-notes/fragments/5395-verification-scope-confidence.md
@@ -1,0 +1,24 @@
+## A gate's scope says how far its claim reaches, and serialises the way receipts do
+
+`VerificationScope` recorded which paths a gate exercised and which it could
+not, but not how far that claim reached or where the evidence behind it
+lives, and it had no serialisation at all — so a scope could not be folded
+into a hashed subject without someone inventing a second canonical form for
+it.
+
+It now carries `confidence`, drawn from the closed set `high` / `partial` /
+`none`, and `evidence_ref`. Three levels is the smallest set that lets a
+later check answer "is a required oracle kind actually absent?" honestly: a
+kind covered only by `none` scopes has no coverage, and collapsing `partial`
+into either neighbour would force a gate to overstate or understate what it
+did. Construction rejects a confidence outside the set, naming the value and
+the allowed members.
+
+Construction also rejects a bare `str` for `checked` or `cannot_check`.
+`str` is iterable, so `checked="a.py"` would have silently become five
+single-character "paths" and the scope would have claimed coverage of files
+named `a` and `.` — a wrong claim that looked like a well-formed one.
+
+`canonical_bytes()` uses sorted keys and compact separators, the convention
+`merge_receipt._canonical_bytes` already keeps, so equal scopes hash
+identically regardless of the order their fields were built in.

--- a/src/bernstein/core/quality/gate_pipeline.py
+++ b/src/bernstein/core/quality/gate_pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -142,6 +143,25 @@ class GatePipelineStep:
     command_override: str | None = None
 
 
+#: Closed set of confidence levels a :class:`VerificationScope` may declare.
+#:
+#: Kept deliberately small (issue #5395 leaves the members to this slice).
+#: The set exists so a later check can ask "is a required oracle kind
+#: actually absent?" and get an honest answer, which needs exactly three
+#: distinctions:
+#:
+#: - ``"high"``   — the oracle exercised each entry in ``checked`` directly.
+#: - ``"partial"`` — it exercised them indirectly or incompletely (a subset,
+#:   a proxy, a sampled run). Coverage exists but does not stand alone.
+#: - ``"none"``   — the oracle ran and established nothing usable. A required
+#:   kind covered only by ``"none"`` scopes is absent in substance, which is
+#:   the case a two-member set could not express without lying.
+#:
+#: Widening this set needs its own issue: every consumer that branches on a
+#: member has to decide what a new one means.
+SCOPE_CONFIDENCE_LEVELS: frozenset[str] = frozenset({"high", "partial", "none"})
+
+
 @dataclass(frozen=True)
 class VerificationScope:
     """What a gate actually exercised, and what it explicitly could not.
@@ -150,9 +170,17 @@ class VerificationScope:
     examined. ``VerificationScope`` is the structured, attestable claim
     of that coverage: which oracle produced the verdict (``oracle_id``),
     what kind of check it was (``kind``), the concrete paths or
-    property names the gate evaluated (``checked``), and the known
-    blind spots the gate could not evaluate (``cannot_check`` — e.g.
-    generated or vendored files the gate was configured to skip).
+    property names the gate evaluated (``checked``), the known blind
+    spots it could not evaluate (``cannot_check`` — e.g. generated or
+    vendored files the gate was configured to skip), how far the claim
+    reaches (``confidence``), and where the underlying evidence lives
+    (``evidence_ref``).
+
+    The value serialises canonically -- sorted keys, compact separators,
+    the convention ``merge_receipt._canonical_bytes`` already uses -- so
+    two equal scopes produce identical bytes regardless of the order
+    their fields were built in, and a scope can be folded into a hashed
+    subject later without a second serialisation convention appearing.
 
     Attributes:
         oracle_id: Stable identifier of the oracle (tool, harness,
@@ -167,14 +195,98 @@ class VerificationScope:
             deterministically enumerate what they covered.
         cannot_check: Ordered tuple of known blind spots the gate could
             not evaluate. Tuples are ordered to match ``checked``.
+        confidence: How far the claim reaches, drawn from
+            :data:`SCOPE_CONFIDENCE_LEVELS`. Defaults to ``"high"``:
+            a gate that names what it checked and says nothing further
+            is claiming it checked those things.
+        evidence_ref: Pointer to the evidence behind the claim (a log
+            path, an artefact digest, a report id). Empty string when
+            the gate has no durable evidence to cite -- an honest empty
+            reference, not a missing field.
 
-    Issue #5397.
+    Issues #5397 (the type) and #5395 (confidence, evidence and
+    canonical serialisation).
     """
 
     oracle_id: str | None
     kind: str | None
     checked: tuple[str, ...]
     cannot_check: tuple[str, ...]
+    confidence: str = "high"
+    evidence_ref: str = ""
+
+    def __post_init__(self) -> None:
+        """Reject values the type cannot honestly represent.
+
+        Mirrors the ``status``/``reason`` invariant ``GateResult``
+        already enforces: a closed set is only closed if construction
+        checks it.
+
+        Two failures are worth catching separately. A ``confidence``
+        outside the closed set is a typo or an un-migrated caller. A
+        bare ``str`` passed for ``checked`` or ``cannot_check`` is worse
+        than either, because ``str`` is iterable: ``checked="a.py"``
+        would silently become seven single-character "paths" and the
+        scope would claim coverage of files named ``a``, ``.`` and
+        ``p``.
+        """
+        if self.confidence not in SCOPE_CONFIDENCE_LEVELS:
+            raise ValueError(
+                f"VerificationScope.confidence={self.confidence!r} is not in "
+                f"the closed set SCOPE_CONFIDENCE_LEVELS="
+                f"{sorted(SCOPE_CONFIDENCE_LEVELS)}"
+            )
+        for field_name in ("checked", "cannot_check"):
+            value = getattr(self, field_name)
+            if isinstance(value, str):
+                raise TypeError(
+                    f"VerificationScope.{field_name} must be a tuple of "
+                    f"strings, not a bare str (got {value!r}); a str would "
+                    "be iterated character by character"
+                )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON-serialisable dict form, lists for the tuples."""
+        return {
+            "oracle_id": self.oracle_id,
+            "kind": self.kind,
+            "checked": list(self.checked),
+            "cannot_check": list(self.cannot_check),
+            "confidence": self.confidence,
+            "evidence_ref": self.evidence_ref,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> VerificationScope:
+        """Rebuild a scope from :meth:`to_dict`, preserving every field.
+
+        Sequences come back as tuples, so a round trip through JSON
+        yields a value equal to the original rather than one that merely
+        looks like it.
+        """
+        return cls(
+            oracle_id=payload["oracle_id"],
+            kind=payload["kind"],
+            checked=tuple(payload["checked"]),
+            cannot_check=tuple(payload["cannot_check"]),
+            confidence=payload.get("confidence", "high"),
+            evidence_ref=payload.get("evidence_ref", ""),
+        )
+
+    def canonical_bytes(self) -> bytes:
+        """Canonical JSON bytes: sorted keys, minimal separators, UTF-8.
+
+        The same convention as ``merge_receipt._canonical_bytes``, so a
+        scope folded into a signed subject later hashes the way the rest
+        of the receipt family already does. Deliberately not a second
+        convention (issue #5395).
+        """
+        return json.dumps(
+            self.to_dict(),
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
 
 
 @dataclass

--- a/src/bernstein/core/quality/gate_runner.py
+++ b/src/bernstein/core/quality/gate_runner.py
@@ -33,11 +33,15 @@ from bernstein.core.quality.gate_pipeline import (
     VALID_GATE_NAMES,
     GatePipelineStep,
     GateReport,
-    GateResult,
     GateStatus,
     build_default_pipeline,
     normalize_gate_condition,
 )
+
+# Explicitly re-exported: `gate_plugins` and other callers import `GateResult`
+# through this module rather than from `gate_pipeline`, and a plain `import`
+# is not a re-export under `--no-implicit-reexport` (issue #5395).
+from bernstein.core.quality.gate_pipeline import GateResult as GateResult
 from bernstein.core.quality.gate_pipeline import (
     is_dep_file as _is_dep_file,
 )

--- a/tests/unit/test_verification_scope.py
+++ b/tests/unit/test_verification_scope.py
@@ -1,0 +1,161 @@
+"""``VerificationScope``: fields, validation and canonical serialisation (#5395).
+
+A gate verdict is only worth what the evidence behind it covers.
+``VerificationScope`` is the value that states that coverage, so the type has
+to hold two properties: it must round-trip without losing a field, and two
+equal scopes must serialise to identical bytes so a scope can be folded into
+a hashed subject later without a second canonical form appearing in the
+codebase.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bernstein.core.quality.gate_pipeline import (
+    SCOPE_CONFIDENCE_LEVELS,
+    GateResult,
+    VerificationScope,
+)
+
+
+def _scope(**overrides: object) -> VerificationScope:
+    """A fully populated scope, so no test depends on a default it forgot."""
+    kwargs: dict[str, object] = {
+        "oracle_id": "ruff",
+        "kind": "lint",
+        "checked": ("src/a.py", "src/b.py"),
+        "cannot_check": ("src/generated_pb2.py",),
+        "confidence": "high",
+        "evidence_ref": "sha256:0f1e",
+    }
+    kwargs.update(overrides)
+    return VerificationScope(**kwargs)  # type: ignore[arg-type]
+
+
+def test_scope_carries_every_declared_field() -> None:
+    """The six fields the type promises are all present and readable."""
+    scope = _scope()
+    assert scope.oracle_id == "ruff"
+    assert scope.kind == "lint"
+    assert scope.checked == ("src/a.py", "src/b.py")
+    assert scope.cannot_check == ("src/generated_pb2.py",)
+    assert scope.confidence == "high"
+    assert scope.evidence_ref == "sha256:0f1e"
+
+
+def test_dict_round_trip_preserves_every_field() -> None:
+    """``from_dict(to_dict(x)) == x``, tuples included.
+
+    Sequences must come back as tuples: a scope whose ``checked`` is a list
+    would compare unequal to the one it was built from, and a frozen
+    dataclass holding a list is not hashable.
+    """
+    scope = _scope()
+    restored = VerificationScope.from_dict(scope.to_dict())
+    assert restored == scope
+    assert isinstance(restored.checked, tuple)
+    assert isinstance(restored.cannot_check, tuple)
+
+
+def test_round_trip_survives_real_json() -> None:
+    """The dict form is JSON-serialisable, not merely dict-shaped."""
+    scope = _scope()
+    assert VerificationScope.from_dict(json.loads(json.dumps(scope.to_dict()))) == scope
+
+
+def test_optional_identity_fields_round_trip_as_none() -> None:
+    """A gate with no oracle identity keeps ``None``, not ``""``."""
+    scope = _scope(oracle_id=None, kind=None)
+    assert VerificationScope.from_dict(scope.to_dict()) == scope
+
+
+def test_equal_scopes_serialise_to_identical_bytes() -> None:
+    """Byte-stability is the whole point: two equal scopes, one digest."""
+    assert _scope().canonical_bytes() == _scope().canonical_bytes()
+
+
+def test_serialisation_key_order_does_not_depend_on_construction_order() -> None:
+    """Keys are sorted, so a scope built field-by-field in any order matches.
+
+    Constructed with keywords in reverse declaration order; the bytes must be
+    the ones the forward-order construction produces.
+    """
+    reversed_order = VerificationScope(
+        evidence_ref="sha256:0f1e",
+        confidence="high",
+        cannot_check=("src/generated_pb2.py",),
+        checked=("src/a.py", "src/b.py"),
+        kind="lint",
+        oracle_id="ruff",
+    )
+    assert reversed_order.canonical_bytes() == _scope().canonical_bytes()
+
+
+def test_canonical_bytes_are_sorted_and_compact() -> None:
+    """The convention is the receipt family's: sorted keys, no whitespace."""
+    raw = _scope().canonical_bytes()
+    assert b", " not in raw and b": " not in raw
+    assert list(json.loads(raw)) == sorted(json.loads(raw))
+
+
+def test_differing_scopes_serialise_differently() -> None:
+    """A blind spot moving into the checked set must change the bytes."""
+    a = _scope(cannot_check=())
+    b = _scope(checked=("src/a.py", "src/b.py", "src/generated_pb2.py"), cannot_check=())
+    assert a.canonical_bytes() != b.canonical_bytes()
+
+
+@pytest.mark.parametrize("bad", ["medium", "HIGH", "", "unknown"])
+def test_confidence_outside_the_closed_set_raises_at_construction(bad: str) -> None:
+    """The message names the offending value and the allowed set."""
+    with pytest.raises(ValueError) as excinfo:
+        _scope(confidence=bad)
+    message = str(excinfo.value)
+    assert repr(bad) in message
+    for level in SCOPE_CONFIDENCE_LEVELS:
+        assert level in message
+
+
+@pytest.mark.parametrize("level", sorted(SCOPE_CONFIDENCE_LEVELS))
+def test_every_declared_confidence_level_is_constructible(level: str) -> None:
+    """The closed set and the validator cannot disagree about a member."""
+    assert _scope(confidence=level).confidence == level
+
+
+@pytest.mark.parametrize("field_name", ["checked", "cannot_check"])
+def test_a_bare_string_is_rejected_rather_than_iterated(field_name: str) -> None:
+    """``checked="a.py"`` must not silently become five one-character paths."""
+    with pytest.raises(TypeError) as excinfo:
+        _scope(**{field_name: "src/a.py"})
+    assert field_name in str(excinfo.value)
+
+
+def test_gate_result_accepts_and_preserves_a_scope() -> None:
+    """The field is carried through unchanged, and still defaults to None."""
+    scope = _scope()
+    result = GateResult(
+        name="lint",
+        status="pass",
+        required=True,
+        blocked=False,
+        cached=False,
+        duration_ms=12,
+        details="",
+        scope=scope,
+    )
+    assert result.scope == scope
+    assert (
+        GateResult(
+            name="lint",
+            status="pass",
+            required=True,
+            blocked=False,
+            cached=False,
+            duration_ms=12,
+            details="",
+        ).scope
+        is None
+    )


### PR DESCRIPTION
Closes #5395.

## Starting point

`VerificationScope` already exists on `main` — #5397 landed `oracle_id`, `kind`, `checked`, `cannot_check`, and the defaulted `GateResult.scope` field. So this slice is the residual: the two fields that were missing, the validation, and the serialisation.

## What this adds

| | |
|---|---|
| `confidence: str = "high"` | drawn from a new closed set `SCOPE_CONFIDENCE_LEVELS` |
| `evidence_ref: str = ""` | pointer to the evidence behind the claim |
| `to_dict()` / `from_dict()` | round trip restoring sequences as tuples |
| `canonical_bytes()` | sorted keys, compact separators, UTF-8 |
| `__post_init__` | rejects a bad confidence, and a bare `str` for either tuple |

## The decision the issue left to this slice

**`SCOPE_CONFIDENCE_LEVELS = {"high", "partial", "none"}`.**

The brief asks for the smallest set that still lets a later "required oracle kind is absent" check work. Three is that minimum:

- `high` — the oracle exercised each entry in `checked` directly.
- `partial` — indirectly or incompletely (a subset, a proxy, a sampled run). Coverage exists but does not stand alone.
- `none` — the oracle ran and established nothing usable.

`none` is what makes the absence check possible: a required kind covered only by `none` scopes is absent *in substance*, which a scope with no confidence field cannot express. `partial` is what keeps it honest — with only two members, a gate that sampled would have to report either `high` (overstating) or `none` (understating, and thereby failing an absence check it should pass). Widening the set later needs its own issue, since every consumer branching on a member has to decide what a new one means.

## Why the bare-string rejection is a separate check

`str` is iterable. `VerificationScope(checked="a.py", ...)` would have produced five one-character entries, and the scope would then claim coverage of files named `a` and `.`. That is a false coverage claim shaped exactly like a true one — worse than a bad confidence value, which at least looks wrong. It raises `TypeError` (a type error, not a value error) and names the field.

## Canonical serialisation

`canonical_bytes()` reuses the convention from `merge_receipt._canonical_bytes` (sorted keys, `separators=(",", ":")`, UTF-8) rather than introducing a second one, per the issue. Tests pin that two equal scopes built with keyword arguments in *reverse* declaration order produce identical bytes, and that key order in the output is sorted.

## One line outside the type, and why

`gate_runner.py` now re-exports `GateResult` explicitly (`from ... import GateResult as GateResult`). `gate_plugins.py:15` imports it *through* `gate_runner`, and under `--no-implicit-reexport` that is an `attr-defined` error. I confirmed this error is present on unmodified `main` — it is not introduced here — but the issue's own acceptance criterion names `mypy --config-file mypy.gate.ini` on those two files, and that command could not have passed without this. `core/quality` is not in `mypy.gate.ini`'s `files` list, so this was not failing CI; it was failing the check the issue asked for.

## Verification

```
uv run pytest tests/unit/test_verification_scope.py -q                    # 18 passed
uv run pytest tests/unit/test_quality_gates.py -x -q                      # 52 passed
uv run pytest tests/unit/test_merge_receipt_cli.py \
             tests/unit/test_verify_coverage_cmd.py -q                    # 29 passed
uv run mypy --config-file mypy.gate.ini \
    src/bernstein/core/quality/gate_pipeline.py \
    src/bernstein/core/quality/gate_plugins.py                            # clean
uv run ruff check src/bernstein/core/quality tests/unit/test_verification_scope.py
uv run ruff format --check ...
```

The merge-receipt suites are included because `merge_receipt.py` defines its own, unrelated `VerificationScope` (`oracle` / `checked` / `skipped`, #5398). This slice leaves it untouched, as the issue requires; running its tests confirms the two types stayed independent.

## Out of scope, as specified

Populating scopes from built-in gates and the registry-wide coverage test; any change to `merge_receipt.py`; CLI surface or docs pages; `absence_coverage.py`; `VerificationNudgeTracker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)