### PR TITLE
fix(tokens): remove ContextCompressor's permanently-dead embedding path

### DIFF
--- a/src/bernstein/core/tokens/context_compression.py
+++ b/src/bernstein/core/tokens/context_compression.py
@@ -20,7 +20,6 @@ from typing import TYPE_CHECKING, Any
 from bernstein.core.tokens.compression_models import CompressionMetrics, CompressionResult
 
 if TYPE_CHECKING:
-    from bernstein.core.embedding_scorer import EmbeddingScorer
     from bernstein.core.models import Task
 
 logger = logging.getLogger(__name__)
@@ -343,27 +342,24 @@ class BM25Ranker:
 
 
 class ContextCompressor:
-    """Orchestrates context compression using dependency graph, BM25, and embedding scoring.
+    """Orchestrates context compression using a dependency graph and BM25.
 
     Selects a minimal set of files relevant to a set of tasks by:
     1. Using BM25/TF-IDF to match task keywords to file content
-    2. Using embedding-based scoring to find semantically relevant files
-    3. Following dependency chains to include transitively-required files
-    4. Limiting total selected files to avoid exceeding token budget
+    2. Following dependency chains to include transitively-required files
+    3. Limiting total selected files to avoid exceeding token budget
 
     Attributes:
         workdir: Project root directory.
         graph: DependencyGraph instance.
         ranker: BM25Ranker instance (or None if no Python files found).
-        embedding_scorer: EmbeddingScorer for semantic file matching.
     """
 
-    def __init__(self, workdir: Path, *, use_embeddings: bool = True) -> None:
+    def __init__(self, workdir: Path) -> None:
         """Initialize ContextCompressor.
 
         Args:
             workdir: Project root directory.
-            use_embeddings: Whether to use embedding-based scoring alongside BM25.
         """
         self.workdir = workdir
         self.graph = DependencyGraph(workdir)
@@ -380,16 +376,6 @@ class ContextCompressor:
             logger.warning("Failed to build BM25 index: %s", e)
 
         self.ranker: BM25Ranker | None = BM25Ranker(file_contents) if file_contents else None
-
-        # Embedding-based scorer for semantic file relevance
-        self.embedding_scorer: object | None = None
-        if use_embeddings:
-            try:
-                from bernstein.core.embedding_scorer import EmbeddingScorer
-
-                self.embedding_scorer = EmbeddingScorer(workdir=workdir)
-            except Exception:
-                logger.debug("Embedding scorer unavailable, using BM25 only")
 
     def select_relevant_files(
         self,
@@ -431,21 +417,7 @@ class ContextCompressor:
                     selected.add(f)
             return sorted(selected)[:max_files], len(bm25_matches), len(dependency_matches)
 
-        # Phase 1: Embedding-based scoring (broader semantic match)
-        embedding_matches: set[str] = set()
-        if self.embedding_scorer is not None:
-            try:
-                scorer: EmbeddingScorer = self.embedding_scorer  # type: ignore[assignment]
-                scored = scorer.score_for_tasks(tasks, top_k=max_files)
-                for sf in scored:
-                    if len(selected) >= max_files:
-                        break
-                    selected.add(sf.path)
-                    embedding_matches.add(sf.path)
-            except Exception:
-                logger.debug("Embedding scoring failed, falling back to BM25 only")
-
-        # Phase 2: BM25 ranking (keyword match, fills remaining slots)
+        # BM25 ranking (keyword match, fills remaining slots)
         for task in tasks:
             query = f"{task.title} {task.description}"
 


### PR DESCRIPTION
## Summary

`ContextCompressor`'s class docstring documented selecting relevant files via a two-phase strategy including "using embedding-based scoring to find semantically relevant files", backed by `__init__` (default `use_embeddings=True`) attempting `from bernstein.core.embedding_scorer import EmbeddingScorer`.

That module does not exist. `src/bernstein/core/__init__.py:185` records why:

```python
# embedding_scorer: removed - dead code, no production importers.
```

It was deliberately deleted elsewhere as dead code, but this one caller in `context_compression.py` was never updated. The import always raised `ModuleNotFoundError`, silently caught by a bare `except Exception: logger.debug(...)`, so `self.embedding_scorer` was **always `None`** — not an edge case, the only possible value for every `ContextCompressor` instance ever constructed. The entire "Phase 1: Embedding-based scoring" branch in `select_relevant_files` (guarded by `if self.embedding_scorer is not None:`) could consequently never execute.

## What this removes

- `use_embeddings` parameter (no caller in `src/` or `tests/` ever passed it explicitly — confirmed by grep before removing it).
- Both dead imports of the nonexistent module (one `TYPE_CHECKING`-only, one at runtime).
- `self.embedding_scorer` attribute.
- The dead "Phase 1" branch in `select_relevant_files` — whose own `embedding_matches` local variable was populated but never read anywhere, independently of the missing-module issue.
- The docstring's false claim; corrected to describe what the class actually does (BM25 + dependency-chain following).

Not proposing resurrecting `embedding_scorer.py` — it was removed deliberately elsewhere in the codebase; this PR just finishes that removal's last loose end.

## Testing

```
uv run python -m pytest tests/unit/test_context_compression.py -v
uv run python -m ruff check src/bernstein/core/tokens/context_compression.py
uv run python -m pyright src/bernstein/core/tokens/context_compression.py
uv run lint-imports
```

25 tests pass unchanged (confirms removing the always-dead branch changes no observable behavior). Ruff clean. Pyright: the `EmbeddingScorer`-related errors are gone; remaining errors on the file are pre-existing, unrelated `bernstein.core.models` redirect-resolution debt (that module is served via a `sys.meta_path` finder pyright's static analysis can't follow — present before this change too). Architecture-contract check clean.

Fixes #5672.
