### PR TITLE
fix(run): do not call a run terminal while a retry is still to be queued

### DIFF
--- a/docs/release-notes/fragments/run-not-terminal-while-retry-pending.md
+++ b/docs/release-notes/fragments/run-not-terminal-while-retry-pending.md
@@ -1,0 +1,19 @@
+## A failed task no longer ends the run before its retry exists
+
+`bernstein run` believed a single quiescent poll. A failed task is not the end
+of a run - the orchestrator's retry sweep reads the snapshot taken at the top
+of the tick, so a task failed later in that same tick is first offered to
+`maybe_retry_task` on the next one. For the whole of that gap the board holds
+nothing open, nothing claimed and no live agent, which is indistinguishable
+from a finished run: the CLI printed its summary, signalled shutdown and
+exited while the run carried on retrying for another half hour.
+
+A quiescent board that still holds a failed task is now re-observed across a
+45 second window before it is believed. A run whose tasks all succeeded has no
+retry to wait for and still exits on the first observation, and a run whose
+failed task has exhausted its retries waits out the window once and then
+exits. The check reads the `failed` count from the full histogram when it is
+available and from `/status` when it is not, so it holds on the poll where the
+original defect fired.
+
+(#5622)

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -1252,6 +1252,30 @@ _ORCHESTRATOR_GONE_CONFIRM_WINDOW_S = 3.0 * WATCHDOG_POLL_S
 #: pause -- would count towards the window just as if it had been.
 _ORCHESTRATOR_GONE_MAX_OBSERVATION_GAP_S = 2.0 * WATCHDOG_POLL_S
 
+#: Monotonic seconds a quiescent board that still holds a FAILED task must be
+#: re-observed across before the run is believed over.
+#:
+#: Sized from where the gap comes from, not from one stopwatch reading. The
+#: tick loop's retry sweep (step 4b) iterates the snapshot fetched at step 1,
+#: so a task the reap fails LATER in the same tick is first offered to
+#: ``maybe_retry_task`` on the NEXT tick: the gap is one whole tick's WALL
+#: duration, not ``ORCHESTRATOR.tick_interval_s`` (3.0s), and a tick that runs
+#: git hygiene and worktree GC is far longer than its sleep - which is why
+#: this is not derived from the tick period. Measured 2026-09-03: a task
+#: failed at 01:30:04, its retry was created at 01:30:28, and the CLI called
+#: the run terminal 2s into that 24s window and exited while the run went on
+#: retrying until 01:57:15. 45s is that gap with roughly 2x headroom.
+#:
+#: Soft by construction: a pathologically long tick can outlast it, and the
+#: cost of that is the old defect at much lower probability. The cost of a
+#: longer window is every already-finished run's CLI waiting it out, since a
+#: task that exhausted its retries stays ``failed`` for the rest of the run.
+#:
+#: Unlike the "orchestrator gone" verdict this window needs no
+#: observation-gap guard: each confirming poll is a POSITIVE reading of the
+#: whole board, not an inference from a process's absence.
+_QUIESCENCE_RETRY_CONFIRM_WINDOW_S = 45.0
+
 
 def _looks_like_status_histogram(payload: dict[str, Any]) -> bool:
     """Whether *payload* is recognisably a per-status task histogram.
@@ -1296,6 +1320,27 @@ def _incomplete_declared_counts(status_payload: dict[str, Any]) -> tuple[int, di
     return count_incomplete_declared(status_payload), None
 
 
+def _retry_may_still_be_queued(status_payload: dict[str, Any], full_counts: dict[str, Any] | None) -> bool:
+    """Does the run hold a FAILED task whose retry may still be queued?
+
+    ``failed`` is the only bucket that answers this. The tick loop's retry
+    sweep (step 4b) offers ``maybe_retry_task`` the ``failed`` list and nothing
+    else, so a cancelled, refused or abandoned task - and either blocked-by-*
+    state - can never grow new work on a later tick and must not hold a
+    finished run open. ``orphaned`` never reaches this test at all: it is in
+    ``_INCOMPLETE_DECLARED_STATUSES``, so the histogram veto in
+    :func:`_is_quiescent` has already answered "not quiescent".
+
+    Unlike ``in_progress``/``orphaned``, ``failed`` HAS a bucket in the
+    ``/status`` payload, so the fallback is a real count rather than the
+    structural zero that makes an undercount dangerous elsewhere in this
+    module. The check therefore keeps working when ``/tasks/counts`` is
+    unavailable, which is the poll the original defect fired on.
+    """
+    counts = full_counts if isinstance(full_counts, dict) else status_payload
+    return int(counts.get("failed", 0) or 0) > 0
+
+
 def _is_quiescent(
     *,
     total: int,
@@ -1308,7 +1353,11 @@ def _is_quiescent(
     """Whether every declared task has reached a terminal outcome, right now.
 
     One definition, shared by the waiting path and the single-poll path, so the
-    two cannot drift into disagreeing about whether a run has finished.
+    two cannot drift into disagreeing about whether a run has finished. The
+    waiting path adds one confirmation on top: a quiescent board that still
+    holds a failed task is re-observed across
+    ``_QUIESCENCE_RETRY_CONFIRM_WINDOW_S`` before it is believed, because the
+    retry of a just-failed task is created on a later orchestrator tick.
 
     The ``open``/``claimed`` test alone calls a run finished while a task sits
     in ``in_progress`` or ``orphaned``, because ``/status`` has no bucket for
@@ -1517,6 +1566,7 @@ def _wait_for_run_completion(
     gone_last_seen: float | None = None
     gone_polls = 0
     gone_pid: int | None = None
+    quiescent_since: float | None = None
 
     def _reset_streak(reason: str, **fields: Any) -> None:
         nonlocal gone_since, gone_last_seen, gone_polls, gone_pid
@@ -1572,6 +1622,20 @@ def _wait_for_run_completion(
                     "/status) - continuing to wait",
                     n_incomplete,
                 )
+            if quiescent and _retry_may_still_be_queued(status_payload, full_counts):
+                if quiescent_since is None:
+                    quiescent_since = mono
+                    logger.info(
+                        "run_quiescent_pending_retry_confirmation: the board is quiescent but holds a "
+                        "failed task, whose retry is queued on a later tick - re-observing for %.0fs",
+                        _QUIESCENCE_RETRY_CONFIRM_WINDOW_S,
+                    )
+                    quiescent = False
+                elif mono - quiescent_since < _QUIESCENCE_RETRY_CONFIRM_WINDOW_S:
+                    quiescent = False
+            elif not quiescent:
+                quiescent_since = None
+
             if quiescent:
                 logger.info(
                     "run_completion_detected: total=%d open=%d claimed=%d agent_count=%d "

--- a/tests/unit/test_run_not_terminal_while_retry_pending.py
+++ b/tests/unit/test_run_not_terminal_while_retry_pending.py
@@ -1,0 +1,247 @@
+"""A run is not over while a retry is still to be queued.
+
+Measured 2026-09-03: the stale-claim releaser failed a task at 01:30:04 and
+the tick loop's retry sweep created its retry at 01:30:28. For those 24 s the
+board held nothing open, nothing claimed and no live agent - indistinguishable
+from a finished run. The CLI polled 2 s in, printed its summary, signalled
+shutdown and exited; the run went on retrying until 01:57:15.
+
+The gap is structural, not incidental: the retry sweep (tick step 4b) iterates
+the snapshot fetched at step 1, so a task the reap fails later in the same tick
+is first offered to ``maybe_retry_task`` on the NEXT tick.
+
+Two harness rules, inherited from ``test_orchestrator_liveness_false_positives``
+because breaking either hides the defect:
+
+* **The clock fakes monotonic and wall together.** A real ``time.sleep(s)``
+  advances both, and the confirmation window is measured on the monotonic one.
+* **``/health`` fixtures carry the ``components`` block.** A real server always
+  emits it, and ``_orchestrator_liveness`` reads it.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+import bernstein.cli.run_bootstrap as rb
+from bernstein.cli.run_bootstrap import (
+    _QUIESCENCE_RETRY_CONFIRM_WINDOW_S,
+    _is_quiescent,
+    _retry_may_still_be_queued,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+class _Clock:
+    """A fake clock whose monotonic and wall readings advance together."""
+
+    def __init__(self) -> None:
+        self.elapsed = 0.0
+        self._base_wall = time.time()
+        self._base_mono = time.monotonic()
+
+    def time(self) -> float:
+        return self._base_wall + self.elapsed
+
+    def monotonic(self) -> float:
+        return self._base_mono + self.elapsed
+
+    def sleep(self, seconds: float) -> None:
+        self.elapsed += seconds
+
+
+def _health() -> dict[str, Any]:
+    """A ``/health`` payload shaped like the real one, reporting a live run."""
+    return {
+        "status": "ok",
+        "agent_count": 0,
+        "components": {
+            "server": {"status": "ok"},
+            "spawner": {"status": "ok", "pid": 1, "detail": ""},
+            "database": {"status": "ok", "type": "TaskStore", "detail": ""},
+            "agents": {"status": "ok", "active": 0, "detail": "no active agents"},
+        },
+    }
+
+
+#: One poll's worth of server state: the ``/status`` payload and the
+#: ``/tasks/counts`` histogram, or ``None`` for a server that does not serve
+#: the histogram route.
+Poll = tuple[dict[str, Any], "dict[str, Any] | None"]
+
+
+def _drive(
+    clock: _Clock,
+    polls: list[Poll],
+    *,
+    timeout_s: float = 300.0,
+    poll_interval_s: float = 2.0,
+) -> tuple[dict[str, Any] | None, int]:
+    """Drive the real wait loop over a sequence of polls. The last one repeats.
+
+    Returns ``(verdict, polls_served)``.
+    """
+    served = {"n": 0}
+
+    def fake_get(path: str) -> Any:
+        index = min(max(served["n"] - 1, 0), len(polls) - 1)
+        if path == "/status":
+            served["n"] += 1
+            return dict(polls[min(served["n"] - 1, len(polls) - 1)][0])
+        if path == "/health":
+            return _health()
+        if path == "/tasks/counts":
+            counts = polls[index][1]
+            # A server without the route answers with an error body, which
+            # `_looks_like_status_histogram` must reject rather than read as
+            # an all-zero histogram.
+            return dict(counts) if counts is not None else {"detail": "Not Found"}
+        return None
+
+    with (
+        patch.object(rb, "server_get", side_effect=fake_get),
+        patch.object(rb, "time", clock),
+        patch.object(rb, "_signal_orchestrator_shutdown"),
+    ):
+        verdict = rb._wait_for_run_completion(poll_interval_s=poll_interval_s, timeout_s=timeout_s)
+    return verdict, served["n"]
+
+
+def _full(**counts: int) -> dict[str, Any]:
+    """A complete per-status histogram with every bucket the CLI reads."""
+    base = {"open": 0, "claimed": 0, "in_progress": 0, "orphaned": 0, "done": 0, "failed": 0}
+    base.update(counts)
+    return {"total": sum(base.values()), **base}
+
+
+#: Quiescent, but one task failed: its retry is queued on a later tick.
+QUIESCENT_WITH_FAILED: Poll = ({"total": 1, "open": 0, "claimed": 0, "done": 0, "failed": 1}, _full(failed=1))
+#: The retry has landed. The board is no longer quiescent.
+RETRY_LANDED: Poll = ({"total": 2, "open": 1, "claimed": 0, "done": 0, "failed": 1}, _full(open=1, failed=1))
+#: Every task succeeded. Nothing can retry.
+ALL_SUCCEEDED: Poll = ({"total": 2, "open": 0, "claimed": 0, "done": 2, "failed": 0}, _full(done=2))
+#: A cancelled task ended without delivering, but is never retried.
+QUIESCENT_WITH_CANCELLED: Poll = (
+    {"total": 2, "open": 0, "claimed": 0, "done": 1, "failed": 0},
+    {**_full(done=1), "cancelled": 1, "total": 2},
+)
+
+
+class TestTheWaitLoopWaitsOutThePendingRetry:
+    def test_a_quiescent_board_holding_a_failed_task_is_re_observed_first(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The measured defect: one quiescent poll ended the run 22 s early."""
+        monkeypatch.chdir(tmp_path)
+        clock = _Clock()
+        verdict, _ = _drive(clock, [QUIESCENT_WITH_FAILED])
+
+        assert verdict is not None, "the run does end once the window passes with no retry in sight"
+        assert clock.elapsed >= _QUIESCENCE_RETRY_CONFIRM_WINDOW_S, (
+            f"the verdict came after {clock.elapsed}s; a quiescent board holding a failed task "
+            f"must be re-observed across {_QUIESCENCE_RETRY_CONFIRM_WINDOW_S}s first, because the "
+            "retry is created on a later orchestrator tick"
+        )
+
+    def test_the_retry_that_arrives_inside_the_window_keeps_the_run_alive(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """What the window is for: the run continues, and the CLI stays attached."""
+        monkeypatch.chdir(tmp_path)
+        clock = _Clock()
+        verdict, served = _drive(
+            clock,
+            [QUIESCENT_WITH_FAILED, QUIESCENT_WITH_FAILED, RETRY_LANDED],
+            timeout_s=120.0,
+        )
+
+        assert verdict is None, "a run whose retry landed is still in flight and must get no verdict"
+        assert served > 3, "the loop must keep polling after the retry appears"
+
+    def test_an_all_successful_run_still_exits_on_the_first_observation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The window must not tax the ordinary case: nothing failed, nothing can retry."""
+        monkeypatch.chdir(tmp_path)
+        clock = _Clock()
+        verdict, served = _drive(clock, [ALL_SUCCEEDED])
+
+        assert verdict is not None
+        assert served == 1, "an all-succeeded run is terminal on the first poll"
+        assert clock.elapsed < _QUIESCENCE_RETRY_CONFIRM_WINDOW_S
+
+    def test_the_check_still_holds_when_the_full_histogram_is_unavailable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`/status` carries a real `failed` bucket, so the fallback is a count, not a guess.
+
+        This is the poll the original defect fired on. Answering from the full
+        histogram alone would go silent here and exit immediately.
+        """
+        monkeypatch.chdir(tmp_path)
+        clock = _Clock()
+        verdict, _ = _drive(clock, [(QUIESCENT_WITH_FAILED[0], None)])
+
+        assert verdict is not None
+        assert clock.elapsed >= _QUIESCENCE_RETRY_CONFIRM_WINDOW_S, (
+            "a missing /tasks/counts must not disable the confirmation window: unlike "
+            "in_progress and orphaned, `failed` has a real bucket in /status"
+        )
+
+    def test_a_cancelled_task_does_not_hold_a_finished_run_open(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only `failed` can grow new work. Cancelled, refused and abandoned cannot.
+
+        The tick loop's retry sweep reads `tasks_by_status["failed"]` and nothing
+        else, so waiting on any other unsuccessful terminal status delays a run
+        that is genuinely over.
+        """
+        monkeypatch.chdir(tmp_path)
+        clock = _Clock()
+        verdict, served = _drive(clock, [QUIESCENT_WITH_CANCELLED])
+
+        assert verdict is not None
+        assert served == 1, "a cancelled task is never retried; the run is over on the first poll"
+        assert clock.elapsed < _QUIESCENCE_RETRY_CONFIRM_WINDOW_S
+
+
+class TestThePendingRetryPredicate:
+    def test_a_failed_task_means_a_retry_may_be_pending(self) -> None:
+        assert _retry_may_still_be_queued({}, _full(failed=1)) is True
+
+    def test_an_all_successful_run_has_nothing_to_wait_for(self) -> None:
+        assert _retry_may_still_be_queued({}, _full(done=2)) is False
+
+    def test_a_status_only_payload_still_answers(self) -> None:
+        """`/status` reports failed, so the fallback is a real count."""
+        assert _retry_may_still_be_queued({"total": 1, "failed": 1}, None) is True
+        assert _retry_may_still_be_queued({"total": 1, "failed": 0}, None) is False
+
+    def test_a_non_histogram_error_body_falls_back_to_status(self) -> None:
+        assert _retry_may_still_be_queued({"total": 1, "failed": 1}, None) is True
+
+    def test_statuses_that_never_retry_do_not_hold_the_run(self) -> None:
+        """Only the retry sweep's own input counts, and it reads `failed` alone."""
+        for status in ("cancelled", "refused", "abandoned", "blocked_by_abandon", "blocked_by_failed_dep"):
+            assert _retry_may_still_be_queued({}, {**_full(done=1), status: 1}) is False, status
+
+
+class TestQuiescencePredicateUnchanged:
+    """`_is_quiescent` still answers only 'right now', as documented."""
+
+    def test_board_with_nothing_outstanding_is_quiescent(self) -> None:
+        assert _is_quiescent(
+            total=4, open_count=0, claimed_count=0, agent_count=0, n_incomplete=0, counts_are_complete=True
+        )
+
+    def test_an_in_progress_task_vetoes_it(self) -> None:
+        assert not _is_quiescent(
+            total=4, open_count=0, claimed_count=0, agent_count=0, n_incomplete=1, counts_are_complete=True
+        )


### PR DESCRIPTION
## What

`_wait_for_run_completion` no longer treats a single quiescent poll as the end
of the run when the board still holds a failed task. It re-observes across
`_QUIESCENCE_RETRY_CONFIRM_WINDOW_S` (45s) first. An all-succeeded run still
exits on the first observation.

## Why

A failed task is not the end of a run, and the CLI had no way to tell the two
apart.

The orchestrator's retry sweep (tick step 4b) iterates
`tasks_by_status["failed"]` from the snapshot fetched at step 1. A task that
the stale-claim releaser fails LATER in the same tick is therefore first
offered to `maybe_retry_task` on the NEXT tick. For the whole of that gap the
board holds nothing open, nothing claimed and no live agent - byte for byte
the shape of a finished run.

Measured 2026-09-03:

| time | event |
|---|---|
| 01:30:04 | the stale-claim releaser fails the task |
| 01:30:06 | the CLI polls, sees a quiescent board, prints its summary, signals shutdown and exits |
| 01:30:28 | the retry sweep creates the retry - 24s after the failure |
| 01:57:15 | the last retry fails; the run had been working for another 27 minutes with no CLI attached |

The exit code derived from that poll is the input to `bernstein run && deploy`
(issue #3010's contract), so the window is not cosmetic.

## How

- `_retry_may_still_be_queued(status_payload, full_counts)` answers "does the
  run hold a failed task whose retry may still be queued". `failed` is the
  only bucket that answers it: step 4b is the tick loop's only retry-creation
  site and it reads no other status. A cancelled, refused or abandoned task -
  and either blocked-by-* state - can never grow new work on a later tick and
  must not hold a finished run open. `orphaned` cannot reach the test at all,
  since it is in `_INCOMPLETE_DECLARED_STATUSES` and the histogram veto in
  `_is_quiescent` has already answered "not quiescent".
- The count is read from the full `/tasks/counts` histogram when available and
  from `/status` when it is not. Unlike `in_progress` and `orphaned`, `failed`
  has a real bucket in `/status`, so the fallback is a genuine count rather
  than the structural zero that makes an undercount dangerous elsewhere in
  this module. Without the fallback the check goes silent on exactly the poll
  where the defect fires - there is a test for that.
- `_wait_for_run_completion` latches `quiescent_since` on the first such
  observation and suppresses the verdict until the window has elapsed. Any
  non-quiescent poll clears the latch, so the window restarts rather than
  accumulating across an interruption. Timing is monotonic, matching the
  existing streak logic in the same loop.
- 45s is sized from the mechanism, not from the single reading: the gap is one
  whole tick's WALL duration, not `ORCHESTRATOR.tick_interval_s` (3.0s), which
  is why it is not derived from the tick period - a tick that runs git hygiene
  and worktree GC is far longer than its sleep. 45s is the measured 24s with
  roughly 2x headroom. The bound is soft by construction: a pathologically
  long tick can outlast it, at much lower probability than before. The cost of
  a longer window is every already-finished run waiting it out, because a task
  that exhausted its retries stays `failed` for the rest of the run.
- No observation-gap guard, deliberately: unlike the "orchestrator gone"
  verdict, each confirming poll here is a positive reading of the whole board
  rather than an inference from a process's absence. The reasoning is written
  next to the constant.

The single-poll path (`_poll_quiescent_status`, used by the detach and
dashboard exits) is unchanged and cannot hold a window; `_is_quiescent`'s
docstring now records that the waiting path adds this confirmation on top, so
its "one shared definition" claim stays accurate.

## Verification

Non-vacuity. Reverted `src/bernstein/cli/run_bootstrap.py` to `origin/main`,
kept the new tests, and defined only the two symbols they import so the
failures are behavioural rather than a collection error:

```
3 failed, 9 passed
FAILED ...::test_a_quiescent_board_holding_a_failed_task_is_re_observed_first
FAILED ...::test_the_retry_that_arrives_inside_the_window_keeps_the_run_alive
FAILED ...::test_the_check_still_holds_when_the_full_histogram_is_unavailable
```

The two behavioural tests that pass on base are the controls, and passing both
ways is the point of them: an all-succeeded run must still exit on the first
poll, and a cancelled task must not hold a finished run open. Both would
regress if the window were applied indiscriminately - against an earlier
revision of this change that keyed on every unsuccessful terminal status, the
cancelled control fails with `assert 24 == 1`, i.e. 24 polls spent waiting 45s
for a retry that can never be created.

On this branch:

```
uv run python scripts/run_tests.py \
  tests/unit/test_run_not_terminal_while_retry_pending.py \
  tests/unit/cli/test_run_bootstrap_helpers.py \
  tests/unit/cli/test_run_bootstrap_init.py
# 3 passed, 0 failed - 12 + 43 + 9 tests

uv run ruff check src/                       # All checks passed!
uv run ruff format --check src/              # already formatted
uv run mypy src/bernstein/cli/run_bootstrap.py
# Success: no issues found in 1 source file
uv run lint-imports                          # 3 contracts kept, 0 broken
```

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes for the affected file - no error on any
      changed line; the file's pre-existing strict-mode partial-unknown count
      is unchanged from `main`, and the repo-wide advisory job gates nothing
- [x] `uv run python scripts/run_tests.py -x` passes for the affected suites
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (N/A - a defect fix in the CLI's
      completion detection; no documented surface changes)
- [x] `docs/operations/<area>.md` updated (N/A - no new operator knob; the
      window is a derived internal constant, not configuration)
- [x] `docs/api/` schema regenerated if a public surface changed (N/A)
- [x] `uv run bernstein agents-md sync` run (N/A - no new module)
- [x] Tests cover the documented behaviour - release-notes fragment added as
      a follow-up commit carrying this PR's number
