### PR TITLE
fix(salvage): exclude .claude/settings.local.json from salvage staging (#5620)

### DIFF
--- a/docs/release-notes/fragments/5620-salvage-exclude-claude-settings.md
+++ b/docs/release-notes/fragments/5620-salvage-exclude-claude-settings.md
@@ -1,0 +1,10 @@
+## Exclude Claude settings.local.json from salvage staging
+
+The Claude CLI adapter creates `<worktree>/.claude/settings.local.json` before
+process launch to declare permissions. In target repositories that do not ignore
+`.claude/`, salvage worktree's `git add -A` staged this orchestrator-written
+configuration file into `[WIP]` commits, polluting run histories and integration
+diffs. `_derive_local_exclude_entries` and `RUN_EXCLUDE_ENTRIES` now include
+`/.claude/settings.local.json` alongside `.claude/mcp.json` and
+`.claude/scheduled_tasks.json`, ensuring orchestrator adapter settings are never
+staged into target repository deliverables (#5620).

--- a/src/bernstein/core/git/local_exclude.py
+++ b/src/bernstein/core/git/local_exclude.py
@@ -50,7 +50,10 @@ EXCLUDE_BLOCK_HEADER: Final[str] = "# bernstein: run-scoped excludes (see core/g
 #: In-tree paths a run must write for a child process to find, anchored to the
 #: repository root with a leading ``/`` so they cannot shadow a same-named
 #: path a target project legitimately keeps elsewhere.
-RUN_EXCLUDE_ENTRIES: Final[tuple[str, ...]] = ("/.claude/mcp.json",)
+RUN_EXCLUDE_ENTRIES: Final[tuple[str, ...]] = (
+    "/.claude/mcp.json",
+    "/.claude/settings.local.json",
+)
 
 
 def resolve_info_exclude_path(workdir: Path) -> Path | None:

--- a/src/bernstein/core/git/worktree.py
+++ b/src/bernstein/core/git/worktree.py
@@ -353,11 +353,12 @@ def _derive_local_exclude_entries() -> tuple[str, ...]:
     list: the orchestrator itself generates a session-specific ``CLAUDE.md``
     at the root of every worktree (see ``worktree_claude_md.write_claude_md``),
     so it is always a duplicate/decoy file at that path, never a genuine
-    target-repo deliverable. Likewise ``/.claude/scheduled_tasks.json``: the
-    spawner injects a per-session health-check cron task at that path (see
-    ``spawner_core._inject_scheduled_tasks``), and the file's content embeds
-    the session id and a creation timestamp, so it always conflicts when two
-    agent branches carrying it merge back. All entries are anchored to the
+    target-repo deliverable. Likewise ``/.claude/scheduled_tasks.json`` and
+    ``/.claude/settings.local.json``: the spawner injects a per-session
+    health-check cron task and Claude adapter settings at those paths (see
+    ``spawner_core._inject_scheduled_tasks`` and ``adapters/claude.py``),
+    which are orchestrator-authored runtime configuration rather than
+    target-repo deliverables. All entries are anchored to the
     worktree root (leading ``/``) so they cannot shadow a same-named path a
     target project legitimately keeps elsewhere (e.g. a nested
     ``docs/CLAUDE.md`` or a ``.claude/`` skill/command the agent was tasked
@@ -367,6 +368,7 @@ def _derive_local_exclude_entries() -> tuple[str, ...]:
     entries.extend(f"/{exact}" for exact in sorted(_MERGE_DENY_EXACT))
     entries.append("/CLAUDE.md")
     entries.append("/.claude/scheduled_tasks.json")
+    entries.append("/.claude/settings.local.json")
     return tuple(entries)
 
 

--- a/tests/unit/test_worktree_gitignore.py
+++ b/tests/unit/test_worktree_gitignore.py
@@ -154,6 +154,7 @@ def _drop_full_deny_list_runtime_state(worktree_path: Path, session_id: str) -> 
     claude_dir = worktree_path / ".claude"
     claude_dir.mkdir(parents=True, exist_ok=True)
     (claude_dir / "mcp.json").write_text("{}\n", encoding="utf-8")
+    (claude_dir / "settings.local.json").write_text("{}\n", encoding="utf-8")
 
 
 def _make_task() -> Task:
@@ -192,6 +193,7 @@ def test_create_writes_worktree_scoped_excludes_not_a_tracked_gitignore(tmp_path
     assert "/.claude/mcp.json" in lines
     assert "/CLAUDE.md" in lines
     assert "/.claude/scheduled_tasks.json" in lines
+    assert "/.claude/settings.local.json" in lines
 
     # Must not blanket-ignore the whole .claude/ tree -- that would drop a
     # legitimate .claude/ deliverable (e.g. a skill or command).
@@ -246,6 +248,22 @@ def test_git_add_dash_a_does_not_stage_full_deny_list_paths(tmp_path: Path, repo
     denied_staged = [p for p in staged if git_pr._is_forbidden_for_merge(p)]
     assert denied_staged == [], f"deny-listed paths must never be staged, got: {denied_staged}"
     assert "src/feature.py" in staged, "the agent's real work must still be staged"
+
+
+def test_claude_settings_local_json_is_not_staged(tmp_path: Path, repo: Path) -> None:
+    """Regression for #5620: adapters/claude.py writes settings.local.json into
+    <worktree>/.claude/, which must not be staged by git add -A."""
+    mgr = WorktreeManager(repo_root=repo)
+    session_id = "sess-claude-settings"
+    worktree_path = mgr.create(session_id)
+
+    claude_dir = worktree_path / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    (claude_dir / "settings.local.json").write_text('{"autoApprove": []}\n', encoding="utf-8")
+
+    _git(worktree_path, "add", "-A")
+    staged = _staged(worktree_path)
+    assert ".claude/settings.local.json" not in staged
 
 
 def test_generated_session_claude_md_is_not_staged(tmp_path: Path, repo: Path) -> None:


### PR DESCRIPTION
Closes #5620.

## Problem

`adapters/claude.py:789-791` creates `<worktree>/.claude/` and writes `settings.local.json` into it unconditionally before process launch. In target repositories whose own `.gitignore` does not cover `.claude/`, `salvage_worktree`'s `git add -A` stages this orchestrator-authored configuration file into `[WIP]` commits, leaking adapter runtime settings into run histories and integration diffs.

## Solution

1. Added `/.claude/settings.local.json` to `_derive_local_exclude_entries()` in `src/bernstein/core/git/worktree.py` alongside the other orchestrator-managed `.claude/` entries.
2. Added `/.claude/settings.local.json` to `RUN_EXCLUDE_ENTRIES` in `src/bernstein/core/git/local_exclude.py`.
3. Updated unit test coverage in `tests/unit/test_worktree_gitignore.py` including a dedicated regression test asserting that `.claude/settings.local.json` is not staged by `git add -A`.
4. Added release note fragment.

## Verification

- `uv run pytest tests/unit/test_worktree_gitignore.py -v`: 18/18 passed.
- `uv run ruff check` and `uv run ruff format --check`: all clean.
