### PR TITLE
perf(mutation): the lineage_tips baseline runs the tests that can kill it (#5595)

### DIFF
--- a/docs/release-notes/fragments/5595-lineage-mutation-baseline.md
+++ b/docs/release-notes/fragments/5595-lineage-mutation-baseline.md
@@ -1,0 +1,19 @@
+## The nightly mutation job measures `lineage_tips` again
+
+The `lineage_tips` baseline ran the whole of `tests/unit/lineage/` — 706 tests,
+~92s — to validate mutations in one file, and it did not finish inside the
+180s subprocess timeout. The nightly reported `BASE-FAIL` and exited 2, so no
+mutation score was produced for the tip tracker at all.
+
+The budget was not the problem. Of the 89s the directory spends, 76s is
+per-test autouse-fixture teardown — about 108ms on every test — against 11.3s
+of actual test work. The baseline was paying for 548 tests that cannot kill a
+mutant in `tips.py`, once for the baseline and again for every mutant run.
+
+The module now names the seven files that can: the five that empirically fail
+when `compute_tips`, `detect_forks` or `_group_by_path` are seeded with
+degenerate returns, plus the two that import `tips` without asserting on it,
+kept as headroom. 158 tests, ~11s, and the same mutants die.
+
+`python3 scripts/mutmut_critical.py --only lineage_tips` now reports
+`93.8% 75% PASS 15/16 killed` in 63s, against a 600s budget.

--- a/scripts/mutmut_critical.py
+++ b/scripts/mutmut_critical.py
@@ -109,11 +109,34 @@ MODULES: tuple[Module, ...] = (
     Module(
         key="lineage_tips",
         source="src/bernstein/core/lineage/tips.py",
-        tests=("tests/unit/lineage/",),
+        # The five files that actually detect a break in tips.py, plus the two
+        # that import it. Measured, not guessed: seeding `compute_tips`,
+        # `detect_forks` and `_group_by_path` with degenerate returns and
+        # running the whole of tests/unit/lineage/ fails exactly
+        # test_tips, test_gate, test_cli, test_conflict_cli and
+        # test_artifact_uri_boundaries. test_merge and test_signed_write_golden
+        # import tips without asserting on it and are kept as headroom, so a
+        # mutation on a line none of the five reaches is still seen.
+        #
+        # The directory has 706 tests and takes ~92s; these seven have 158 and
+        # take ~11s. That gap is not the tests -- 76s of the 89s is per-test
+        # autouse-fixture teardown, ~108ms on every test, against 11.3s of
+        # actual test work. The baseline therefore paid for 548 tests that
+        # cannot kill a single mutant, once for the baseline and again for
+        # every mutant run (#5595).
+        tests=(
+            "tests/unit/lineage/test_tips.py",
+            "tests/unit/lineage/test_gate.py",
+            "tests/unit/lineage/test_cli.py",
+            "tests/unit/lineage/test_conflict_cli.py",
+            "tests/unit/lineage/test_artifact_uri_boundaries.py",
+            "tests/unit/lineage/test_merge.py",
+            "tests/unit/lineage/test_signed_write_golden.py",
+        ),
         threshold=0.75,
         budget_seconds=600,
         max_candidates=60,
-        note="Lineage v1 tip tracker.",
+        note="Lineage v1 tip tracker. Baseline ~11s over 158 tests (was ~92s over 706).",
     ),
     Module(
         key="lineage_merge",


### PR DESCRIPTION
Closes #5595.

## The measurement first, as the issue asks

The issue says to choose between "raise the budget" and "the suite is slow for a fixable reason" **from a measurement**. Here it is.

`tests/unit/lineage/` is 706 tests. With `--durations=0`:

| phase | total | n | mean |
|---|---|---|---|
| call | **11.3s** | 37 | 0.304s |
| setup | 1.5s | 46 | 0.032s |
| **teardown** | **76.1s** | 706 | 0.108s |

86% of the suite is per-test teardown, and the actual test work is 11 seconds.

I checked whether that was a lineage fixture: a throwaway file of 200 `assert i >= 0` tests reproduces the same ~108ms per test, so the cost is the repo's eleven autouse fixtures, not anything under `tests/unit/lineage/`. Disabling them one at a time saves ~10ms each — it is the count, not one offender, so fixing it is a repo-wide change and a different issue from this one.

One caveat on the numbers: `_memory_guard`'s teardown is Darwin-only (`if system != "Darwin": return`), so a raw local timing overstates the Linux runner. **92s** is the figure with it disabled; 123s with it on.

## So this is outcome 2, not outcome 1

The budget is not too small. The baseline was running 548 tests that cannot kill a mutant in `tips.py` — once for the baseline, and again for every mutant run the 600s budget has to cover. 16 candidates × 92s is ~25 minutes against a 600s budget, so even a baseline that squeaked under the timeout could never have completed the module.

## Choosing the seven files by measurement, not by reading imports

Seeding `compute_tips`, `detect_forks` and `_group_by_path` with degenerate returns and running the full directory fails exactly:

```
test_tips.py  test_gate.py  test_cli.py  test_conflict_cli.py  test_artifact_uri_boundaries.py
```

`test_merge.py` and `test_signed_write_golden.py` import `tips` but do not assert on its behaviour — they survive all three. I kept them anyway as headroom, so a mutation on a line the five do not reach is still seen. Grepping for imports alone would have given a different (and wrong in both directions) answer.

## The result, from a run

```
$ python3 scripts/mutmut_critical.py --only lineage_tips
[lineage_tips] 16 candidate(s); budget 600s
=== Mutation gate summary ===
module                kill rate    thr   status  notes
lineage_tips              93.8%    75%     PASS  15/16 killed
```

63s wall clock for the whole module. A kill rate and `PASS`, not `BASE-FAIL` — the issue's stated acceptance.

The one survivor is real and worth knowing about: `tips.py:88`, `if len(children) < 2` → `< 1`, a genuine coverage gap in the fork detector rather than an artefact of this change. Say the word and I will file it.

## What I did not change

`budget_seconds` stays at 600. It now has roughly four times the headroom it needs, and raising it would have papered over the reason the baseline was slow — which is the outcome the issue explicitly warns against.

This composes with #5587 rather than competing with it: that PR makes a timed-out baseline record an untrusted module instead of crashing the job. This one stops `lineage_tips` timing out at all, so #5587's path is no longer reached for this module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)