### PR TITLE
test(conformance): add attribution conformance vectors for questions 1, 2, 7 and 14 (#5058)

### DIFF
--- a/scripts/auditor_conformance.py
+++ b/scripts/auditor_conformance.py
@@ -35,6 +35,7 @@ from tests.conformance.auditor.scoreboard import REPORT_PATH_ENV, read_report  #
 VECTORS = (
     "tests/conformance/auditor/test_vectors.py",
     "tests/conformance/auditor/test_data_endpoint_vectors.py",
+    "tests/conformance/auditor/test_attribution_vectors.py",
 )
 SCORE_PLUGIN = "tests.conformance.auditor.scoreboard"
 

--- a/tests/conformance/auditor/README.md
+++ b/tests/conformance/auditor/README.md
@@ -4,9 +4,9 @@ One recorded run, one exported bundle, and 21 questions that must be
 answerable **from the bundle alone** by someone who never had access to
 the machine that produced it.
 
-The score is `n/21`. It is a progress instrument, not a claim: nine
-questions have vectors, of which three pass and six explicitly
-record missing evidence with strict expected failures. The other twelve
+The score is `n/21`. It is a progress instrument, not a claim: thirteen
+questions have vectors, of which five pass and eight explicitly
+record missing evidence with strict expected failures. The other eight
 have no vector yet. This describes the committed scenario, not coverage
 of every production run.
 
@@ -31,6 +31,7 @@ of every production run.
 | `scoreboard.py` | Pytest plugin that records which questions the run answered. |
 | `test_vectors.py` | Integrity and independence vectors (15–20), with supporting controls. |
 | `test_data_endpoint_vectors.py` | Data and endpoint vectors (8–10). |
+| `test_attribution_vectors.py` | Attribution vectors (1, 2, 7, 14). |
 | `test_harness.py` | Holds the instrument honest; answers no question. |
 
 ## Commands
@@ -41,7 +42,7 @@ uv run python scripts/auditor_conformance.py regenerate
 
 # Run the vectors and print the score
 uv run python scripts/auditor_conformance.py score
-#   -> auditor conformance: 3/21
+#   -> auditor conformance: 5/21
 
 # Run the whole suite, harness included
 uv run pytest tests/conformance/auditor -q
@@ -74,7 +75,8 @@ and endpoints (8, 9, 10), integrity and independence (15, 16, 18, 19,
 only passing question-marked
 vectors move the score. Questions 8 and 9 assert the recorded restricted
 file and delegated model endpoint in both receipts. Question 10 remains
-a strict expected failure for missing admission history (#5038). No
+a strict expected failure for missing admission history (#5038). Questions 1 and 2 pass; 7 and 14 remain strict expected failures (no
+identity presented to the tool, no agent code/config/toolset digest). No
 fixture fields were added to answer these questions. A
 weak assertion that passes is worse than an honest failure: it hides
 exactly the gap this suite exists to measure.

--- a/tests/conformance/auditor/test_attribution_vectors.py
+++ b/tests/conformance/auditor/test_attribution_vectors.py
@@ -1,0 +1,90 @@
+"""Attribution questions answered only from the exported bundle (#5058)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.conformance.auditor import recorder
+
+if TYPE_CHECKING:
+    from tests.conformance.auditor.bundle import BundleReader
+
+
+@pytest.mark.question(1)
+def test_q1_the_record_names_the_initiating_principal(bundle_reader: BundleReader) -> None:
+    """Q1: the exported bundle identifies the human or principal who started the run."""
+    run = bundle_reader.read_json(recorder.RUN_RECEIPT_NAME)
+    start_events = [e for e in run["journal"]["events"] if e["event"] == "run_started"]
+    assert start_events, "run_started event missing from journal"
+    assert start_events[0]["principal"] == "user:operator@example.org"
+
+    audit = bundle_reader.read_json(recorder.AUDIT_RECEIPT_NAME)
+    start_audit = [e for e in audit["events"] if e["event_type"] == "run.started"]
+    assert start_audit, "run.started event missing from audit receipt"
+    assert start_audit[0]["actor"] == "user:operator@example.org"
+
+
+@pytest.mark.question(2)
+def test_q2_the_record_names_the_agent_for_each_recorded_action(bundle_reader: BundleReader) -> None:
+    """Q2: each action in the journal and spine records which agent performed it."""
+    run = bundle_reader.read_json(recorder.RUN_RECEIPT_NAME)
+    action_events = [
+        e
+        for e in run["journal"]["events"]
+        if e["event"] in ("tool_called", "file_read", "model_request", "artifact_written")
+    ]
+    assert action_events, "no action events recorded in journal"
+    for e in action_events:
+        assert "agent_id" in e, f"event {e['event']} missing agent_id"
+        assert e["agent_id"] in ("agent-a", "agent-b")
+
+    spine_entries = run["spine"]["entries"]
+    assert spine_entries, "spine has no entries"
+    for entry in spine_entries:
+        assert entry.get("actor") == "agent-a"
+
+
+@pytest.mark.question(7)
+@pytest.mark.xfail(
+    strict=True,
+    raises=AssertionError,
+    reason=(
+        "the exported bundle has no per-tool-call identity record binding the "
+        "acting agent to the identity presented to the tool server (#5058)"
+    ),
+)
+def test_q7_the_identity_presented_to_the_tool_is_recorded(bundle_reader: BundleReader) -> None:
+    """Q7: which identity was presented to the tool server during tool calls."""
+    run = bundle_reader.read_json(recorder.RUN_RECEIPT_NAME)
+    tool_calls = [e for e in run["journal"]["events"] if e["event"] == "tool_called"]
+    assert tool_calls, "no tool_called event in journal"
+    for call in tool_calls:
+        assert call.get("presented_identity"), "journal tool_called missing presented_identity (#5058)"
+
+    audit = bundle_reader.read_json(recorder.AUDIT_RECEIPT_NAME)
+    audit_calls = [e for e in audit["events"] if e["event_type"] == "tool.called"]
+    assert audit_calls, "no tool.called event in audit receipt"
+    for call in audit_calls:
+        assert call["details"].get("presented_identity"), "audit tool.called missing presented_identity (#5058)"
+
+
+@pytest.mark.question(14)
+@pytest.mark.xfail(
+    strict=True,
+    raises=AssertionError,
+    reason=(
+        "the exported bundle does not bind the agent identity to a code, config "
+        "and tool set digest for the agent that ran (#5058)"
+    ),
+)
+def test_q14_the_agent_code_config_and_toolset_digest_is_recorded(bundle_reader: BundleReader) -> None:
+    """Q14: which agent code, config and tool set actually ran."""
+    run = bundle_reader.read_json(recorder.RUN_RECEIPT_NAME)
+    spawns = [e for e in run["journal"]["events"] if e["event"] == "agent_spawned"]
+    assert spawns, "no agent_spawned events in journal"
+    for spawn in spawns:
+        assert spawn.get("code_digest"), "agent_spawned missing code_digest (#5058)"
+        assert spawn.get("config_digest"), "agent_spawned missing config_digest (#5058)"
+        assert spawn.get("toolset_digest"), "agent_spawned missing toolset_digest (#5058)"

--- a/tests/conformance/auditor/test_attribution_vectors.py
+++ b/tests/conformance/auditor/test_attribution_vectors.py
@@ -14,7 +14,15 @@ if TYPE_CHECKING:
 
 @pytest.mark.question(1)
 def test_q1_the_record_names_the_initiating_principal(bundle_reader: BundleReader) -> None:
-    """Q1: the exported bundle identifies the human or principal who started the run."""
+    """Q1: the exported bundle identifies the human or principal who started the run.
+
+    This test passes because the scripted recorder fixture populates ``principal``
+    and ``actor`` from ``recorder.py:88-114``; the orchestrator's own
+    ``run_started`` event (``orchestrator.py:3173-3181``) does not yet carry a
+    principal field in production runs.  The test validates the *bundle schema*
+    — that the field can be written and round-tripped — not that every production
+    run will populate it.
+    """
     run = bundle_reader.read_json(recorder.RUN_RECEIPT_NAME)
     start_events = [e for e in run["journal"]["events"] if e["event"] == "run_started"]
     assert start_events, "run_started event missing from journal"
@@ -28,8 +36,16 @@ def test_q1_the_record_names_the_initiating_principal(bundle_reader: BundleReade
 
 @pytest.mark.question(2)
 def test_q2_the_record_names_the_agent_for_each_recorded_action(bundle_reader: BundleReader) -> None:
-    """Q2: each action in the journal and spine records which agent performed it."""
+    """Q2: each action in the journal and spine records which agent performed it.
+
+    This test passes because the scripted recorder fixture populates ``agent_id``
+    and ``actor`` explicitly (``recorder.py:88-114``).  The two agent IDs in the
+    fixture are ``agent-a`` and ``agent-b``; the spine only records ``agent-a``
+    actions in the bundled scenario.  This validates the bundle *schema*, not that
+    every production writer populates these fields consistently.
+    """
     run = bundle_reader.read_json(recorder.RUN_RECEIPT_NAME)
+    agent_ids = {"agent-a", "agent-b"}
     action_events = [
         e
         for e in run["journal"]["events"]
@@ -38,12 +54,12 @@ def test_q2_the_record_names_the_agent_for_each_recorded_action(bundle_reader: B
     assert action_events, "no action events recorded in journal"
     for e in action_events:
         assert "agent_id" in e, f"event {e['event']} missing agent_id"
-        assert e["agent_id"] in ("agent-a", "agent-b")
+        assert e["agent_id"] in agent_ids
 
     spine_entries = run["spine"]["entries"]
     assert spine_entries, "spine has no entries"
     for entry in spine_entries:
-        assert entry.get("actor") == "agent-a"
+        assert entry.get("actor") in agent_ids
 
 
 @pytest.mark.question(7)
@@ -51,23 +67,41 @@ def test_q2_the_record_names_the_agent_for_each_recorded_action(bundle_reader: B
     strict=True,
     raises=AssertionError,
     reason=(
-        "the exported bundle has no per-tool-call identity record binding the "
-        "acting agent to the identity presented to the tool server (#5058)"
+        "the exported bundle does not carry a ToolCallIdentityAttestation record "
+        "per tool call; the gateway today writes actor='mcp_gateway' for every call "
+        "(core/protocols/mcp/mcp_gateway.py:392) and the attestation fields "
+        "(args_digest, intent_digest, identity_anchor_ref, tool_signing_kid) "
+        "defined in core/security/toolcall_identity.py:26-45 do not reach the "
+        "bundle (#5058)"
     ),
 )
 def test_q7_the_identity_presented_to_the_tool_is_recorded(bundle_reader: BundleReader) -> None:
-    """Q7: which identity was presented to the tool server during tool calls."""
+    """Q7: which identity was presented to the tool server during tool calls.
+
+    When ToolCallIdentityAttestation reaches the bundle, each tool_called event
+    in the journal and audit receipt should carry the attestation fields defined
+    in ``core/security/toolcall_identity.py:26-45``:
+    ``args_digest``, ``intent_digest``, ``identity_anchor_ref``, ``tool_signing_kid``.
+    """
     run = bundle_reader.read_json(recorder.RUN_RECEIPT_NAME)
     tool_calls = [e for e in run["journal"]["events"] if e["event"] == "tool_called"]
     assert tool_calls, "no tool_called event in journal"
     for call in tool_calls:
-        assert call.get("presented_identity"), "journal tool_called missing presented_identity (#5058)"
+        # These fields are defined in ToolCallIdentityAttestation (toolcall_identity.py:39-45)
+        assert call.get("args_digest"), "journal tool_called missing args_digest (#5058)"
+        assert call.get("intent_digest"), "journal tool_called missing intent_digest (#5058)"
+        assert call.get("identity_anchor_ref"), "journal tool_called missing identity_anchor_ref (#5058)"
+        assert call.get("tool_signing_kid"), "journal tool_called missing tool_signing_kid (#5058)"
 
     audit = bundle_reader.read_json(recorder.AUDIT_RECEIPT_NAME)
     audit_calls = [e for e in audit["events"] if e["event_type"] == "tool.called"]
     assert audit_calls, "no tool.called event in audit receipt"
     for call in audit_calls:
-        assert call["details"].get("presented_identity"), "audit tool.called missing presented_identity (#5058)"
+        details = call.get("details", {})
+        assert details.get("args_digest"), "audit tool.called missing args_digest (#5058)"
+        assert details.get("intent_digest"), "audit tool.called missing intent_digest (#5058)"
+        assert details.get("identity_anchor_ref"), "audit tool.called missing identity_anchor_ref (#5058)"
+        assert details.get("tool_signing_kid"), "audit tool.called missing tool_signing_kid (#5058)"
 
 
 @pytest.mark.question(14)

--- a/tests/conformance/auditor/test_harness.py
+++ b/tests/conformance/auditor/test_harness.py
@@ -116,10 +116,10 @@ def test_scoreboard_target_prints_the_score_out_of_twenty_one(tmp_path: Path) ->
         check=False,
     )
     assert completed.returncode == 0, completed.stdout + completed.stderr
-    assert f"3/{TOTAL_QUESTIONS}" in completed.stdout
+    assert f"5/{TOTAL_QUESTIONS}" in completed.stdout
 
     report = json.loads((tmp_path / "score.json").read_text(encoding="utf-8"))
-    assert report["passed"] == [8, 9, 17]
+    assert report["passed"] == [1, 2, 8, 9, 17]
 
 
 def test_regenerating_the_fixture_rewrites_the_bundle(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #5058.
Part of #5054. Depends on #5057.

## What this does

Delivers the conformance test vectors under `tests/conformance/auditor/test_attribution_vectors.py` answering the four attribution questions from the 21-question auditor scoreboard:

- **Question 1**: "Which principal initiated the run?" — Passes: asserts `run_started` in `run-receipt.json` and `run.started` in `audit-receipt.json` both record the initiating principal.
- **Question 2**: "Which agent performed each recorded action?" — Passes: asserts recorded actions in the journal (`tool_called`, `file_read`, `model_request`, `artifact_written`) record `agent_id`, and spine entries record `actor`.
- **Question 7**: "Which identity was presented to the tool?" — `xfail(strict=True)`: the bundle records no presented authenticated identity per tool call (`mcp_gateway.py:393`).
- **Question 14**: "Which agent code, config and tool set actually ran?" — `xfail(strict=True)`: the bundle does not bind the acting agent to a code, configuration, or toolset digest.

## Verification

- `uv run pytest tests/conformance/auditor/test_attribution_vectors.py -v`: 2 passed, 2 xfailed.
- `uv run ruff check tests/conformance/auditor/test_attribution_vectors.py`: clean.
- `uv run ruff format --check tests/conformance/auditor/test_attribution_vectors.py`: clean.
