### PR TITLE
chore(ci): ratchet coverage baseline up to 84.7%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,8 +1,8 @@
 {
   "diff_coverage_floor_percent": 89,
-  "head_sha": "c18e88dc660e6a05ee1cb37f53bf4cb3f7f0fe53",
-  "line_rate": 0.8459,
-  "run_id": "33988006865",
-  "total_coverage_percent": 84.59,
-  "updated_at": "2026-09-05T20:28:41+00:00"
+  "head_sha": "406ba3a78dbcc58972bea28c6a04876fac34bfe9",
+  "line_rate": 0.847,
+  "run_id": "34415941851",
+  "total_coverage_percent": 84.7,
+  "updated_at": "2026-09-10T00:20:50+00:00"
 }


### PR DESCRIPTION
Total line coverage rose on `main`, so the monotonic ratchet
bumped the committed high-water mark in `.coverage-baseline.json`
to **84.7%**.

Measured on `406ba3a78dbcc58972bea28c6a04876fac34bfe9` from the
`coverage-report` artifact of CI run
[34415941851](https://github.com/sipyourdrink-ltd/bernstein/actions/runs/34415941851).
Those, and the raw Cobertura `line-rate` the percentage was
rounded from, are recorded in the baseline, so the number in the
diff can be re-derived from the file itself:

```bash
uv run python scripts/coverage_ratchet.py verify \
    --baseline .coverage-baseline.json --require-provenance
```

From here, any later push whose total coverage falls below this
mark is flagged by the LEVEL 2 ratchet. The gate stays advisory
until promoted; see `docs/operations/coverage-ratchet.md`.

Generated by `.github/workflows/coverage-ratchet.yml`.