### PR TITLE
fix(volunteer): correct dangling TYPE_CHECKING import for CheckRunClient (#5669)

### DIFF
--- a/docs/release-notes/fragments/5669-fix-checkrunclient-import.md
+++ b/docs/release-notes/fragments/5669-fix-checkrunclient-import.md
@@ -1,0 +1,5 @@
+## Fix dangling TYPE_CHECKING import for CheckRunClient
+
+`src/bernstein/core/volunteer/verification_check_run.py` imported `CheckRunClient`
+from nonexistent `bernstein.core.github_app.check_runs`. The import now points
+to the actual module path `bernstein.github_app.check_runs` (#5669).

--- a/src/bernstein/core/volunteer/verification_check_run.py
+++ b/src/bernstein/core/volunteer/verification_check_run.py
@@ -34,7 +34,7 @@ from bernstein.core.volunteer.manifest import VolunteerManifest, load_manifest_f
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from bernstein.core.github_app.check_runs import CheckRunClient
+    from bernstein.github_app.check_runs import CheckRunClient
 
 # Pattern to extract bundle JSON from PR body or comments
 _BUNDLE_JSON_PATTERN = re.compile(


### PR DESCRIPTION
## Summary
Resolves #5669.

`src/bernstein/core/volunteer/verification_check_run.py` had a `TYPE_CHECKING`-only import from `bernstein.core.github_app.check_runs`, which does not exist (`CheckRunClient` lives at `bernstein.github_app.check_runs`). This caused strict type-checkers (pyright) to report `CheckRunClient` as an unresolved type import across multiple annotations and docstrings in the file.

### Changes
- Updated `src/bernstein/core/volunteer/verification_check_run.py` to import `CheckRunClient` from `bernstein.github_app.check_runs`.
- Added release notes fragment `docs/release-notes/fragments/5669-fix-checkrunclient-import.md`.

### Verification
- `ruff check src/bernstein/core/volunteer/verification_check_run.py` (clean).
- `pytest tests/unit/test_volunteer_conformance.py` (25 passed).
