### PR TITLE
fix(lifecycle): a session that exited 0 is not failed on a log-pattern match

### DIFF
--- a/docs/release-notes/fragments/clean-exit-is-not-a-log-pattern-failure.md
+++ b/docs/release-notes/fragments/clean-exit-is-not-a-log-pattern-failure.md
@@ -1,0 +1,20 @@
+## An agent that exited 0 is no longer failed for what it printed
+
+The orphan path greps a dead agent's transcript for failure signatures
+("401", "rate limit", "timeout") and fast-fails the task on a hit. It ran for
+every orphaned session, exit-0 sessions included, so an agent that merely
+mentioned one of those strings was treated as an agent that died of it. On
+2026-09-02 a task whose work had already merged was failed with
+`auth_error detected in agent log (exit_code=0)`, retried twice and sent to
+the DLQ, because the agent's final message quoted an `HTTP 401` it had
+already handled. Tightening the patterns could not close this on its own
+(#2183): an error word on the same line is exactly what a report about an
+error looks like.
+
+A process that exited 0 did not die of anything, so its transcript is no
+longer consulted; the session goes to the ordinary orphan recovery path,
+which decides on commits, the completion data and the fast-exit probe. A
+session reaped without an exit status is unchanged and still classified from
+its log.
+
+(#5618)

--- a/src/bernstein/core/agents/agent_lifecycle.py
+++ b/src/bernstein/core/agents/agent_lifecycle.py
@@ -1255,11 +1255,33 @@ def _handle_failure_detection(
 ) -> bool:
     """Detect fatal failure signatures in the agent log and handle them.
 
+    A session that exited 0 is never handled here: log patterns are evidence
+    only for a session that actually died.
+
     Returns True if handled (task already failed/retried/compacted - caller
     must not fall through to the generic orphan-no-signals path).
     """
     _rl_tracker = getattr(orch, "_rate_limit_tracker", None)
     if _rl_tracker is None or not session.provider:
+        return False
+
+    # A process that exited 0 did not die of anything. The scanner greps the
+    # agent's transcript for risky substrings ("401", "rate limit", "timeout"),
+    # and an agent MENTIONING one is not an agent that failed on one: a task
+    # about auth code legitimately prints "HTTP 401" in its final message. On
+    # 2026-09-02 that failed a task whose work had already merged, twice
+    # retried it and DLQ'd it. Log patterns are evidence only for a session
+    # that actually died. A clean exit is handed to the ordinary orphan path
+    # instead, which decides on commits, the completion data and the fast-exit
+    # probe - and still fails it as clean_exit_unverified where the probe says
+    # so. This suppresses one wrong verdict; it does not auto-complete
+    # anything on its own.
+    if session.exit_code == 0:
+        logger.info(
+            "_handle_failure_detection: session %s exited 0 (task=%s); not failing on log patterns",
+            session.id,
+            task_id,
+        )
         return False
 
     _log_path = _resolve_agent_log_path(orch._workdir, session)

--- a/tests/unit/test_agent_lifecycle.py
+++ b/tests/unit/test_agent_lifecycle.py
@@ -1118,6 +1118,60 @@ def test_handle_orphaned_task_provider_fatal_types_fast_fail_and_throttle(tmp_pa
         orch._record_provider_health.assert_called_once_with(session, success=False)
 
 
+def test_handle_orphaned_task_clean_exit_is_never_failed_by_a_log_pattern(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """2026-09-02: an agent that exited 0 printed "HTTP 401" in its final message,
+    the scanner classified the transcript as auth_error, and the task - whose work
+    had already merged - was retried twice and DLQ'd. exit_code 0 is not a death:
+    the log is never consulted, and recovery is left to the orphan path."""
+    task = _make_task()
+    task.status = TaskStatus.CLAIMED
+    session = AgentSession(
+        id="sess-1",
+        role="backend",
+        provider="claude",
+        model_config=ModelConfig("sonnet", "high"),
+        task_ids=[task.id],
+        exit_code=0,
+    )
+    orch = _make_orch_fast_fail(tmp_path, "auth_error")
+
+    with (
+        patch("bernstein.core.agents.agent_lifecycle.retry_or_fail_task") as retry_or_fail_task,
+        patch(
+            "bernstein.core.agents.agent_lifecycle._handle_orphan_no_signals", return_value=(True, None)
+        ) as no_signals,
+    ):
+        handle_orphaned_task(orch, task.id, session, {"claimed": [task], "open": [], "in_progress": [], "done": []})
+
+    retry_or_fail_task.assert_not_called()
+    orch._rate_limit_tracker.detect_failure_type.assert_not_called()
+    orch._rate_limit_tracker.throttle_provider.assert_not_called()
+    orch._cascade_manager.find_fallback.assert_not_called()
+    no_signals.assert_called_once()
+
+
+def test_an_unknown_exit_status_still_reaches_the_scanner(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """The guard is exit_code == 0, not "not a failure": a session reaped without
+    an exit status (exit_code None) is still classified from its log."""
+    task = _make_task()
+    task.status = TaskStatus.CLAIMED
+    session = AgentSession(
+        id="sess-2",
+        role="backend",
+        provider="claude",
+        model_config=ModelConfig("sonnet", "high"),
+        task_ids=[task.id],
+    )
+    orch = _make_orch_fast_fail(tmp_path, "auth_error")
+
+    with patch("bernstein.core.agents.agent_lifecycle.retry_or_fail_task") as retry_or_fail_task:
+        handle_orphaned_task(orch, task.id, session, {"claimed": [task], "open": [], "in_progress": [], "done": []})
+
+    retry_or_fail_task.assert_called_once()
+    assert "auth_error" in retry_or_fail_task.call_args.args[1]
+    orch._rate_limit_tracker.throttle_provider.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # Issue #4222: deferred death judgment must be re-evaluable after the
 # session that deferred it is reaped, and must not defer forever on a


### PR DESCRIPTION
## What

The orphan path no longer greps the transcript of an agent that exited 0.
A clean exit is handed to the ordinary orphan recovery path instead of
being fast-failed on a substring its own output happened to contain.

## Why

`_handle_failure_detection` classifies a dead agent by scanning the last 500
lines of its transcript for failure signatures, then fast-fails the task and
throttles the provider. It ran for every orphaned session, including sessions
that exited 0 - so an agent that *mentioned* `401` was treated as an agent
that died of it.

Measured 2026-09-02, on 3.19.0: a task whose work had already merged was
failed, retried twice and sent to the DLQ. The reason string said so itself:

    Agent <id> died; auth_error detected in agent log (exit_code=0)

The agent's final message quoted an `HTTP 401` it had already handled.

This is a known class. #2183 fixed it once by tightening the patterns: the
bare tokens now need a word boundary plus error context on the same line, and
structured `tool_call`/`assistant` lines are skipped. That was the right
narrowing and it is kept. It cannot close the class on its own, because an
error word on the same line is exactly what a report *about* an error looks
like: the error-context regex matches `error|status|http|code|exception|failed|failure|traceback`,
so `"the endpoint returned HTTP 401"` still matches. The 2026-09-02 incident
happened on a build that already had the tightening.

The exit status is the signal the pattern list cannot supply.

## How

One early return in `_handle_failure_detection`, placed after the
tracker/provider gate and before the log is resolved:

```python
if session.exit_code == 0:
    logger.info(...)
    return False
```

**On the placement.** This is an early return, so it is worth stating that it
skips no later check - `c7cb542cc` (#5580) is the standing reminder that one
can. Everything after this point in the function is "classify a death and act
on it": throttle the provider, run the cascade fallback, `retry_or_fail_task`.
None of it is an invariant a live-and-clean session should satisfy. The
fall-through is in fact the *more* complete path - it writes the WAL entry,
reads the real recovered cost, and records provider health with the true
outcome, none of which the fast-fail branches do.

**On the tracker.** `detect_failure_type` is pure (`exists` -> `read_text` ->
match -> bool; no counters, no state, no files), so skipping it loses no
observability - the one INFO line it would have emitted on a match is
replaced by the new one, which names the session, the task and the decision.
`throttle_provider` is the only mutation, and it is a penalty: 60s-3600s
exponential backoff plus background suppression plus router `RATE_LIMITED`.
Charging that to a provider that served the session correctly was the harm.
Provider health is still recorded, at the end of `handle_orphaned_task`, with
the outcome that actually happened.

## Scope, stated plainly

This suppresses one wrong verdict. It does not auto-complete anything on its
own: a clean exit still reaches `_handle_orphan_no_signals`, which fails it
as `clean_exit_unverified` if the fast-exit probe finds it suspicious. It
does not touch the pattern list, the detector, or any other caller -
`_handle_failure_detection` has exactly one.

The guard is `exit_code == 0`, not "not a failure". A session reaped without
an exit status has `exit_code is None`, which does not match, so it still
scans - the direction that keeps an unknown death classifiable.

One residual: the non-default `IN_PROCESS` backend fabricates `exit_code = 0`
in `in_process_agent.py` when a thread's status was never reaped or the agent
was stopped on a wall-clock timeout. On that backend a genuine timeout
signature can now be suppressed. The default `SUBPROCESS` backend propagates
the real status through `bernstein-worker` (a SIGTERM'd child yields 143), and
`_check_alive_process` refuses to record a code while the process group is
still alive. Trading a non-default backend's fabricated zero against a
false-failure that reaches every backend seemed the right way round; happy to
gate on backend if you would rather.

Related, in the opposite direction: #2873 tightened trust in
`exit_code == 0` for *auto-completion* - a suspicious fast clean exit stopped
being auto-completed. This widens trust in it for *failure suppression*. They
are different questions and both still hold.

## Reproduction

`tests/unit/test_agent_lifecycle.py`, two added tests:

- `test_handle_orphaned_task_clean_exit_is_never_failed_by_a_log_pattern` -
  **fails on `main`**. With the tracker classifying the log as `auth_error`
  and the session at `exit_code=0`, `main` calls `retry_or_fail_task` and
  throttles the provider. Verified by reverting the source file to
  `origin/main` and re-running: 1 failed, 1 passed.
- `test_an_unknown_exit_status_still_reaches_the_scanner` - **passes both
  before and after**, kept as the guard against over-correction: an
  `exit_code is None` session must still be classified from its log.

## Tests

```
uv run python scripts/run_tests.py tests/unit/test_agent_lifecycle.py
  1 file passed, 0 failed  (32 tests: 30 existing + 2 new)

uv run ruff check <touched files>       All checks passed!
uv run ruff format --check <touched>    already formatted
```

## Docs

`docs/release-notes/fragments/clean-exit-is-not-a-log-pattern-failure.md`
added as a follow-up commit carrying this PR's number. No README,
`docs/operations/` or `docs/api/` surface changes: the log-pattern classifier
is not documented in `docs/operations/`, no CLI flag, MCP tool, HTTP route or
adapter contract moves, and no new module, so `bernstein agents-md sync` has
nothing to pick up.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright --project pyrightconfig.strict.json` passes
- [x] `uv run python scripts/run_tests.py -x` passes for the affected files
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (N/A - internal reliability fix)
- [x] `docs/operations/<area>.md` updated (N/A - this classifier is not documented there)
- [x] `docs/api/` schema regenerated if a public surface changed (N/A)
- [x] `uv run bernstein agents-md sync` run (N/A - no new module)
- [x] Tests cover the documented behaviour
