### PR TITLE
docs: refresh curated context files against recent subtree churn (#5617)

### DIFF
--- a/src/bernstein/adapters/AGENTS.md
+++ b/src/bernstein/adapters/AGENTS.md
@@ -1,40 +1,40 @@
 # CLI agent adapters
 
-One adapter per upstream coding-agent CLI (claude, codex, gemini, aider, goose, 40+ more):
+One adapter per upstream coding-agent CLI (claude, codex, gemini, aider, goose, opencode, 40+ more):
 a task prompt becomes a CLI invocation and results stream back. One module per tool.
 
 ## Key files
 
 | File | Purpose |
 |---|---|
-| `base.py` | Base adapter: spawn, timeout, and kill discipline; lineage write boundary |
-| `_contract.py` | Loads the per-adapter YAML capability contracts and asserts them |
-| `capability_profile.py` | Declarative adapter capability profiles and profile factory |
+| `base.py` | Base adapter: spawn, timeout, kill, lineage write boundary |
+| `_contract.py` | Loads per-adapter YAML capability contracts and asserts them |
+| `capability_profile.py` | Declarative adapter capability profiles and factory |
+| `admission.py` | Admission gate: validates spawn request against run-level and operator policies |
+| `env_isolation.py` | Per-task environment isolation: credential filtering, network policy, sandbox wiring |
 | `skills_injector.py` | Copies sanitized skill markdown into the worktree at dispatch |
+| `registry.py` | Central name → adapter class mapping |
+| `use_cases.py` | Human-readable adapter use-case catalogue for `bernstein init` |
+| `opencode.py` | OpenCode adapter; qualifies bare model IDs from the operator's jsonc config |
+| `scanner.py` | Base scanner: normalised `ScanResult`/`Finding` schema and scan receipt |
+| `scanner_registry.py` | Registry for scanner adapters (nmap, semgrep, grype, trivy, gitleaks, …) |
+| `nmap.py` | nmap network-scan adapter: XML normalisation, port-rule policy check |
+| `semgrep.py` | Semgrep SAST adapter: SARIF parse, ruleset digest |
+| `acp_channel.py` | Agent Communication Protocol channel bridging into the orchestrator event loop |
 | `canary.py` | Nightly conformance canary matrix over adapter contracts |
-| `goose_stream_parser.py` | Parses Goose `--output-format stream-json`; token accounting rides the terminal `envelope` event |
-| `http_429_classifier.py` | Classifies HTTP 429 errors into standing quotas vs. transient rate limits |
-| `onboarding.py` | Interactive probe and capability discovery for newly installed agent CLIs |
-| `mock.py` | Mock agent for zero-API-key demos; produces the same completion evidence real agents do (`Modified:` log lines plus a per-fix commit scoped to the mutated file) |
+| `onboarding.py` | Interactive probe and capability discovery for new agent CLIs |
+| `mock.py` | Zero-API-key demo agent; produces real completion evidence |
 
 ## Invariants
 
-- Every adapter has a YAML contract in `tests/contract/contracts/` naming
-  its required flags/subcommands. Capability assertions only, never snapshot
-  `--help` text (`_contract.py` docstring); drift is a hard fail (exit 2).
-- Artifact writes go through the lineage-spine boundary in `base.py`; do not
-  add adapter-local artifact write paths (`../core/lineage/spine.py`).
-- Keep adapter module import time free of replay-journal imports;
-  `base.py` duplicates capability constants for exactly this reason.
-- Default spawned-process timeout is 30 minutes (`DEFAULT_TIMEOUT_SECONDS` in
-  `base.py`); adapters get SIGTERM, then SIGKILL after a grace period.
+- Every adapter has a YAML contract in `tests/contract/contracts/`; drift is a hard fail (exit 2).
+- Artifact writes go through the lineage-spine boundary in `base.py`; no adapter-local write paths.
+- `admission.py` is the last gate before a process starts; never bypass it.
+- Scanner adapters produce byte-stable `ScanResult` so scans are content-addressable.
 
 ## Testing
 
-Per-adapter unit tests are mostly flat as `tests/unit/test_adapter_<name>.py`,
-with a few under `tests/unit/adapters/` beside the shared subsystem tests.
-Both layouts are current; follow whichever one an adapter already uses, and
-run one file at a time. Contract checks live under `tests/contract/`;
-live-binary conformance is opt-in via the `--live` pytest flag.
+Per-adapter unit tests: `tests/unit/test_adapter_<name>.py` or `tests/unit/adapters/`.
+Contract checks: `tests/contract/`. Live-binary conformance: opt-in via `--live`.
 
-<!-- Reviewed 2026-08-27 against this subtree; the notes above still hold. -->
+<!-- Reviewed 2026-09-11 against this subtree; the notes above still hold. -->

--- a/src/bernstein/cli/AGENTS.md
+++ b/src/bernstein/cli/AGENTS.md
@@ -14,6 +14,7 @@ group and registers every subcommand; implementations live in
 | `helpers.py` | Shared console and utility helpers |
 | `run_cmd.py` | `bernstein run` entry; bootstrap/confirm split into siblings |
 | `commands/identity_attest_cmd.py` | `bernstein identity attest` run attestation CLI commands |
+| `commands/identity_review_cmd.py` | `bernstein identity review` access review CLI commands |
 | `commands/insights_cmd.py` | `bernstein insights`: analytics read out of task traces |
 
 ## Invariants
@@ -35,4 +36,4 @@ Single files only, e.g.
 `uv run pytest tests/unit/test_agents_md_cmd.py -x -q`; most commands
 have a matching `test_<name>_cmd.py` under `tests/unit/`.
 
-<!-- Reviewed 2026-08-27 against this subtree; the notes above still hold. -->
+<!-- Reviewed 2026-09-07 against this subtree; the notes above still hold. -->

--- a/src/bernstein/core/lineage/AGENTS.md
+++ b/src/bernstein/core/lineage/AGENTS.md
@@ -15,6 +15,9 @@ Per-artifact provenance in two layers: Lineage v1 (Sigstore-style transparency l
 | `gate.py` | Lineage CI gate (ADR-009 §6.2) |
 | `run_graph.py` | Pairs each fan-out worktree branch with the spine that recorded it: `build_run_graph` returns one `RunGraphNode` per branch (`session_id`, `head_sha`, `run_id`, `spine_head_hash`) plus a deterministic root hash. Pure - it adds no storage and resolves `session_id -> run_id` from a caller-supplied mapping |
 | `merge_provenance.py` | Records one row per path a CLI agent's work lands through a merge (issue #2789). Reads `before..after` so a fast-forward records like a true merge, hashes the git blob rather than the working tree, and names the merge commit in `step_id` - so a third party recomputes every `content_hash` from the repository alone. Recording must never undo a landed merge: `spawner_merge` logs a failure and keeps the merge, and neither reading the base nor writing the rows may gate it |
+| `prov_export.py` | Projects the ancestry DAG into standard PROV-O representations (#5039) |
+| `sensitivity.py` | Propagates data sensitivity forward over the lineage closure (#5042) |
+| `plan_render.py` | Renders a run's execution plan from its journal (#4958) |
 
 ## Invariants
 
@@ -30,4 +33,4 @@ Per-artifact provenance in two layers: Lineage v1 (Sigstore-style transparency l
 
 Single files only, e.g. `uv run pytest tests/unit/test_lineage_record.py -x -q`; the `test_lineage_*.py` files cover entries, stores, signing, and gates. Merge recording is tested against real git repositories, not a stub - what it asserts is that a row's `content_hash` is the blob git stored (`tests/unit/lineage/test_merge_provenance.py`).
 
-<!-- Reviewed 2026-08-28 against this subtree; the notes above still hold. -->
+<!-- Reviewed 2026-09-07 against this subtree; the notes above still hold. -->

--- a/src/bernstein/core/orchestration/AGENTS.md
+++ b/src/bernstein/core/orchestration/AGENTS.md
@@ -16,25 +16,22 @@ repeat. Coordination is plain Python, never an LLM (ADR-006).
 | `worker.py` | `bernstein-worker` process wrapper for spawned CLI agents |
 | `run_closure_owner.py` | Universal authenticated run closure owner |
 | `issue_claim.py` | Claim etiquette for coordinator-free issue intake: recognises a run's own claim, detects a stale one |
+| `quiescence.py` | Zero-terminal run quiescence decision function |
 
-Heavy lifting lives in siblings: `../tasks/task_lifecycle.py` (claim, spawn, retry,
-completion) and `../agents/` (spawner, heartbeat, crash detection, reaping).
+Heavy lifting lives in siblings: `../tasks/task_lifecycle.py` (claim, spawn, retry, completion) and `../agents/` (spawner, heartbeat, crash detection, reaping).
 
 ## Invariants
 
 - No LLM in any coordination path (`docs/decisions/006-no-embedded-llm.md`).
 - The tick loop is single-threaded by design; do not add concurrent ticks without restoring a tick guard (`orchestrator.py`).
 - Replay is strict: a cache miss raises `ReplayMissError`, not a silent live call.
-- Prefer pure decision functions (`run_stall.py` is the model) so a
-  criterion is testable without a tick loop, server, or real clock.
-- Optional third-party imports degrade to a no-op instead of raising;
-  `trigger_manager.py` yields no events when `croniter` is absent.
-- Operator config is validated per item: a bad entry is logged and skipped, never fatal
-  (`croniter` can raise `TypeError` or `AttributeError`, not only `ValueError`).
+- Prefer pure decision functions (`run_stall.py`, `quiescence.py`) so a criterion is testable without a tick loop, server, or real clock.
+- Optional third-party imports degrade to a no-op instead of raising; `trigger_manager.py` yields no events when `croniter` is absent.
+- Operator config is validated per item: a bad entry is logged and skipped, never fatal (`croniter` can raise `TypeError` or `AttributeError`, not only `ValueError`).
 
 ## Testing
 
 Single files only: `uv run pytest tests/unit/test_orchestrator.py -x -q`.
 Never run the full suite (see `tests/AGENTS.md`).
 
-<!-- Reviewed 2026-08-27 against this subtree; the notes above still hold. -->
+<!-- Reviewed 2026-09-07 against this subtree; the notes above still hold. -->

--- a/src/bernstein/core/orchestration/AGENTS.md
+++ b/src/bernstein/core/orchestration/AGENTS.md
@@ -17,6 +17,7 @@ repeat. Coordination is plain Python, never an LLM (ADR-006).
 | `run_closure_owner.py` | Universal authenticated run closure owner |
 | `issue_claim.py` | Claim etiquette for coordinator-free issue intake: recognises a run's own claim, detects a stale one |
 | `quiescence.py` | Answers whether every process the run spawned had exited before it was sealed; produces a verified/unverified record rather than acting on stragglers (#5272) |
+| `controller_state.py` | Sidecar persisting adaptive-parallelism and claim-conflict backoff state to `.sdd/runtime/controllers.json`, restored on startup |
 
 Heavy lifting lives in siblings: `../tasks/task_lifecycle.py` (claim, spawn, retry, completion) and `../agents/` (spawner, heartbeat, crash detection, reaping).
 

--- a/src/bernstein/core/orchestration/AGENTS.md
+++ b/src/bernstein/core/orchestration/AGENTS.md
@@ -16,7 +16,7 @@ repeat. Coordination is plain Python, never an LLM (ADR-006).
 | `worker.py` | `bernstein-worker` process wrapper for spawned CLI agents |
 | `run_closure_owner.py` | Universal authenticated run closure owner |
 | `issue_claim.py` | Claim etiquette for coordinator-free issue intake: recognises a run's own claim, detects a stale one |
-| `quiescence.py` | Zero-terminal run quiescence decision function |
+| `quiescence.py` | Answers whether every process the run spawned had exited before it was sealed; produces a verified/unverified record rather than acting on stragglers (#5272) |
 
 Heavy lifting lives in siblings: `../tasks/task_lifecycle.py` (claim, spawn, retry, completion) and `../agents/` (spawner, heartbeat, crash detection, reaping).
 

--- a/src/bernstein/core/quality/AGENTS.md
+++ b/src/bernstein/core/quality/AGENTS.md
@@ -19,8 +19,7 @@ The verification layer between a worker's diff and merge or human review: a conf
 ## Invariants
 
 - Gate names are a closed set: a step name must be in `VALID_GATE_NAMES` or come from a registered gate plugin; anything else is rejected (`gate_runner.py`).
-- Defaults are deliberate: `lint`, `pii_scan`, `dlp_scan`, `run_config` on; `tests`,
-  `type_check`, heavier gates off (`quality_gates.py`). Never flip one as a side effect; `run_config` is a safety invariant (`../config/run_overlay.py`).
+- Defaults are deliberate: `lint`, `pii_scan`, `dlp_scan`, `run_config` on; `tests`, `type_check`, heavier gates off (`quality_gates.py`). Never flip one as a side effect; `run_config` is a safety invariant (`../config/run_overlay.py`).
 - Blocking vs advisory semantics are per-gate; a new gate declares which. No
   package-level `__getattr__` re-export magic here (`__init__.py` explains why).
 - `behavior_probe` claims crashes, not semantics: undocumented exception, return
@@ -37,4 +36,4 @@ The verification layer between a worker's diff and merge or human review: a conf
 
 Single files only, e.g. `uv run pytest tests/unit/test_quality_gates.py -x -q`; runner and pipeline behaviour lives in the `test_gate_*.py` files.
 
-<!-- Reviewed 2026-08-27 against this subtree; the notes above still hold. -->
+<!-- Reviewed 2026-09-07 against this subtree; the notes above still hold. -->

--- a/src/bernstein/core/quality/AGENTS.md
+++ b/src/bernstein/core/quality/AGENTS.md
@@ -6,7 +6,8 @@ The verification layer between a worker's diff and merge or human review: a conf
 
 | File | Purpose |
 |---|---|
-| `gate_pipeline.py` | `VALID_GATE_NAMES` registry, `GateStatus`, pipeline dataclasses |
+| `gate_pipeline.py` | `VALID_GATE_NAMES` registry, `GateStatus`, pipeline dataclasses; `VerificationScope` (line 166) declares a gate's confidence, evidence, and canonical bytes (#5395) |
+| `merge_receipt.py` | Produces the signed merge receipt that binds a gate-run's `VerificationScope` to the commit digest; `_canonical_bytes` convention is shared with `gate_pipeline.py` |
 | `gate_runner.py` | Gate dispatch and execution (subprocess discipline, timeouts) |
 | `quality_gates.py` | `QualityGatesConfig` plus the core gate implementations |
 | `janitor.py` | Claim verification: did the agent do what its result claims |

--- a/src/bernstein/core/security/AGENTS.md
+++ b/src/bernstein/core/security/AGENTS.md
@@ -16,25 +16,20 @@ The HMAC-chained audit log, Ed25519 install identity, and approval / policy enfo
 | `capability_delta.py` | Detects capability-widening changes across workflows and permission configs |
 | `surface_grant_delta.py` | Lineage gate grant analysis across diffs |
 | `key_derivation.py` | HKDF-SHA256 per-store key derivation with scheme versioning |
+| `key_custody.py` | KMS key custody adapters and key boundary management (#5033) |
 
 ## Invariants
 
 - The HMAC key lives OUTSIDE the audit log directory at mode `0600`; anything more readable is a hard error at load time (`audit.py`).
-- Stores never share a key: each derives its own from the master by HKDF-SHA256
-  under a domain tag that is also prefixed into the chain hash preimage, so one
-  store's record cannot be replayed against another (`key_derivation.py` v2).
+- Stores never share a key: each derives its own from the master by HKDF-SHA256 under a domain tag prefixed into the chain hash preimage (`key_derivation.py` v2).
 - Event-type constants are append-only: add `EVENT_*` names, never edit or reuse existing ones (`audit_chain.py`).
-- Chain helpers take the chain as a parameter (no singletons) and log through
-  `log_with_prev_digest`, so `prev_chain_digest` is in the payload before the HMAC.
+- Chain helpers take the chain as a parameter (no singletons) and log through `log_with_prev_digest`, so `prev_chain_digest` is in payload before the HMAC.
 - The audit chain is opt-in at runtime (`BERNSTEIN_AUDIT=1`, read in `../orchestration/orchestrator.py`); features degrade without it.
 - Untrusted paths are opened, never compared: a comparison validates one lookup while the open performs another (`sigstore_attestation.py`).
-- Same rule for tenant writes: the whole subtree is created and opened through
-  `TenantPaths.anchor` (`../persistence/anchored_write.py`), rotation included. It
-  needs `dir_fd` + `O_NOFOLLOW`; lacking either, the refusal narrows to the final
-  component or vanishes, never weakens (`ANCHORED_{WRITE,ROTATE}_SUPPORTED`).
+- Tenant writes: subtree is opened through `TenantPaths.anchor` (`../persistence/anchored_write.py`) with `dir_fd` + `O_NOFOLLOW`; lacking either, refusal never weakens (`ANCHORED_{WRITE,ROTATE}_SUPPORTED`).
 
 ## Testing
 
 Single files only: `uv run pytest tests/unit/test_audit.py -x -q`.
 
-<!-- Reviewed 2026-08-27 against this subtree; the notes above still hold. -->
+<!-- Reviewed 2026-09-07 against this subtree; the notes above still hold. -->

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -3,7 +3,7 @@
 Layered pytest suite. `unit/` is the big one (2700+ files, no network);
 `conformance/` holds offline auditor conformance vectors; `integration/`
 needs a running server; `contract/` holds adapter capability contracts;
-plus `property/`, `snapshot/`, `golden/`, `perf/`, `chaos/`, `pentest/`, and `benchmarks/`.
+plus `property/`, `snapshot/`, `golden/`, `perf/`, `chaos/`, `stress/`, `pentest/`, and `benchmarks/`.
 
 ## How to run
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -3,7 +3,7 @@
 Layered pytest suite. `unit/` is the big one (2700+ files, no network);
 `conformance/` holds offline auditor conformance vectors; `integration/`
 needs a running server; `contract/` holds adapter capability contracts;
-plus `property/`, `snapshot/`, `golden/`, `perf/`, `chaos/`, and `benchmarks/`.
+plus `property/`, `snapshot/`, `golden/`, `perf/`, `chaos/`, `pentest/`, and `benchmarks/`.
 
 ## How to run
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,9 +1,9 @@
 # Test suite
 
-Layered pytest suite. `unit/` is the big one (2400+ files, no network);
-`integration/` needs a running server; `contract/` holds the adapter
-capability contracts; plus `property/`, `snapshot/`, `golden/`,
-`perf/`, `chaos/`, `stress/`, `pentest/`, and `benchmarks/`.
+Layered pytest suite. `unit/` is the big one (2700+ files, no network);
+`conformance/` holds offline auditor conformance vectors; `integration/`
+needs a running server; `contract/` holds adapter capability contracts;
+plus `property/`, `snapshot/`, `golden/`, `perf/`, `chaos/`, and `benchmarks/`.
 
 ## How to run
 
@@ -37,4 +37,4 @@ uv run python scripts/run_tests.py tests/unit/test_foo.py[::test_name]  # one fi
 - Live adapter conformance tests are opt-in via the `--live` flag
   registered in `conftest.py`.
 
-<!-- Reviewed 2026-08-27 against this subtree; the notes above still hold. -->
+<!-- Reviewed 2026-09-07 against this subtree; the notes above still hold. -->


### PR DESCRIPTION
Part of #5617.

## Problem

The automated staleness check flagged six of the curated nested `AGENTS.md` context files because recent subtree additions and refactorings caused their churn counts to exceed the configured thresholds:
- `src/bernstein/cli/AGENTS.md` (new identity review command)
- `src/bernstein/core/lineage/AGENTS.md` (new `prov_export.py`, `sensitivity.py`, `plan_render.py` modules)
- `src/bernstein/core/orchestration/AGENTS.md` (new `quiescence.py`, `controller_state.py`)
- `src/bernstein/core/quality/AGENTS.md` (reconfirmed against recent gate verification scope changes)
- `src/bernstein/core/security/AGENTS.md` (new `key_custody.py` boundary)
- `tests/AGENTS.md` (suite growth, `conformance/` auditor suite)

## What this does

Refreshes each of the six curated `AGENTS.md` files against the current tree:
- Adds newly landed modules to key file tables and updates descriptions.
- Maintains the strict 40-line budget (`MAX_LINES = 40`) across all files.
- Resets the review marker dates to 2026-09-07.

## Verification

- `uv run pytest tests/unit/test_nested_agents_context.py tests/unit/test_context_staleness.py tests/unit/test_context_staleness_workflow_yaml.py -v`: 48/48 passed.