### PR TITLE
refactor(lineage): drop a fork guard the content check already subsumes

### DIFF
--- a/src/bernstein/core/lineage/tips.py
+++ b/src/bernstein/core/lineage/tips.py
@@ -84,9 +84,12 @@ def detect_forks(entries: Iterable[LineageEntry]) -> list[Fork]:
                 continue
             by_parent.setdefault(e.parent_hashes[0], []).append(e)
         for parent_hash, children in by_parent.items():
-            # Need >= 2 children AND at least two distinct content_hashes.
-            if len(children) < 2:
-                continue
+            # Two distinct content hashes IS the fork condition, and it already implies two
+            # children: a single child contributes one hash, so the set can never reach two
+            # without them. The separate `len(children) < 2` guard that used to sit here was
+            # therefore unreachable as a decision -- mutating it to `< 1` changed no behaviour,
+            # which is exactly how the mutation gate reported it: a survivor that could not be
+            # killed, because there was no observable difference to write a test against.
             distinct_content = {c.content_hash for c in children}
             if len(distinct_content) < 2:
                 continue

--- a/tests/unit/lineage/test_tips.py
+++ b/tests/unit/lineage/test_tips.py
@@ -154,6 +154,20 @@ def test_detect_forks_n_way() -> None:
     assert len(forks[0].child_hashes) == 5
 
 
+def test_one_child_is_never_a_fork_whatever_its_content() -> None:
+    """A single child cannot fork, and the content check alone is what says so.
+
+    `detect_forks` used to guard `len(children) < 2` before comparing content hashes. That guard
+    could never decide anything: one child contributes one content hash, so the distinct-content
+    check below it already rejects the case. The mutation gate reported it as an unkillable
+    survivor for exactly that reason -- there was no observable difference to write a test
+    against. This pins the property the removal rests on (#5595 measurement).
+    """
+    g = _mk("a.py", _h("1"), [], ts_ns=1)
+    only_child = _mk("a.py", _h("2"), [entry_hash(g)], ts_ns=2)
+    assert detect_forks([g, only_child]) == []
+
+
 def test_fork_requires_distinct_content() -> None:
     # Two entries with same parent AND same content_hash → NOT a fork (idempotent re-record)
     g = _mk("a.py", _h("1"), [], ts_ns=1)


### PR DESCRIPTION
Found by running the mutation gate for #5595, not by reading.

## The finding

`detect_forks` guarded `len(children) < 2` before comparing content hashes:

```python
if len(children) < 2:
    continue
distinct_content = {c.content_hash for c in children}
if len(distinct_content) < 2:
    continue
```

The first guard cannot decide anything. One child contributes exactly one content hash, so the second check rejects that case already — and `by_parent` is built by appending, so a group with zero children cannot exist.

## Why it is worth removing rather than leaving

`' 2' -> ' 1'` on that line was the **only** survivor for `lineage_tips`, and it survived because it is an **equivalent mutant**: there is no observable difference for a test to assert. That is worse than an ordinary survivor. It reads in the ratchet as missing coverage, it invites someone to go hunting for a test, and no test can ever close it.

```
before:  lineage_tips   93.8%  75%  PASS  15/16 killed
                        survivor: tips.py:88 ' 2' -> ' 1'
after:   lineage_tips  100.0%  75%  PASS  13/13 killed
```

The score is now honest rather than permanently carrying a line nobody could kill.

## Verification

```
uv run pytest tests/unit/lineage/ -q     # 706 passed — no behaviour change
uv run ruff check / format --check       # clean
python3 scripts/mutmut_critical.py --only lineage_tips   # 100.0%, 13/13
```

`test_detect_forks_linear_no_fork` already covered the single-child case. `test_one_child_is_never_a_fork_whatever_its_content` pins the property the removal actually rests on, and records why it exists so the guard is not re-added as an "obvious" optimisation.

## One dependency worth knowing

The mutation figures were produced with #5610's narrowed baseline applied locally. On `main` as it stands, the `lineage_tips` baseline times out before any mutant runs, so the gate cannot report this module at all — which is what #5595 is about. That change is **not** duplicated in this branch; the only file touched here besides the test is `tips.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)