### PR TITLE
fix(security): SIEM audit exports now carry a checkable chain (#5034)

### DIFF
--- a/docs/release-notes/fragments/5034-audit-export-chain-fields.md
+++ b/docs/release-notes/fragments/5034-audit-export-chain-fields.md
@@ -1,0 +1,14 @@
+## SIEM exports carry the chain, not just an opaque hmac
+
+An exported audit record used to carry only `hmac` -- a string the receiver
+could not check, since they never hold the signing key. `AuditEntry` now also
+carries `prev_hmac` and a monotonic `sequence`, emitted by all six SIEM
+exporters (Splunk, Elasticsearch, CloudWatch, syslog, webhook, file). Each
+exported batch can be closed with a signed `SegmentReceipt` -- first/last
+sequence, entry count, and the batch's chain-head HMAC, signed with the same
+Ed25519 key used for lineage -- and `bernstein audit verify-export <file>`
+checks an exported JSONL file for deletion, reordering, and gaps between
+batches using only the file and the signer's public key, no database and no
+HMAC key required. A batch that fails to export can now also write an
+`audit.export.failed` chain event, so a silent forwarding outage is itself
+part of the audit trail (#5034).

--- a/docs/security/audit-log.md
+++ b/docs/security/audit-log.md
@@ -709,7 +709,11 @@ batch's chain-head hmac. `FileExporter` writes it as a trailing
 
 `bernstein audit verify-export <file>` reads that file back and reports
 whether it is contiguous, has a gap, was reordered, or was tampered with
--- using only the file and, optionally, the signer's public key:
+-- using only the file and, optionally, the signer's public key. An
+export produced before #5034 has no `sequence` field on its records, which
+reads as `sequence 0` on every record and is reported as `REORDERED` --
+that label means "this export predates the feature", not "records were
+reordered"; re-export with the current build to check it properly.
 
 ```bash
 bernstein audit verify-export .sdd/exports/audit.jsonl
@@ -717,10 +721,25 @@ bernstein audit verify-export .sdd/exports/audit.jsonl --public-key signer-publi
 ```
 
 Without `--public-key`, each receipt's embedded key is trusted on first
-use. With it, a receipt signed by any other key is reported as
-`TAMPERED`. This is the property that makes the SIEM copy a portable,
-offline-verifiable segment of the chain rather than just a log: a SOC
-analyst or auditor can check it for themselves.
+use -- the command's `PASSED` panel says so explicitly (`Trust: signer
+trusted on first use -- authenticity NOT verified, re-run with
+--public-key`), because an attacker who rewrites the export and re-signs
+every receipt with their own key passes an unpinned check. Pin the signer
+with `--public-key` to actually verify authenticity: a receipt signed by
+any other key is then reported as `TAMPERED`. An export with no segment
+receipts at all reports `Trust: no segment receipts -- sequence continuity
+only` -- there is no signature evidence to check in that case.
+
+What the command proves either way is that the export is **contiguous, in
+order, and chain-linked**: each record's `prev_hmac` matches the previous
+record's stored `hmac`. It does not recompute any record's `hmac` from its
+content, so it cannot detect a record whose `details` were edited while
+its stored `hmac` was left alone -- that is a content-integrity question,
+answered only by `bernstein audit verify` against the source database and
+the HMAC signing key. This is the property that makes the SIEM copy a
+portable, offline-verifiable segment of the chain rather than just a log:
+a SOC analyst or auditor can check completeness and order for themselves,
+without holding the key.
 
 ### Sample dashboards
 

--- a/docs/security/audit-log.md
+++ b/docs/security/audit-log.md
@@ -675,6 +675,8 @@ webhook payload, one batch:
     "outcome": "success",
     "details": {"from_status": "open", "to_status": "claimed"},
     "hmac": "d4e5f6…",
+    "prev_hmac": "a1b2c3…",
+    "sequence": 4271,
     "source": "bernstein-audit"
   }
 ]
@@ -682,9 +684,43 @@ webhook payload, one batch:
 
 retry behaviour: failed batches retry with exponential backoff
 (`max_retries`, `retry_backoff_s`) before being counted in
-`total_failed`. the chain on disk is the source of truth - SIEM is
-a mirror, not the master copy. if the SIEM drops a batch, replay
-from `.sdd/audit/` with `bernstein audit query`.
+`total_failed`. a batch that still fails writes an
+`audit.export.failed` event to the chain itself (when the exporter was
+constructed with a `failure_log`), so a silent forwarding outage shows
+up in `bernstein audit query` rather than being indistinguishable from
+quiet. the chain on disk is the source of truth - SIEM is a mirror,
+not the master copy. if the SIEM drops a batch, replay from
+`.sdd/audit/` with `bernstein audit query`.
+
+### Verifying an export without the source database
+
+Before issue #5034, `hmac` was the only field on an exported record, and
+it proves nothing to a receiver who never held the signing key: a
+deleted, reordered, or gapped record was invisible in the SIEM copy. Every
+`AuditEntry` now also carries `prev_hmac` and `sequence`, so the chain
+linkage survives the export.
+
+When the exporter is constructed with a `kms_adapter`
+(`bernstein.core.security.key_custody.KMSAdapter` -- the same Ed25519
+signer the lineage subsystem uses), each flushed batch is closed with a
+signed `SegmentReceipt`: first/last sequence, entry count, and the
+batch's chain-head hmac. `FileExporter` writes it as a trailing
+`{"segment_receipt": {...}}` line in the JSONL output.
+
+`bernstein audit verify-export <file>` reads that file back and reports
+whether it is contiguous, has a gap, was reordered, or was tampered with
+-- using only the file and, optionally, the signer's public key:
+
+```bash
+bernstein audit verify-export .sdd/exports/audit.jsonl
+bernstein audit verify-export .sdd/exports/audit.jsonl --public-key signer-public.jwk.json
+```
+
+Without `--public-key`, each receipt's embedded key is trusted on first
+use. With it, a receipt signed by any other key is reported as
+`TAMPERED`. This is the property that makes the SIEM copy a portable,
+offline-verifiable segment of the chain rather than just a log: a SOC
+analyst or auditor can check it for themselves.
 
 ### Sample dashboards
 

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -501,13 +501,19 @@ def verify_cmd(
     ),
 )
 def verify_export_cmd(export_file: Path, public_key_path: Path | None) -> None:
-    """Verify a SIEM export file is contiguous, in order, and unmodified.
+    """Verify a SIEM export file is contiguous, in order, and chain-linked.
 
     Reads a JSONL file produced by :class:`~bernstein.core.security.audit_export.FileExporter`
     -- exported records plus the interleaved ``segment_receipt`` lines -- and
     reports whether it is contiguous, has a gap, is reordered, or was
     tampered with. Works on the file alone: no database, no HMAC key,
     just the export and (optionally) the signer's public key (issue #5034).
+
+    This checks chain linkage (each record's ``prev_hmac`` against the
+    previous record's stored ``hmac``), not record content: a stored
+    ``hmac`` that no longer matches what it was computed over is not
+    detectable from the export alone. Content verification needs the HMAC
+    signing key, via ``bernstein audit verify``.
     """
     import json as _json
 
@@ -520,6 +526,7 @@ def verify_export_cmd(export_file: Path, public_key_path: Path | None) -> None:
 
     entries: list[AuditEntry] = []
     receipts: list[SegmentReceipt] = []
+    skipped_lines = 0
     for lineno, raw_line in enumerate(export_file.read_text(encoding="utf-8").splitlines(), start=1):
         line = raw_line.strip()
         if not line:
@@ -528,8 +535,10 @@ def verify_export_cmd(export_file: Path, public_key_path: Path | None) -> None:
             row = _json.loads(line)
         except _json.JSONDecodeError:
             console.print(f"[red]Line {lineno} is not valid JSON -- skipping.[/red]")
+            skipped_lines += 1
             continue
         if not isinstance(row, dict):
+            skipped_lines += 1
             continue
         row = cast("dict[str, Any]", row)
         if "segment_receipt" in row:
@@ -556,12 +565,36 @@ def verify_export_cmd(export_file: Path, public_key_path: Path | None) -> None:
 
     result = verify_exported_records(entries, receipts, trusted_public_key_jwk=trusted_jwk)
 
+    # Which trust mode actually produced this result -- distinct claims that
+    # must not read the same way in the panel: a pinned signer, an
+    # unpinned (trust-on-first-use) signer, or no signature evidence at all.
+    if trusted_jwk is not None:
+        trust = "signer pinned"
+    elif receipts:
+        trust = "signer trusted on first use -- authenticity NOT verified, re-run with --public-key"
+    else:
+        trust = "no segment receipts -- sequence continuity only"
+
     console.print()
+    if result.ok and skipped_lines:
+        console.print(
+            Panel(
+                f"[bold yellow]Export Verification: INCOMPLETE[/bold yellow]\n"
+                f"[dim]{len(entries)} record(s), {len(receipts)} segment receipt(s) -- {result.detail}, "
+                f"but {skipped_lines} line(s) could not be parsed and were excluded from the check. "
+                "A skipped line is not accounted for by sequence continuity.[/dim]",
+                border_style="yellow",
+                expand=False,
+            )
+        )
+        console.print()
+        raise SystemExit(1)
     if result.ok:
         console.print(
             Panel(
                 f"[bold green]Export Verification: PASSED[/bold green]\n"
-                f"[dim]{len(entries)} record(s), {len(receipts)} segment receipt(s) -- {result.detail}.[/dim]",
+                f"[dim]{len(entries)} record(s), {len(receipts)} segment receipt(s) -- {result.detail}.\n"
+                f"Trust: {trust}.[/dim]",
                 border_style="green",
                 expand=False,
             )

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -21,6 +21,7 @@ Commands:
                                      status callback offline.
   bernstein audit verify-hmac        Verify HMAC chain across all audit files.
   bernstein audit verify-gates       Verify clearance-gate integrity offline.
+  bernstein audit verify-export      Verify a SIEM export file offline (#5034).
   bernstein audit export             Export a signed Article 12 evidence pack.
   bernstein audit pack               Build a SOC 2 evidence checklist.
   bernstein audit capabilities       Print lethal-trifecta capability matrix.
@@ -479,6 +480,104 @@ def verify_cmd(
     console.print(
         Panel(
             f"[bold red]Audit Verification: FAILED[/bold red]\n\n[bold]Failing pillar(s):[/bold]\n{failing_list}",
+            border_style="red",
+            expand=False,
+        )
+    )
+    console.print()
+    raise SystemExit(1)
+
+
+@audit_group.command("verify-export")
+@click.argument("export_file", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option(
+    "--public-key",
+    "public_key_path",
+    default=None,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help=(
+        "Trusted Ed25519 public-key JWK (JSON file) to pin the segment-receipt "
+        "signer. Without it, each receipt's embedded key is trusted on first use."
+    ),
+)
+def verify_export_cmd(export_file: Path, public_key_path: Path | None) -> None:
+    """Verify a SIEM export file is contiguous, in order, and unmodified.
+
+    Reads a JSONL file produced by :class:`~bernstein.core.security.audit_export.FileExporter`
+    -- exported records plus the interleaved ``segment_receipt`` lines -- and
+    reports whether it is contiguous, has a gap, is reordered, or was
+    tampered with. Works on the file alone: no database, no HMAC key,
+    just the export and (optionally) the signer's public key (issue #5034).
+    """
+    import json as _json
+
+    from bernstein.core.security.audit_export import (
+        AuditEntry,
+        ExportVerifyStatus,
+        SegmentReceipt,
+        verify_exported_records,
+    )
+
+    entries: list[AuditEntry] = []
+    receipts: list[SegmentReceipt] = []
+    for lineno, raw_line in enumerate(export_file.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            row = _json.loads(line)
+        except _json.JSONDecodeError:
+            console.print(f"[red]Line {lineno} is not valid JSON -- skipping.[/red]")
+            continue
+        if not isinstance(row, dict):
+            continue
+        row = cast("dict[str, Any]", row)
+        if "segment_receipt" in row:
+            receipts.append(SegmentReceipt.from_dict(row["segment_receipt"]))
+            continue
+        entries.append(
+            AuditEntry(
+                timestamp=float(row.get("timestamp", 0.0)),
+                event_type=str(row.get("event_type", "")),
+                actor=str(row.get("actor", "")),
+                resource=str(row.get("resource", "")),
+                action=str(row.get("action", "")),
+                outcome=str(row.get("outcome", "success")),
+                details=dict(row.get("details") or {}),
+                hmac=str(row.get("hmac", "")),
+                prev_hmac=str(row.get("prev_hmac", "")),
+                sequence=int(row.get("sequence", 0)),
+            )
+        )
+
+    trusted_jwk: dict[str, Any] | None = None
+    if public_key_path is not None:
+        trusted_jwk = _json.loads(public_key_path.read_text(encoding="utf-8"))
+
+    result = verify_exported_records(entries, receipts, trusted_public_key_jwk=trusted_jwk)
+
+    console.print()
+    if result.ok:
+        console.print(
+            Panel(
+                f"[bold green]Export Verification: PASSED[/bold green]\n"
+                f"[dim]{len(entries)} record(s), {len(receipts)} segment receipt(s) -- {result.detail}.[/dim]",
+                border_style="green",
+                expand=False,
+            )
+        )
+        console.print()
+        raise SystemExit(0)
+
+    status_label = {
+        ExportVerifyStatus.GAP: "GAP",
+        ExportVerifyStatus.REORDERED: "REORDERED",
+        ExportVerifyStatus.TAMPERED: "TAMPERED",
+    }.get(result.status, result.status.value.upper())
+    at = f" at sequence {result.at_sequence}" if result.at_sequence is not None else ""
+    console.print(
+        Panel(
+            f"[bold red]Export Verification: {status_label}{at}[/bold red]\n\n{result.detail}",
             border_style="red",
             expand=False,
         )

--- a/src/bernstein/core/security/audit_export.py
+++ b/src/bernstein/core/security/audit_export.py
@@ -7,10 +7,30 @@ target format.
 
 All exporters are non-blocking: they buffer entries and flush in batches.
 Failed batches are retried with exponential backoff.
+
+Verifiable export (issue #5034)
+--------------------------------
+An exported batch used to carry only ``hmac`` -- an opaque string the
+receiver cannot check, since they never hold the signing key. Nothing in
+the export said what order the records were in or whether one had been
+removed, so a SIEM copy of the log looked stronger than a plain log while
+proving exactly as little.
+
+Every :class:`AuditEntry` now also carries ``prev_hmac`` and a monotonic
+``sequence``, so the chain linkage that already exists internally survives
+the export. :func:`build_segment_receipt` closes each export batch with a
+receipt -- first/last sequence, entry count, and the batch's chain-head
+HMAC, signed with the same Ed25519 key used for lineage (reusing
+:mod:`bernstein.core.security.audit_head_signature`, not new signing code).
+:func:`verify_exported_records` then lets a receiver -- no database, no
+HMAC key, just the exported file and the signer's public key -- confirm
+the batch is contiguous, in order, and unmodified. ``bernstein audit
+verify-export`` (``cli/commands/audit_cmd.py``) is the CLI surface over it.
 """
 
 from __future__ import annotations
 
+import itertools
 import json
 import logging
 import time
@@ -18,7 +38,15 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.security.audit_head_signature import build_head_signature, verify_head_signature
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from bernstein.core.security.audit import AuditLog
+    from bernstein.core.security.key_custody import KMSAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -184,6 +212,14 @@ class AuditEntry:
         outcome: Result of the action (success/failure).
         details: Additional structured details.
         hmac: HMAC chain value for integrity.
+        prev_hmac: HMAC of the preceding record in the internal chain.
+            Carried through so an exported batch can be checked for
+            deletions and reordering without the receiver holding the
+            HMAC key (issue #5034) -- see :func:`verify_exported_records`.
+        sequence: Monotonic position of this record in the internal chain.
+            The internal HMAC chain alone does not say how many hops to
+            expect; the sequence number is what lets a receiver notice a
+            missing tail or a missing batch between two segment receipts.
     """
 
     timestamp: float = 0.0
@@ -194,6 +230,8 @@ class AuditEntry:
     outcome: str = "success"
     details: dict[str, Any] = field(default_factory=dict[str, Any])
     hmac: str = ""
+    prev_hmac: str = ""
+    sequence: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -213,6 +251,10 @@ class ExportResult:
         error: Error message if failed.
         timestamp: When the export occurred.
         duration_s: Time taken in seconds.
+        segment_receipt: The signed boundary receipt for this batch, when
+            the exporter was constructed with a ``kms_adapter``. ``None``
+            when no signer was configured -- the field the export carries
+            without one is exactly what it carried before issue #5034.
     """
 
     target: SIEMTarget = SIEMTarget.SPLUNK
@@ -222,6 +264,208 @@ class ExportResult:
     error: str = ""
     timestamp: float = field(default_factory=time.time)
     duration_s: float = 0.0
+    segment_receipt: SegmentReceipt | None = None
+
+
+# ---------------------------------------------------------------------------
+# Segment receipts: the boundary a receiver can check without our database
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SegmentReceipt:
+    """Signed boundary for one exported batch.
+
+    Lets a receiver holding only the exported file and the signer's public
+    key bound what they were sent: how many records, which sequence range,
+    and the chain-head HMAC the batch ended on. See
+    :func:`build_segment_receipt` and :func:`verify_exported_records`.
+
+    Attributes:
+        first_sequence: ``sequence`` of the first entry in the batch.
+        last_sequence: ``sequence`` of the last entry in the batch.
+        entry_count: Number of entries the batch carried.
+        chain_head_hmac: ``hmac`` of the batch's last entry -- the position
+            in the internal chain this receipt attests to.
+        head_signature: Ed25519 signature block over ``chain_head_hmac``,
+            built by :func:`~bernstein.core.security.audit_head_signature.build_head_signature`.
+    """
+
+    first_sequence: int = 0
+    last_sequence: int = 0
+    entry_count: int = 0
+    chain_head_hmac: str = ""
+    head_signature: dict[str, Any] = field(default_factory=dict[str, Any])
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise for embedding as a JSON line alongside exported entries."""
+        return {
+            "first_sequence": self.first_sequence,
+            "last_sequence": self.last_sequence,
+            "entry_count": self.entry_count,
+            "chain_head_hmac": self.chain_head_hmac,
+            "head_signature": self.head_signature,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> SegmentReceipt:
+        """Reconstruct a receipt read back from an exported file."""
+        return cls(
+            first_sequence=int(payload.get("first_sequence", 0)),
+            last_sequence=int(payload.get("last_sequence", 0)),
+            entry_count=int(payload.get("entry_count", 0)),
+            chain_head_hmac=str(payload.get("chain_head_hmac", "")),
+            head_signature=dict(payload.get("head_signature") or {}),
+        )
+
+
+def build_segment_receipt(entries: Sequence[AuditEntry], *, kms_adapter: KMSAdapter) -> SegmentReceipt:
+    """Build the signed boundary receipt for one export batch.
+
+    Args:
+        entries: The batch, in the order it will be exported. Must be
+            non-empty -- an empty batch has no chain head to sign over.
+        kms_adapter: Signer used for the Ed25519 head signature. The same
+            adapter (and key) the lineage signer uses; see
+            :mod:`bernstein.core.security.key_custody`.
+
+    Returns:
+        The :class:`SegmentReceipt` to export alongside the batch.
+
+    Raises:
+        ValueError: If ``entries`` is empty.
+    """
+    if not entries:
+        raise ValueError("cannot build a segment receipt for an empty batch")
+    head = entries[-1]
+    return SegmentReceipt(
+        first_sequence=entries[0].sequence,
+        last_sequence=head.sequence,
+        entry_count=len(entries),
+        chain_head_hmac=head.hmac,
+        head_signature=build_head_signature(head.hmac, kms_adapter=kms_adapter),
+    )
+
+
+class ExportVerifyStatus(StrEnum):
+    """Outcome of checking an exported batch for completeness and order."""
+
+    CONTIGUOUS = "contiguous"
+    GAP = "gap"
+    REORDERED = "reordered"
+    TAMPERED = "tampered"
+
+
+@dataclass(frozen=True)
+class ExportVerification:
+    """Result of :func:`verify_exported_records`.
+
+    Attributes:
+        ok: ``True`` only for :attr:`ExportVerifyStatus.CONTIGUOUS`.
+        status: What was found.
+        detail: Human-readable explanation, for the CLI and logs.
+        at_sequence: The sequence number the finding is about, when one
+            finding applies to a specific position rather than the batch
+            as a whole.
+    """
+
+    ok: bool
+    status: ExportVerifyStatus
+    detail: str
+    at_sequence: int | None = None
+
+
+def verify_exported_records(
+    entries: Sequence[AuditEntry],
+    segment_receipts: Sequence[SegmentReceipt] = (),
+    *,
+    trusted_public_key_jwk: dict[str, Any] | None = None,
+) -> ExportVerification:
+    """Check an exported batch for deletion, reordering, and tampering.
+
+    Works on the export alone -- no source database, no HMAC key. Entries
+    are checked in the order given (never re-sorted, since silently
+    correcting the order would hide the very defect this exists to catch).
+
+    Args:
+        entries: Exported records, in file order.
+        segment_receipts: Segment receipts read from the same export,
+            sorted or not -- this function sorts them by ``first_sequence``
+            before checking inter-segment gaps.
+        trusted_public_key_jwk: When given, every receipt's embedded JWK
+            must match it (pins the signer); when ``None``, each receipt's
+            embedded JWK is trusted on first use, same as
+            :func:`~bernstein.core.security.audit_head_signature.verify_head_signature`.
+
+    Returns:
+        :class:`ExportVerification` naming the first defect found, or a
+        ``CONTIGUOUS`` / ``ok=True`` result when none is.
+    """
+    if not entries:
+        return ExportVerification(ok=True, status=ExportVerifyStatus.CONTIGUOUS, detail="no records to verify")
+
+    for prev, curr in itertools.pairwise(entries):
+        if curr.sequence <= prev.sequence:
+            return ExportVerification(
+                ok=False,
+                status=ExportVerifyStatus.REORDERED,
+                detail=f"sequence {curr.sequence} follows sequence {prev.sequence} out of order",
+                at_sequence=curr.sequence,
+            )
+        if curr.sequence != prev.sequence + 1:
+            return ExportVerification(
+                ok=False,
+                status=ExportVerifyStatus.GAP,
+                detail=f"sequence jumps from {prev.sequence} to {curr.sequence} -- record(s) missing",
+                at_sequence=prev.sequence + 1,
+            )
+        if curr.prev_hmac != prev.hmac:
+            return ExportVerification(
+                ok=False,
+                status=ExportVerifyStatus.TAMPERED,
+                detail=f"record at sequence {curr.sequence} does not chain onto sequence {prev.sequence}'s hmac",
+                at_sequence=curr.sequence,
+            )
+
+    by_sequence = {entry.sequence: entry for entry in entries}
+    ordered_receipts = sorted(segment_receipts, key=lambda r: r.first_sequence)
+    for receipt in ordered_receipts:
+        verification = verify_head_signature(
+            receipt.chain_head_hmac,
+            receipt.head_signature,
+            trusted_public_key_jwk=trusted_public_key_jwk,
+        )
+        if not verification.ok:
+            return ExportVerification(
+                ok=False,
+                status=ExportVerifyStatus.TAMPERED,
+                detail=f"segment receipt ending at sequence {receipt.last_sequence} failed signature "
+                f"verification: {'; '.join(verification.errors)}",
+                at_sequence=receipt.last_sequence,
+            )
+        head_entry = by_sequence.get(receipt.last_sequence)
+        if head_entry is not None and head_entry.hmac != receipt.chain_head_hmac:
+            return ExportVerification(
+                ok=False,
+                status=ExportVerifyStatus.TAMPERED,
+                detail=f"exported record at sequence {receipt.last_sequence} does not match the signed "
+                "segment receipt's chain head",
+                at_sequence=receipt.last_sequence,
+            )
+
+    for prev_receipt, next_receipt in itertools.pairwise(ordered_receipts):
+        if next_receipt.first_sequence != prev_receipt.last_sequence + 1:
+            return ExportVerification(
+                ok=False,
+                status=ExportVerifyStatus.GAP,
+                detail=(
+                    f"missing batch between segment receipts: sequence {prev_receipt.last_sequence} "
+                    f"is followed by {next_receipt.first_sequence}, not {prev_receipt.last_sequence + 1}"
+                ),
+                at_sequence=prev_receipt.last_sequence + 1,
+            )
+
+    return ExportVerification(ok=True, status=ExportVerifyStatus.CONTIGUOUS, detail="contiguous, in order, unmodified")
 
 
 # ---------------------------------------------------------------------------
@@ -237,14 +481,32 @@ class BaseSIEMExporter(ABC):
 
     Args:
         config: Base export configuration.
+        kms_adapter: When given, each flushed batch is closed with a signed
+            :class:`SegmentReceipt` (issue #5034) so a receiver holding only
+            the export and this signer's public key can check it for
+            deletion, reordering, and gaps between batches. ``None`` keeps
+            the export exactly as before -- opt-in, not a behaviour change
+            for existing callers.
+        failure_log: When given, a batch that fails to export writes an
+            ``audit.export.failed`` event to this chain, so a silent
+            forwarding outage is itself part of the audit trail rather than
+            indistinguishable from quiet.
     """
 
-    def __init__(self, config: SIEMExportConfig) -> None:
+    def __init__(
+        self,
+        config: SIEMExportConfig,
+        *,
+        kms_adapter: KMSAdapter | None = None,
+        failure_log: AuditLog | None = None,
+    ) -> None:
         self._config = config
         self._buffer: list[AuditEntry] = []
         self._last_flush: float = time.time()
         self._total_exported: int = 0
         self._total_failed: int = 0
+        self._kms_adapter = kms_adapter
+        self._failure_log = failure_log
 
     @property
     def config(self) -> SIEMExportConfig:
@@ -295,6 +557,33 @@ class BaseSIEMExporter(ABC):
             Formatted entries ready for the target system.
         """
 
+    def _build_segment_receipt(self, batch: list[AuditEntry]) -> SegmentReceipt | None:
+        """Return the batch's signed receipt, or ``None`` when no signer is configured."""
+        if self._kms_adapter is None or not batch:
+            return None
+        return build_segment_receipt(batch, kms_adapter=self._kms_adapter)
+
+    def _record_export_failure(self, result: ExportResult) -> None:
+        """Write a chain event for a batch that failed to export.
+
+        A no-op when no ``failure_log`` was configured. Best-effort: a
+        failure here must not mask the export failure it is trying to
+        record, so any error writing the chain event is logged and
+        swallowed rather than raised.
+        """
+        if self._failure_log is None:
+            return
+        try:
+            self._failure_log.log(
+                "audit.export.failed",
+                actor="siem_exporter",
+                resource_type="siem_target",
+                resource_id=str(self._config.target.value),
+                details={"entries_sent": result.entries_sent, "error": result.error},
+            )
+        except OSError:
+            logger.exception("Failed to record export-failure chain event for target %s", self._config.target)
+
     def flush(self) -> ExportResult:
         """Flush the buffer, formatting and exporting entries.
 
@@ -317,6 +606,7 @@ class BaseSIEMExporter(ABC):
             entries_sent=len(batch),
             entries_accepted=len(formatted),
             success=True,
+            segment_receipt=self._build_segment_receipt(batch),
         )
 
         self._buffer = self._buffer[self._config.batch_size :]
@@ -342,8 +632,15 @@ class SplunkHECExporter(BaseSIEMExporter):
         self,
         config: SIEMExportConfig | None = None,
         splunk_config: SplunkHECConfig | None = None,
+        *,
+        kms_adapter: KMSAdapter | None = None,
+        failure_log: AuditLog | None = None,
     ) -> None:
-        super().__init__(config or SIEMExportConfig(target=SIEMTarget.SPLUNK))
+        super().__init__(
+            config or SIEMExportConfig(target=SIEMTarget.SPLUNK),
+            kms_adapter=kms_adapter,
+            failure_log=failure_log,
+        )
         self._splunk = splunk_config or SplunkHECConfig()
 
     @property
@@ -375,6 +672,8 @@ class SplunkHECExporter(BaseSIEMExporter):
                     "outcome": entry.outcome,
                     "details": entry.details,
                     "hmac": entry.hmac,
+                    "prev_hmac": entry.prev_hmac,
+                    "sequence": entry.sequence,
                 },
             }
             events.append(event)
@@ -398,9 +697,14 @@ class ElasticsearchExporter(BaseSIEMExporter):
         self,
         config: SIEMExportConfig | None = None,
         es_config: ElasticsearchConfig | None = None,
+        *,
+        kms_adapter: KMSAdapter | None = None,
+        failure_log: AuditLog | None = None,
     ) -> None:
         super().__init__(
             config or SIEMExportConfig(target=SIEMTarget.ELASTICSEARCH),
+            kms_adapter=kms_adapter,
+            failure_log=failure_log,
         )
         self._es = es_config or ElasticsearchConfig()
 
@@ -429,6 +733,8 @@ class ElasticsearchExporter(BaseSIEMExporter):
                 "outcome": entry.outcome,
                 "details": entry.details,
                 "hmac": entry.hmac,
+                "prev_hmac": entry.prev_hmac,
+                "sequence": entry.sequence,
                 "source": "bernstein-audit",
             }
             docs.append(doc)
@@ -452,9 +758,14 @@ class CloudWatchExporter(BaseSIEMExporter):
         self,
         config: SIEMExportConfig | None = None,
         cw_config: CloudWatchConfig | None = None,
+        *,
+        kms_adapter: KMSAdapter | None = None,
+        failure_log: AuditLog | None = None,
     ) -> None:
         super().__init__(
             config or SIEMExportConfig(target=SIEMTarget.CLOUDWATCH),
+            kms_adapter=kms_adapter,
+            failure_log=failure_log,
         )
         self._cw = cw_config or CloudWatchConfig()
 
@@ -485,6 +796,8 @@ class CloudWatchExporter(BaseSIEMExporter):
                         "outcome": entry.outcome,
                         "details": entry.details,
                         "hmac": entry.hmac,
+                        "prev_hmac": entry.prev_hmac,
+                        "sequence": entry.sequence,
                     }
                 ),
             }
@@ -509,8 +822,15 @@ class SyslogExporter(BaseSIEMExporter):
         self,
         config: SIEMExportConfig | None = None,
         syslog_config: SyslogConfig | None = None,
+        *,
+        kms_adapter: KMSAdapter | None = None,
+        failure_log: AuditLog | None = None,
     ) -> None:
-        super().__init__(config or SIEMExportConfig(target=SIEMTarget.SYSLOG))
+        super().__init__(
+            config or SIEMExportConfig(target=SIEMTarget.SYSLOG),
+            kms_adapter=kms_adapter,
+            failure_log=failure_log,
+        )
         self._syslog = syslog_config or SyslogConfig()
 
     @property
@@ -541,6 +861,8 @@ class SyslogExporter(BaseSIEMExporter):
                     "outcome": entry.outcome,
                     "details": entry.details,
                     "hmac": entry.hmac,
+                    "prev_hmac": entry.prev_hmac,
+                    "sequence": entry.sequence,
                 },
             )
             messages.append(
@@ -573,8 +895,15 @@ class WebhookExporter(BaseSIEMExporter):
         self,
         config: SIEMExportConfig | None = None,
         webhook_config: WebhookConfig | None = None,
+        *,
+        kms_adapter: KMSAdapter | None = None,
+        failure_log: AuditLog | None = None,
     ) -> None:
-        super().__init__(config or SIEMExportConfig(target=SIEMTarget.WEBHOOK))
+        super().__init__(
+            config or SIEMExportConfig(target=SIEMTarget.WEBHOOK),
+            kms_adapter=kms_adapter,
+            failure_log=failure_log,
+        )
         self._webhook = webhook_config or WebhookConfig()
 
     @property
@@ -601,6 +930,8 @@ class WebhookExporter(BaseSIEMExporter):
                 "outcome": entry.outcome,
                 "details": entry.details,
                 "hmac": entry.hmac,
+                "prev_hmac": entry.prev_hmac,
+                "sequence": entry.sequence,
                 "source": "bernstein-audit",
             }
             for entry in entries
@@ -625,8 +956,15 @@ class FileExporter(BaseSIEMExporter):
         self,
         config: SIEMExportConfig | None = None,
         file_config: FileExportConfig | None = None,
+        *,
+        kms_adapter: KMSAdapter | None = None,
+        failure_log: AuditLog | None = None,
     ) -> None:
-        super().__init__(config or SIEMExportConfig(target=SIEMTarget.FILE))
+        super().__init__(
+            config or SIEMExportConfig(target=SIEMTarget.FILE),
+            kms_adapter=kms_adapter,
+            failure_log=failure_log,
+        )
         self._file = file_config or FileExportConfig()
 
     @property
@@ -653,6 +991,8 @@ class FileExporter(BaseSIEMExporter):
                 "outcome": entry.outcome,
                 "details": entry.details,
                 "hmac": entry.hmac,
+                "prev_hmac": entry.prev_hmac,
+                "sequence": entry.sequence,
             }
             for entry in entries
         ]
@@ -660,6 +1000,13 @@ class FileExporter(BaseSIEMExporter):
 
     def flush(self) -> ExportResult:
         """Flush buffered entries to the configured file path.
+
+        When constructed with a ``kms_adapter``, a JSONL export also gets a
+        trailing ``{"segment_receipt": {...}}`` line per batch (issue
+        #5034), so ``bernstein audit verify-export`` can check the file
+        without needing anything else. The JSON-array format has no
+        analogous append point and does not get a receipt line; use
+        ``jsonl`` when the segment receipt matters.
 
         Returns:
             ExportResult with the outcome.
@@ -674,6 +1021,7 @@ class FileExporter(BaseSIEMExporter):
 
         batch = self._buffer[: self._config.batch_size]
         formatted = self.format_entries(batch)
+        receipt = self._build_segment_receipt(batch)
 
         start = time.time()
         try:
@@ -687,6 +1035,8 @@ class FileExporter(BaseSIEMExporter):
             if self._file.format == "jsonl":
                 with out_path.open("a") as fh:
                     fh.writelines(json.dumps(doc) + "\n" for doc in formatted)
+                    if receipt is not None:
+                        fh.write(json.dumps({"segment_receipt": receipt.to_dict()}) + "\n")
             else:
                 existing: list[dict[str, Any]] = []
                 if out_path.exists():
@@ -704,12 +1054,13 @@ class FileExporter(BaseSIEMExporter):
                 entries_accepted=len(formatted),
                 success=True,
                 duration_s=duration,
+                segment_receipt=receipt,
             )
         except OSError as exc:
             duration = time.time() - start
             self._total_failed += len(batch)
             logger.error("File export failed: %s", exc)
-            return ExportResult(
+            result = ExportResult(
                 target=SIEMTarget.FILE,
                 entries_sent=len(batch),
                 entries_accepted=0,
@@ -717,3 +1068,5 @@ class FileExporter(BaseSIEMExporter):
                 error=str(exc),
                 duration_s=duration,
             )
+            self._record_export_failure(result)
+            return result

--- a/src/bernstein/core/security/audit_export.py
+++ b/src/bernstein/core/security/audit_export.py
@@ -35,6 +35,7 @@ CLI surface over :func:`verify_exported_records`.
 
 from __future__ import annotations
 
+import bisect
 import itertools
 import json
 import logging
@@ -411,6 +412,21 @@ def verify_exported_records(
         ``CONTIGUOUS`` / ``ok=True`` result when none is.
     """
     if not entries:
+        if segment_receipts:
+            # A signed receipt with nothing behind it at all -- the whole
+            # export was deleted and the receipt is the only survivor. An
+            # empty entries list is not "nothing to verify" when a receipt
+            # says otherwise.
+            earliest = min(segment_receipts, key=lambda r: r.first_sequence)
+            return ExportVerification(
+                ok=False,
+                status=ExportVerifyStatus.GAP,
+                detail=(
+                    f"segment receipt covers sequence {earliest.first_sequence}-{earliest.last_sequence}, "
+                    "but the export carries no records at all"
+                ),
+                at_sequence=earliest.first_sequence,
+            )
         return ExportVerification(ok=True, status=ExportVerifyStatus.CONTIGUOUS, detail="no records to verify")
 
     for prev, curr in itertools.pairwise(entries):
@@ -437,6 +453,7 @@ def verify_exported_records(
             )
 
     by_sequence = {entry.sequence: entry for entry in entries}
+    present_sequences = sorted(by_sequence)
     ordered_receipts = sorted(segment_receipts, key=lambda r: r.first_sequence)
     for receipt in ordered_receipts:
         verification = verify_head_signature(
@@ -452,8 +469,36 @@ def verify_exported_records(
                 f"verification: {'; '.join(verification.errors)}",
                 at_sequence=receipt.last_sequence,
             )
-        head_entry = by_sequence.get(receipt.last_sequence)
-        if head_entry is not None and head_entry.hmac != receipt.chain_head_hmac:
+        # The receipt's own claimed span must be fully present. Counting via
+        # bisect over the sorted sequence list -- rather than iterating
+        # range(first_sequence, last_sequence) -- means a corrupt or hostile
+        # receipt claiming an enormous span costs a couple of binary
+        # searches, not an unbounded loop. A batch whose entries were
+        # deleted wholesale (the receipt survives; every entry it attests to
+        # does not) previously passed here silently: `by_sequence.get(...)`
+        # on an absent sequence returned `None`, and `None is not None` is
+        # `False`, so the one check guarding this used to skip entirely
+        # instead of failing.
+        expected_count = receipt.last_sequence - receipt.first_sequence + 1
+        present_count = bisect.bisect_right(present_sequences, receipt.last_sequence) - bisect.bisect_left(
+            present_sequences, receipt.first_sequence
+        )
+        if present_count != expected_count:
+            return ExportVerification(
+                ok=False,
+                status=ExportVerifyStatus.GAP,
+                detail=(
+                    f"segment receipt covers sequence {receipt.first_sequence}-{receipt.last_sequence} "
+                    f"({expected_count} record(s)), but only {present_count} are present in the export -- "
+                    "the batch it attests to was partially or entirely deleted"
+                ),
+                at_sequence=receipt.first_sequence,
+            )
+        # The count check above guarantees last_sequence is present (it is
+        # one of expected_count == present_count matching values drawn from
+        # exactly the claimed span), so this lookup cannot raise.
+        head_entry = by_sequence[receipt.last_sequence]
+        if head_entry.hmac != receipt.chain_head_hmac:
             return ExportVerification(
                 ok=False,
                 status=ExportVerifyStatus.TAMPERED,

--- a/src/bernstein/core/security/audit_export.py
+++ b/src/bernstein/core/security/audit_export.py
@@ -24,8 +24,13 @@ HMAC, signed with the same Ed25519 key used for lineage (reusing
 :mod:`bernstein.core.security.audit_head_signature`, not new signing code).
 :func:`verify_exported_records` then lets a receiver -- no database, no
 HMAC key, just the exported file and the signer's public key -- confirm
-the batch is contiguous, in order, and unmodified. ``bernstein audit
-verify-export`` (``cli/commands/audit_cmd.py``) is the CLI surface over it.
+the batch is contiguous, in order, and chain-linked. That is not the same
+claim as "record contents are unmodified": the verifier checks that each
+record's ``prev_hmac`` chains onto the previous record's stored ``hmac``,
+never that the stored ``hmac`` itself still matches the record's content --
+doing that needs the HMAC signing key, via ``bernstein audit verify``.
+``bernstein audit verify-export`` (``cli/commands/audit_cmd.py``) is the
+CLI surface over :func:`verify_exported_records`.
 """
 
 from __future__ import annotations
@@ -381,11 +386,15 @@ def verify_exported_records(
     *,
     trusted_public_key_jwk: dict[str, Any] | None = None,
 ) -> ExportVerification:
-    """Check an exported batch for deletion, reordering, and tampering.
+    """Check an exported batch for deletion, reordering, and chain tampering.
 
     Works on the export alone -- no source database, no HMAC key. Entries
     are checked in the order given (never re-sorted, since silently
     correcting the order would hide the very defect this exists to catch).
+    "Tampering" here means the chain linkage or a segment receipt's
+    signature -- a record whose ``details`` were edited with its stored
+    ``hmac`` left untouched is not detectable from the export alone; that
+    needs the signing key, via ``bernstein audit verify``.
 
     Args:
         entries: Exported records, in file order.
@@ -465,7 +474,9 @@ def verify_exported_records(
                 at_sequence=prev_receipt.last_sequence + 1,
             )
 
-    return ExportVerification(ok=True, status=ExportVerifyStatus.CONTIGUOUS, detail="contiguous, in order, unmodified")
+    return ExportVerification(
+        ok=True, status=ExportVerifyStatus.CONTIGUOUS, detail="contiguous, in order, chain-linked"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_audit_cmd_paths.py
+++ b/tests/unit/cli/test_audit_cmd_paths.py
@@ -27,6 +27,8 @@ from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 from bernstein.cli.commands.audit_cmd import (
     _parse_filename_date,
@@ -34,6 +36,8 @@ from bernstein.cli.commands.audit_cmd import (
     audit_group,
 )
 from bernstein.core.security.audit import AUDIT_KEY_ENV
+from bernstein.core.security.audit_export import AuditEntry, FileExportConfig, FileExporter
+from bernstein.core.security.key_custody import FileBasedKMSAdapter
 
 # ---------------------------------------------------------------------------
 # fixtures / helpers
@@ -308,6 +312,105 @@ def test_query_no_match_reports_yellow(isolated_audit: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# audit verify-export (issue #5034)
+# ---------------------------------------------------------------------------
+
+
+def _kms(tmp_path: Path, *, seed: bytes = b"\x04" * 32, name: str = "segment-receipt.pem") -> FileBasedKMSAdapter:
+    key_path = tmp_path / name
+    private_key = Ed25519PrivateKey.from_private_bytes(seed)
+    key_path.write_bytes(
+        private_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+    )
+    return FileBasedKMSAdapter(key_path, kid="verify-export-cli-test")
+
+
+def _write_export(tmp_path: Path, *, entry_count: int = 3, kms_adapter: FileBasedKMSAdapter | None = None) -> Path:
+    """Write a valid JSONL export (with segment receipt, if signed) and return its path."""
+    sdd_dir = tmp_path / ".sdd"
+    sdd_dir.mkdir(exist_ok=True)
+    exporter = FileExporter(
+        file_config=FileExportConfig(path="export.jsonl", format="jsonl"),
+        kms_adapter=kms_adapter,
+    )
+    prev = ""
+    for i in range(entry_count):
+        entry = AuditEntry(
+            timestamp=1.0,
+            event_type="task.created",
+            actor="alice",
+            resource="task-1",
+            action="create",
+            outcome="success",
+            hmac=f"{i:064x}",
+            prev_hmac=prev,
+            sequence=i,
+        )
+        exporter.add_entry(entry)
+        prev = entry.hmac
+    exporter.flush()
+    return sdd_dir / "exports" / "export.jsonl"
+
+
+def test_verify_export_passes_on_a_contiguous_unsigned_export(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    export_path = _write_export(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(audit_group, ["verify-export", str(export_path)])
+    assert result.exit_code == 0, result.output
+    assert "PASSED" in result.output
+
+
+def test_verify_export_passes_with_a_signed_segment_receipt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    export_path = _write_export(tmp_path, kms_adapter=_kms(tmp_path))
+    runner = CliRunner()
+    result = runner.invoke(audit_group, ["verify-export", str(export_path)])
+    assert result.exit_code == 0, result.output
+    assert "PASSED" in result.output
+
+
+def test_verify_export_detects_a_deleted_record(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    export_path = _write_export(tmp_path, entry_count=4)
+    lines = [line for line in export_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    del lines[1]  # delete the record at sequence 1
+    export_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(audit_group, ["verify-export", str(export_path)])
+    assert result.exit_code == 1, result.output
+    assert "GAP" in result.output
+
+
+def test_verify_export_rejects_an_untrusted_signer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    export_path = _write_export(tmp_path, kms_adapter=_kms(tmp_path))
+    other_key_path = tmp_path / "other-public.json"
+    other_signer = _kms(tmp_path, seed=b"\x05" * 32, name="other-signer.pem")
+    other_key_path.write_text(json.dumps(other_signer.public_key_jwk()), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        audit_group,
+        ["verify-export", str(export_path), "--public-key", str(other_key_path)],
+    )
+    assert result.exit_code == 1, result.output
+    assert "TAMPERED" in result.output
+
+
+def test_verify_export_missing_file_exits_nonzero() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(audit_group, ["verify-export", "does-not-exist.jsonl"])
+    assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
 # audit capabilities
 # ---------------------------------------------------------------------------
 
@@ -359,7 +462,7 @@ def test_audit_group_help_lists_subcommands() -> None:
     runner = CliRunner()
     result = runner.invoke(audit_group, ["--help"])
     assert result.exit_code == 0, result.output
-    for sub in ("show", "seal", "verify", "verify-hmac", "export", "query", "slice", "archive"):
+    for sub in ("show", "seal", "verify", "verify-hmac", "verify-export", "export", "query", "slice", "archive"):
         assert sub in result.output, f"missing subcommand {sub} in audit --help"
 
 

--- a/tests/unit/cli/test_audit_cmd_paths.py
+++ b/tests/unit/cli/test_audit_cmd_paths.py
@@ -357,21 +357,41 @@ def _write_export(tmp_path: Path, *, entry_count: int = 3, kms_adapter: FileBase
 
 
 def test_verify_export_passes_on_a_contiguous_unsigned_export(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No segment receipts at all: the panel must say so, not read like an authenticity result."""
     monkeypatch.chdir(tmp_path)
     export_path = _write_export(tmp_path)
     runner = CliRunner()
     result = runner.invoke(audit_group, ["verify-export", str(export_path)])
     assert result.exit_code == 0, result.output
     assert "PASSED" in result.output
+    assert "no segment receipts" in result.output.lower()
 
 
 def test_verify_export_passes_with_a_signed_segment_receipt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No --public-key given: the panel must say trust-on-first-use, not just PASSED."""
     monkeypatch.chdir(tmp_path)
     export_path = _write_export(tmp_path, kms_adapter=_kms(tmp_path))
     runner = CliRunner()
     result = runner.invoke(audit_group, ["verify-export", str(export_path)])
     assert result.exit_code == 0, result.output
     assert "PASSED" in result.output
+    assert "trusted on first use" in result.output.lower()
+    assert "authenticity not verified" in result.output.lower()
+
+
+def test_verify_export_with_pinned_key_reports_signer_pinned(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """--public-key given and matching: the panel must distinguish this from trust-on-first-use."""
+    monkeypatch.chdir(tmp_path)
+    kms = _kms(tmp_path)
+    export_path = _write_export(tmp_path, kms_adapter=kms)
+    key_path = tmp_path / "trusted-public.json"
+    key_path.write_text(json.dumps(kms.public_key_jwk()), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(audit_group, ["verify-export", str(export_path), "--public-key", str(key_path)])
+    assert result.exit_code == 0, result.output
+    assert "PASSED" in result.output
+    assert "signer pinned" in result.output.lower()
 
 
 def test_verify_export_detects_a_deleted_record(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -401,6 +421,27 @@ def test_verify_export_rejects_an_untrusted_signer(tmp_path: Path, monkeypatch: 
     )
     assert result.exit_code == 1, result.output
     assert "TAMPERED" in result.output
+
+
+def test_verify_export_with_a_malformed_line_reports_incomplete_not_passed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A line that cannot be parsed must not disappear into a silent green PASSED.
+
+    A corrupt line is excluded from the sequence-continuity check entirely,
+    so nothing else can prove the export is complete once one is skipped --
+    the run must say INCOMPLETE and exit non-zero rather than PASSED.
+    """
+    monkeypatch.chdir(tmp_path)
+    export_path = _write_export(tmp_path, entry_count=3)
+    with export_path.open("a", encoding="utf-8") as fh:
+        fh.write("{not valid json\n")
+
+    runner = CliRunner()
+    result = runner.invoke(audit_group, ["verify-export", str(export_path)])
+    assert result.exit_code == 1, result.output
+    assert "INCOMPLETE" in result.output
+    assert "PASSED" not in result.output
 
 
 def test_verify_export_missing_file_exits_nonzero() -> None:

--- a/tests/unit/test_audit_export.py
+++ b/tests/unit/test_audit_export.py
@@ -290,6 +290,18 @@ class TestVerifyExportedRecords:
         assert result.ok
         assert result.status == ExportVerifyStatus.CONTIGUOUS
 
+    def test_the_detail_string_claims_chain_linkage_not_unmodified_content(self) -> None:
+        """The verifier never recomputes an hmac from content -- the detail must not claim it does.
+
+        A record's ``details`` could be edited with its stored ``hmac`` left
+        untouched and this check would still pass: it only proves
+        ``prev_hmac`` chains onto the previous record's stored ``hmac``, not
+        that any hmac still matches its content.
+        """
+        result = verify_exported_records(_chain(3))
+        assert result.detail == "contiguous, in order, chain-linked"
+        assert "unmodified" not in result.detail
+
     def test_verifier_detects_a_deleted_record_in_an_exported_batch(self) -> None:
         entries = _chain(5)
         del entries[2]  # delete the record at sequence 2

--- a/tests/unit/test_audit_export.py
+++ b/tests/unit/test_audit_export.py
@@ -4,25 +4,45 @@ from __future__ import annotations
 
 import json
 import time
+from pathlib import Path
 
+import pytest
 from bernstein.core.audit_export import (
     AuditEntry,
     CloudWatchConfig,
     CloudWatchExporter,
     ElasticsearchConfig,
     ElasticsearchExporter,
+    ExportVerifyStatus,
+    FileExportConfig,
+    FileExporter,
     SIEMExportConfig,
     SIEMTarget,
     SplunkHECConfig,
     SplunkHECExporter,
+    SyslogExporter,
+    WebhookExporter,
+    build_segment_receipt,
+    verify_exported_records,
 )
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from bernstein.core.security.audit import AuditLog
+from bernstein.core.security.key_custody import FileBasedKMSAdapter
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
-def _make_entry(event_type: str = "task.created") -> AuditEntry:
+def _make_entry(
+    event_type: str = "task.created",
+    *,
+    hmac: str = "abc123",
+    prev_hmac: str = "",
+    sequence: int = 0,
+) -> AuditEntry:
     return AuditEntry(
         timestamp=time.time(),
         event_type=event_type,
@@ -31,8 +51,41 @@ def _make_entry(event_type: str = "task.created") -> AuditEntry:
         action="create",
         outcome="success",
         details={"role": "backend"},
-        hmac="abc123",
+        hmac=hmac,
+        prev_hmac=prev_hmac,
+        sequence=sequence,
     )
+
+
+def _hex_hmac(i: int) -> str:
+    """A distinct, hex-valid stand-in hmac -- ``build_head_signature`` requires valid hex."""
+    return f"{i:064x}"
+
+
+def _chain(n: int) -> list[AuditEntry]:
+    """Return *n* entries whose hmac/prev_hmac/sequence form a valid chain."""
+    entries = []
+    prev = ""
+    for i in range(n):
+        entry = _make_entry(hmac=_hex_hmac(i), prev_hmac=prev, sequence=i)
+        entries.append(entry)
+        prev = entry.hmac
+    return entries
+
+
+def _kms(tmp_path: Path) -> FileBasedKMSAdapter:
+    """Deterministic file-backed Ed25519 signer for segment-receipt tests."""
+    key_path = tmp_path / "segment-receipt.pem"
+    if not key_path.exists():
+        private_key = Ed25519PrivateKey.from_private_bytes(b"\x02" * 32)
+        key_path.write_bytes(
+            private_key.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption(),
+            )
+        )
+    return FileBasedKMSAdapter(key_path, kid="segment-receipt-test")
 
 
 # ---------------------------------------------------------------------------
@@ -172,3 +225,186 @@ class TestBufferManagement:
         exporter.flush()
         exporter.flush()
         assert exporter.total_exported == 4  # 2 + 2
+
+
+# ---------------------------------------------------------------------------
+# Issue #5034: exported records carry the chain, not just an opaque hmac
+# ---------------------------------------------------------------------------
+
+
+class TestAuditEntryChainFields:
+    def test_export_entry_carries_prev_hmac_and_sequence(self) -> None:
+        entry = _make_entry(hmac="hmac-1", prev_hmac="hmac-0", sequence=1)
+        assert entry.prev_hmac == "hmac-0"
+        assert entry.sequence == 1
+
+
+@pytest.mark.parametrize(
+    ("exporter", "extract"),
+    [
+        pytest.param(
+            SplunkHECExporter(),
+            lambda formatted: formatted[0]["event"],
+            id="splunk",
+        ),
+        pytest.param(
+            ElasticsearchExporter(),
+            lambda formatted: formatted[0],
+            id="elasticsearch",
+        ),
+        pytest.param(
+            CloudWatchExporter(),
+            lambda formatted: json.loads(formatted[0]["message"]),
+            id="cloudwatch",
+        ),
+        pytest.param(
+            SyslogExporter(),
+            lambda formatted: json.loads(formatted[0]["msg"]),
+            id="syslog",
+        ),
+        pytest.param(
+            WebhookExporter(),
+            lambda formatted: formatted[0],
+            id="webhook",
+        ),
+        pytest.param(
+            FileExporter(),
+            lambda formatted: formatted[0],
+            id="file",
+        ),
+    ],
+)
+class TestEveryExporterSerialisesTheChainFields:
+    def test_every_exporter_serialises_the_chain_fields(self, exporter, extract) -> None:
+        entry = _make_entry(hmac="hmac-9", prev_hmac="hmac-8", sequence=9)
+        formatted = exporter.format_entries([entry])
+        record = extract(formatted)
+        assert record["hmac"] == "hmac-9"
+        assert record["prev_hmac"] == "hmac-8"
+        assert record["sequence"] == 9
+
+
+class TestVerifyExportedRecords:
+    def test_a_valid_chain_is_contiguous(self) -> None:
+        result = verify_exported_records(_chain(5))
+        assert result.ok
+        assert result.status == ExportVerifyStatus.CONTIGUOUS
+
+    def test_verifier_detects_a_deleted_record_in_an_exported_batch(self) -> None:
+        entries = _chain(5)
+        del entries[2]  # delete the record at sequence 2
+
+        result = verify_exported_records(entries)
+
+        assert not result.ok
+        assert result.status == ExportVerifyStatus.GAP
+        assert result.at_sequence == 2
+
+    def test_verifier_detects_a_reordered_record(self) -> None:
+        entries = _chain(4)
+        entries[0], entries[1] = entries[1], entries[0]  # swap the first two records
+
+        result = verify_exported_records(entries)
+
+        assert not result.ok
+        assert result.status == ExportVerifyStatus.REORDERED
+
+    def test_verifier_detects_a_missing_batch_between_two_segment_receipts(self, tmp_path: Path) -> None:
+        kms = _kms(tmp_path)
+        batch_a = _chain(3)  # sequence 0, 1, 2
+        batch_b = [
+            _make_entry(hmac=_hex_hmac(5), prev_hmac=_hex_hmac(4), sequence=5),
+            _make_entry(hmac=_hex_hmac(6), prev_hmac=_hex_hmac(5), sequence=6),
+        ]  # an entire batch (sequence 3, 4) never arrived
+        receipt_a = build_segment_receipt(batch_a, kms_adapter=kms)
+        receipt_b = build_segment_receipt(batch_b, kms_adapter=kms)
+
+        result = verify_exported_records(batch_a + batch_b, [receipt_a, receipt_b])
+
+        assert not result.ok
+        assert result.status == ExportVerifyStatus.GAP
+
+    def test_verifier_runs_without_the_source_database(self, tmp_path: Path) -> None:
+        # No AuditLog, no filesystem audit dir -- only the exported records
+        # and, when present, receipts signed with a standalone key file.
+        kms = _kms(tmp_path)
+        batch = _chain(4)
+        receipt = build_segment_receipt(batch, kms_adapter=kms)
+
+        result = verify_exported_records(batch, [receipt])
+
+        assert result.ok
+        assert result.status == ExportVerifyStatus.CONTIGUOUS
+
+    def test_verifier_detects_a_tampered_segment_receipt(self, tmp_path: Path) -> None:
+        kms = _kms(tmp_path)
+        batch = _chain(3)
+        receipt = build_segment_receipt(batch, kms_adapter=kms)
+        # Simulate the exported chain-head record being altered after the
+        # receipt was signed: it no longer matches what was attested to.
+        tampered = list(batch)
+        tampered[-1] = _make_entry(hmac="forged", prev_hmac=batch[-1].prev_hmac, sequence=batch[-1].sequence)
+
+        result = verify_exported_records(tampered, [receipt])
+
+        assert not result.ok
+        assert result.status == ExportVerifyStatus.TAMPERED
+
+    def test_verifier_rejects_a_receipt_from_an_untrusted_key(self, tmp_path: Path) -> None:
+        real_kms = _kms(tmp_path)
+        other_key_path = tmp_path / "other.pem"
+        other_key_path.write_bytes(
+            Ed25519PrivateKey.from_private_bytes(b"\x03" * 32).private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption(),
+            )
+        )
+        other_kms = FileBasedKMSAdapter(other_key_path, kid="untrusted")
+        batch = _chain(2)
+        receipt = build_segment_receipt(batch, kms_adapter=other_kms)
+
+        result = verify_exported_records(
+            batch,
+            [receipt],
+            trusted_public_key_jwk=real_kms.public_key_jwk(),
+        )
+
+        assert not result.ok
+        assert result.status == ExportVerifyStatus.TAMPERED
+
+
+class TestFailedExportWritesAChainEvent:
+    def test_failed_export_batch_writes_a_chain_event(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        sdd_dir = tmp_path / ".sdd"
+        sdd_dir.mkdir()
+        # Block "exports/" from ever being created as a directory, so the
+        # exporter's own mkdir() fails and the write never happens.
+        (sdd_dir / "exports").write_text("not a directory")
+
+        audit_log = AuditLog(sdd_dir / "audit", key=b"0" * 64)
+        exporter = FileExporter(
+            file_config=FileExportConfig(path="audit.jsonl", format="jsonl"),
+            failure_log=audit_log,
+        )
+        exporter.add_entry(_make_entry())
+
+        result = exporter.flush()
+
+        assert not result.success
+        events = audit_log.query(event_type="audit.export.failed")
+        assert len(events) == 1
+        assert events[0].resource_id == "file"
+
+    def test_a_successful_export_writes_no_failure_event(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".sdd").mkdir()
+        audit_log = AuditLog(tmp_path / ".sdd" / "audit", key=b"0" * 64)
+        exporter = FileExporter(failure_log=audit_log)
+        exporter.add_entry(_make_entry())
+
+        result = exporter.flush()
+
+        assert result.success
+        assert audit_log.query(event_type="audit.export.failed") == []

--- a/tests/unit/test_audit_export.py
+++ b/tests/unit/test_audit_export.py
@@ -362,6 +362,56 @@ class TestVerifyExportedRecords:
         assert not result.ok
         assert result.status == ExportVerifyStatus.TAMPERED
 
+    def test_verifier_detects_a_whole_batch_deleted_while_its_receipt_survives(self, tmp_path: Path) -> None:
+        """The gap a signature check alone cannot see: every entry one receipt attests to is gone.
+
+        Before this fix, ``by_sequence.get(receipt.last_sequence)`` returned
+        ``None`` for a deleted entry, and the guard clause
+        (``if head_entry is not None and ...``) treated "nothing to compare"
+        as "nothing wrong" -- a receipt whose entire batch had been deleted
+        verified as signed and CONTIGUOUS, as long as some other batch's
+        entries were still present to keep ``entries`` non-empty. Load-bearing.
+        """
+        kms = _kms(tmp_path)
+        batch_a = [
+            _make_entry(hmac=_hex_hmac(i), prev_hmac=_hex_hmac(i - 1) if i else "", sequence=i) for i in range(5)
+        ]  # sequence 0-4, entirely deleted below
+        batch_b = [
+            _make_entry(hmac=_hex_hmac(i), prev_hmac=_hex_hmac(i - 1), sequence=i) for i in range(5, 8)
+        ]  # sequence 5-7, survives
+        receipt_a = build_segment_receipt(batch_a, kms_adapter=kms)
+        receipt_b = build_segment_receipt(batch_b, kms_adapter=kms)
+
+        # batch_a's own entries are gone; only its signed receipt survives,
+        # alongside batch_b's entries and receipt (both intact).
+        result = verify_exported_records(batch_b, [receipt_a, receipt_b])
+
+        assert not result.ok
+        assert result.status == ExportVerifyStatus.GAP
+
+    def test_verifier_detects_a_partially_deleted_batch_behind_a_surviving_receipt(self, tmp_path: Path) -> None:
+        """A receipt's tail entries deleted, its earlier entries left in place, still verifies clean without this fix."""
+        kms = _kms(tmp_path)
+        batch = _chain(5)  # sequence 0-4
+        receipt = build_segment_receipt(batch, kms_adapter=kms)
+        surviving = batch[:2]  # sequence 0, 1 only -- 2, 3, 4 deleted, including the receipt's own chain head
+
+        result = verify_exported_records(surviving, [receipt])
+
+        assert not result.ok
+        assert result.status == ExportVerifyStatus.GAP
+
+    def test_verifier_rejects_a_receipt_with_no_entries_at_all(self, tmp_path: Path) -> None:
+        """An export reduced to nothing but a lone surviving receipt is not "nothing to verify"."""
+        kms = _kms(tmp_path)
+        batch = _chain(3)
+        receipt = build_segment_receipt(batch, kms_adapter=kms)
+
+        result = verify_exported_records([], [receipt])
+
+        assert not result.ok
+        assert result.status == ExportVerifyStatus.GAP
+
     def test_verifier_rejects_a_receipt_from_an_untrusted_key(self, tmp_path: Path) -> None:
         real_kms = _kms(tmp_path)
         other_key_path = tmp_path / "other.pem"


### PR DESCRIPTION
## Summary

Closes #5034.

`AuditEntry` (the record every SIEM exporter emits) carried only an opaque `hmac` and dropped `prev_hmac` and any sequence number. A receiver holding only the exported records — a SOC analyst, an auditor, a regulator — could not check the export for deletion, reordering, or gaps, and never holds the internal HMAC key anyway. The export *looked* stronger than a plain log while proving exactly as little.

This PR:

1. Adds `prev_hmac: str` and `sequence: int` to `AuditEntry`, and emits both from all six exporters (Splunk HEC, Elasticsearch, CloudWatch, syslog, webhook, file) — the six `entry.hmac` serialization sites named in the issue.
2. Adds `SegmentReceipt` + `build_segment_receipt()`: each export batch can be closed with a signed boundary — first/last sequence, entry count, and the batch's chain-head HMAC — signed with an Ed25519 key. This **reuses** `core/security/audit_head_signature.py`'s `build_head_signature` / `verify_head_signature` (the same infra the lineage subsystem signs with), rather than adding new signing code, per the issue's guidance. Opt-in via an optional `kms_adapter` constructor argument on every exporter; existing callers that don't pass one see no behavior change.
3. Adds `verify_exported_records()`: given only the exported records (+ optional segment receipts), reports `contiguous` / `gap at N` / `reordered at N` / `tampered` — no source database, no HMAC key, just the file and (optionally) the signer's public key.
4. Adds `bernstein audit verify-export <file> [--public-key <jwk.json>]` — the CLI surface over point 3. `FileExporter` writes a trailing `{"segment_receipt": {...}}` JSONL line per batch when constructed with a `kms_adapter`, so the same file the CLI reads carries both entries and receipts.
5. Adds an opt-in `failure_log` constructor argument: a batch that fails to export writes an `audit.export.failed` event to the audit chain itself, so a silent forwarding outage is auditable rather than indistinguishable from quiet. Wired into `FileExporter`'s existing `OSError` path (the only exporter here with a real failure mode — the network exporters don't perform real I/O yet).

## Design notes

- No new export targets, no change to the internal HMAC chain format — both explicitly out of scope per the issue.
- The Ed25519 signer is the same `KMSAdapter` protocol / `FileBasedKMSAdapter` used across lineage, receipts, and mesh coordination — chosen deliberately over inventing a second signing mechanism.
- `verify_exported_records` never re-sorts input records — silently correcting order would hide the defect it exists to catch.

## Tests

All 7 acceptance tests from the issue, plus a few extra edge cases (tampered receipt, untrusted signer, CLI-level round trips):

- `tests/unit/test_audit_export.py` — `TestAuditEntryChainFields`, `TestEveryExporterSerialisesTheChainFields` (parametrized over all six exporters), `TestVerifyExportedRecords` (deleted record / reordered record / missing batch between segment receipts / runs without a database / tampered receipt / untrusted signer), `TestFailedExportWritesAChainEvent`.
- `tests/unit/cli/test_audit_cmd_paths.py` — `bernstein audit verify-export`: passes on a contiguous unsigned export, passes with a signed receipt, detects a deleted record, rejects an untrusted signer, exits non-zero on a missing file.

```
uv run python scripts/run_tests.py tests/unit/test_audit_export.py tests/unit/cli/test_audit_cmd_paths.py -x
# 57 passed
uv run ruff check src/ tests/
uv run ruff format --check src/ tests/
uv run python -m pyright src/bernstein/core/security/audit_export.py src/bernstein/cli/commands/audit_cmd.py
# 0 new errors (114 pre-existing errors in audit_cmd.py, unchanged from main, all outside the touched range)
uv run lint-imports
# 3 kept, 0 broken
uv run python scripts/check_routes_broad_except.py
# OK
```

## Docs

- `docs/security/audit-log.md` — documents the new `prev_hmac`/`sequence` fields, segment receipts, and `bernstein audit verify-export`.
- `docs/release-notes/fragments/5034-audit-export-chain-fields.md` — release-note fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)