### PR TITLE
fix(test): use POSIX path in test_read_paths out-of-tree assertion (#5665)

### DIFF
--- a/docs/release-notes/fragments/5665-test-read-paths-out-of-tree-posix.md
+++ b/docs/release-notes/fragments/5665-test-read-paths-out-of-tree-posix.md
@@ -1,0 +1,7 @@
+## Fix out-of-tree POSIX path assertion in test_read_paths on Windows
+
+`derive_read_paths` returns `ReadPathSet.out_of_tree` with POSIX forward-slash
+separators. `test_out_of_tree_path_lands_in_separate_set` in
+`tests/unit/core/replay/test_read_paths.py` compared against `str(Path)`, which
+uses backslash separators on Windows. The test now compares against the POSIX
+form (`outside.as_posix()`), allowing the suite to pass across all platforms (#5665).

--- a/tests/unit/core/replay/test_read_paths.py
+++ b/tests/unit/core/replay/test_read_paths.py
@@ -196,7 +196,7 @@ def test_out_of_tree_path_lands_in_separate_set(tmp_path: Path) -> None:
     result = derive_read_paths(path, tmp_path)
 
     assert result.read_paths == frozenset({"src/foo.py"})
-    assert result.out_of_tree == frozenset({str(outside)})
+    assert result.out_of_tree == frozenset({outside.as_posix()})
 
 
 def test_determinism_across_insertion_orders(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Resolves #5665.

`derive_read_paths` documents `ReadPathSet.out_of_tree` as containing "Absolute POSIX paths" (`_posix()` normalizes paths with `/` separators). In `tests/unit/core/replay/test_read_paths.py`, `test_out_of_tree_path_lands_in_separate_set` compared `result.out_of_tree` against `frozenset({str(outside)})`, which produces Windows backslash separators on Windows systems and fails the assertion.

### Changes
- Updated `test_out_of_tree_path_lands_in_separate_set` in `tests/unit/core/replay/test_read_paths.py` to compare against `frozenset({outside.as_posix()})`.
- Added release notes fragment `docs/release-notes/fragments/5665-test-read-paths-out-of-tree-posix.md`.

### Verification
- `pytest tests/unit/core/replay/test_read_paths.py` (11 passed, 1 skipped).
- `ruff check tests/unit/core/replay/test_read_paths.py` (clean).
