### PR TITLE
fix(tests): run onboarding fixtures with Python

### DIFF
--- a/tests/unit/adapters/test_adapter_onboard_draft.py
+++ b/tests/unit/adapters/test_adapter_onboard_draft.py
@@ -26,11 +26,24 @@ from pathlib import Path
 
 import pytest
 
+from bernstein.adapters import onboarding
+
 FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "probe"
 
 
 def _read_evidence(path: Path) -> dict[str, object]:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _run_python_fixture(monkeypatch: pytest.MonkeyPatch, fixture: Path) -> None:
+    """Execute one Python fixture without changing the logical probe command."""
+    run_capture = onboarding._run_capture
+
+    def run_fixture(cmd: list[str], *, timeout: int, env: dict[str, str] | None = None) -> tuple[int, str]:
+        assert cmd[0] == str(fixture)
+        return run_capture([sys.executable, *cmd], timeout=timeout, env=env)
+
+    monkeypatch.setattr(onboarding, "_run_capture", run_fixture)
 
 
 def _load_fixture_help_text(fixture_name: str) -> str:
@@ -167,17 +180,18 @@ def test_draft_argv_reconstructable_from_evidence_backed_fields(tmp_path: Path) 
 RECORDABLE_FIXTURE = FIXTURES / "probe_recordable.py"
 
 
-def test_draft_from_probe_wires_a_real_probe_into_drafting(tmp_path: Path) -> None:
+def test_draft_from_probe_wires_a_real_probe_into_drafting(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """draft_from_probe() runs a real probe subprocess and drafts from its --help capture.
 
-    Uses the already-executable ``probe_recordable.py`` fixture directly (no
-    fixture-file rewrite): a real subprocess is spawned, real evidence files
-    land on disk under ``evidence_dir``, and the draft built from them is
-    identical in shape to one built from a hand-written evidence file.
+    Uses ``probe_recordable.py`` through the current Python interpreter: a real
+    subprocess is spawned, real evidence files land on disk under
+    ``evidence_dir``, and the draft built from them is identical in shape to one
+    built from a hand-written evidence file.
     """
     from bernstein.adapters.onboarding import draft_from_probe
 
     evidence_dir = tmp_path / "evidence"
+    _run_python_fixture(monkeypatch, RECORDABLE_FIXTURE)
     draft = draft_from_probe(str(RECORDABLE_FIXTURE), evidence_dir)
 
     assert draft.invocation.binary == str(RECORDABLE_FIXTURE)
@@ -191,17 +205,21 @@ def test_draft_from_probe_wires_a_real_probe_into_drafting(tmp_path: Path) -> No
     assert len(evidence_files) >= 2, f"expected real probe evidence on disk, found {evidence_files}"
 
 
-def test_draft_from_probe_refuses_naming_the_missing_field_from_a_real_probe(tmp_path: Path) -> None:
+def test_draft_from_probe_refuses_naming_the_missing_field_from_a_real_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """draft_from_probe() forwards required_fields and refuses on a real probe with no --model.
 
-    ``probe_ok.py`` is a real, directly-executable fixture whose --help text
-    carries no model flag; asking drafting to require one must refuse and
-    name it, not silently return a profile with model_flag=None.
+    ``probe_ok.py`` is a real Python fixture whose --help text carries no model
+    flag; asking drafting to require one must refuse and name it, not silently
+    return a profile with model_flag=None.
     """
     from bernstein.adapters.onboarding import draft_from_probe
 
-    binary = str(FIXTURES / "probe_ok.py")
+    fixture = FIXTURES / "probe_ok.py"
+    binary = str(fixture)
     evidence_dir = tmp_path / "evidence"
+    _run_python_fixture(monkeypatch, fixture)
 
     with pytest.raises(Exception) as exc_info:
         draft_from_probe(binary, evidence_dir, required_fields={"model_flag"})

--- a/tests/unit/adapters/test_adapter_onboard_probe.py
+++ b/tests/unit/adapters/test_adapter_onboard_probe.py
@@ -8,8 +8,12 @@ three must produce a content-addressed evidence file and never raise.
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
+import pytest
+
+from bernstein.adapters import onboarding
 from bernstein.adapters.onboarding import probe_cli
 
 FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "probe"
@@ -19,9 +23,22 @@ def _read_evidence(path: Path) -> dict[str, object]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def test_deterministic_hash(tmp_path: Path) -> None:
+def _run_python_fixture(monkeypatch: pytest.MonkeyPatch, fixture: Path) -> None:
+    """Execute one Python fixture without changing the logical probe command."""
+    run_capture = onboarding._run_capture
+
+    def run_fixture(cmd: list[str], *, timeout: int, env: dict[str, str] | None = None) -> tuple[int, str]:
+        assert cmd[0] == str(fixture)
+        return run_capture([sys.executable, *cmd], timeout=timeout, env=env)
+
+    monkeypatch.setattr(onboarding, "_run_capture", run_fixture)
+
+
+def test_deterministic_hash(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Probing the same fixture twice yields identical content hashes."""
-    binary = str(FIXTURES / "probe_ok.py")
+    fixture = FIXTURES / "probe_ok.py"
+    binary = str(fixture)
+    _run_python_fixture(monkeypatch, fixture)
 
     first = probe_cli(binary, tmp_path / "a")
     second = probe_cli(binary, tmp_path / "b")
@@ -31,13 +48,17 @@ def test_deterministic_hash(tmp_path: Path) -> None:
     version_ev = first[0]
     assert version_ev.path.is_file()
     doc = _read_evidence(version_ev.path)
+    assert doc["binary"] == binary
+    assert doc["command"] == f"{binary} --version"
     assert doc["exit_code"] == 0
     assert "probe-fixture 1.2.3" in doc["output"]
 
 
-def test_failed_probe_evidence(tmp_path: Path) -> None:
+def test_failed_probe_evidence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A non-zero ``--version`` exit is recorded, not raised."""
-    binary = str(FIXTURES / "probe_fail_version.py")
+    fixture = FIXTURES / "probe_fail_version.py"
+    binary = str(fixture)
+    _run_python_fixture(monkeypatch, fixture)
 
     evidence = probe_cli(binary, tmp_path)
 

--- a/tests/unit/adapters/test_adapter_onboard_record.py
+++ b/tests/unit/adapters/test_adapter_onboard_record.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -36,7 +37,8 @@ def _profile(*, extra_args: tuple[str, ...] = ()) -> AdapterCapabilityProfile:
         name="recordable-fixture",
         display_name="Recordable Fixture",
         invocation=InvocationSpec(
-            binary=str(FIXTURE),
+            binary=sys.executable,
+            subcommands=(str(FIXTURE),),
             model_flag="--model",
             prompt_flag="--prompt",
             prompt_positional=False,
@@ -45,11 +47,11 @@ def _profile(*, extra_args: tuple[str, ...] = ()) -> AdapterCapabilityProfile:
     )
 
 
-def _write_evidence(path: Path, *, binary: str = str(FIXTURE)) -> Path:
+def _write_evidence(path: Path, *, binary: str = sys.executable) -> Path:
     """Write a synthetic probe record without running the probing step."""
     document = {
         "binary": binary,
-        "command": f"{binary} --help",
+        "command": f"{binary} {FIXTURE} --help",
         "exit_code": 0,
         "output": "--model <name> --prompt <text>",
     }

--- a/tests/unit/cli/test_adapters_draft_cmd.py
+++ b/tests/unit/cli/test_adapters_draft_cmd.py
@@ -9,11 +9,13 @@ written only when the operator accepts.
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
 
+from bernstein.adapters import onboarding
 from bernstein.adapters.draft import Draft, read_draft_document
 from bernstein.cli.commands.adapters_draft_cmd import _execute_draft
 from bernstein.cli.main import cli
@@ -23,15 +25,29 @@ RECORDABLE_FIXTURE = FIXTURES / "probe_recordable.py"
 NO_MODEL_FIXTURE = FIXTURES / "probe_ok.py"
 
 
+def _run_python_fixture(monkeypatch: pytest.MonkeyPatch, fixture: Path) -> None:
+    """Execute one Python fixture without changing the logical probe command."""
+    run_capture = onboarding._run_capture
+
+    def run_fixture(cmd: list[str], *, timeout: int, env: dict[str, str] | None = None) -> tuple[int, str]:
+        assert cmd[0] == str(fixture)
+        return run_capture([sys.executable, *cmd], timeout=timeout, env=env)
+
+    monkeypatch.setattr(onboarding, "_run_capture", run_fixture)
+
+
 # ---------------------------------------------------------------------------
 # _execute_draft: the full pipeline (real probe subprocess, real file),
 # confirmation injected so no test depends on a TTY.
 # ---------------------------------------------------------------------------
 
 
-def test_execute_draft_confirmed_persists_a_real_file_showing_the_exact_argv(tmp_path: Path) -> None:
+def test_execute_draft_confirmed_persists_a_real_file_showing_the_exact_argv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A confirmed draft persists YAML to out_dir, and the operator saw the real argv first."""
     seen_previews: list[str] = []
+    _run_python_fixture(monkeypatch, RECORDABLE_FIXTURE)
 
     def confirm(preview: str) -> bool:
         seen_previews.append(preview)
@@ -62,9 +78,10 @@ def test_execute_draft_confirmed_persists_a_real_file_showing_the_exact_argv(tmp
     assert document["invocation"]["model_flag"] == "--model"
 
 
-def test_execute_draft_declined_leaves_out_dir_untouched(tmp_path: Path) -> None:
+def test_execute_draft_declined_leaves_out_dir_untouched(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Declining the confirmation writes nothing - out_dir is never even created."""
     out_dir = tmp_path / "drafts"
+    _run_python_fixture(monkeypatch, RECORDABLE_FIXTURE)
 
     rc, target = _execute_draft(
         str(RECORDABLE_FIXTURE),
@@ -82,8 +99,11 @@ def test_execute_draft_declined_leaves_out_dir_untouched(tmp_path: Path) -> None
     assert not out_dir.exists(), "a declined draft must not create out_dir"
 
 
-def test_execute_draft_yes_flag_never_calls_the_confirmation_gate(tmp_path: Path) -> None:
+def test_execute_draft_yes_flag_never_calls_the_confirmation_gate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """--yes bypasses confirmation entirely, not merely auto-answers it."""
+    _run_python_fixture(monkeypatch, RECORDABLE_FIXTURE)
 
     def confirm(_preview: str) -> bool:
         raise AssertionError("confirm() must not be called when assume_yes=True")
@@ -104,10 +124,11 @@ def test_execute_draft_yes_flag_never_calls_the_confirmation_gate(tmp_path: Path
 
 
 def test_execute_draft_refuses_missing_required_field_without_ever_confirming(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A --require'd field missing from a real probe refuses before confirmation, writes nothing."""
     out_dir = tmp_path / "drafts"
+    _run_python_fixture(monkeypatch, NO_MODEL_FIXTURE)
 
     def confirm(_preview: str) -> bool:
         raise AssertionError("confirm() must not be called when drafting itself refused")
@@ -134,10 +155,13 @@ def test_execute_draft_refuses_missing_required_field_without_ever_confirming(
 # ---------------------------------------------------------------------------
 
 
-def test_adapters_draft_cli_confirmed_via_stdin_writes_the_draft(tmp_path: Path) -> None:
+def test_adapters_draft_cli_confirmed_via_stdin_writes_the_draft(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """The registered CLI command, invoked the way an operator would, persists on 'y'."""
     out_dir = tmp_path / "drafts"
     runner = CliRunner()
+    _run_python_fixture(monkeypatch, RECORDABLE_FIXTURE)
 
     result = runner.invoke(
         cli,
@@ -159,10 +183,11 @@ def test_adapters_draft_cli_confirmed_via_stdin_writes_the_draft(tmp_path: Path)
     assert len(written) == 1, written
 
 
-def test_adapters_draft_cli_declined_via_stdin_writes_nothing(tmp_path: Path) -> None:
+def test_adapters_draft_cli_declined_via_stdin_writes_nothing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """The registered CLI command exits 1 and writes nothing when the operator answers 'n'."""
     out_dir = tmp_path / "drafts"
     runner = CliRunner()
+    _run_python_fixture(monkeypatch, RECORDABLE_FIXTURE)
 
     result = runner.invoke(
         cli,


### PR DESCRIPTION
## What

Run onboarding Python probe fixtures through the active interpreter so the documented isolated test suite does not rely on shebang execution.

## Why

Windows does not execute `.py` fixtures from shebangs when they are passed as bare subprocess binaries.

Fixes #5647

## How

- Model the transcript-recording fixture as `sys.executable` plus the fixture path subcommand, and align its synthetic evidence with that invocation.
- Wrap real Python fixture subprocesses in the onboarding probe, onboarding draft, and CLI draft tests with `sys.executable`, while preserving the fixture path as the logical binary/evidence value and leaving missing-binary coverage untouched.

All four affected test files pass along with Ruff formatting/lint and import architecture checks. The full isolated suite passes the modified CLI draft file before stopping at the previously identified unrelated narrow-TTY startup-banner failure.

## Checklist

- [x] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` passes
- [ ] `uv run python scripts/run_tests.py -x` passes
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (N/A: internal-only test portability fix)
- [x] `docs/operations/<area>.md` updated (N/A: no operator workflow change)
- [x] `docs/api/` schema regenerated if a public surface changed (N/A: no public surface changed)
- [x] `uv run bernstein agents-md sync` run so AGENTS.md, CLAUDE.md, `.goosehints`, `CONVENTIONS.md`, and `.cursor/rules/*.mdc` reflect any new module (N/A: no new module)
- [x] Tests cover the documented behaviour