### PR TITLE
fix(planning): a roadmap wave reports why it emitted nothing (#5573)

### DIFF
--- a/docs/release-notes/fragments/5573-roadmap-wave-says-why.md
+++ b/docs/release-notes/fragments/5573-roadmap-wave-says-why.md
@@ -1,0 +1,19 @@
+## A roadmap wave that emits nothing now says why
+
+From a fresh workspace, `.bernstein/scenarios` was documented and unreachable.
+`emit_roadmap_wave` checked for `.sdd/roadmaps/open` and returned an empty
+list when it was absent — one line before the line that loads the scenario
+library. A fresh workspace has no roadmap directory, so an operator who
+followed the documentation and wrote scenarios got exactly what an operator
+who wrote none got: an empty list and no error.
+
+The library is now loaded before the roadmap check, and every exit carries a
+reason from a closed set: `backlog-missing`, `ticket-ceiling`, `no-scenarios`,
+`no-roadmap`, `no-eligible-scenarios`, `emitted`. `no-roadmap` reports how
+many scenarios were found and skipped, so the case that used to be invisible
+is the one that now states itself most plainly. The orchestrator logs it at
+warning level when scenarios exist and produced nothing, and at debug when
+there was nothing to report.
+
+`emit_roadmap_wave` still returns a plain list of paths, so existing callers
+are unchanged; `emit_roadmap_wave_outcome` is the one that answers "why".

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -1655,11 +1655,19 @@ class Orchestrator:
         #    Gated behind _run_normal - no need to scan 300 files every tick.
         if _run_normal:
             try:
-                from bernstein.core.roadmap_runtime import emit_roadmap_wave
+                from bernstein.core.roadmap_runtime import emit_roadmap_wave_outcome
 
-                emitted = emit_roadmap_wave(self._workdir)
-                if emitted:
-                    logger.info("Emitted %d roadmap ticket(s) into backlog/open", len(emitted))
+                outcome = emit_roadmap_wave_outcome(self._workdir)
+                if outcome.emitted:
+                    logger.info("Emitted %d roadmap ticket(s) into backlog/open", len(outcome.emitted))
+                elif outcome.scenarios_found:
+                    # Scenarios exist and produced nothing. Saying so is the
+                    # whole point of #5573: the old code returned an empty
+                    # list here and an operator who had written scenarios saw
+                    # no difference from having written none.
+                    logger.warning("roadmap wave emitted nothing (%s): %s", outcome.reason, outcome.detail)
+                else:
+                    logger.debug("roadmap wave emitted nothing (%s): %s", outcome.reason, outcome.detail)
             except (OSError, ValueError) as exc:
                 logger.warning("roadmap wave emission failed: %s", exc)
 

--- a/src/bernstein/core/planning/roadmap_runtime.py
+++ b/src/bernstein/core/planning/roadmap_runtime.py
@@ -33,23 +33,129 @@ class RoadmapCursor:
     task_index: int = 0
 
 
+#: Closed set of reasons a wave produced what it produced.
+#:
+#: Every exit from :func:`emit_roadmap_wave_outcome` carries one, so a tick
+#: that emits nothing is never silent about why (issue #5573).
+WAVE_REASONS: frozenset[str] = frozenset(
+    {
+        # Tickets were written.
+        "emitted",
+        # ``.sdd/backlog/open`` does not exist: nowhere to put a ticket.
+        "backlog-missing",
+        # Already at or over the open-ticket ceiling.
+        "ticket-ceiling",
+        # No scenario library: nothing exists to sequence.
+        "no-scenarios",
+        # Scenarios exist, but no ``.sdd/roadmaps/open`` sequences them.
+        # This is the fresh-workspace case: the library was found and is
+        # unreachable, which used to be indistinguishable from an empty one.
+        "no-roadmap",
+        # Roadmaps and scenarios both exist, but no roadmap entry resolved
+        # to a ticket this tick (cursor exhausted, ids absent from the
+        # library, or every file failed to parse).
+        "no-eligible-scenarios",
+    }
+)
+
+
+@dataclass(frozen=True)
+class RoadmapWaveOutcome:
+    """What one wave did, and -- when it did nothing -- why.
+
+    ``emit_roadmap_wave`` returns only the emitted paths, so an empty list
+    conflated six different situations. Callers that need to tell them apart
+    read this instead.
+
+    Attributes:
+        emitted: Ticket files written this wave, in emission order.
+        reason: A member of :data:`WAVE_REASONS`.
+        scenarios_found: Scenarios loaded from ``.bernstein/scenarios``.
+            Non-zero with ``reason="no-roadmap"`` is the case worth
+            reporting: the operator wrote scenarios that nothing consumes.
+        detail: One sentence a human can act on.
+    """
+
+    emitted: tuple[Path, ...]
+    reason: str
+    scenarios_found: int
+    detail: str
+
+    def __post_init__(self) -> None:
+        """Keep ``reason`` inside the closed set it advertises."""
+        if self.reason not in WAVE_REASONS:
+            raise ValueError(f"RoadmapWaveOutcome.reason={self.reason!r} is not in WAVE_REASONS={sorted(WAVE_REASONS)}")
+
+
 def emit_roadmap_wave(workdir: Path, *, max_open_tickets: int = 10) -> list[Path]:
-    """Emit next wave of roadmap tickets into ``.sdd/backlog/open``."""
+    """Emit next wave of roadmap tickets into ``.sdd/backlog/open``.
+
+    Thin wrapper kept for the existing call sites; see
+    :func:`emit_roadmap_wave_outcome` for the reason a wave was empty.
+    """
+    return list(emit_roadmap_wave_outcome(workdir, max_open_tickets=max_open_tickets).emitted)
+
+
+def emit_roadmap_wave_outcome(workdir: Path, *, max_open_tickets: int = 10) -> RoadmapWaveOutcome:
+    """Emit the next wave and report what happened, including nothing.
+
+    The scenario library is loaded *before* the roadmap-directory check.
+    That ordering is the fix for #5573: a fresh workspace has no
+    ``.sdd/roadmaps/open``, so the old order returned at that guard and the
+    library on the next line was never read. An operator following the
+    documentation, writing scenarios into ``.bernstein/scenarios``, got an
+    empty list and no indication that the directory the product told them to
+    fill is not reachable from where they are.
+
+    The two capacity guards still run first and are still cheap: a missing
+    backlog directory or a full one means there is nowhere to put a ticket,
+    which is true whatever the library holds. They no longer exit silently
+    either -- each names itself in the outcome.
+    """
     backlog_open = workdir / ".sdd" / "backlog" / "open"
     if not backlog_open.exists():
-        return []
+        return RoadmapWaveOutcome(
+            emitted=(),
+            reason="backlog-missing",
+            scenarios_found=0,
+            detail=f"{backlog_open} does not exist, so there is nowhere to write a ticket.",
+        )
     current_open = len(list(backlog_open.glob("*.yaml")))
     if current_open >= max_open_tickets:
-        return []
-
-    roadmaps_dir = workdir / ".sdd" / "roadmaps" / "open"
-    if not roadmaps_dir.exists():
-        return []
+        return RoadmapWaveOutcome(
+            emitted=(),
+            reason="ticket-ceiling",
+            scenarios_found=0,
+            detail=(
+                f"{current_open} open ticket(s) at a ceiling of {max_open_tickets}; "
+                "close or complete some before the next wave."
+            ),
+        )
 
     library_root = workdir / ".bernstein" / "scenarios"
     library = load_scenario_library(library_root)
+    scenarios_found = len(library.scenarios)
+
+    roadmaps_dir = workdir / ".sdd" / "roadmaps" / "open"
+    if not roadmaps_dir.exists():
+        return RoadmapWaveOutcome(
+            emitted=(),
+            reason="no-roadmap",
+            scenarios_found=scenarios_found,
+            detail=(
+                f"Found {scenarios_found} scenario(s) under {library_root} and skipped "
+                f"them: {roadmaps_dir} does not exist, and a scenario is only emitted "
+                "as a ticket when a roadmap sequences it."
+            ),
+        )
+
     if not library.scenarios:
-        return []
+        return RoadmapWaveOutcome(
+            emitted=(),
+            reason="no-scenarios",
+            scenarios_found=0,
+            detail=f"No scenarios under {library_root}, so the roadmaps have nothing to sequence.",
+        )
 
     runtime_dir = workdir / ".sdd" / "runtime" / "roadmaps"
     runtime_dir.mkdir(parents=True, exist_ok=True)
@@ -66,7 +172,23 @@ def emit_roadmap_wave(workdir: Path, *, max_open_tickets: int = 10) -> list[Path
         new_files = _emit_for_spec(spec, cursor, cursor_path, library, backlog_open, max_items=available_slots)
         emitted.extend(new_files)
         available_slots -= len(new_files)
-    return emitted
+    if not emitted:
+        return RoadmapWaveOutcome(
+            emitted=(),
+            reason="no-eligible-scenarios",
+            scenarios_found=scenarios_found,
+            detail=(
+                f"{len(list(roadmaps_dir.glob('*.yaml')) + list(roadmaps_dir.glob('*.yml')))} "
+                f"roadmap file(s) and {scenarios_found} scenario(s), but no entry resolved to a "
+                "ticket: every cursor is exhausted, or the ids they name are absent from the library."
+            ),
+        )
+    return RoadmapWaveOutcome(
+        emitted=tuple(emitted),
+        reason="emitted",
+        scenarios_found=scenarios_found,
+        detail=f"Emitted {len(emitted)} ticket(s) into {backlog_open}.",
+    )
 
 
 def _emit_for_spec(

--- a/tests/unit/test_roadmap_runtime.py
+++ b/tests/unit/test_roadmap_runtime.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from bernstein.core.roadmap_runtime import emit_roadmap_wave
+import pytest
+from bernstein.core.roadmap_runtime import (
+    RoadmapWaveOutcome,
+    emit_roadmap_wave,
+    emit_roadmap_wave_outcome,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -62,3 +67,125 @@ def test_emit_roadmap_wave_respects_open_ticket_cap(tmp_path: Path) -> None:
 
     emitted = emit_roadmap_wave(tmp_path, max_open_tickets=1)
     assert emitted == []
+
+
+# --- The wave says why it emitted nothing (issue #5573) --------------------
+
+
+def _seed_backlog(root: Path) -> None:
+    (root / ".sdd" / "backlog" / "open").mkdir(parents=True, exist_ok=True)
+
+
+def test_scenarios_without_a_roadmap_are_reported_not_swallowed(tmp_path: Path) -> None:
+    """The fresh-workspace case: scenarios exist, nothing sequences them.
+
+    This is the defect. A workspace with a populated ``.bernstein/scenarios``
+    and no ``.sdd/roadmaps/open`` used to be indistinguishable from one with
+    no scenarios at all, because the roadmap guard returned before the
+    library was ever loaded.
+    """
+    _seed_backlog(tmp_path)
+    _seed_scenario(tmp_path)
+
+    outcome = emit_roadmap_wave_outcome(tmp_path)
+
+    assert outcome.emitted == ()
+    assert outcome.reason == "no-roadmap"
+    assert outcome.scenarios_found == 1, "the library must be read before the roadmap guard"
+    assert "roadmaps" in outcome.detail and "skipped" in outcome.detail
+
+
+def test_an_empty_library_is_distinguishable_from_an_unreachable_one(tmp_path: Path) -> None:
+    """Zero scenarios and one unreachable scenario are different facts."""
+    _seed_backlog(tmp_path)
+
+    empty = emit_roadmap_wave_outcome(tmp_path)
+    _seed_scenario(tmp_path)
+    unreachable = emit_roadmap_wave_outcome(tmp_path)
+
+    assert (empty.reason, empty.scenarios_found) == ("no-roadmap", 0)
+    assert (unreachable.reason, unreachable.scenarios_found) == ("no-roadmap", 1)
+
+
+def test_a_missing_backlog_directory_names_itself(tmp_path: Path) -> None:
+    """No capacity to write a ticket is still a stated reason, not silence."""
+    _seed_scenario(tmp_path)
+    _seed_roadmap(tmp_path)
+
+    outcome = emit_roadmap_wave_outcome(tmp_path)
+
+    assert outcome.reason == "backlog-missing"
+    assert str(tmp_path / ".sdd" / "backlog" / "open") in outcome.detail
+
+
+def test_the_ticket_ceiling_names_itself_and_the_ceiling(tmp_path: Path) -> None:
+    backlog_open = tmp_path / ".sdd" / "backlog" / "open"
+    backlog_open.mkdir(parents=True, exist_ok=True)
+    (backlog_open / "existing.yaml").write_text("---\nid: existing\n---\n", encoding="utf-8")
+    _seed_scenario(tmp_path)
+    _seed_roadmap(tmp_path)
+
+    outcome = emit_roadmap_wave_outcome(tmp_path, max_open_tickets=1)
+
+    assert outcome.reason == "ticket-ceiling"
+    assert "1" in outcome.detail
+
+
+def test_a_roadmap_with_no_library_reports_no_scenarios(tmp_path: Path) -> None:
+    """Roadmaps present, library empty: the roadmaps have nothing to sequence."""
+    _seed_backlog(tmp_path)
+    _seed_roadmap(tmp_path)
+
+    outcome = emit_roadmap_wave_outcome(tmp_path)
+
+    assert outcome.reason == "no-scenarios"
+    assert outcome.scenarios_found == 0
+
+
+def test_a_roadmap_naming_an_absent_scenario_reports_no_eligible_scenarios(tmp_path: Path) -> None:
+    """Both directories populated, but the ids do not meet in the middle."""
+    _seed_backlog(tmp_path)
+    _seed_scenario(tmp_path)
+    roadmaps_dir = tmp_path / ".sdd" / "roadmaps" / "open"
+    roadmaps_dir.mkdir(parents=True, exist_ok=True)
+    (roadmaps_dir / "roadmap.yaml").write_text(
+        "id: rm1\ntitle: Roadmap One\nwave_size: 1\nscenarios:\n  - scenario-absent\n",
+        encoding="utf-8",
+    )
+
+    outcome = emit_roadmap_wave_outcome(tmp_path)
+
+    assert outcome.reason == "no-eligible-scenarios"
+    assert outcome.scenarios_found == 1
+
+
+def test_a_successful_wave_reports_emitted_with_the_paths(tmp_path: Path) -> None:
+    _seed_backlog(tmp_path)
+    _seed_scenario(tmp_path)
+    _seed_roadmap(tmp_path)
+
+    outcome = emit_roadmap_wave_outcome(tmp_path)
+
+    assert outcome.reason == "emitted"
+    assert len(outcome.emitted) == 1
+    assert outcome.emitted[0].exists()
+    assert outcome.scenarios_found == 1
+
+
+def test_every_reason_the_function_can_return_is_in_the_closed_set(tmp_path: Path) -> None:
+    """A reason string that drifts out of the set fails at construction."""
+    with pytest.raises(ValueError) as excinfo:
+        RoadmapWaveOutcome(emitted=(), reason="made-up", scenarios_found=0, detail="")
+    assert "made-up" in str(excinfo.value)
+
+
+def test_the_wrapper_still_returns_a_plain_list_of_paths(tmp_path: Path) -> None:
+    """Existing call sites keep the contract they were written against."""
+    _seed_backlog(tmp_path)
+    _seed_scenario(tmp_path)
+    _seed_roadmap(tmp_path)
+
+    emitted = emit_roadmap_wave(tmp_path)
+
+    assert isinstance(emitted, list)
+    assert len(emitted) == 1


### PR DESCRIPTION
Closes #5573.

## The defect, reproduced

`emit_roadmap_wave` returns at the roadmap guard one line before it would load the scenario library:

```python
roadmaps_dir = workdir / ".sdd" / "roadmaps" / "open"
if not roadmaps_dir.exists():
    return []                                    # a fresh workspace exits here
library_root = workdir / ".bernstein" / "scenarios"
library = load_scenario_library(library_root)    # never reached
```

An operator who followed the documentation and filled `.bernstein/scenarios` got `[]`. An operator who wrote no scenarios at all got `[]`. Nothing distinguished them — which is why the issue calls the gap reachability rather than documentation, and why "silence is the one unacceptable outcome."

`test_an_empty_library_is_distinguishable_from_an_unreachable_one` is the test that pins exactly this: same call, same empty result, two different facts, now reported differently.

## The choice I made, and why

The issue offers two routes — reorder so the library is not hidden behind the roadmap preconditions, or give scenario consumption its own entry point. **I took the reorder**, because a separate entry point would leave the existing path still silently wrong for anyone who does not know to call the new one; moving the load fixes the path operators are already on.

The scenario library now loads *before* the roadmap check, so "scenarios exist and nothing sequences them" becomes a state the code can observe. Every exit returns a `RoadmapWaveOutcome`:

| reason | meaning |
|---|---|
| `emitted` | tickets were written |
| `backlog-missing` | `.sdd/backlog/open` absent — nowhere to write |
| `ticket-ceiling` | at or over `max_open_tickets` |
| `no-scenarios` | roadmaps exist, library empty |
| `no-roadmap` | **the fresh-workspace case** — reports how many scenarios were found and skipped, and why |
| `no-eligible-scenarios` | both populated, but no entry resolved to a ticket |

Each carries `scenarios_found` and one actionable sentence. `reason` is validated against a closed set at construction, the way `GateResult.reason` already is.

## What I deliberately did *not* reorder

The two capacity guards (missing backlog directory, ticket ceiling) still run first. A missing or full `.sdd/backlog/open` means there is nowhere to put a ticket whatever the library holds, and loading the library to discover that would be wasted I/O on every orchestrator tick. They no longer exit silently — each names itself in the outcome — so the issue's requirement is met without paying for it on the hot path. Happy to move them if you would rather have one uniform order.

## Compatibility

`emit_roadmap_wave` keeps its signature and returns a plain `list[Path]`; it now delegates to `emit_roadmap_wave_outcome`. The single production call site (`orchestration/orchestrator.py:1658`) moves to the outcome form and logs a wave that emitted nothing at **warning** when scenarios were found, **debug** otherwise — so a workspace with no scenarios does not warn on every tick. Both pre-existing tests pass untouched, and `test_the_wrapper_still_returns_a_plain_list_of_paths` pins the old contract.

## Verification

```
uv run pytest tests/unit/test_roadmap_runtime.py -q     # 11 passed (2 pre-existing + 9 new)
uv run ruff check src/bernstein/core/planning src/bernstein/core/orchestration/orchestrator.py tests/unit/test_roadmap_runtime.py
uv run ruff format --check ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)