### PR TITLE
feat(security): sign run-receipt binding bytes as RFC 8785 (jcs-v2)

### DIFF
--- a/docs/release-notes/fragments/5274-run-receipt-hash-profile.md
+++ b/docs/release-notes/fragments/5274-run-receipt-hash-profile.md
@@ -1,0 +1,11 @@
+## Run receipt binding bytes can be signed as RFC 8785 (JCS)
+
+`build_run_receipt` accepts `hash_profile="jcs-v2"` to sign the subject
+binding as RFC 8785 canonical JSON instead of the legacy `py-json-v1`
+(`json.dumps(..., ensure_ascii=True)`) bytes, so a run whose journal or spine
+carries non-ASCII text (a task title, a model name) hashes the same way here
+as it already does in the TRACE projection and audit-chain digests. The
+default stays `py-json-v1`; existing receipts and callers are unaffected.
+`verify_run_receipt` reads the profile from the receipt (absent means
+`py-json-v1`) and fails closed on an unrecognised value. Slice 1 of #5274;
+the journal and lineage-spine hashes are unchanged pending later slices.

--- a/docs/security/receipt-format-spec.md
+++ b/docs/security/receipt-format-spec.md
@@ -188,6 +188,26 @@ a canonical subject dictionary:
 - Under schema `1.1.0`, embedding an audit range binds `audit_range_since`,
   `audit_range_until`, `audit_range_event_count`, and `audit_range_head_hmac`
   alongside `audit_range_head_sha256` to prevent post-signing window relabelling.
+
+#### Canonicalization profile
+
+The binding block above is turned into bytes by one of two profiles, named by
+a top-level `hash_profile` field on the receipt and echoed into the binding
+block itself:
+
+- `py-json-v1` (default): `json.dumps(obj, sort_keys=True, separators=(",",
+  ":"))`, the profile every run receipt used before this field existed.
+  `ensure_ascii` defaults to `True`, so a non-ASCII property value is escaped
+  as `\uXXXX`.
+- `jcs-v2`: RFC 8785 (JCS) via the same `canonicalize_jcs` the TRACE
+  projection and audit-chain digests already use. Non-ASCII text is emitted
+  as raw UTF-8, and numbers follow the ECMAScript `Number::toString` rule.
+
+A receipt carrying no `hash_profile` field is `py-json-v1` - the field is
+added only when a receipt is signed under `jcs-v2`, so a `py-json-v1` receipt
+is byte-identical to one built before this field existed. A verifier that
+reads an unrecognised `hash_profile` value fails closed (`status:
+"malformed"`) rather than guessing a profile to recompute under.
 - Under legacy schema `1.0.0`, only `audit_range_head_sha256` is bound. Legacy
   receipts verify with a warning (`"audit window unbound in schema 1.0.0"`).
 

--- a/src/bernstein/core/replay/run_receipt.py
+++ b/src/bernstein/core/replay/run_receipt.py
@@ -231,6 +231,24 @@ def _canonical_json_bytes(obj: dict[str, Any]) -> bytes:
     return _cjb(obj)
 
 
+#: Legacy binding-bytes profile (the only one before this field existed).
+HASH_PROFILE_LEGACY: str = "py-json-v1"
+
+#: RFC 8785 (JCS) binding-bytes profile.
+HASH_PROFILE_JCS_V2: str = "jcs-v2"
+
+
+def _canonical_bytes_for_profile(obj: dict[str, Any], hash_profile: str) -> bytes:
+    """Binding bytes for *obj* under *hash_profile* - the audit-receipt dispatch, reused.
+
+    Raises:
+        ValueError: *hash_profile* is neither known profile.
+    """
+    from bernstein.core.security.audit_receipt import _canonical_bytes_for_profile as _cbfp
+
+    return _cbfp(obj, hash_profile)
+
+
 def _binding_block(
     *,
     run_id: str,
@@ -246,6 +264,7 @@ def _binding_block(
     audit_event_count: int | None = None,
     audit_head_hmac: str | None = None,
     schema_version: str = RUN_RECEIPT_SCHEMA_VERSION,
+    hash_profile: str = HASH_PROFILE_LEGACY,
 ) -> dict[str, Any]:
     """The subject binding: one canonical block over every recomputed head.
 
@@ -279,6 +298,12 @@ def _binding_block(
     resolved set rather than asserting a digest nothing re-derives; a run
     that recorded no such event binds no field and older receipts keep
     verifying unchanged.
+
+    ``hash_profile`` selects the canonicalization :func:`_canonical_bytes_for_profile`
+    (or the verifier's matching rebuild) uses to turn this block into bytes.
+    It is bound into the block itself only when it is not the legacy default,
+    so a receipt built under :data:`HASH_PROFILE_LEGACY` produces byte-identical
+    bytes to a caller that never knew this parameter existed.
     """
     block: dict[str, Any] = {
         "journal_event_count": journal_count,
@@ -287,6 +312,8 @@ def _binding_block(
         "spine_entry_count": spine_count,
         "spine_head": spine_head,
     }
+    if hash_profile != HASH_PROFILE_LEGACY:
+        block["hash_profile"] = hash_profile
     if endpoint_identities is not None and len(endpoint_identities) > 0:
         block["endpoints"] = endpoint_identities
     if extension_set_digest is not None:
@@ -558,6 +585,7 @@ def build_run_receipt(
     audit_until: str | None = None,
     write: bool = True,
     output_path: Path | None = None,
+    hash_profile: str = HASH_PROFILE_LEGACY,
 ) -> RunReceipt:
     """Build (and by default write) the signed receipt for one run.
 
@@ -581,6 +609,12 @@ def build_run_receipt(
         write: When ``False``, build in-memory only.
         output_path: Override the on-disk destination (defaults to
             ``.sdd/runs/<run_id>/run-receipt.json``).
+        hash_profile: Canonicalization for the signed binding bytes.
+            :data:`HASH_PROFILE_LEGACY` (default) reproduces every byte this
+            function has always produced. :data:`HASH_PROFILE_JCS_V2` signs
+            RFC 8785 bytes instead, so a non-ASCII payload hashes the same
+            here as it already does in the TRACE projection and audit-chain
+            digests.
 
     Returns:
         A :class:`RunReceipt`.
@@ -590,10 +624,13 @@ def build_run_receipt(
             row is malformed (never sign over a parseable subset - the
             build refuses on the first bad line rather than signing the
             surviving rows as a shorter run), an embedded chain does not
-            recompute (never sign a broken chain), or the opt-in audit
-            range was requested without its inputs.
+            recompute (never sign a broken chain), the opt-in audit range
+            was requested without its inputs, or ``hash_profile`` names
+            neither known profile.
         JournalPathError: ``run_id`` is not a safe path segment.
     """
+    if hash_profile not in (HASH_PROFILE_LEGACY, HASH_PROFILE_JCS_V2):
+        raise RunReceiptError(f"unknown hash_profile {hash_profile!r}")
     journal_path = run_journal_path(sdd_dir, run_id)
     events = _load_journal_rows_strict(journal_path, run_id)
     if not events:
@@ -654,8 +691,9 @@ def build_run_receipt(
         audit_event_count=audit_block["event_count"] if audit_block is not None else None,
         audit_head_hmac=audit_block["head_hmac"] if audit_block is not None else None,
         schema_version=RUN_RECEIPT_SCHEMA_VERSION,
+        hash_profile=hash_profile,
     )
-    binding_bytes = _canonical_json_bytes(binding)
+    binding_bytes = _canonical_bytes_for_profile(binding, hash_profile)
     subject_sha256 = hashlib.sha256(binding_bytes).hexdigest()
     signature = kms_adapter.sign(_signature_preimage(binding_bytes))
     jwk = kms_adapter.public_key_jwk()
@@ -689,6 +727,8 @@ def build_run_receipt(
     }
     if audit_block is not None:
         receipt["audit_range"] = audit_block
+    if hash_profile != HASH_PROFILE_LEGACY:
+        receipt["hash_profile"] = hash_profile
     receipt_bytes = _canonical_json_bytes(receipt) + b"\n"
 
     receipt_path: Path | None = None
@@ -814,6 +854,13 @@ def verify_run_receipt(
         return _malformed(f"unsupported schema_version {raw_schema_version!r}", run_id=run_id)
     schema_version = str(raw_schema_version)
 
+    raw_hash_profile = receipt.get("hash_profile", HASH_PROFILE_LEGACY)
+    if raw_hash_profile not in (HASH_PROFILE_LEGACY, HASH_PROFILE_JCS_V2):
+        return _malformed(
+            f"unsupported hash_profile {raw_hash_profile!r}", run_id=run_id, binding_version=schema_version
+        )
+    hash_profile = str(raw_hash_profile)
+
     journal_block = receipt.get("journal")
     spine_block = receipt.get("spine")
     signing = receipt.get("signing")
@@ -933,8 +980,9 @@ def verify_run_receipt(
         audit_event_count=audit_event_count,
         audit_head_hmac=audit_head_hmac,
         schema_version=schema_version,
+        hash_profile=hash_profile,
     )
-    binding_bytes = _canonical_json_bytes(binding)
+    binding_bytes = _canonical_bytes_for_profile(binding, hash_profile)
     recomputed_subject = hashlib.sha256(binding_bytes).hexdigest()
     stated_subject = str(((receipt.get("subject") or {}).get("digest") or {}).get("sha256", ""))
     if stated_subject != recomputed_subject:
@@ -1106,6 +1154,8 @@ def write_run_receipt_if_configured(run_id: str, sdd_dir: Path) -> Path | None:
 
 
 __all__ = [
+    "HASH_PROFILE_JCS_V2",
+    "HASH_PROFILE_LEGACY",
     "RUN_RECEIPT_FILENAME",
     "RUN_RECEIPT_PAYLOAD_TYPE",
     "RUN_RECEIPT_SCHEMA_VERSION",

--- a/src/bernstein/core/security/audit_receipt.py
+++ b/src/bernstein/core/security/audit_receipt.py
@@ -170,6 +170,38 @@ def _canonical_json_bytes(obj: dict[str, Any]) -> bytes:
     return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
 
+#: Legacy profile: :func:`_canonical_json_bytes`, unchanged (``ensure_ascii``
+#: default True, no numeric normalisation).
+HASH_PROFILE_LEGACY: str = "py-json-v1"
+
+#: RFC 8785 (JCS) profile via
+#: :func:`bernstein.core.security.agent_card_signer.canonicalize_jcs`, already
+#: used by the TRACE projection and audit-chain digests.
+HASH_PROFILE_JCS_V2: str = "jcs-v2"
+
+
+def _canonical_bytes_for_profile(obj: dict[str, Any], hash_profile: str) -> bytes:
+    """Return canonical bytes for *obj* under a named hash profile.
+
+    A record with no ``hash_profile`` field is :data:`HASH_PROFILE_LEGACY` by
+    convention; callers resolve that default before calling this function.
+    Does not change :func:`_canonical_json_bytes` itself, so every receipt
+    that already relies on its bytes keeps them.
+
+    Raises:
+        ValueError: *hash_profile* is neither known profile. Callers on an
+            untrusted read path (a receipt someone else produced) must catch
+            this and fail closed rather than let it propagate.
+    """
+    if hash_profile == HASH_PROFILE_JCS_V2:
+        from bernstein.core.security.agent_card_signer import canonicalize_jcs
+
+        return canonicalize_jcs(obj)
+    if hash_profile == HASH_PROFILE_LEGACY:
+        return _canonical_json_bytes(obj)
+    raise ValueError(f"unknown hash_profile {hash_profile!r}")
+
+
 def _canonical_event_bytes(event: dict[str, Any]) -> bytes:
     """Return the canonical single-event bytes used as a Merkle leaf.
 

--- a/tests/unit/test_run_receipt.py
+++ b/tests/unit/test_run_receipt.py
@@ -561,6 +561,157 @@ def test_receipt_without_audit_range_binding_bytes_unchanged(tmp_path: Path) -> 
     assert _canonical_json_bytes(block_100) == _canonical_json_bytes(block_110)
 
 
+# ---------------------------------------------------------------------------
+# Hash profile (RFC 8785 / jcs-v2, issue #5274 slice 1)
+# ---------------------------------------------------------------------------
+
+
+def _seed_run_with_unicode_endpoint(sdd_dir: Path, run_id: str = _RUN_ID) -> None:
+    """Like ``_seed_run``, plus one ``agent_spawned`` event with a non-ASCII model name."""
+    journal = EventJournal(run_id=run_id, sdd_dir=sdd_dir)
+    journal.record("run_started", run_id=run_id)
+    journal.record(
+        "agent_spawned",
+        endpoint_adapter_name="mockcli",
+        endpoint_model="задача \U0001f680",
+        endpoint_base_url="",
+        endpoint_profile_name="",
+    )
+    journal.record("run_completed", run_id=run_id, ticks=1)
+    spine = LineageSpine(sdd_dir / "lineage", run_id=run_id, hmac_key=_HMAC_KEY)
+    spine.record(
+        artifact_path="src/app.py",
+        content=b"print('hi')\n",
+        actor="backend",
+        step_id="T-1",
+        model="m1",
+        timestamp=1111,
+    )
+
+
+def test_receipt_binding_bytes_are_jcs_under_v2() -> None:
+    """Under hash_profile=jcs-v2 the binding bytes are RFC 8785, not json.dumps.
+
+    A non-ASCII property value is where the two profiles diverge: legacy
+    json.dumps escapes it to \\uXXXX (ensure_ascii defaults True), RFC 8785
+    keeps it as raw UTF-8. Pins that divergence rather than asserting the
+    dispatcher merely delegated somewhere.
+    """
+    from bernstein.core.replay.run_receipt import _binding_block, _canonical_bytes_for_profile
+    from bernstein.core.security.agent_card_signer import canonicalize_jcs
+
+    block = _binding_block(
+        run_id="run-1",
+        journal_head="h1",
+        journal_count=1,
+        spine_head="s1",
+        spine_count=1,
+        audit_head_sha256=None,
+        endpoint_identities=[{"adapter": "a", "model": "задача \U0001f680", "base_url": "", "profile": ""}],
+        hash_profile="jcs-v2",
+    )
+    jcs_bytes = _canonical_bytes_for_profile(block, "jcs-v2")
+    legacy_bytes = _canonical_bytes_for_profile(block, "py-json-v1")
+
+    assert jcs_bytes == canonicalize_jcs(block)
+    assert "задача \U0001f680".encode() in jcs_bytes
+    assert "задача \U0001f680".encode() not in legacy_bytes
+    assert b"\\u0437" in legacy_bytes  # Cyrillic 'з' (U+0437), still \u-escaped under the legacy profile
+
+
+def test_canonical_bytes_for_profile_rejects_unknown_profile() -> None:
+    """The dispatcher itself refuses a third profile name rather than silently defaulting."""
+    from bernstein.core.replay.run_receipt import _canonical_bytes_for_profile
+
+    with pytest.raises(ValueError, match="unknown hash_profile"):
+        _canonical_bytes_for_profile({"a": 1}, "py-json-v2")
+
+
+def test_default_hash_profile_binding_bytes_unchanged(tmp_path: Path) -> None:
+    """Not passing hash_profile produces byte-identical output to before this field existed."""
+    sdd = tmp_path / ".sdd"
+    _seed_run(sdd)
+    default_build = build_run_receipt(_RUN_ID, sdd, _kms(tmp_path), write=False)
+    explicit_legacy = build_run_receipt(_RUN_ID, sdd, _kms(tmp_path), write=False, hash_profile="py-json-v1")
+    assert default_build.receipt_bytes == explicit_legacy.receipt_bytes
+    assert "hash_profile" not in default_build.receipt
+    assert default_build.receipt["subject"] == explicit_legacy.receipt["subject"]
+
+
+def test_hash_profile_jcs_v2_round_trips_through_build_and_verify(tmp_path: Path) -> None:
+    """A jcs-v2 receipt carrying non-ASCII endpoint data builds and verifies offline."""
+    sdd = tmp_path / ".sdd"
+    _seed_run_with_unicode_endpoint(sdd)
+    receipt = build_run_receipt(_RUN_ID, sdd, _kms(tmp_path), write=False, hash_profile="jcs-v2")
+    assert receipt.receipt["hash_profile"] == "jcs-v2"
+    models = [row.get("endpoint_model") for row in receipt.receipt["journal"]["events"]]
+    assert "задача \U0001f680" in models
+
+    result = verify_run_receipt(receipt.receipt_bytes)
+    assert result.ok, result.errors
+    assert result.status == "ok"
+
+
+def test_hash_profile_jcs_v2_fails_under_legacy_recompute() -> None:
+    """Sanity check the round trip is testing something: legacy recompute must reject it.
+
+    Rebuilds the same binding under py-json-v1 and confirms the digest it
+    produces differs from the one the jcs-v2 build actually signed, i.e. the
+    profile genuinely changes the signed bytes rather than being decorative.
+    """
+    from bernstein.core.replay.run_receipt import _binding_block, _canonical_bytes_for_profile
+
+    identities = [{"adapter": "a", "model": "задача \U0001f680", "base_url": "", "profile": ""}]
+    block = _binding_block(
+        run_id="run-1",
+        journal_head="h1",
+        journal_count=1,
+        spine_head="s1",
+        spine_count=1,
+        audit_head_sha256=None,
+        endpoint_identities=identities,
+        hash_profile="jcs-v2",
+    )
+    signed_bytes = _canonical_bytes_for_profile(block, "jcs-v2")
+    legacy_recompute = _canonical_bytes_for_profile(block, "py-json-v1")
+    assert hashlib.sha256(signed_bytes).hexdigest() != hashlib.sha256(legacy_recompute).hexdigest()
+
+
+def test_unknown_hash_profile_fails_closed_at_verify(tmp_path: Path) -> None:
+    """A receipt claiming a hash_profile this verifier does not know is malformed, not skipped."""
+    sdd = tmp_path / ".sdd"
+    _seed_run(sdd)
+    receipt = build_run_receipt(_RUN_ID, sdd, _kms(tmp_path), write=False)
+    doc = dict(receipt.receipt)
+    doc["hash_profile"] = "py-json-v2"
+
+    result = verify_run_receipt(_reserialize(doc))
+    assert result.ok is False
+    assert result.status == "malformed"
+    assert "hash_profile" in "; ".join(result.errors)
+
+
+def test_tampered_hash_profile_field_fails_verification(tmp_path: Path) -> None:
+    """Relabelling a signed jcs-v2 receipt back to py-json-v1 post-signing collapses verification."""
+    sdd = tmp_path / ".sdd"
+    _seed_run_with_unicode_endpoint(sdd)
+    receipt = build_run_receipt(_RUN_ID, sdd, _kms(tmp_path), write=False, hash_profile="jcs-v2")
+    doc = dict(receipt.receipt)
+    doc["hash_profile"] = "py-json-v1"
+
+    result = verify_run_receipt(_reserialize(doc))
+    assert result.ok is False
+    assert result.status == "tampered"
+
+
+def test_build_run_receipt_rejects_unknown_hash_profile(tmp_path: Path) -> None:
+    """The writer validates hash_profile up front rather than signing under a typo'd name."""
+    sdd = tmp_path / ".sdd"
+    _seed_run(sdd)
+    with pytest.raises(RunReceiptError, match="unknown hash_profile"):
+        build_run_receipt(_RUN_ID, sdd, _kms(tmp_path), write=False, hash_profile="jcs-v3")
+
+
 def test_audit_range_requires_build_inputs(tmp_path: Path) -> None:
     """include_audit_range without key/window is refused, never half-built."""
     sdd = tmp_path / ".sdd"


### PR DESCRIPTION
Slice 1 only, as the issue scopes it.

`_binding_block`'s bytes go through `json.dumps(ensure_ascii=True, ...)`, so a non-ASCII endpoint model or run id gets \u-escaped while the TRACE projection and audit-chain digests already sign the same kind of value through JCS. `build_run_receipt` now takes `hash_profile="jcs-v2"` to route the binding bytes through the existing `canonicalize_jcs` instead. Default stays `py-json-v1`, and the field is only added to the block and the envelope when it isn't the default, so nothing that doesn't pass the new kwarg changes output. `verify_run_receipt` reads it back the same way (absent means `py-json-v1`) and fails closed on an unrecognised value instead of silently defaulting.

Two things I did differently from the brief:

- Didn't bump `schema_version` past 1.1.0. It already landed with the audit-range PR, and `hash_profile` is additive on top of it, so there's no wire-format break to version.
- Step 4 points at `_build_audit_receipt_vectors.py`, which mints the COSE/DSSE/transparency envelope, a different receipt type from the one this issue is about. Left it alone and added the vectors as ordinary unit tests against the run-receipt binding instead (Cyrillic plus an astral emoji through an `agent_spawned` endpoint). `valid-run-receipt.json`/`tampered-run-receipt.json` still verify unchanged.

Added tests for the round trip, the fail-closed case, and that a default build still produces the exact bytes it did before this field existed. `uv run pytest tests/unit/test_run_receipt.py tests/unit/test_run_receipt_format_vectors.py` passes, and ruff, lint-imports, and the mypy gated zone are clean. Left the journal and spine hashing alone, and didn't change `audit_receipt._canonical_json_bytes`'s own behavior, per the issue's "do not" list.

Refs #5274
