### PR TITLE
chore(auto): nightly mirror + format drift sweep

### DIFF
--- a/tests/fixtures/agent-card-utf16-vector/_build_agent_card_utf16_vector.py
+++ b/tests/fixtures/agent-card-utf16-vector/_build_agent_card_utf16_vector.py
@@ -157,7 +157,9 @@ def build(dest: Path) -> Path:
     (dest / _SIGNATURE_NAME).write_bytes(canonicalize_jcs(signature_payload) + b"\n")
 
     (dest / _KEY_NAME).write_bytes(
-        _private_key().public_key().public_bytes(
+        _private_key()
+        .public_key()
+        .public_bytes(
             encoding=serialization.Encoding.PEM,
             format=serialization.PublicFormat.SubjectPublicKeyInfo,
         )

--- a/tests/fixtures/utf16-ordering-vector/_build_utf16_ordering_vector.py
+++ b/tests/fixtures/utf16-ordering-vector/_build_utf16_ordering_vector.py
@@ -52,7 +52,7 @@ HERE = Path(__file__).resolve().parent
 #: U+FFFF: BMP, one UTF-16 code unit, FFFF.
 BMP_KEY = "\uffff"
 #: U+1D11E MUSICAL SYMBOL G CLEF: supplementary plane, surrogate pair D834 DD1E.
-SUPPLEMENTARY_KEY = "\U0001D11E"
+SUPPLEMENTARY_KEY = "\U0001d11e"
 
 #: A fixed Ed25519 seed, so the vector is byte-reproducible. Test key only.
 SEED = bytes(range(32))
@@ -109,8 +109,7 @@ def main() -> None:
     )
     (HERE / "public-key.pem").write_bytes(public_pem)
     (HERE / "public-key.jwk.json").write_text(
-        json.dumps(ed25519_public_jwk(public_pem, kid="utf16-ordering-vector"), indent=2)
-        + "\n",
+        json.dumps(ed25519_public_jwk(public_pem, kid="utf16-ordering-vector"), indent=2) + "\n",
         encoding="utf-8",
     )
     print("wrote card.json, signature.json, public-key.pem, public-key.jwk.json")

--- a/tests/unit/test_orphan_refetches_task_live.py
+++ b/tests/unit/test_orphan_refetches_task_live.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import httpx
 import pytest
+
 from bernstein.core.agents import agent_lifecycle
 from bernstein.core.agents.agent_lifecycle import handle_orphaned_task
 from bernstein.core.tasks.models import Task

--- a/tests/unit/test_retry_unblocks_dependents.py
+++ b/tests/unit/test_retry_unblocks_dependents.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+
 from bernstein.core.tasks.models import Task, TaskStatus
 from bernstein.core.tasks.task_store_core import TaskStore
 from bernstein.core.tasks.unreachable import blocking_dependency, satisfied_dependency_ids

--- a/tests/unit/test_utf16_key_ordering_vector.py
+++ b/tests/unit/test_utf16_key_ordering_vector.py
@@ -72,9 +72,7 @@ def _code_point_canonical(value: object) -> bytes:
     ASCII escaping. So the *only* difference from our output is the ordering
     rule, which is what makes it a fair stand-in for a shortcut implementation.
     """
-    return json.dumps(
-        value, sort_keys=True, ensure_ascii=False, separators=(",", ":")
-    ).encode("utf-8")
+    return json.dumps(value, sort_keys=True, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
 
 
 def test_the_fixture_carries_a_supplementary_plane_key(card_body: dict) -> None:
@@ -109,22 +107,16 @@ def test_a_code_point_canonicalizer_computes_different_signing_bytes(
     card_body: dict,
 ) -> None:
     """The failure a verifier would actually hit."""
-    assert canonicalize_jcs(card_body["extensions"]) != _code_point_canonical(
-        card_body["extensions"]
-    )
+    assert canonicalize_jcs(card_body["extensions"]) != _code_point_canonical(card_body["extensions"])
 
 
-def test_our_verifier_accepts_the_record(
-    card_body: dict, signature: AgentCardSignature
-) -> None:
+def test_our_verifier_accepts_the_record(card_body: dict, signature: AgentCardSignature) -> None:
     card = AgentIdentityCard(**card_body)
     public_key = (VECTOR_DIR / "public-key.pem").read_bytes()
     assert verify_agent_card(card, signature, public_key) is True
 
 
-def test_a_code_point_ordering_would_be_rejected(
-    card_body: dict, signature: AgentCardSignature
-) -> None:
+def test_a_code_point_ordering_would_be_rejected(card_body: dict, signature: AgentCardSignature) -> None:
     """The other direction: wrong order, wrong signing input, no verification.
 
     The JWS is detached, so its payload segment is empty and the signing input


### PR DESCRIPTION
Nightly sweep regenerated AGENTS.md mirrors and ran ruff format on main. Diff is mechanical and may be merged after CI passes.

Source run: https://github.com/sipyourdrink-ltd/bernstein/actions/runs/34121406473