### PR TITLE
fix(docs): correct capability_contract.md rows for copilot, kilo, letta_code

### DIFF
--- a/docs/adapters/capability_contract.md
+++ b/docs/adapters/capability_contract.md
@@ -139,7 +139,7 @@ adapters at a glance.
 | `cody` | unsupported | unsupported | text-signals |
 | `composio` | unsupported | unsupported | hooks |
 | `continue` | unsupported | unsupported | text-signals |
-| `copilot` | unsupported | unsupported | text-signals |
+| `copilot` | unsupported | cli-flag | text-signals |
 | `cursor` | unsupported | cli-flag | stream-json |
 | `devin_terminal` | unsupported | unsupported | poll-pty |
 | `droid` | unsupported | unsupported | text-signals |
@@ -151,10 +151,10 @@ adapters at a glance.
 | `hermes` | unsupported | always-on | text-signals |
 | `iac` | unsupported | unsupported | text-signals |
 | `junie` | unsupported | unsupported | text-signals |
-| `kilo` | unsupported | unsupported | text-signals |
+| `kilo` | unsupported | unsupported | acp |
 | `kimi` | unsupported | cli-flag | text-signals |
 | `kiro` | unsupported | unsupported | text-signals |
-| `letta_code` | unsupported | cli-flag | text-signals |
+| `letta_code` | unsupported | cli-flag | stream-json |
 | `mistral` | unsupported | unsupported | text-signals |
 | `mock` | unsupported | unsupported | text-signals |
 | `muse` | unsupported | cli-flag | text-signals |

--- a/tests/unit/test_capability_contract_doc_drift.py
+++ b/tests/unit/test_capability_contract_doc_drift.py
@@ -1,0 +1,53 @@
+"""``docs/adapters/capability_contract.md`` must match ``STRATEGY_MATRIX`` (#5627).
+
+``STRATEGY_MATRIX`` in ``src/bernstein/adapters/_contract.py`` is the
+authoritative declaration; the doc table is a rendering of it for
+operators. Three rows (``copilot``, ``kilo``, ``letta_code``) drifted from
+the matrix silently -- nothing compared the two files, so a row could be
+wrong for as long as nobody happened to read both at once. This test reads
+the real matrix and the rendered markdown table and fails on any row where
+they disagree, so the next drift surfaces in CI instead of in a future
+issue like this one.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from bernstein.adapters._contract import strategy_table
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DOC = _REPO_ROOT / "docs" / "adapters" / "capability_contract.md"
+
+#: One row of the big adapter table: `` | `name` | resume | dangerous | channel | ``.
+_ROW_RE = re.compile(r"^\|\s*`([a-z0-9_]+)`\s*\|\s*([a-z-]+)\s*\|\s*([a-z-]+)\s*\|\s*([a-z-]+)\s*\|", re.MULTILINE)
+
+
+def _doc_rows() -> dict[str, tuple[str, str, str]]:
+    text = _DOC.read_text(encoding="utf-8")
+    return {name: (resume, dangerous, channel) for name, resume, dangerous, channel in _ROW_RE.findall(text)}
+
+
+def test_every_documented_adapter_row_matches_the_strategy_matrix() -> None:
+    doc_rows = _doc_rows()
+    matrix_rows = {row["adapter"]: row for row in strategy_table()}
+
+    # Every adapter this test can check must actually be documented -- a
+    # name present in the matrix but silently absent from the table is its
+    # own kind of drift, distinct from a wrong row.
+    documented_adapters = set(doc_rows) & set(matrix_rows)
+    assert documented_adapters, "the table regex matched nothing -- did the table's layout change?"
+
+    mismatches: list[str] = []
+    for name in sorted(documented_adapters):
+        doc_resume, doc_dangerous, doc_channel = doc_rows[name]
+        matrix_row = matrix_rows[name]
+        actual = (matrix_row["resume"], matrix_row["dangerous_mode"], matrix_row["event_channel"])
+        documented = (doc_resume, doc_dangerous, doc_channel)
+        if documented != actual:
+            mismatches.append(
+                f"`{name}`: docs say {documented!r}, STRATEGY_MATRIX says {actual!r}",
+            )
+
+    assert not mismatches, "capability_contract.md disagrees with STRATEGY_MATRIX:\n" + "\n".join(mismatches)


### PR DESCRIPTION
## Summary

`docs/adapters/capability_contract.md`'s own header states that `STRATEGY_MATRIX` in `src/bernstein/adapters/_contract.py` is authoritative and the doc table is a rendering of it. Three rows had drifted, each against a matrix entry that carries an explicit, deliberate rationale in an inline comment:

| Adapter | Doc said | Matrix says (with its own stated reason) |
|---|---|---|
| `copilot` | `unsupported \| unsupported \| text-signals` | `unsupported \| cli-flag \| text-signals` — drives unattended via `--allow-all-tools` / `--no-ask-user` in print mode |
| `kilo` | `unsupported \| unsupported \| text-signals` | `unsupported \| unsupported \| acp` — declares native ACP so lifecycle events arrive as schema-validated JSON-RPC frames, not a bespoke stdout parser |
| `letta_code` | `unsupported \| cli-flag \| text-signals` | `unsupported \| cli-flag \| stream-json` |

Checked all 44 comparable rows against the real matrix before fixing anything (loaded `strategy_table()` and diffed it against the rendered markdown) — no other mismatches.

## Why this matters

A reader following the doc for `kilo` would conclude the adapter has no structured event channel and needs prose parsing, when it actually already declares native ACP support. Same class of bug as #3676 (opencode's event channel, merged in #5541).

## What this adds

- Fixed the three doc rows.
- `tests/unit/test_capability_contract_doc_drift.py`: reads the real `STRATEGY_MATRIX` and the rendered markdown table, fails on any row where they disagree. No such check existed before this — the drift went unnoticed until I happened to write a one-off comparison script while working on an unrelated adapter issue earlier this session.
- Verified the test actually catches a regression, not just written and trusted: reverted the `kilo` fix locally, reran, confirmed the failure names exactly `kilo`'s mismatch (`docs say ('unsupported', 'unsupported', 'text-signals'), STRATEGY_MATRIX says ('unsupported', 'unsupported', 'acp')`), then restored the fix.

## Testing

```
uv run python -m pytest tests/unit/test_capability_contract_doc_drift.py -v
uv run python -m ruff check tests/unit/test_capability_contract_doc_drift.py
uv run python -m pyright tests/unit/test_capability_contract_doc_drift.py
uv run lint-imports
```

All clean.

Fixes #5627.
