### PR TITLE
fix(tokens): drop dead embedding-scorer references in ContextCompressor (#5672)

### DIFF
--- a/docs/release-notes/fragments/5672-drop-dead-embedding-scorer.md
+++ b/docs/release-notes/fragments/5672-drop-dead-embedding-scorer.md
@@ -1,0 +1,7 @@
+## Remove dead embedding-scorer references in ContextCompressor
+
+`ContextCompressor` in `src/bernstein/core/tokens/context_compression.py` imported
+`EmbeddingScorer` from `bernstein.core.embedding_scorer`, which was previously
+removed as dead code. The dead import, unreachable Phase 1 scoring branch, and
+`use_embeddings` parameter have been removed, and the class docstring updated
+to reflect the actual BM25 and dependency graph selection pipeline (#5672).

--- a/src/bernstein/core/tokens/context_compression.py
+++ b/src/bernstein/core/tokens/context_compression.py
@@ -20,7 +20,6 @@ from typing import TYPE_CHECKING, Any
 from bernstein.core.tokens.compression_models import CompressionMetrics, CompressionResult
 
 if TYPE_CHECKING:
-    from bernstein.core.embedding_scorer import EmbeddingScorer
     from bernstein.core.models import Task
 
 logger = logging.getLogger(__name__)
@@ -343,27 +342,24 @@ class BM25Ranker:
 
 
 class ContextCompressor:
-    """Orchestrates context compression using dependency graph, BM25, and embedding scoring.
+    """Orchestrates context compression using dependency graph and BM25 ranking.
 
     Selects a minimal set of files relevant to a set of tasks by:
     1. Using BM25/TF-IDF to match task keywords to file content
-    2. Using embedding-based scoring to find semantically relevant files
-    3. Following dependency chains to include transitively-required files
-    4. Limiting total selected files to avoid exceeding token budget
+    2. Following dependency chains to include transitively-required files
+    3. Limiting total selected files to avoid exceeding token budget
 
     Attributes:
         workdir: Project root directory.
         graph: DependencyGraph instance.
         ranker: BM25Ranker instance (or None if no Python files found).
-        embedding_scorer: EmbeddingScorer for semantic file matching.
     """
 
-    def __init__(self, workdir: Path, *, use_embeddings: bool = True) -> None:
+    def __init__(self, workdir: Path) -> None:
         """Initialize ContextCompressor.
 
         Args:
             workdir: Project root directory.
-            use_embeddings: Whether to use embedding-based scoring alongside BM25.
         """
         self.workdir = workdir
         self.graph = DependencyGraph(workdir)
@@ -380,16 +376,6 @@ class ContextCompressor:
             logger.warning("Failed to build BM25 index: %s", e)
 
         self.ranker: BM25Ranker | None = BM25Ranker(file_contents) if file_contents else None
-
-        # Embedding-based scorer for semantic file relevance
-        self.embedding_scorer: object | None = None
-        if use_embeddings:
-            try:
-                from bernstein.core.embedding_scorer import EmbeddingScorer
-
-                self.embedding_scorer = EmbeddingScorer(workdir=workdir)
-            except Exception:
-                logger.debug("Embedding scorer unavailable, using BM25 only")
 
     def select_relevant_files(
         self,
@@ -431,21 +417,7 @@ class ContextCompressor:
                     selected.add(f)
             return sorted(selected)[:max_files], len(bm25_matches), len(dependency_matches)
 
-        # Phase 1: Embedding-based scoring (broader semantic match)
-        embedding_matches: set[str] = set()
-        if self.embedding_scorer is not None:
-            try:
-                scorer: EmbeddingScorer = self.embedding_scorer  # type: ignore[assignment]
-                scored = scorer.score_for_tasks(tasks, top_k=max_files)
-                for sf in scored:
-                    if len(selected) >= max_files:
-                        break
-                    selected.add(sf.path)
-                    embedding_matches.add(sf.path)
-            except Exception:
-                logger.debug("Embedding scoring failed, falling back to BM25 only")
-
-        # Phase 2: BM25 ranking (keyword match, fills remaining slots)
+        # BM25 ranking (keyword match, fills remaining slots)
         for task in tasks:
             query = f"{task.title} {task.description}"
 

--- a/tests/unit/test_context_compression.py
+++ b/tests/unit/test_context_compression.py
@@ -380,3 +380,12 @@ class TestPromptCompressor:
         reduction = 1.0 - compressed_tok / max(1, orig)
         assert reduction >= 0.30, f"Expected ≥30% reduction, got {reduction:.1%}"
         assert len(dropped) >= 1
+
+
+def test_context_compressor_has_no_embedding_scorer_attribute(project: Path) -> None:
+    """Regression test for #5672: embedding scorer was removed as dead code."""
+    from bernstein.core.context_compression import ContextCompressor
+
+    compressor = ContextCompressor(project)
+    assert not hasattr(compressor, "embedding_scorer")
+


### PR DESCRIPTION
## Summary
Resolves #5672.

`ContextCompressor` in `src/bernstein/core/tokens/context_compression.py` attempted to import `EmbeddingScorer` from `bernstein.core.embedding_scorer`, which was previously removed from the codebase. The import always failed and was swallowed, leaving `self.embedding_scorer` permanently `None` and the Phase 1 embedding scoring branch in `select_relevant_files` unreachable dead code.

### Changes
- Removed the dead `TYPE_CHECKING` and runtime imports of `EmbeddingScorer`.
- Removed `use_embeddings` parameter and `self.embedding_scorer` from `ContextCompressor.__init__`.
- Removed the unreachable Phase 1 embedding-scoring branch in `select_relevant_files`.
- Updated the class docstring to accurately describe the BM25 + dependency-chain selection strategy.
- Added regression test `test_context_compressor_has_no_embedding_scorer_attribute` in `tests/unit/test_context_compression.py`.
- Added release notes fragment `docs/release-notes/fragments/5672-drop-dead-embedding-scorer.md`.

### Verification
- `ruff check src/bernstein/core/tokens/context_compression.py tests/unit/test_context_compression.py` (clean).
- `pytest tests/unit/test_context_compression.py` (all tests passed).
