### PR TITLE
chore(ci): raise diff-coverage floor to 90%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,8 +1,8 @@
 {
-  "diff_coverage_floor_percent": 89,
+  "diff_coverage_floor_percent": 90,
   "head_sha": "c18e88dc660e6a05ee1cb37f53bf4cb3f7f0fe53",
   "line_rate": 0.8459,
   "run_id": "33988006865",
   "total_coverage_percent": 84.59,
-  "updated_at": "2026-09-05T20:28:41+00:00"
+  "updated_at": "2026-09-07T13:33:57+00:00"
 }


### PR DESCRIPTION
Weekly nudge of the LEVEL 1 diff-coverage floor.

The diff-coverage gate in `.github/workflows/ci.yml` reads
`diff_coverage_floor_percent` from `.coverage-baseline.json`.
This PR raises that floor so every subsequent PR must cover a
slightly higher share of its changed lines.

New floor: **90%**.

The gate stays advisory (`continue-on-error`) until an operator
promotes it; see `docs/operations/coverage-ratchet.md` for the
promotion and override procedure. If the increment is too steep
for the current trunk, close this PR - the floor only moves when
the PR merges.

Generated by `.github/workflows/coverage-ratchet-weekly.yml`.