### PR TITLE
docs(adapters): sync capability_contract.md with STRATEGY_MATRIX (#5627)

### DIFF
--- a/docs/adapters/capability_contract.md
+++ b/docs/adapters/capability_contract.md
@@ -139,7 +139,7 @@ adapters at a glance.
 | `cody` | unsupported | unsupported | text-signals |
 | `composio` | unsupported | unsupported | hooks |
 | `continue` | unsupported | unsupported | text-signals |
-| `copilot` | unsupported | unsupported | text-signals |
+| `copilot` | unsupported | cli-flag | text-signals |
 | `cursor` | unsupported | cli-flag | stream-json |
 | `devin_terminal` | unsupported | unsupported | poll-pty |
 | `droid` | unsupported | unsupported | text-signals |
@@ -151,10 +151,10 @@ adapters at a glance.
 | `hermes` | unsupported | always-on | text-signals |
 | `iac` | unsupported | unsupported | text-signals |
 | `junie` | unsupported | unsupported | text-signals |
-| `kilo` | unsupported | unsupported | text-signals |
+| `kilo` | unsupported | unsupported | acp |
 | `kimi` | unsupported | cli-flag | text-signals |
 | `kiro` | unsupported | unsupported | text-signals |
-| `letta_code` | unsupported | cli-flag | text-signals |
+| `letta_code` | unsupported | cli-flag | stream-json |
 | `mistral` | unsupported | unsupported | text-signals |
 | `mock` | unsupported | unsupported | text-signals |
 | `muse` | unsupported | cli-flag | text-signals |

--- a/docs/release-notes/fragments/5627-capability-contract-drift.md
+++ b/docs/release-notes/fragments/5627-capability-contract-drift.md
@@ -1,0 +1,8 @@
+## Adapter capability contract table synced with STRATEGY_MATRIX
+
+The capability matrix table in `docs/adapters/capability_contract.md` drifted from
+authoritative declarations in `STRATEGY_MATRIX` for `copilot` (`dangerous_mode` is
+`cli-flag`), `kilo` (`event_channel` is `acp`), and `letta_code` (`event_channel`
+is `stream-json`). The rows have been aligned and protected by a regression test.
+
+(#5627)

--- a/tests/unit/test_capability_contract_doc.py
+++ b/tests/unit/test_capability_contract_doc.py
@@ -1,0 +1,51 @@
+"""Regression tests verifying docs/adapters/capability_contract.md matches STRATEGY_MATRIX."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from bernstein.adapters._contract import strategy_for
+
+DOC_PATH = Path(__file__).resolve().parents[2] / "docs" / "adapters" / "capability_contract.md"
+TABLE_ROW_RE = re.compile(
+    r"^\|\s*`(?P<adapter>[^`]+)`\s*\|\s*(?P<resume>[^|]+)\s*\|\s*(?P<dangerous>[^|]+)\s*\|\s*(?P<channel>[^|]+)\s*\|"
+)
+
+
+def _parse_doc_table() -> list[tuple[str, str, str, str]]:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    rows: list[tuple[str, str, str, str]] = []
+    for line in text.splitlines():
+        m = TABLE_ROW_RE.match(line.strip())
+        if m:
+            rows.append(
+                (
+                    m.group("adapter").strip(),
+                    m.group("resume").strip(),
+                    m.group("dangerous").strip(),
+                    m.group("channel").strip(),
+                )
+            )
+    return rows
+
+
+def test_capability_contract_doc_table_matches_strategy_matrix() -> None:
+    """Every row in docs/adapters/capability_contract.md must match STRATEGY_MATRIX."""
+    rows = _parse_doc_table()
+    assert rows, f"No table rows found in {DOC_PATH}"
+
+    mismatches: list[str] = []
+    for adapter, resume, dangerous, channel in rows:
+        strat = strategy_for(adapter).to_dict()
+        expected_resume = strat["resume"]
+        expected_dangerous = strat["dangerous_mode"]
+        expected_channel = strat["event_channel"]
+
+        if (resume, dangerous, channel) != (expected_resume, expected_dangerous, expected_channel):
+            mismatches.append(
+                f"{adapter}: doc=({resume}, {dangerous}, {channel}) != "
+                f"expected=({expected_resume}, {expected_dangerous}, {expected_channel})"
+            )
+
+    assert not mismatches, "Doc table drifts from STRATEGY_MATRIX:\n" + "\n".join(mismatches)


### PR DESCRIPTION
## Problem

`docs/adapters/capability_contract.md`'s adapter capability table drifted from the authoritative declarations in `STRATEGY_MATRIX` (`src/bernstein/adapters/_contract.py`) for three rows:

- `copilot`: dangerous mode is `cli-flag` (`--allow-all-tools` / `--no-ask-user`), not `unsupported`.
- `kilo`: event channel is `acp` (native ACP support over JSON-RPC frames), not `text-signals`.
- `letta_code`: event channel is `stream-json`, not `text-signals`.

## Solution

1. Aligned the three rows in `docs/adapters/capability_contract.md` to match `STRATEGY_MATRIX`.
2. Added `tests/unit/test_capability_contract_doc.py` to parse the doc table and assert every row strictly matches `strategy_for(adapter).to_dict()`, preventing future drift.
3. Added release notes fragment `docs/release-notes/fragments/5627-capability-contract-drift.md`.

Closes #5627. Refs #5597.
