### PR TITLE
fix(volunteer): correct CheckRunClient import path

### DIFF
--- a/src/bernstein/core/volunteer/verification_check_run.py
+++ b/src/bernstein/core/volunteer/verification_check_run.py
@@ -34,7 +34,7 @@ from bernstein.core.volunteer.manifest import VolunteerManifest, load_manifest_f
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from bernstein.core.github_app.check_runs import CheckRunClient
+    from bernstein.github_app.check_runs import CheckRunClient
 
 # Pattern to extract bundle JSON from PR body or comments
 _BUNDLE_JSON_PATTERN = re.compile(


### PR DESCRIPTION
## Summary

`verification_check_run.py`'s `TYPE_CHECKING`-only import of `CheckRunClient` pointed at `bernstein.core.github_app.check_runs` — a module that does not exist. `github_app` is a top-level package (`src/bernstein/github_app/`), not a submodule of `core`. `CheckRunClient` actually lives at `bernstein.github_app.check_runs`.

Never an `ImportError` at runtime (it's type-checking only), but every annotation using `CheckRunClient` in this file — lines 634, 853, 885, plus the matching docstring `Args:` entries — resolved as `Unknown` to a strict type checker.

Confirmed the broken import before touching anything:

```
$ python -c "import bernstein.core.github_app.check_runs"
ModuleNotFoundError: No module named 'bernstein.core.github_app'
```

Confirmed after the fix that pyright no longer reports `CheckRunClient` as unresolved on this file (the remaining pyright errors on the file are pre-existing, unrelated `reportUnknownVariableType`/`reportUnnecessaryIsInstance` debt, present before this change too).

Same class of bug already fixed once this cycle in `core/security/agent_card_signer.py` (issue #5551, PR #5571) — a dangling `TYPE_CHECKING` import left over from a module relocation.

## Testing

```
uv run python -m pytest tests/unit/volunteer/test_volunteer_verification_check_run.py -q
uv run python -m ruff check src/bernstein/core/volunteer/verification_check_run.py
uv run lint-imports
```

36 tests pass; ruff and the architecture-contract check are clean.

Fixes #5669.
