### PR TITLE
test(replay): fix out-of-tree path assertion to use POSIX form on Windows

### DIFF
--- a/tests/unit/core/replay/test_read_paths.py
+++ b/tests/unit/core/replay/test_read_paths.py
@@ -196,7 +196,9 @@ def test_out_of_tree_path_lands_in_separate_set(tmp_path: Path) -> None:
     result = derive_read_paths(path, tmp_path)
 
     assert result.read_paths == frozenset({"src/foo.py"})
-    assert result.out_of_tree == frozenset({str(outside)})
+    # out_of_tree is documented as "Absolute POSIX paths"; compare in POSIX form
+    # so the assertion holds on Windows (backslash separators) and POSIX alike.
+    assert result.out_of_tree == frozenset({outside.as_posix()})
 
 
 def test_determinism_across_insertion_orders(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes #5665.

`ReadPathSet.out_of_tree` is documented as holding **"Absolute POSIX paths"** (forward-slash separators). The production code in `_posix()` (`read_paths.py:173-175`) already does this correctly. However, `test_out_of_tree_path_lands_in_separate_set` built its expected oracle with `str(outside)`, which on Windows gives backslash-separated paths — causing the assertion to fail on every clean Windows clone:

```
AssertionError: assert frozenset({'C:/Users/.../outside/secret.py'}) == frozenset({'C:\Users\...\outside\secret.py'})
```

## Change

- `tests/unit/core/replay/test_read_paths.py` — replace `str(outside)` with `outside.as_posix()` in the oracle for `test_out_of_tree_path_lands_in_separate_set`. `Path.as_posix()` always returns forward-slash separators, matching the documented POSIX contract of `out_of_tree` on all platforms.

No production-code change is needed; `_posix()` was already correct.

## Test

The changed test now passes on both POSIX and Windows. No other tests are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)