### PR TITLE
fix(mutation): derive mutant timeout from module budget and do not score timeouts as kills (#5621)

### DIFF
--- a/docs/release-notes/fragments/5621-mutant-timeout-from-budget.md
+++ b/docs/release-notes/fragments/5621-mutant-timeout-from-budget.md
@@ -1,0 +1,9 @@
+## Derive mutant run timeout from module budget and stop scoring timeouts as kills
+
+`scripts/mutmut_critical.py` scored timed-out mutant runs as kills, inflating
+the kill rate when slow test suites hit their cap without actually asserting
+mutant detection. In addition, mutant runs were capped at a flat 180-second
+constant regardless of the module's configured `budget_seconds`. Mutant runs now
+derive their timeout from `budget_seconds` (matching the baseline policy),
+timed-out mutants are no longer counted towards `killed`, and runs with a
+material share of timeouts report as unmeasured (#5621).

--- a/scripts/mutmut_critical.py
+++ b/scripts/mutmut_critical.py
@@ -230,8 +230,17 @@ class ModuleResult:
         return (self.killed / self.total) if self.total else 0.0
 
     @property
+    def timeout_rate(self) -> float:
+        return (self.timeouts / self.total) if self.total else 0.0
+
+    @property
+    def unmeasured(self) -> bool:
+        """A run with a material fraction of timed-out mutants (>= 20%) is untrustworthy."""
+        return self.total > 0 and self.timeout_rate >= 0.20
+
+    @property
     def passed(self) -> bool:
-        return self.baseline_ok and self.kill_rate >= self.threshold
+        return self.baseline_ok and not self.unmeasured and self.kill_rate >= self.threshold
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -245,6 +254,7 @@ class ModuleResult:
             "passed": self.passed,
             "baseline_ok": self.baseline_ok,
             "baseline_timeout": self.baseline_timeout,
+            "unmeasured": self.unmeasured,
             "elapsed_seconds": round(self.elapsed_seconds, 1),
             "budget_exceeded": self.timed_out,
         }
@@ -279,6 +289,17 @@ def _baseline_timeout_seconds(mod: Module) -> int:
     run of the suite, while a mutant run is one of many inside the same
     budget - floored at the per-mutant cap so the baseline never gets a
     smaller allowance than a single mutant (issue #5570).
+    """
+
+    return max(mod.budget_seconds // 4, _MUTANT_RUN_TIMEOUT)
+
+
+def _mutant_timeout_seconds(mod: Module) -> int:
+    """Wall-clock budget for an individual mutant pytest run.
+
+    Derived from the module's own ``budget_seconds`` floored at the
+    per-mutant cap, matching the baseline allowance so a slow suite is not
+    capped at a flat constant (issue #5621).
     """
 
     return max(mod.budget_seconds // 4, _MUTANT_RUN_TIMEOUT)
@@ -349,10 +370,11 @@ def _mutate_module(mod: Module, *, verbose: bool = True) -> ModuleResult:
             lines[line_no] = new_line
             target.write_text("".join(lines))
             try:
-                survived = _run_tests(mod.tests)
+                survived = _run_tests(mod.tests, timeout=_mutant_timeout_seconds(mod))
             except subprocess.TimeoutExpired:
                 res.timeouts += 1
-                res.killed += 1
+                if verbose:
+                    print(f"  [{idx + 1}/{len(candidates)}] TIMEOUT line {line_no + 1}", flush=True)
                 continue
             if survived:
                 res.survivors.append(f"{mod.source}:{line_no + 1} '{search}' -> '{replace}': {line.rstrip()}")
@@ -372,10 +394,20 @@ def _print_summary(results: list[ModuleResult]) -> None:
     print("=== Mutation gate summary ===")
     print(f"{'module':<20} {'kill rate':>10} {'thr':>6} {'status':>8}  notes")
     for r in results:
-        status = "PASS" if r.passed else ("BASE-FAIL" if not r.baseline_ok else "FAIL")
+        status = (
+            "PASS" if r.passed else ("BASE-FAIL" if not r.baseline_ok else ("UNTRUSTED" if r.unmeasured else "FAIL"))
+        )
         rate = f"{100 * r.kill_rate:5.1f}%" if r.total else "  n/a"
         thr = f"{100 * r.threshold:4.0f}%"
-        suffix = " (baseline timed out)" if r.baseline_timeout else (" (budget exceeded)" if r.timed_out else "")
+        suffix = (
+            " (baseline timed out)"
+            if r.baseline_timeout
+            else (
+                f" ({r.timeouts} timed out - unmeasured)"
+                if r.unmeasured
+                else (f" ({r.timeouts} timed out)" if r.timeouts else (" (budget exceeded)" if r.timed_out else ""))
+            )
+        )
         print(f"{r.key:<20} {rate:>10} {thr:>6} {status:>8}  {r.killed}/{r.total} killed{suffix}")
     for r in results:
         if r.survivors:

--- a/scripts/mutmut_critical.py
+++ b/scripts/mutmut_critical.py
@@ -15,7 +15,8 @@ mutations in that file. A module is "passing" when
     kill_rate >= threshold
 
 where ``kill_rate = killed / total`` and ``total = killed + survivors``
-(timeouts count as kills - an infinite loop is a meaningful signal).
+(timeouts are recorded separately and do not affect the kill rate;
+a material fraction of timeouts marks the run as unmeasured).
 
 CLI:
 

--- a/tests/unit/test_mutmut_critical_mutant_timeout.py
+++ b/tests/unit/test_mutmut_critical_mutant_timeout.py
@@ -1,0 +1,87 @@
+"""Regression tests for mutant timeout scoring and budget derivation (issue #5621).
+
+``scripts/mutmut_critical.py`` formerly counted timed-out mutant runs as kills,
+which inflated the kill rate of slow test suites. Furthermore, mutant runs used
+a flat 180s constant timeout instead of deriving from the module's own
+budget_seconds. These tests pin the fixed behaviour using mocked runs.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from scripts.mutmut_critical import (
+    Module,
+    _mutant_timeout_seconds,  # pyright: ignore[reportPrivateUsage]
+    _mutate_module,  # pyright: ignore[reportPrivateUsage]
+)
+
+TEST_MODULE = Module(
+    key="test_mod",
+    source="src/bernstein/core/lineage/tips.py",
+    tests=("tests/unit/lineage/",),
+    threshold=0.75,
+    budget_seconds=800,
+    max_candidates=2,
+    note="Test module for mutant timeout regression.",
+)
+
+
+def test_mutant_timeout_derived_from_module_budget() -> None:
+    """Mutant run timeout must be derived from mod.budget_seconds floored at 180s."""
+    mod_small = Module(key="small", source="s", tests=(), threshold=0.7, budget_seconds=400)
+    # 400 // 4 = 100, floored at 180
+    assert _mutant_timeout_seconds(mod_small) == 180
+
+    mod_large = Module(key="large", source="s", tests=(), threshold=0.7, budget_seconds=1200)
+    # 1200 // 4 = 300
+    assert _mutant_timeout_seconds(mod_large) == 300
+
+
+def test_timed_out_mutant_is_not_scored_as_kill(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A timed-out mutant is recorded in timeouts, not in killed."""
+    call_count = 0
+
+    def _mock_run(cmd: list[str], timeout: int | None = None, **_: Any) -> SimpleNamespace:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # Baseline run passes
+            return SimpleNamespace(returncode=0)
+        # Mutant run times out
+        raise subprocess.TimeoutExpired(cmd, timeout=timeout if timeout is not None else 180.0)
+
+    monkeypatch.setattr(subprocess, "run", _mock_run)
+    res = _mutate_module(TEST_MODULE, verbose=False)
+
+    assert res.baseline_ok is True
+    assert res.baseline_timeout is False
+    assert res.timeouts > 0
+    assert res.killed == 0
+    assert res.kill_rate == 0.0
+
+
+def test_material_timeouts_mark_module_unmeasured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When timed-out mutants constitute >= 20% of candidates, module is unmeasured."""
+    call_count = 0
+
+    def _mock_run(cmd: list[str], timeout: int | None = None, **_: Any) -> SimpleNamespace:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return SimpleNamespace(returncode=0)
+        raise subprocess.TimeoutExpired(cmd, timeout=timeout if timeout is not None else 180.0)
+
+    monkeypatch.setattr(subprocess, "run", _mock_run)
+    res = _mutate_module(TEST_MODULE, verbose=False)
+
+    assert res.unmeasured is True
+    assert res.passed is False
+    assert res.to_dict()["unmeasured"] is True


### PR DESCRIPTION
Closes #5621.

## Problem

`scripts/mutmut_critical.py` counted timed-out mutant runs as kills (`res.killed += 1`), artificially inflating the reported kill rate when a slow test suite exceeded its cap without verifying any mutations were actually caught. In addition, mutant runs were capped at a flat 180s constant timeout instead of deriving from the module's configured `budget_seconds`.

## Solution

1. Derived mutant pytest timeout from `mod.budget_seconds` via `_mutant_timeout_seconds(mod)` (matching the quarter-budget floored at 180s formula used for the baseline run).
2. Removed `res.killed += 1` on `subprocess.TimeoutExpired`, so timed-out runs only increment `res.timeouts`.
3. Marked runs where timed-out mutants reach a material fraction of candidates (>= 20%) as `unmeasured` in `ModuleResult` so they cannot pass quietly as green.
4. Added unit tests in `tests/unit/test_mutmut_critical_mutant_timeout.py` verifying timeout derivation, that timed-out mutants do not move the kill count, and that material timeouts report as `unmeasured`.
5. Added release note fragment.

## Verification

- `uv run pytest tests/unit/test_mutmut_critical_baseline_timeout.py tests/unit/test_mutmut_critical_mutant_timeout.py -v`: 6 passed.
- `uv run ruff check scripts/mutmut_critical.py tests/unit/test_mutmut_critical_mutant_timeout.py`: clean.
- `uv run ruff format --check scripts/mutmut_critical.py tests/unit/test_mutmut_critical_mutant_timeout.py`: clean.
