### PR TITLE
fix(replay): derive_read_paths descends into args/frame payload carriers

### DIFF
--- a/src/bernstein/core/replay/journal.py
+++ b/src/bernstein/core/replay/journal.py
@@ -96,6 +96,13 @@ _NON_DETERMINISTIC_FIELDS = frozenset({"ts", "elapsed_s", "index", "prev_hash", 
 #: run touched).
 PATH_FIELDS = ("path", "file_path")
 
+#: Known nested payload carriers whose sub-dicts are also scanned for
+#: :data:`PATH_FIELDS`.  ``args`` is the standard tool-call argument map
+#: (e.g. ``{"type": "tool_call", "args": {"path": "README.md"}}``);
+#: ``frame`` wraps entire ACP events emitted by ``ACPEventJournalSink``.
+#: Extending this tuple makes new carriers visible to *all* consumers.
+PAYLOAD_CARRIERS: tuple[str, ...] = ("args", "frame")
+
 _GENESIS_HASH = ""
 
 #: A run_id names exactly one journal directory and must be a single safe path

--- a/src/bernstein/core/replay/read_paths.py
+++ b/src/bernstein/core/replay/read_paths.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING
 
 from bernstein.core.replay.journal import (
     PATH_FIELDS,
+    PAYLOAD_CARRIERS,
     JournalParseError,
     load_events,
     verify_events,
@@ -145,10 +146,26 @@ def derive_read_paths(journal_path: Path, worktree_root: Path) -> ReadPathSet:
     read_paths: set[str] = set()
     out_of_tree: set[str] = set()
     for row in loaded.events:
-        for field in PATH_FIELDS:
-            raw = row.get(field)
-            if not isinstance(raw, str) or not raw:
-                continue
+        # Collect every raw path string this row records: scan top-level
+        # PATH_FIELDS first, then each known nested payload carrier (e.g.
+        # "args" in tool_call rows, "frame" in ACP sink rows).  No
+        # production code emits path or file_path at the top level, so
+        # without the carrier descent the read set is empty on every real
+        # run and the merge-admission gate never fires.
+        raw_paths: list[str] = []
+        for f in PATH_FIELDS:
+            val = row.get(f)
+            if isinstance(val, str) and val:
+                raw_paths.append(val)
+        for carrier in PAYLOAD_CARRIERS:
+            nested = row.get(carrier)
+            if isinstance(nested, dict):
+                for f in PATH_FIELDS:
+                    val = nested.get(f)
+                    if isinstance(val, str) and val:
+                        raw_paths.append(val)
+
+        for raw in raw_paths:
             candidate = os.path.normpath(raw if os.path.isabs(raw) else os.path.join(root_norm, raw))
             try:
                 relative = os.path.relpath(candidate, root_norm)

--- a/tests/unit/core/replay/test_read_paths.py
+++ b/tests/unit/core/replay/test_read_paths.py
@@ -5,6 +5,8 @@ read, and that set must come from the Merkle-chained journal rather than
 from anything the agent declares. These tests pin the derivation contract:
 
 * known rows yield exactly the expected worktree-relative POSIX path set;
+* paths nested under ``args`` or ``frame`` payload carriers are collected
+  alongside top-level paths, matching how production adapters journal reads;
 * a mutated row (byte flip in the file) raises the dedicated error instead
   of returning a smaller set;
 * an unparsable row raises the dedicated error with the malformed reason,
@@ -215,3 +217,52 @@ def test_determinism_across_insertion_orders(tmp_path: Path) -> None:
         sorted(second.read_paths),
         sorted(second.out_of_tree),
     )
+
+
+def test_path_nested_under_args_is_collected(tmp_path: Path) -> None:
+    # Production adapters (e.g. openai_agents_builtins) journal file reads as
+    #   {"type": "tool_call", "args": {"path": "README.md"}}
+    # rather than at the top level.  Before the fix the derivation scanned
+    # only top-level PATH_FIELDS, so every real run produced an empty read set
+    # and the merge-admission gate never fired.
+    path = _journal(
+        tmp_path,
+        [
+            {"event": "tool_call", "tool": "fs.read", "args": {"path": "README.md"}},
+            {"event": "read", "path": "src/foo.py"},
+        ],
+    )
+
+    result = derive_read_paths(path, tmp_path)
+
+    assert result.read_paths == frozenset({"README.md", "src/foo.py"})
+    assert result.out_of_tree == frozenset()
+
+
+def test_path_nested_under_frame_is_collected(tmp_path: Path) -> None:
+    # ACPEventJournalSink wraps entire event dicts under the ``frame`` key.
+    path = _journal(
+        tmp_path,
+        [
+            {"event": "acp_event", "frame": {"path": "src/bar.py"}},
+        ],
+    )
+
+    result = derive_read_paths(path, tmp_path)
+
+    assert result.read_paths == frozenset({"src/bar.py"})
+
+
+def test_args_carrier_with_non_dict_value_is_skipped(tmp_path: Path) -> None:
+    # If ``args`` holds a non-dict value the row should not crash derivation.
+    path = _journal(
+        tmp_path,
+        [
+            {"event": "tool_call", "args": "not-a-dict"},
+            {"event": "read", "path": "src/foo.py"},
+        ],
+    )
+
+    result = derive_read_paths(path, tmp_path)
+
+    assert result.read_paths == frozenset({"src/foo.py"})


### PR DESCRIPTION
## Summary

Fixes #5646.

`derive_read_paths` only scanned top-level `PATH_FIELDS` (`"path"`, `"file_path"`) on each journal row. In production, file reads are recorded one level deeper:

```python
# openai_agents_builtins.py:355
emit({"type": "tool_call", "name": "read_file", "args": {"path": path}, ...})

# ACPEventJournalSink wraps entire frames
emit({"type": "acp_event", "frame": {..., "path": "..."}})
```

No production code emits `path` or `file_path` at the top level. The derived read set was therefore always empty on every real run: `check_read_set_changed` always computed an empty changed set and the merge-admission gate admitted every merge. `build_refusal_receipt` had no reachable production caller. **A gate that cannot fire is not a gate.**

## Changes

### `src/bernstein/core/replay/journal.py`
- Added `PAYLOAD_CARRIERS: tuple[str, ...] = ("args", "frame")` alongside `PATH_FIELDS`. These are the known nested dicts whose contents are also scanned for path strings. Living in `journal.py` (the canonical schema location) means adding a new carrier is a one-line change that's visible to all consumers.

### `src/bernstein/core/replay/read_paths.py`
- Updated the inner derivation loop to collect path strings from:
  1. Top-level `PATH_FIELDS` (backward-compatible — journals using these still work)
  2. Each `PAYLOAD_CARRIERS` sub-dict (`args`, `frame`), if the value is a `dict`
- Non-dict carrier values are silently skipped (no crash, no false positives).

### `tests/unit/core/replay/test_read_paths.py`
- `test_path_nested_under_args_is_collected` — exercises the exact `tool_call`/`args` shape from production adapters (was the root-cause repro from the issue).
- `test_path_nested_under_frame_is_collected` — exercises ACP `frame` wrapping.
- `test_args_carrier_with_non_dict_value_is_skipped` — asserts no crash when `args` is a non-dict value.

## Backward compatibility

Existing sealed journals are unaffected. The payload hash covers the raw journal bytes, not the derived path set, so already-recorded journals continue to verify byte-identically. The fix only changes what the derivation extracts, not what the journal writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)