### PR TITLE
feat(bench): result bundles carry harness fingerprint and drift gate (#5568)

### DIFF
--- a/docs/eval/bench.md
+++ b/docs/eval/bench.md
@@ -195,6 +195,16 @@ Two runners on the same `suite_hash` provably ran the same task set.
       "harness_output": {"...": "..."}
     }
   ],
+  "harness_fingerprint": "<sha256 of canonical harness settings>",
+  "harness_settings": {
+    "decomposition": null,
+    "effort": "high",
+    "prompt_templates": {},
+    "retry_policy": {},
+    "sandbox": "none",
+    "timeouts": {},
+    "tool_allowlist": []
+  },
   "signature": "<Ed25519 JWS>",
   "signer_fingerprint": "..."
 }
@@ -203,6 +213,20 @@ Two runners on the same `suite_hash` provably ran the same task set.
 The `receipt` is the replay substrate.  The `score` only means something
 because the receipt exists to replay it.  Removing or corrupting the receipt
 makes the entire bundle fail verification.
+
+### Harness fingerprint and drift prevention
+
+To prevent attributing harness or prompt variations to model capability shifts, bundles compute a `harness_fingerprint` (SHA-256) over canonical run settings:
+- `decomposition`: task decomposition configuration
+- `effort`: reasoning / thinking effort tier
+- `prompt_templates`: mapping of prompt template names to content hashes
+- `retry_policy`: retry parameters and bounds
+- `sandbox`: execution sandbox isolation profile
+- `timeouts`: per-task and per-step timeouts
+- `tool_allowlist`: permitted tools (sorted)
+
+`bernstein bench compare <bundle_a> <bundle_b>` compares two bundles and refuses to rank them if their harness fingerprints differ, reporting the differing keys, unless `--allow-harness-drift` is passed.
+
 
 ---
 

--- a/docs/release-notes/fragments/5568-bench-harness-fingerprint.md
+++ b/docs/release-notes/fragments/5568-bench-harness-fingerprint.md
@@ -1,0 +1,10 @@
+## Bench result bundles carry harness fingerprint and drift gate
+
+Submission bundles now compute and persist a deterministic `harness_fingerprint`
+over canonical run-shaping settings (`decomposition`, `effort`, `prompt_templates`,
+`retry_policy`, `sandbox`, `timeouts`, `tool_allowlist`). The new `bernstein bench
+compare` command refuses to rank bundles produced with differing harness configurations
+unless `--allow-harness-drift` is passed, and leaderboards group submissions by
+harness fingerprint prefix.
+
+(#5568)

--- a/src/bernstein/eval/bench/bench_cli.py
+++ b/src/bernstein/eval/bench/bench_cli.py
@@ -193,6 +193,39 @@ def bench_verify(bundle: str, suite: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# bernstein bench compare
+# ---------------------------------------------------------------------------
+
+
+@bench_group.command(name="compare")
+@click.argument("bundle_a", type=click.Path(exists=True, dir_okay=False))
+@click.argument("bundle_b", type=click.Path(exists=True, dir_okay=False))
+@click.option(
+    "--allow-harness-drift",
+    is_flag=True,
+    default=False,
+    help="Allow ranking bundles from different harness configurations.",
+)
+def bench_compare(bundle_a: str, bundle_b: str, allow_harness_drift: bool) -> None:
+    """Compare two submission bundles.
+
+    Refuses to rank if harness fingerprints differ unless --allow-harness-drift is passed.
+    """
+    from bernstein.eval.bench.bundle import SubmissionBundle
+    from bernstein.eval.bench.compare import HarnessDriftError, compare_bundles
+
+    b_a = SubmissionBundle.load(Path(bundle_a))
+    b_b = SubmissionBundle.load(Path(bundle_b))
+
+    try:
+        res = compare_bundles(b_a, b_b, allow_harness_drift=allow_harness_drift)
+    except HarnessDriftError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    click.echo(res.report())
+
+
+# ---------------------------------------------------------------------------
 # Reliability: pass^k floor (issue #2933)
 # ---------------------------------------------------------------------------
 

--- a/src/bernstein/eval/bench/bundle.py
+++ b/src/bernstein/eval/bench/bundle.py
@@ -108,9 +108,17 @@ class SubmissionBundle:
     # Install identity fingerprint (public-key fingerprint of the signer).
     signer_fingerprint: str = ""
     holdout_hash: str = ""
+    harness_settings: dict[str, Any] = field(default_factory=dict)
+    harness_fingerprint: str = ""
 
     # Computed lazily.
     _bundle_hash: str | None = field(default=None, init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if self.harness_settings and not self.harness_fingerprint:
+            from bernstein.eval.bench.fingerprint import compute_harness_fingerprint
+
+            self.harness_fingerprint = compute_harness_fingerprint(self.harness_settings)
 
     # ------------------------------------------------------------------
     # Derived metrics
@@ -147,6 +155,10 @@ class SubmissionBundle:
         }
         if self.holdout_hash:
             payload_dict["holdout_hash"] = self.holdout_hash
+        if self.harness_fingerprint:
+            payload_dict["harness_fingerprint"] = self.harness_fingerprint
+        if self.harness_settings:
+            payload_dict["harness_settings"] = self.harness_settings
         payload = json.dumps(
             payload_dict,
             sort_keys=True,
@@ -173,6 +185,10 @@ class SubmissionBundle:
         }
         if self.holdout_hash:
             d["holdout_hash"] = self.holdout_hash
+        if self.harness_fingerprint:
+            d["harness_fingerprint"] = self.harness_fingerprint
+        if self.harness_settings:
+            d["harness_settings"] = self.harness_settings
         return d
 
     def save(self, path: Path) -> None:
@@ -217,6 +233,8 @@ class SubmissionBundle:
             signature=raw.get("signature", ""),
             signer_fingerprint=raw.get("signer_fingerprint", ""),
             holdout_hash=raw.get("holdout_hash", ""),
+            harness_settings=raw.get("harness_settings", {}),
+            harness_fingerprint=raw.get("harness_fingerprint", ""),
         )
         # Integrity guard: recompute hash and compare.
         if bundle.bundle_hash() != raw["bundle_hash"]:

--- a/src/bernstein/eval/bench/compare.py
+++ b/src/bernstein/eval/bench/compare.py
@@ -1,0 +1,71 @@
+"""Bundle comparison with harness-fingerprint drift enforcement."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from bernstein.eval.bench.fingerprint import find_differing_settings
+
+if TYPE_CHECKING:
+    from bernstein.eval.bench.bundle import SubmissionBundle
+
+
+class HarnessDriftError(ValueError):
+    """Raised when comparing bundles with differing harness fingerprints."""
+
+
+@dataclass(frozen=True)
+class CompareResult:
+    score_delta: float
+    pass_rate_delta: float
+    fingerprint_match: bool
+    differing_keys: list[str]
+    allowed_drift: bool = False
+
+    def report(self) -> str:
+        lines: list[str] = []
+        if not self.fingerprint_match:
+            lines.append("Harness drift detected:")
+            for k in self.differing_keys:
+                lines.append(f"  - {k} differs between bundles")
+            if not self.allowed_drift:
+                lines.append(
+                    "Refusing to rank bundles with differing harnesses (pass --allow-harness-drift to override)."
+                )
+                return "\n".join(lines)
+            lines.append("Ranking permitted via --allow-harness-drift.")
+        lines.append(f"Score delta     : {self.score_delta:+.4f}")
+        lines.append(f"Pass rate delta : {self.pass_rate_delta:+.2%}")
+        return "\n".join(lines)
+
+
+def compare_bundles(
+    bundle_a: SubmissionBundle,
+    bundle_b: SubmissionBundle,
+    *,
+    allow_harness_drift: bool = False,
+) -> CompareResult:
+    """Compare two submission bundles, refusing to rank if harness fingerprints differ."""
+    fp_a = bundle_a.harness_fingerprint
+    fp_b = bundle_b.harness_fingerprint
+    match = fp_a == fp_b
+
+    differing = find_differing_settings(bundle_a.harness_settings, bundle_b.harness_settings)
+    if not match and not allow_harness_drift:
+        raise HarnessDriftError(
+            f"Cannot compare bundles with different harness fingerprints ({fp_a[:8]} vs {fp_b[:8]}). "
+            f"Differing settings: {', '.join(differing) if differing else 'fingerprint mismatch'}. "
+            "Use --allow-harness-drift to compare anyway."
+        )
+
+    score_delta = bundle_b.overall_score - bundle_a.overall_score
+    pass_rate_delta = bundle_b.pass_rate - bundle_a.pass_rate
+
+    return CompareResult(
+        score_delta=score_delta,
+        pass_rate_delta=pass_rate_delta,
+        fingerprint_match=match,
+        differing_keys=differing,
+        allowed_drift=allow_harness_drift,
+    )

--- a/src/bernstein/eval/bench/fingerprint.py
+++ b/src/bernstein/eval/bench/fingerprint.py
@@ -1,0 +1,90 @@
+"""Harness fingerprint computation for bench submission bundles.
+
+The harness fingerprint is a deterministic SHA-256 over a canonical JSON
+representation of the run-shaping settings. Two bundles with differing
+fingerprints represent different harness configurations (prompts, tools,
+budgets, sandboxes) and must not be compared directly as if the underlying
+model changed.
+
+Canonical keys included in the fingerprint:
+- ``decomposition``: Dict configuring task decomposition depth and fanout.
+- ``effort``: Thinking/effort tier or budget.
+- ``prompt_templates``: Mapping of template name to template content hash.
+- ``retry_policy``: Dict of retry thresholds and backoff strategies.
+- ``sandbox``: Sandbox isolation type or profile.
+- ``timeouts``: Dict of per-task and per-step timeout limits.
+- ``tool_allowlist``: Sorted list of permitted tools.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+CANONICAL_KEYS = (
+    "decomposition",
+    "effort",
+    "prompt_templates",
+    "retry_policy",
+    "sandbox",
+    "timeouts",
+    "tool_allowlist",
+)
+
+
+def compute_harness_fingerprint(settings: dict[str, Any] | None) -> str:
+    """Compute a SHA-256 fingerprint over canonical harness settings.
+
+    Keys included:
+      - ``decomposition``: decomposition configuration or None
+      - ``effort``: reasoning / thinking effort setting
+      - ``prompt_templates``: mapping of prompt template names to content hashes
+      - ``retry_policy``: retry parameters
+      - ``sandbox``: execution sandbox profile
+      - ``timeouts``: task / step timeout bounds
+      - ``tool_allowlist``: allowed tool names (sorted)
+
+    Settings outside CANONICAL_KEYS or ephemeral values (timestamps, paths)
+    are ignored.
+    """
+    raw = settings or {}
+    canonical: dict[str, Any] = {}
+    for key in CANONICAL_KEYS:
+        val = raw.get(key)
+        if key == "tool_allowlist" and isinstance(val, (list, set, tuple)):
+            canonical[key] = sorted(str(t) for t in val)
+        elif key == "prompt_templates" and isinstance(val, dict):
+            canonical[key] = {k: str(v) for k, v in sorted(val.items())}
+        else:
+            canonical[key] = val
+
+    payload = json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def find_differing_settings(
+    settings_a: dict[str, Any] | None,
+    settings_b: dict[str, Any] | None,
+) -> list[str]:
+    """Return the list of canonical keys that differ between two settings dicts."""
+    raw_a = settings_a or {}
+    raw_b = settings_b or {}
+    differing: list[str] = []
+    for key in CANONICAL_KEYS:
+        val_a = raw_a.get(key)
+        val_b = raw_b.get(key)
+        if key == "tool_allowlist":
+            norm_a = sorted(str(t) for t in val_a) if isinstance(val_a, (list, set, tuple)) else val_a
+            norm_b = sorted(str(t) for t in val_b) if isinstance(val_b, (list, set, tuple)) else val_b
+            if norm_a != norm_b:
+                differing.append(key)
+        elif key == "prompt_templates":
+            norm_a = {k: str(v) for k, v in sorted(val_a.items())} if isinstance(val_a, dict) else val_a
+            norm_b = {k: str(v) for k, v in sorted(val_b.items())} if isinstance(val_b, dict) else val_b
+            if norm_a != norm_b:
+                differing.append(key)
+        else:
+            if val_a != val_b:
+                differing.append(key)
+    return differing

--- a/src/bernstein/eval/bench/leaderboard.py
+++ b/src/bernstein/eval/bench/leaderboard.py
@@ -38,6 +38,7 @@ class LeaderboardEntry:
     signer_fingerprint: str = ""
     # Path to the bundle file (relative to the leaderboard root).
     bundle_path: str = ""
+    harness_fingerprint: str = ""
 
     def submitted_at_iso(self) -> str:
         import datetime
@@ -56,6 +57,7 @@ class LeaderboardEntry:
             "submitted_at_iso": self.submitted_at_iso(),
             "signer_fingerprint": self.signer_fingerprint,
             "bundle_path": self.bundle_path,
+            "harness_fingerprint": self.harness_fingerprint,
         }
 
 
@@ -116,6 +118,7 @@ class Leaderboard:
                 submitted_at=e["submitted_at"],
                 signer_fingerprint=e.get("signer_fingerprint", ""),
                 bundle_path=e.get("bundle_path", ""),
+                harness_fingerprint=e.get("harness_fingerprint", ""),
             )
             for e in raw.get("entries", [])
         ]
@@ -124,6 +127,13 @@ class Leaderboard:
             suite_version=raw["suite_version"],
             entries=entries,
         )
+
+    def groups_by_fingerprint(self) -> dict[str, list[LeaderboardEntry]]:
+        """Group leaderboard entries by their harness fingerprint, preserving ranking order."""
+        groups: dict[str, list[LeaderboardEntry]] = {}
+        for entry in self.entries:
+            groups.setdefault(entry.harness_fingerprint, []).append(entry)
+        return groups
 
     def check_rotation_due(self, threshold: float = 0.9, consecutive_required: int = 3) -> RotationStatus:
         """Check if rotation is due based on saturation of baseline submissions."""
@@ -163,8 +173,8 @@ class Leaderboard:
             f"Suite version: **{self.suite_version}**  ",
             f"Suite hash: `{self.suite_hash}`",
             "",
-            "| Rank | Score | Pass rate | Tasks | Submitted | Bundle hash |",
-            "|------|------:|----------:|------:|-----------|-------------|",
+            "| Rank | Score | Pass rate | Tasks | Harness | Submitted | Bundle hash |",
+            "|------|------:|----------:|------:|:-------:|-----------|-------------|",
         ]
 
         for rank, entry in enumerate(self.entries, start=1):
@@ -172,11 +182,13 @@ class Leaderboard:
             pass_pct = f"{entry.pass_rate * 100:.1f}%"
             short_hash = entry.bundle_hash[:16]
             bundle_link = f"[`{short_hash}…`]({entry.bundle_path})" if entry.bundle_path else f"`{short_hash}…`"
+            fp_prefix = f"`{entry.harness_fingerprint[:8]}`" if entry.harness_fingerprint else "-"
             lines.append(
                 f"| {rank} "
                 f"| {score_pct} "
                 f"| {pass_pct} "
                 f"| {entry.num_tasks} "
+                f"| {fp_prefix} "
                 f"| {entry.submitted_at_iso()} "
                 f"| {bundle_link} |"
             )

--- a/tests/unit/eval/bench/test_harness_fingerprint.py
+++ b/tests/unit/eval/bench/test_harness_fingerprint.py
@@ -1,0 +1,146 @@
+"""Tests for harness fingerprinting, bundle comparison drift enforcement, and leaderboard grouping.
+
+Refs: #5568.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.eval.bench.bundle import SubmissionBundle, TaskResult
+from bernstein.eval.bench.compare import HarnessDriftError, compare_bundles
+from bernstein.eval.bench.fingerprint import compute_harness_fingerprint
+from bernstein.eval.bench.leaderboard import Leaderboard, LeaderboardEntry
+
+
+def _sample_task_result(task_id: str = "task-1", passed: bool = True, score: float = 1.0) -> TaskResult:
+    return TaskResult(
+        task_id=task_id,
+        task_hash="abc123hash",
+        receipt={"journal_head": "jh1", "spine_head": "sh1"},
+        passed=passed,
+        score=score,
+    )
+
+
+def _sample_bundle(
+    harness_settings: dict | None = None,
+    overall_score: float = 1.0,
+    suite_hash: str = "suite-hash-1",
+) -> SubmissionBundle:
+    results = [_sample_task_result(passed=(overall_score > 0.5), score=overall_score)]
+    return SubmissionBundle(
+        suite_hash=suite_hash,
+        suite_version="golden-v1",
+        task_results=results,
+        scheduler_config={"scheduler": "default"},
+        harness_settings=harness_settings or {},
+    )
+
+
+def test_fingerprint_changes_when_a_prompt_template_changes() -> None:
+    settings_v1 = {
+        "effort": "high",
+        "prompt_templates": {"system": "hash_version_1", "role": "hash_role_1"},
+        "tool_allowlist": ["bash", "file_edit"],
+    }
+    settings_v2 = {
+        "effort": "high",
+        "prompt_templates": {"system": "hash_version_2", "role": "hash_role_1"},
+        "tool_allowlist": ["bash", "file_edit"],
+    }
+    fp1 = compute_harness_fingerprint(settings_v1)
+    fp2 = compute_harness_fingerprint(settings_v2)
+    assert fp1 != fp2, "Harness fingerprint must change when a prompt template changes"
+
+
+def test_fingerprint_is_stable_across_identical_runs() -> None:
+    settings = {
+        "effort": "high",
+        "prompt_templates": {"system": "hash_version_1", "role": "hash_role_1"},
+        "tool_allowlist": ["file_edit", "bash"],  # ordering difference in allowlist
+        "decomposition": {"depth": 2},
+    }
+    settings_reordered = {
+        "decomposition": {"depth": 2},
+        "tool_allowlist": ["bash", "file_edit"],
+        "prompt_templates": {"role": "hash_role_1", "system": "hash_version_1"},
+        "effort": "high",
+    }
+    fp1 = compute_harness_fingerprint(settings)
+    fp2 = compute_harness_fingerprint(settings_reordered)
+    assert fp1 == fp2, "Harness fingerprint must be deterministic and stable across identical runs"
+
+
+def test_compare_refuses_different_fingerprints_without_the_flag() -> None:
+    bundle_a = _sample_bundle(
+        harness_settings={"effort": "low", "sandbox": "none"},
+        overall_score=0.8,
+    )
+    bundle_b = _sample_bundle(
+        harness_settings={"effort": "high", "sandbox": "docker"},
+        overall_score=0.9,
+    )
+
+    assert bundle_a.harness_fingerprint != bundle_b.harness_fingerprint
+
+    # Without flag: raises HarnessDriftError
+    with pytest.raises(HarnessDriftError) as exc_info:
+        compare_bundles(bundle_a, bundle_b, allow_harness_drift=False)
+    assert "Cannot compare bundles with different harness fingerprints" in str(exc_info.value)
+    assert "effort" in str(exc_info.value)
+    assert "sandbox" in str(exc_info.value)
+
+    # With flag: permits ranking and reports deltas
+    res = compare_bundles(bundle_a, bundle_b, allow_harness_drift=True)
+    assert res.allowed_drift is True
+    assert res.score_delta == pytest.approx(0.1)
+
+
+def test_leaderboard_groups_rows_by_fingerprint() -> None:
+    fp_a = "aaaaaaaa" * 8
+    fp_b = "bbbbbbbb" * 8
+
+    entry_1 = LeaderboardEntry(
+        bundle_hash="hash-1",
+        suite_hash="suite-1",
+        suite_version="v1",
+        overall_score=0.95,
+        pass_rate=0.95,
+        num_tasks=10,
+        submitted_at=100.0,
+        harness_fingerprint=fp_a,
+    )
+    entry_2 = LeaderboardEntry(
+        bundle_hash="hash-2",
+        suite_hash="suite-1",
+        suite_version="v1",
+        overall_score=0.90,
+        pass_rate=0.90,
+        num_tasks=10,
+        submitted_at=110.0,
+        harness_fingerprint=fp_b,
+    )
+    entry_3 = LeaderboardEntry(
+        bundle_hash="hash-3",
+        suite_hash="suite-1",
+        suite_version="v1",
+        overall_score=0.85,
+        pass_rate=0.85,
+        num_tasks=10,
+        submitted_at=120.0,
+        harness_fingerprint=fp_a,
+    )
+
+    board = Leaderboard(suite_hash="suite-1", suite_version="v1")
+    board.add_entry(entry_1)
+    board.add_entry(entry_2)
+    board.add_entry(entry_3)
+
+    groups = board.groups_by_fingerprint()
+    assert fp_a in groups
+    assert fp_b in groups
+    assert len(groups[fp_a]) == 2
+    assert len(groups[fp_b]) == 1
+    assert groups[fp_a][0].bundle_hash == "hash-1"
+    assert groups[fp_a][1].bundle_hash == "hash-3"


### PR DESCRIPTION
## Problem

When benchmarking models, runs with different decomposition depths, prompt templates, tool allowlists, thinking effort, or sandbox configurations produce different scores. Without a recorded harness fingerprint, submission bundles cannot tell them apart and a leaderboard row risks attributing harness changes to model changes.

## Solution

1. Added `compute_harness_fingerprint` in `src/bernstein/eval/bench/fingerprint.py`: computes a canonical SHA-256 over run-shaping settings (`decomposition`, `effort`, `prompt_templates`, `retry_policy`, `sandbox`, `timeouts`, `tool_allowlist`).
2. Updated `SubmissionBundle` (`bundle.py`) to store `harness_settings` and `harness_fingerprint` in both bundle hash calculation and serialization.
3. Added `bernstein bench compare <bundle_a> <bundle_b>` (`compare.py` & `bench_cli.py`), which compares bundles, prints differing settings, and refuses to rank bundles from different harnesses unless `--allow-harness-drift` is passed.
4. Updated `Leaderboard` (`leaderboard.py`) to group entries by harness fingerprint and display the fingerprint prefix in table projections.
5. Documented the key list and compare behavior in `docs/eval/bench.md`.
6. Added full test coverage in `tests/unit/eval/bench/test_harness_fingerprint.py`.

Closes #5568.
