### PR TITLE
fix(tests): invoke the onboarding fixture through the interpreter, not its shebang (#5647)

### DIFF
--- a/docs/release-notes/fragments/5647-windows-onboarding-fixture.md
+++ b/docs/release-notes/fragments/5647-windows-onboarding-fixture.md
@@ -1,0 +1,12 @@
+## Test suite runs on a clean Windows clone
+
+`tests/unit/adapters/test_adapter_onboard_record.py` invoked its fixture CLI
+(`tests/fixtures/probe/probe_recordable.py`) by executing the `.py` file
+directly, relying on its `#!/usr/bin/env python3` shebang. Windows has no
+shebang interpretation, so `scripts/run_tests.py -x` halted on a fresh
+Windows clone with `FileNotFoundError [WinError 2]` before the fixture ever
+ran. The test now invokes the fixture through the current interpreter
+(`sys.executable <fixture path>`), which changes nothing about what the
+fixture receives -- `InvocationSpec.build_argv` already emits
+`[binary, *subcommands, ...]`. Test-only change; no production behavior
+moves (#5647).

--- a/tests/unit/adapters/test_adapter_onboard_record.py
+++ b/tests/unit/adapters/test_adapter_onboard_record.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -29,6 +30,16 @@ FIXTURE = Path(__file__).resolve().parents[2] / "fixtures" / "probe" / "probe_re
 SMOKE_PROMPT = "describe the public fixture"
 SMOKE_MODEL = "fixture-model"
 
+# Issue #5647: the fixture is a `.py` file relying on its `#!/usr/bin/env
+# python3` shebang to be directly executable. That only works on POSIX --
+# Windows has no shebang interpretation, so `subprocess.run([str(FIXTURE),
+# ...])` fails with `FileNotFoundError [WinError 2]` before the fixture ever
+# runs. Invoking it through the current interpreter as a subcommand
+# (`build_argv` already emits `[binary, *subcommands, ...]`) is portable and
+# changes nothing about what the fixture receives or how it behaves.
+_FIXTURE_BINARY = sys.executable
+_FIXTURE_SUBCOMMANDS: tuple[str, ...] = (str(FIXTURE),)
+
 
 def _profile(*, extra_args: tuple[str, ...] = ()) -> AdapterCapabilityProfile:
     """Build the fixture profile used by the onboarding tests."""
@@ -36,7 +47,8 @@ def _profile(*, extra_args: tuple[str, ...] = ()) -> AdapterCapabilityProfile:
         name="recordable-fixture",
         display_name="Recordable Fixture",
         invocation=InvocationSpec(
-            binary=str(FIXTURE),
+            binary=_FIXTURE_BINARY,
+            subcommands=_FIXTURE_SUBCOMMANDS,
             model_flag="--model",
             prompt_flag="--prompt",
             prompt_positional=False,
@@ -45,7 +57,7 @@ def _profile(*, extra_args: tuple[str, ...] = ()) -> AdapterCapabilityProfile:
     )
 
 
-def _write_evidence(path: Path, *, binary: str = str(FIXTURE)) -> Path:
+def _write_evidence(path: Path, *, binary: str = _FIXTURE_BINARY) -> Path:
     """Write a synthetic probe record without running the probing step."""
     document = {
         "binary": binary,


### PR DESCRIPTION
## Summary

Closes #5647.

`tests/unit/adapters/test_adapter_onboard_record.py` executed `tests/fixtures/probe/probe_recordable.py` directly, relying on its `#!/usr/bin/env python3` shebang to make it directly executable. Windows has no shebang interpretation, so `subprocess.run([str(fixture), ...])` raised `FileNotFoundError [WinError 2]` before the fixture ever ran — the process the OS looks for is a `.py` file, not an executable. This halted `scripts/run_tests.py -x` on a clean Windows clone (reproduced on a fresh `upstream/main` worktree, so not branch-specific).

## Fix

Both shared test helpers (`_profile()`, `_write_evidence()`) now invoke the fixture as `sys.executable <fixture path>` instead of `<fixture path>` directly:

```python
_FIXTURE_BINARY = sys.executable
_FIXTURE_SUBCOMMANDS: tuple[str, ...] = (str(FIXTURE),)
```

`InvocationSpec.build_argv` already emits `[binary, *subcommands, model-pair, extra-args, prompt]`, so this changes nothing about what the fixture actually receives on any platform — `python <fixture> --model ... --prompt ...` and `<fixture> --model ... --prompt ...` (via shebang, on POSIX) parse identically inside the fixture's own `sys.argv[1:]`.

`_write_evidence`'s default `binary` parameter was updated to match `_FIXTURE_BINARY`, since `derive_held_out_invocations` raises `ValueError` when the recorded evidence's `binary` field doesn't match the `InvocationSpec.binary` it's checked against (`onboarding.py:435`) — the two have to agree.

**Test-only change.** No production code (`onboarding.py`, `capability_profile.py`) was touched; only how these tests spawn the shared fixture.

## A second hidden instance, fixed for free

The original bug report noted: *"Because `-x` stops at the first failure, other Unix-only fixtures may sit behind this one. I have not enumerated them."* There is one, in this same file: `test_failed_smoke_and_evidence_mismatch_do_not_write_transcript` also calls `record_golden_transcript(_profile(...), ...)` and expects the fixture itself to reject an unknown flag and exit non-zero — same shebang-execution problem, same fix, since both go through the shared `_profile()` helper.

## Verification

```
uv run python scripts/run_tests.py tests/unit/adapters/test_adapter_onboard_record.py -x
# PASS  tests/unit/adapters/test_adapter_onboard_record.py (79.0s) 7 passed
```

Run directly on Windows 11 / Python 3.14, the same platform/version combination from the bug report. (Note: running this file alongside many other concurrent background processes on a resource-constrained machine can push real subprocess-spawn wall time well past a short timeout — that's host contention, not a hang; a clean run consistently finishes in ~80s, matching a direct `pytest` invocation of the same file almost exactly.)

```
uv run ruff check tests/unit/adapters/test_adapter_onboard_record.py
# All checks passed
uv run python -m pyright tests/unit/adapters/test_adapter_onboard_record.py
# 2 pre-existing findings (reportPrivateUsage on _transcripts_for / _ADAPTERS), both unrelated
# to and unchanged by this diff
```

## Docs

`docs/release-notes/fragments/5647-windows-onboarding-fixture.md` — release-note fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)