### PR TITLE
docs(i18n): adopt the Thai README translation (#5288)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -791,7 +791,7 @@ languages = ["zh-Hans", "zh-TW", "ja", "ko", "hi", "bn", "ru", "es", "pt", "de",
 "he" = "@chernistry"
 "id" = "@chernistry"
 "vi" = "@chernistry"
-"th" = "@chernistry"
+"th" = "@thegoodengineer"
 
 [tool.pytest.ini_options]
 minversion = "8.0"


### PR DESCRIPTION
## Summary
Resolves #5288.

Adopts the Thai README translation (`docs/i18n/README.th.md`) by listing `@thegoodengineer` as its owner in `[tool.bernstein.readme-l10n.owners]` in `pyproject.toml`.

### Verification
- Ran `bernstein readme-l10n verify --workdir .` (all 23 translated READMEs in sync, exit code 0).
