### PR TITLE
fix(ci): raise lineage_tips and lineage_merge mutation budget to 900 s

### DIFF
--- a/scripts/mutmut_critical.py
+++ b/scripts/mutmut_critical.py
@@ -119,18 +119,29 @@ MODULES: tuple[Module, ...] = (
         source="src/bernstein/core/lineage/tips.py",
         tests=("tests/unit/lineage/",),
         threshold=0.75,
-        budget_seconds=600,
+        budget_seconds=900,
         max_candidates=60,
-        note="Lineage v1 tip tracker.",
+        note=(
+            "Lineage v1 tip tracker. Suite shares tests/unit/lineage/ with "
+            "lineage_gate and lineage_merge; baseline budget raised from 600 "
+            "to 900 (baseline allowance 225 s) to match the measured suite "
+            "runtime, which exceeds the 180 s floor derived from 600 s "
+            "(issue #5595)."
+        ),
     ),
     Module(
         key="lineage_merge",
         source="src/bernstein/core/lineage/merge.py",
         tests=("tests/unit/lineage/",),
         threshold=0.75,
-        budget_seconds=600,
+        budget_seconds=900,
         max_candidates=60,
-        note="Lineage v1 merge resolution.",
+        note=(
+            "Lineage v1 merge resolution. Suite shares tests/unit/lineage/ "
+            "with lineage_gate and lineage_tips; baseline budget raised from "
+            "600 to 900 (baseline allowance 225 s) to match the measured "
+            "suite runtime (issue #5595)."
+        ),
     ),
     Module(
         key="config_seed_parser",


### PR DESCRIPTION
## Summary

Fixes #5595.

The mutation nightly's `lineage_tips` entry reported `BASE-FAIL` because the `tests/unit/lineage/` baseline run exceeded its wall-clock allowance.

## Root cause

The baseline budget for `lineage_tips` (and `lineage_merge`) was `budget_seconds=600`:

```python
_baseline_timeout_seconds(mod) = max(mod.budget_seconds // 4, _MUTANT_RUN_TIMEOUT)
                                = max(600 // 4, 180)
                                = max(150, 180)
                                = 180 s
```

The `tests/unit/lineage/` suite exceeds 180 s on CI runners. `lineage_gate` uses the same test directory with `budget_seconds=900` (baseline = 225 s) and passes, so the suite completes within 225 s.

## Fix

Raise `budget_seconds` from 600 → 900 for both `lineage_tips` and `lineage_merge`, giving the same 225-second baseline allowance as `lineage_gate`:

```
max(900 // 4, 180) = max(225, 180) = 225 s
```

`lineage_merge` is raised at the same time because it uses the same test directory with the same 600 s budget and faces the same risk.

The `note` field on each entry documents the measured bound and issue reference for future maintainers.

## Verification

After this change, running:
```bash
python3 scripts/mutmut_critical.py --only lineage_tips
```
should show a kill rate (e.g. `75% PASS`) instead of `BASE-FAIL`, and the job should exit 0 or 1 rather than 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)