### PR TITLE
chore(deps): update docs/requirements.txt transitive pins (#5623)

### DIFF
--- a/docs/release-notes/fragments/5623-docs-requirements-pins.md
+++ b/docs/release-notes/fragments/5623-docs-requirements-pins.md
@@ -1,0 +1,7 @@
+## Fresh resolve for docs/requirements.txt transitive pins
+
+Transitive pins in `docs/requirements.txt` compiled from `docs/requirements.in` have
+been refreshed to match the latest resolve: `cairosvg` updated from 2.9.0 to 2.9.1
+and `platformdirs` updated from 4.11.5 to 4.11.7, with all sha256 hashes recomputed.
+
+(#5623)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -20,9 +20,9 @@ cairocffi==1.7.1 \
     --hash=sha256:2e48ee864884ec4a3a34bfa8c9ab9999f688286eb714a15a43ec9d068c36557b \
     --hash=sha256:9803a0e11f6c962f3b0ae2ec8ba6ae45e957a146a004697a1ac1bbf16b073b3f
     # via cairosvg
-cairosvg==2.9.0 \
-    --hash=sha256:1debb00cd2da11350d8b6f5ceb739f1b539196d71d5cf5eb7363dbd1bfbc8dc5 \
-    --hash=sha256:4b82d07d145377dffdfc19d9791bd5fb65539bb4da0adecf0bdbd9cd4ffd7c68
+cairosvg==2.9.1 \
+    --hash=sha256:861bc28ad97ce4f537d50eb3d6ee97a7afcccec9c61ac25c4e7d073fe409aec7 \
+    --hash=sha256:f91c5628e834be024a0ed4544d76261cd84016a4c73bcdf26c386495825c05a1
     # via mkdocs-material
 certifi==2026.7.22 \
     --hash=sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775 \
@@ -311,7 +311,9 @@ click==8.5.0 \
 colorama==0.4.6 \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
-    # via mkdocs-material
+    # via
+    #   mkdocs
+    #   mkdocs-material
 csscompressor==0.9.5 \
     --hash=sha256:afa22badbcf3120a4f392e4d22f9fff485c044a1feda4a950ecc5eba9dd31a05
     # via mkdocs-minify-plugin
@@ -580,9 +582,9 @@ pillow==12.3.0 \
     # via
     #   cairosvg
     #   mkdocs-material
-platformdirs==4.11.5 \
-    --hash=sha256:89f8d42695853b89c7170bd49bc3dc593f98a71e695ede88e06a3b247bc4563b \
-    --hash=sha256:e8b31f4f8bcbbedef91a6b57a706255e4f148d2a4e01648382a0a47342539173
+platformdirs==4.11.7 \
+    --hash=sha256:4f41487eeeeeb07f3a6625e61d9bc0ae6809f92d3386dbd74392fbb76108104d \
+    --hash=sha256:8a02cb259042c79d1cd0450facc2fe6dc9d303ae7901afbe33bf8ea0b188cef6
     # via mkdocs-get-deps
 pycparser==3.0 \
     --hash=sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29 \


### PR DESCRIPTION
## Problem

As reported in #5623, 2 transitive pins in `docs/requirements.txt` compiled from `docs/requirements.in` lagged behind fresh resolves on PyPI:
- `cairosvg`: 2.9.0 -> 2.9.1
- `platformdirs`: 4.11.5 -> 4.11.7

## Solution

1. Recompiled `docs/requirements.txt` from `docs/requirements.in` via `pip-compile --generate-hashes --strip-extras` updating `cairosvg` to 2.9.1 and `platformdirs` to 4.11.7 with updated hashes.
2. Verified all direct requirements stay within declared bounds via `scripts/check_docs_requirements_pins.py`.
3. Added release notes fragment `docs/release-notes/fragments/5623-docs-requirements-pins.md`.

Closes #5623.
