### PR TITLE
fix(tui): guard poll completion during app teardown

### DIFF
--- a/docs/release-notes/fragments/5616-dashboard-poll-teardown.md
+++ b/docs/release-notes/fragments/5616-dashboard-poll-teardown.md
@@ -1,0 +1,10 @@
+## Dashboard polls stop updating once app shutdown begins
+
+A background dashboard poll could finish while Textual was dismantling the
+screen tree and dispatch its success message before the app message queue
+closed. Depending on timing, the handler then queried a removed tasks table or
+read focus after the screen stack was empty, raising `NoMatches` or
+`ScreenStackError` during shutdown. Poll results are now ignored as soon as the
+app stops running.
+
+(#5616)

--- a/src/bernstein/cli/dashboard_app.py
+++ b/src/bernstein/cli/dashboard_app.py
@@ -503,6 +503,8 @@ class BernsteinApp(App[None]):
             self._write_activity("system", message)
 
     def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
+        if not self.is_running:
+            return
         worker: Worker[dict[str, Any]] = event.worker  # type: ignore[assignment]
         if worker.group != "poll" or event.state != WorkerState.SUCCESS:
             return

--- a/tests/unit/test_dashboard_poll_during_teardown.py
+++ b/tests/unit/test_dashboard_poll_during_teardown.py
@@ -1,0 +1,53 @@
+"""A completed dashboard poll must be harmless once teardown has begun.
+
+Textual tears down the screen tree before it closes the app's message queue or
+cancels thread workers. A poll can therefore report success after widgets have
+been pruned or the screen stack has been cleared. This pins completion after
+the latter point, where touching the dashboard's focus used to crash shutdown.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import threading
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import bernstein.cli.dashboard_app as dashboard_app
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "render_tui_snapshot.py"
+
+
+def test_a_poll_completing_after_screens_close_does_not_crash_teardown() -> None:
+    """Thread-worker success may still be dispatched while shutdown is underway."""
+    spec = importlib.util.spec_from_file_location("render_tui_snapshot_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    snapshot = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(snapshot)
+
+    release = threading.Event()
+
+    class PollCompletesDuringTeardown(dashboard_app.BernsteinApp):
+        def _schedule_poll(self) -> None:
+            fetch = dashboard_app._fetch_all
+
+            def work() -> dict[str, Any]:
+                release.wait(10.0)
+                return fetch()
+
+            self.run_worker(work, thread=True, group="poll", exclusive=True)
+
+        async def _close_all(self) -> None:
+            await super()._close_all()
+            assert not self._screen_stack
+            release.set()
+            for _ in range(500):
+                await asyncio.sleep(0.002)
+                if self._exception is not None:
+                    break
+
+    with patch.object(dashboard_app, "BernsteinApp", PollCompletesDuringTeardown):
+        snapshot.render()


### PR DESCRIPTION
## What

Ignore worker state changes once the dashboard app is no longer running, and
add a regression test that pins a poll thread's completion after Textual has
cleared the screen stack but before it closes the app message queue.

The code change is an early return at the top of
`DashboardApp.on_worker_state_changed`. It prevents a completed poll from
reading focus, querying `#tasks-table`, or applying data after teardown has
begun.

## Failure mechanism

The dashboard starts a one-second poll interval in `on_mount` and runs
`_fetch_all` as a thread worker in the exclusive `poll` group. Thread workers
complete on executor time rather than event-loop time.

In Textual 8.2.8, `App._shutdown` sets `self._running = False` at app.py:3740,
then awaits `_close_all()` at app.py:3744. `_close_all()` progressively prunes
screen children and then clears every screen stack. Only afterward does
`_shutdown` await `_close_messages()`, which sets `_closing` and makes
`post_message` refuse new messages. Worker cancellation occurs later in the
app run loop. A poll worker can therefore post `Worker.StateChanged(SUCCESS)`
while the widget tree is being dismantled and have it dispatched into the
handler.

The two observed failures are the same unsafe interval:

- Early in `_close_all`, the screen remains on the stack but its children have
  been pruned, so `query_one("#tasks-table")` raises `NoMatches`.
- After `_close_all` clears the stacks, `self.focused` reaches `App.screen` and
  raises `ScreenStackError: No screens on stack`.

`MessagePump.is_running` is exactly `return self._running` at
message_pump.py:290-292. Because `_shutdown` clears that flag before entering
`_close_all`, `if not self.is_running: return` covers the entire teardown
interval by construction, including both variants.

## Evidence

Upstream CI run
https://github.com/sipyourdrink-ltd/bernstein/actions/runs/34090767902,
attempt 1, job `Test (ubuntu-latest, Python 3.13, shard 3)`, failed
`tests/unit/test_tui_render_freshness.py::test_the_committed_render_matches_what_the_dashboard_draws`
with the `ScreenStackError`. It was the only failure among 676 test files. The
Python 3.12 shard-3 job in the same run passed the same file on the same commit.

PR #5303 records the identical local failure on 2026-09-02 and correctly notes
that it was unrelated to that change. PR #5576 raised test parallelism from
four to six workers three commits before the failing run. That run was the
first completed ubuntu-3.13 shard-3 job under the new setting; its suite took
2465.7 seconds versus 1844.9 seconds on the passing Python 3.12 shard, which is
consistent with load amplifying a narrow completion window.

The bisect-on-red bot comment on #5381 blamed commit e5f3e1a using a
files-touched heuristic. None of that commit's files is on the render script's
import path, verified from `sys.modules` after loading the script and dashboard
app. This fix and deterministic reproducer settle that false-positive
`regression` label.

## Verification

- With the guard removed, the new deterministic regression test fails 1/1
  with `ScreenStackError` at `dashboard_app.py:513`, reached through
  `self.focused` and re-raised by `run_test.__aexit__`. This reproduces the CI
  traceback using the shipped app and unmodified Textual.
- With the guard restored, the same test passes: 1 passed in 4.9 seconds.
- `uv run python scripts/run_tests.py
  tests/unit/test_dashboard_poll_during_teardown.py
  tests/unit/test_tui_render_freshness.py`: 18 passed across 2 files in 6.9
  seconds. The local runner environment injects `NO_COLOR=1`, so that variable
  was removed for the committed color snapshot comparison.
- `uv run ruff check src/bernstein/cli/dashboard_app.py
  tests/unit/test_dashboard_poll_during_teardown.py`: all checks passed.
- `uv run ruff format --check src/bernstein/cli/dashboard_app.py
  tests/unit/test_dashboard_poll_during_teardown.py`: 2 files already
  formatted.
- Guarded timing validation over 200 real renders with poll delays swept from
  285.0 through 304.9 ms: 200 clean, 0 exceptions.
- The same unguarded timing sweep on this machine today was 200 clean and did
  not sample the narrow scheduler window. The deterministic test above is the
  base failure proof. An earlier 200-render development sweep measured a 3.4
  ms vulnerable window: 188 clean, 12 `NoMatches` at dashboard_app.py:514, and
  2 `ScreenStackError` at dashboard_app.py:513.

## Alternatives considered

Cancelling the poll and stopping its interval in `scripts/render_tui_snapshot.py`
would protect that one caller but leave the dashboard handler unsafe during
normal app shutdown. Catching `ScreenStackError` and `NoMatches` around the
handler would also cover the observed exceptions, but the running-state guard
matches Textual's teardown boundary directly and avoids suppressing query
failures while the app is active.

Release-note fragment: `docs/release-notes/fragments/5616-dashboard-poll-teardown.md`.
