### PR TITLE
test(conformance): add policy and approval conformance vectors for questions 6, 11, 12 and 13 (#5060)

### DIFF
--- a/scripts/auditor_conformance.py
+++ b/scripts/auditor_conformance.py
@@ -35,6 +35,7 @@ from tests.conformance.auditor.scoreboard import REPORT_PATH_ENV, read_report  #
 VECTORS = (
     "tests/conformance/auditor/test_vectors.py",
     "tests/conformance/auditor/test_data_endpoint_vectors.py",
+    "tests/conformance/auditor/test_policy_vectors.py",
 )
 SCORE_PLUGIN = "tests.conformance.auditor.scoreboard"
 

--- a/tests/conformance/auditor/README.md
+++ b/tests/conformance/auditor/README.md
@@ -4,9 +4,9 @@ One recorded run, one exported bundle, and 21 questions that must be
 answerable **from the bundle alone** by someone who never had access to
 the machine that produced it.
 
-The score is `n/21`. It is a progress instrument, not a claim: nine
-questions have vectors, of which three pass and six explicitly
-record missing evidence with strict expected failures. The other twelve
+The score is `n/21`. It is a progress instrument, not a claim: thirteen
+questions have vectors, of which three pass and ten explicitly
+record missing evidence with strict expected failures. The other eight
 have no vector yet. This describes the committed scenario, not coverage
 of every production run.
 
@@ -31,6 +31,7 @@ of every production run.
 | `scoreboard.py` | Pytest plugin that records which questions the run answered. |
 | `test_vectors.py` | Integrity and independence vectors (15–20), with supporting controls. |
 | `test_data_endpoint_vectors.py` | Data and endpoint vectors (8–10). |
+| `test_policy_vectors.py` | Policy and approval vectors (6, 11, 12, 13). |
 | `test_harness.py` | Holds the instrument honest; answers no question. |
 
 ## Commands
@@ -74,7 +75,9 @@ and endpoints (8, 9, 10), integrity and independence (15, 16, 18, 19,
 only passing question-marked
 vectors move the score. Questions 8 and 9 assert the recorded restricted
 file and delegated model endpoint in both receipts. Question 10 remains
-a strict expected failure for missing admission history (#5038). No
+a strict expected failure for missing admission history (#5038). Questions 6, 11, 12 and 13 remain strict expected failures: the bundle
+carries no GovernanceDecision record and no approver identity or
+timestamp. No
 fixture fields were added to answer these questions. A
 weak assertion that passes is worse than an honest failure: it hides
 exactly the gap this suite exists to measure.

--- a/tests/conformance/auditor/test_policy_vectors.py
+++ b/tests/conformance/auditor/test_policy_vectors.py
@@ -17,11 +17,18 @@ if TYPE_CHECKING:
     strict=True,
     raises=AssertionError,
     reason=(
-        "the exported bundle has no policy reference or version binding the decision that allowed the tool call (#5060)"
+        "the exported bundle has no policy reference or version binding the decision "
+        "that allowed the tool call; the bundle exports no GovernanceDecision record "
+        "(core/security/governance.py:217) — that is the field a follow-up must add (#5060)"
     ),
 )
 def test_q6_the_policy_and_version_allowing_the_tool_call_is_recorded(bundle_reader: BundleReader) -> None:
-    """Q6: which policy, at which version, allowed the tool call."""
+    """Q6: which policy, at which version, allowed the tool call.
+
+    When ``GovernanceDecision`` reaches the bundle (``core/security/governance.py:217``),
+    each ``tool_called`` journal event should carry ``policy_id`` and ``policy_version``
+    binding the allow decision to the policy that made it.
+    """
     run = bundle_reader.read_json(recorder.RUN_RECEIPT_NAME)
     events = run["journal"]["events"]
     tool_calls = [e for e in events if e["event"] == "tool_called"]
@@ -41,6 +48,7 @@ def test_q11_the_record_states_whether_human_approval_was_required(bundle_reader
     """Q11: was human approval required for the final action."""
     audit = bundle_reader.read_json(recorder.AUDIT_RECEIPT_NAME)
     events = audit["events"]
+    # Real approval events emitted by approval_gate.py:488,521 are approval_pending
     changes = [e for e in events if e["event_type"] == "repo.changed"]
     assert changes, "no repo.changed event in audit receipt"
     for change in changes:
@@ -52,15 +60,27 @@ def test_q11_the_record_states_whether_human_approval_was_required(bundle_reader
     strict=True,
     raises=AssertionError,
     reason=(
-        "the exported bundle cannot distinguish approval from expiry or record "
-        "the approver identity and timestamp (#5051, #5060)"
+        "the exported bundle does not record the approver identity or approval "
+        "timestamp in approval_resolved events; approval_gate.py:571-578 now records "
+        "outcome and decision_source for timeout-defaults but approved_by and timestamp "
+        "are absent for human approvals (#5060)"
     ),
 )
 def test_q12_the_approver_and_approval_timestamp_are_recorded(bundle_reader: BundleReader) -> None:
-    """Q12: if approval was required, who approved it and when."""
+    """Q12: if approval was required, who approved it and when.
+
+    The real approval event names emitted by the approval gate are
+    ``approval_pending`` (core/orchestration/approval_gate.py:488,521) and
+    ``approval_resolved`` (core/orchestration/approval_gate.py:504,543,571).
+    This test matches those exact names so it will turn XPASS as soon as the
+    approver identity and timestamp reach the bundle.
+    """
     audit = bundle_reader.read_json(recorder.AUDIT_RECEIPT_NAME)
     events = audit["events"]
-    approvals = [e for e in events if e["event_type"].startswith("approval.")]
+    # Match the real event names emitted by approval_gate.py, not a prefix guess
+    approvals = [
+        e for e in events if e["event_type"] in ("approval_pending", "approval_resolved")
+    ]
     assert approvals, "no approval event recorded in audit receipt (#5060)"
     for approval in approvals:
         assert approval["details"].get("approved_by"), "approval record missing approved_by (#5060)"
@@ -71,10 +91,19 @@ def test_q12_the_approver_and_approval_timestamp_are_recorded(bundle_reader: Bun
 @pytest.mark.xfail(
     strict=True,
     raises=AssertionError,
-    reason=("the exported bundle has no policy hash or version in force at decision time (#5060)"),
+    reason=(
+        "the exported bundle has no policy hash or version in force at decision time; "
+        "the bundle exports no GovernanceDecision record "
+        "(core/security/governance.py:217) — that is the field a follow-up must add (#5060)"
+    ),
 )
 def test_q13_the_policy_version_in_force_at_decision_time_is_recorded(bundle_reader: BundleReader) -> None:
-    """Q13: which policy version was in force at decision time, not export time."""
+    """Q13: which policy version was in force at decision time, not export time.
+
+    When ``GovernanceDecision`` reaches the bundle (``core/security/governance.py:217``),
+    events should carry ``policy_digest`` capturing the hash of the policy that was
+    evaluated at the moment of decision.
+    """
     run = bundle_reader.read_json(recorder.RUN_RECEIPT_NAME)
     events = run["journal"]["events"]
     assert events, "no events in journal"

--- a/tests/conformance/auditor/test_policy_vectors.py
+++ b/tests/conformance/auditor/test_policy_vectors.py
@@ -1,0 +1,83 @@
+"""Policy and approval questions answered only from the exported bundle (#5060)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.conformance.auditor import recorder
+
+if TYPE_CHECKING:
+    from tests.conformance.auditor.bundle import BundleReader
+
+
+@pytest.mark.question(6)
+@pytest.mark.xfail(
+    strict=True,
+    raises=AssertionError,
+    reason=(
+        "the exported bundle has no policy reference or version binding the decision that allowed the tool call (#5060)"
+    ),
+)
+def test_q6_the_policy_and_version_allowing_the_tool_call_is_recorded(bundle_reader: BundleReader) -> None:
+    """Q6: which policy, at which version, allowed the tool call."""
+    run = bundle_reader.read_json(recorder.RUN_RECEIPT_NAME)
+    events = run["journal"]["events"]
+    tool_calls = [e for e in events if e["event"] == "tool_called"]
+    assert tool_calls, "no tool_called event in journal"
+    for call in tool_calls:
+        assert call.get("policy_id"), "decision does not name the policy (#5060)"
+        assert call.get("policy_version"), "decision does not name the policy version (#5060)"
+
+
+@pytest.mark.question(11)
+@pytest.mark.xfail(
+    strict=True,
+    raises=AssertionError,
+    reason=("the exported bundle does not record whether human approval was required for the action (#5060)"),
+)
+def test_q11_the_record_states_whether_human_approval_was_required(bundle_reader: BundleReader) -> None:
+    """Q11: was human approval required for the final action."""
+    audit = bundle_reader.read_json(recorder.AUDIT_RECEIPT_NAME)
+    events = audit["events"]
+    changes = [e for e in events if e["event_type"] == "repo.changed"]
+    assert changes, "no repo.changed event in audit receipt"
+    for change in changes:
+        assert "approval_required" in change["details"], "repo.changed does not record approval_required (#5060)"
+
+
+@pytest.mark.question(12)
+@pytest.mark.xfail(
+    strict=True,
+    raises=AssertionError,
+    reason=(
+        "the exported bundle cannot distinguish approval from expiry or record "
+        "the approver identity and timestamp (#5051, #5060)"
+    ),
+)
+def test_q12_the_approver_and_approval_timestamp_are_recorded(bundle_reader: BundleReader) -> None:
+    """Q12: if approval was required, who approved it and when."""
+    audit = bundle_reader.read_json(recorder.AUDIT_RECEIPT_NAME)
+    events = audit["events"]
+    approvals = [e for e in events if e["event_type"].startswith("approval.")]
+    assert approvals, "no approval event recorded in audit receipt (#5060)"
+    for approval in approvals:
+        assert approval["details"].get("approved_by"), "approval record missing approved_by (#5060)"
+        assert approval.get("timestamp"), "approval record missing timestamp (#5060)"
+
+
+@pytest.mark.question(13)
+@pytest.mark.xfail(
+    strict=True,
+    raises=AssertionError,
+    reason=("the exported bundle has no policy hash or version in force at decision time (#5060)"),
+)
+def test_q13_the_policy_version_in_force_at_decision_time_is_recorded(bundle_reader: BundleReader) -> None:
+    """Q13: which policy version was in force at decision time, not export time."""
+    run = bundle_reader.read_json(recorder.RUN_RECEIPT_NAME)
+    events = run["journal"]["events"]
+    assert events, "no events in journal"
+    for event in events:
+        if event.get("event") in ("tool_called", "artifact_written"):
+            assert event.get("policy_digest"), "event has no policy_digest anchored at decision time (#5060)"


### PR DESCRIPTION
Closes #5060.
Part of #5054. Depends on #5057.

## What this does

Delivers the conformance test vectors under `tests/conformance/auditor/test_policy_vectors.py` answering the four policy and approval questions from the 21-question auditor scoreboard:

- **Question 6**: "Which policy, at which version, allowed the tool call?" — `xfail(strict=True)`: decisions carry `inputs_hash` but no policy identifier or version.
- **Question 11**: "Was human approval required for the final action?" — `xfail(strict=True)`: the bundle does not record whether human approval was required for the action.
- **Question 12**: "If required, who approved it and when?" — `xfail(strict=True)`: the bundle cannot distinguish approval from expiry or name the approver identity and timestamp (#5051).
- **Question 13**: "Which policy version was in force at decision time, not export time?" — `xfail(strict=True)`: decisions do not capture the policy digest in force at decision time.

## Verification

- `uv run pytest tests/conformance/auditor/test_policy_vectors.py -v`: 4 xfailed (strict).
- `uv run ruff check tests/conformance/auditor/test_policy_vectors.py`: clean.
- `uv run ruff format --check tests/conformance/auditor/test_policy_vectors.py`: clean.
