### PR TITLE
fix(replay): the ordinary task_merged row now names its merge commit (#5271, slice 1)

### DIFF
--- a/docs/release-notes/fragments/5271-task-merged-commit.md
+++ b/docs/release-notes/fragments/5271-task-merged-commit.md
@@ -1,0 +1,11 @@
+## The ordinary `task_merged` row now names the commit it produced
+
+Neither `MergeResult` nor the `task_merged` journal row it feeds could be
+tied back to a git object -- the row said a task was merged, but not which
+commit that was. `MergeResult` now carries `merge_commit`, read via
+`git rev-parse HEAD` right after a successful merge commit, and
+`record_task_merged` accepts an optional `merge_commit` that lands on the
+row when one exists. A merge that found nothing to commit (branches
+already identical) records no `merge_commit`, rather than fabricating one
+(#5271, slice 1 of 2 -- the salvage-merge path for a crashed agent's
+partial work is a separate follow-up).

--- a/src/bernstein/core/git/git_pr.py
+++ b/src/bernstein/core/git/git_pr.py
@@ -45,6 +45,15 @@ class MergeResult:
             this is the list of forbidden paths that were staged.  The
             merge is aborted and never produces a commit in this case
             (fix for defect 28, the decoy-commit secret-leak path).
+        merge_commit: The sha of the merge commit this merge produced on
+            the integration branch, when it produced one. Empty when the
+            merge failed, was refused, or found nothing to commit
+            (branches already identical) -- there is no commit to name in
+            any of those cases. Read right after the commit succeeds so a
+            caller (e.g. the ``task_merged`` journal row, issue #5271) can
+            tie the recorded merge decision back to the git object it
+            actually produced, rather than recording only that *a* merge
+            happened.
     """
 
     success: bool
@@ -52,6 +61,7 @@ class MergeResult:
     merge_diff: str = ""
     error: str = ""
     refused_forbidden_files: list[str] = field(default_factory=list)
+    merge_commit: str = ""
 
 
 @dataclass(frozen=True)
@@ -422,7 +432,9 @@ def merge_with_conflict_detection(
         commit_r = run_git(["commit", "-m", msg], cwd, timeout=30)
         if commit_r.ok:
             diff = run_git(["diff", "HEAD~1", "--stat"], cwd, timeout=30).stdout
-            return MergeResult(success=True, conflicting_files=[], merge_diff=diff)
+            rev_r = run_git(["rev-parse", "HEAD"], cwd, timeout=10)
+            commit_sha = rev_r.stdout.strip() if rev_r.ok else ""
+            return MergeResult(success=True, conflicting_files=[], merge_diff=diff, merge_commit=commit_sha)
         # Nothing to commit (branches already identical)
         run_git(["merge", "--abort"], cwd, timeout=10)
         return MergeResult(success=True, conflicting_files=[])

--- a/src/bernstein/core/replay/review_board.py
+++ b/src/bernstein/core/replay/review_board.py
@@ -439,7 +439,13 @@ def list_board_runs(sdd_dir: Path) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
-def record_task_merged(recorder: EventJournal | None, *, task_id: str, agent_id: str | None) -> None:
+def record_task_merged(
+    recorder: EventJournal | None,
+    *,
+    task_id: str,
+    agent_id: str | None,
+    merge_commit: str | None = None,
+) -> None:
     """Record a ``task_merged`` event into the run journal.
 
     Called by the task lifecycle right after a verified task's work is
@@ -451,10 +457,18 @@ def record_task_merged(recorder: EventJournal | None, *, task_id: str, agent_id:
         recorder: The run's :class:`EventJournal` (or ``None``).
         task_id: The merged task's identifier.
         agent_id: The producing agent session id, when known.
+        merge_commit: The sha of the commit the merge produced on the
+            integration branch (issue #5271), when one exists -- a merge
+            that found nothing to commit (branches already identical)
+            produced none. Optional and keyword-only so existing callers
+            keep compiling; omitted from the row entirely rather than
+            recorded as an empty string, so an older journal reader that
+            does not know the field sees exactly what it saw before.
     """
     if recorder is None:
         return
-    recorder.record(EVENT_TASK_MERGED, task_id=task_id, agent_id=agent_id)
+    extra: dict[str, Any] = {"merge_commit": merge_commit} if merge_commit else {}
+    recorder.record(EVENT_TASK_MERGED, task_id=task_id, agent_id=agent_id, **extra)
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -3830,7 +3830,15 @@ def _reap_and_cleanup_session(
         # issue #2365: chain the merge decision into the run journal so the
         # review board's merged column is a projection of the journal, not a
         # side inference. No-op when the orchestrator has no recorder.
-        record_task_merged(getattr(orch, "_recorder", None), task_id=task.id, agent_id=session.id)
+        # issue #5271: carry the merge commit sha so the row can be tied back
+        # to the git object it actually produced, not just to "a merge
+        # happened". None when the merge found nothing to commit.
+        record_task_merged(
+            getattr(orch, "_recorder", None),
+            task_id=task.id,
+            agent_id=session.id,
+            merge_commit=getattr(merge_result, "merge_commit", None),
+        )
 
     # issue #2559: reconcile what the task declared it would produce against what
     # this run's spine actually carries, and record an artifact-keyed attempt for

--- a/tests/unit/test_conflict_resolution.py
+++ b/tests/unit/test_conflict_resolution.py
@@ -97,6 +97,11 @@ class TestMergeWithConflictDetection:
     # commit, diff --stat. These tests used to mock a 7-call sequence
     # from the old rebase-first implementation, so the stdout for
     # ``diff --stat`` landed at index 6 and was never reached.
+    #
+    # Issue #5271 added a 6th call after a successful commit -- rev-parse
+    # HEAD, to read the merge commit sha onto MergeResult -- so every
+    # clean-merge mock sequence below carries one more entry than it used
+    # to.
 
     @patch("bernstein.core.git.git_pr.run_git")
     def test_clean_merge(self, mock: MagicMock) -> None:
@@ -106,11 +111,13 @@ class TestMergeWithConflictDetection:
             GitResult(0, "src/foo.py\n", ""),  # _verify_merge_staging_is_safe: staged files
             GitResult(0, "", ""),  # commit -m <msg>
             GitResult(0, "1 file changed\n", ""),  # diff HEAD~1 --stat
+            GitResult(0, "abc1234\n", ""),  # rev-parse HEAD (issue #5271)
         ]
         result = merge_with_conflict_detection(REPO, "agent/session-1")
         assert result.success
         assert result.conflicting_files == []
         assert "1 file changed" in result.merge_diff
+        assert result.merge_commit == "abc1234"
 
     @patch("bernstein.core.git.git_pr.run_git")
     def test_clean_merge_custom_message(self, mock: MagicMock) -> None:
@@ -120,6 +127,7 @@ class TestMergeWithConflictDetection:
             GitResult(0, "src/foo.py\n", ""),  # _verify_merge_staging_is_safe
             GitResult(0, "", ""),  # commit
             GitResult(0, "", ""),  # diff --stat
+            GitResult(0, "", ""),  # rev-parse HEAD (issue #5271)
         ]
         merge_with_conflict_detection(REPO, "feature/x", message="Custom merge msg")
         # Verify the commit used the custom message. Sequence: merge (0),

--- a/tests/unit/test_git_pr.py
+++ b/tests/unit/test_git_pr.py
@@ -167,6 +167,62 @@ def test_merge_with_conflict_detection_allows_pure_deliverable_staged_set(
     assert result.refused_forbidden_files == []
 
 
+def test_merge_with_conflict_detection_returns_the_commit_sha(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A successful commit-producing merge reports the sha it produced (issue #5271).
+
+    Without this, neither ``MergeResult`` nor the ``task_merged`` journal
+    row it feeds could be tied back to the git object the merge actually
+    created.
+    """
+    staged = ["src/bernstein/cli/cli.py"]
+    fake = _make_clean_merge_fake(staged)
+    orig_fake = fake
+    expected_sha = "deadbeef" * 5
+
+    def _fake_with_commit_and_rev_parse(
+        args: list[str], cwd: Path, timeout: int = 30, **kwargs: object
+    ) -> GitResult:
+        if args[:1] == ["commit"]:
+            return GitResult(returncode=0, stdout="", stderr="")
+        if args[:2] == ["rev-parse", "HEAD"]:
+            return GitResult(returncode=0, stdout=f"{expected_sha}\n", stderr="")
+        return orig_fake(args, cwd, timeout=timeout, **kwargs)
+
+    _fake_with_commit_and_rev_parse.seen = orig_fake.seen  # type: ignore[attr-defined]
+    monkeypatch.setattr(git_pr, "run_git", _fake_with_commit_and_rev_parse)
+
+    result = git_pr.merge_with_conflict_detection(tmp_path, "agent/qa-aa55cebb")
+
+    assert result.success is True
+    assert result.merge_commit == expected_sha
+
+
+def test_merge_with_conflict_detection_leaves_commit_empty_on_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A conflicting merge -- no commit ever produced -- reports no merge_commit."""
+
+    def _fake_run_git(args: list[str], cwd: Path, timeout: int = 30, **kwargs: object) -> GitResult:
+        if args[:3] == ["merge", "--no-commit", "--no-ff"]:
+            return GitResult(returncode=1, stdout="", stderr="merge failed")
+        if args[:2] == ["status", "--porcelain"]:
+            return GitResult(returncode=0, stdout="UU src/demo.py\n", stderr="")
+        if args[:2] == ["merge", "--abort"]:
+            return GitResult(returncode=0, stdout="", stderr="")
+        raise AssertionError(f"unexpected git args: {args}")
+
+    monkeypatch.setattr(git_pr, "run_git", _fake_run_git)
+
+    result = git_pr.merge_with_conflict_detection(tmp_path, "agent/qa-aa55cebb")
+
+    assert result.success is False
+    assert result.merge_commit == ""
+
+
 def test_is_forbidden_for_merge_matches_deny_list() -> None:
     """Unit-level coverage of the deny-list predicate.  This is the
     cheap "no ``git add -A`` in main repo" canary: every path that the

--- a/tests/unit/test_review_board_projection.py
+++ b/tests/unit/test_review_board_projection.py
@@ -244,6 +244,25 @@ def test_record_task_merged_tolerates_missing_recorder(tmp_path: Path) -> None:
     record_task_merged(None, task_id="t-8", agent_id=None)
 
 
+def test_record_task_merged_carries_the_merge_commit(tmp_path: Path) -> None:
+    """The row names the git object the merge actually produced (issue #5271)."""
+    journal = EventJournal("run-commit", tmp_path / ".sdd")
+    record_task_merged(journal, task_id="t-9", agent_id="agent-c", merge_commit="deadbeef" * 5)
+
+    events = load_events(journal.path).events
+    assert len(events) == 1
+    assert events[0]["merge_commit"] == "deadbeef" * 5
+
+
+def test_record_task_merged_omits_merge_commit_when_none(tmp_path: Path) -> None:
+    """A merge that found nothing to commit must not fabricate a sha."""
+    journal = EventJournal("run-no-commit", tmp_path / ".sdd")
+    record_task_merged(journal, task_id="t-10", agent_id="agent-c", merge_commit=None)
+
+    events = load_events(journal.path).events
+    assert "merge_commit" not in events[0]
+
+
 def test_reap_and_cleanup_records_task_merged(tmp_path: Path, monkeypatch: Any) -> None:
     """The lifecycle merge seam records task_merged after a successful merge."""
     from types import SimpleNamespace
@@ -254,7 +273,7 @@ def test_reap_and_cleanup_records_task_merged(tmp_path: Path, monkeypatch: Any) 
     monkeypatch.setattr(task_lifecycle, "seal_evidence_on_completion", lambda *_a, **_k: None)
 
     recorder = EventJournal("run-seam", tmp_path / ".sdd")
-    merge_result = SimpleNamespace(success=True, conflicting_files=[])
+    merge_result = SimpleNamespace(success=True, conflicting_files=[], merge_commit="cafef00d" * 5)
     spawner = SimpleNamespace(
         reap_completed_agent=lambda *_a, **_k: merge_result,
         cleanup_worktree=lambda _sid: None,
@@ -284,6 +303,7 @@ def test_reap_and_cleanup_records_task_merged(tmp_path: Path, monkeypatch: Any) 
     assert len(merged) == 1
     assert merged[0]["task_id"] == "t-42"
     assert merged[0]["agent_id"] == "sess-1"
+    assert merged[0]["merge_commit"] == "cafef00d" * 5
 
 
 def test_reap_and_cleanup_skips_merge_receipt_when_merge_skipped(tmp_path: Path, monkeypatch: Any) -> None:
@@ -322,6 +342,47 @@ def test_reap_and_cleanup_skips_merge_receipt_when_merge_skipped(tmp_path: Path,
 
     events = load_events(recorder.path).events
     assert [e for e in events if e.get("event") == EVENT_TASK_MERGED] == []
+
+
+def test_reap_and_cleanup_omits_merge_commit_when_merge_produced_none(tmp_path: Path, monkeypatch: Any) -> None:
+    """A merge that found nothing to commit (branches already identical) must not fabricate a sha."""
+    from types import SimpleNamespace
+
+    from bernstein.core.tasks import task_lifecycle
+
+    monkeypatch.setattr(task_lifecycle, "_close_completed_task", lambda *_a, **_k: None)
+    monkeypatch.setattr(task_lifecycle, "seal_evidence_on_completion", lambda *_a, **_k: None)
+
+    recorder = EventJournal("run-no-commit-seam", tmp_path / ".sdd")
+    merge_result = SimpleNamespace(success=True, conflicting_files=[])  # no merge_commit attribute
+    spawner = SimpleNamespace(
+        reap_completed_agent=lambda *_a, **_k: merge_result,
+        cleanup_worktree=lambda _sid: None,
+    )
+    orch = SimpleNamespace(
+        _spawner=spawner,
+        _workdir=tmp_path,
+        _config=SimpleNamespace(ab_test=False),
+        _recorder=recorder,
+    )
+    session = SimpleNamespace(id="sess-3", status="dead", exit_code=0, task_ids=["t-44"])
+    task = SimpleNamespace(id="t-44", metadata={})
+
+    task_lifecycle._reap_and_cleanup_session(
+        orch,
+        task,
+        session,
+        None,
+        janitor_passed=True,
+        skip_merge=False,
+        _completion_data=None,
+        cache_diff_lines=0,
+    )
+
+    events = load_events(recorder.path).events
+    merged = [e for e in events if e.get("event") == EVENT_TASK_MERGED]
+    assert len(merged) == 1
+    assert "merge_commit" not in merged[0]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Partial fix for #5271 — this is **slice 1 of 2** (explicitly called out in the issue as "small, independent; take it alone if you want a warm-up"). Not claiming "Closes" — slice 2 (recording a journal row for the salvage-merge path of a crashed/orphaned agent's partial work) is separate follow-up work.

**The gap:** neither `MergeResult` nor the `task_merged` journal row it feeds could be tied back to a git object. The row said a task's work was merged, but not which commit — so an operator or auditor reading the journal could not correlate a merge decision with what actually landed on the integration branch.

## Changes

1. `MergeResult` (`src/bernstein/core/git/git_pr.py`) gains a `merge_commit: str` field, populated via `git rev-parse HEAD` immediately after the merge commit succeeds in `merge_with_conflict_detection`. Empty (`""`) when the merge failed, was refused by the preflight safety guard, or found nothing to commit (branches already identical) — there's no commit to name in any of those cases.
2. `record_task_merged` (`src/bernstein/core/replay/review_board.py`) accepts an optional, keyword-only `merge_commit: str | None = None`. The field is only added to the recorded row when a commit exists — a merge that produced no commit does not fabricate a `merge_commit` key, so an older journal reader sees exactly the row shape it saw before.
3. `task_lifecycle.py`'s recorded merge path (`_reap_and_cleanup_session`) threads the sha through from the `MergeResult` it already holds.

## Design notes

- Used `getattr(merge_result, "merge_commit", None)` at the `task_lifecycle.py` call site rather than a direct attribute access. `MergeResult` reaches this module only through a `TYPE_CHECKING`-only import via the `bernstein.core.git_ops` back-compat alias, which pyright can't resolve statically (same pre-existing pattern already affecting `merge_result.success` / `.conflicting_files` a few lines below) — `getattr` keeps this to the minimum possible new pyright finding (+1) rather than +2, without touching the alias-resolution issue itself, which is out of scope here.
- Kept the field optional/keyword-only on both `MergeResult` and `record_task_merged` so no existing caller (including test doubles built as `SimpleNamespace(success=True, conflicting_files=[])` with no `merge_commit` attribute) needs to change.

## Tests

- `tests/unit/test_git_pr.py` — `test_merge_with_conflict_detection_returns_the_commit_sha` (a successful commit-producing merge reports the sha), `test_merge_with_conflict_detection_leaves_commit_empty_on_conflict` (a conflicting merge reports none).
- `tests/unit/test_review_board_projection.py` — `test_record_task_merged_carries_the_merge_commit`, `test_record_task_merged_omits_merge_commit_when_none`, plus updates to the existing `test_reap_and_cleanup_records_task_merged` end-to-end seam test and a new `test_reap_and_cleanup_omits_merge_commit_when_merge_produced_none` covering the "nothing to commit" path through the full `_reap_and_cleanup_session` call.

```
uv run python scripts/run_tests.py tests/unit/test_git_pr.py tests/unit/test_review_board_projection.py -x
# 58 passed
uv run ruff check src/ tests/
uv run lint-imports
# 3 kept, 0 broken
uv run python -m pyright src/bernstein/core/git/git_pr.py src/bernstein/core/replay/review_board.py src/bernstein/core/tasks/task_lifecycle.py
# +1 new finding vs main (327 vs 326), from the getattr() call described above; every other
# finding is byte-identical to main (same 326 pre-existing errors, unrelated to this change)
```

## Docs

`docs/release-notes/fragments/5271-task-merged-commit.md` — release-note fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)