### PR TITLE
fix(plugins): stop PluginTrust from claiming crypto/provenance verification

### DIFF
--- a/src/bernstein/plugins/plugin_trust.py
+++ b/src/bernstein/plugins/plugin_trust.py
@@ -24,11 +24,24 @@ _MANIFEST_FIELDS = frozenset({"name", "version", "author"})
 class PluginTrust:
     """Trust assessment for a Bernstein plugin.
 
+    None of these signals involve cryptographic verification. ``signed``
+    means a file named ``.signature`` exists in the plugin directory --
+    its bytes are hashed, never checked against a key or trust anchor, so
+    any plugin author can create one. ``source_verified`` means
+    ``pyproject.toml`` contains the literal substrings ``name``,
+    ``version`` and ``author`` in a recognised section -- it has nothing
+    to do with provenance attestation. A ``"trusted"`` risk level is
+    therefore a statement about which *metadata files are present*, not
+    a statement that the plugin's authorship or integrity was verified.
+
     Attributes:
         plugin_name: Plugin display name, extracted from metadata or directory name.
         risk_level: One of ``"trusted"``, ``"verified"``, ``"community"``, or ``"unknown"``.
-        signed: Whether the plugin has a valid cryptographic signature.
-        source_verified: Whether the source code includes verified provenance.
+        signed: Whether a ``.signature`` file is present in the plugin directory.
+            Presence only -- not verified against any key.
+        source_verified: Whether ``pyproject.toml`` declares the minimum expected
+            metadata fields (``name``, ``version``, ``author``). Presence of
+            those fields only -- not a provenance attestation.
         has_readme: Whether a README file is present.
         has_tests: Whether a ``tests/`` directory or ``test_*.py`` files exist.
         trust_score: Integer 0-100 computed from trust signals.
@@ -231,10 +244,13 @@ def format_trust_warning(trust: PluginTrust) -> str:
         f"[bold]Trust score:[/bold] {trust.trust_score}/100",
         "",
         "[bold]Signals:[/bold]",
-        f"  Cryptographic signature: {_yes_no(trust.signed)}",
-        f"  Source verified:         {_yes_no(trust.source_verified)}",
+        f"  Signature file present:  {_yes_no(trust.signed)}",
+        f"  Package metadata present:{_yes_no(trust.source_verified)}",
         f"  README present:          {_yes_no(trust.has_readme)}",
         f"  Tests present:           {_yes_no(trust.has_tests)}",
+        "",
+        "[dim]None of these are cryptographic checks -- a signature file's bytes are hashed, "
+        "never checked against a key, and metadata presence is not a provenance attestation.[/dim]",
     ]
 
     if trust.risk_level in ("unknown", "community"):

--- a/tests/unit/test_plugin_trust.py
+++ b/tests/unit/test_plugin_trust.py
@@ -273,3 +273,24 @@ class TestFormatTrustWarning:
         )
         result = format_trust_warning(trust)
         assert "WARNING" not in result
+
+    def test_panel_does_not_claim_cryptographic_or_provenance_verification(self) -> None:
+        """Regression for #5676: `signed` is file presence, not signature validity.
+
+        `source_verified` is metadata-field presence, not provenance
+        attestation. The panel a plugin author or operator reads must not
+        claim either check is something it is not.
+        """
+        trust = PluginTrust(
+            plugin_name="safe",
+            risk_level="trusted",
+            signed=True,
+            source_verified=True,
+            has_readme=True,
+            has_tests=True,
+            trust_score=100,
+        )
+        result = format_trust_warning(trust)
+        assert "Cryptographic signature" not in result
+        assert "Source verified" not in result
+        assert "never checked against a key" in result


### PR DESCRIPTION
## Summary

`PluginTrust`'s `signed` and `source_verified` fields never verify anything cryptographically, but claimed to:

- `signed` means a file named `.signature` exists in the plugin directory. `_compute_signature_fingerprint` hashes its bytes — never checks it against a key or trust anchor. Any plugin author can create one. The dataclass docstring said: "Whether the plugin has a **valid cryptographic signature**."
- `source_verified` means `pyproject.toml` contains the literal substrings `name`, `version`, `author` in a recognised section. The docstring said: "Whether the source code includes **verified provenance**."

Both feed `_derive_risk_level` / `_compute_trust_score`, and both were printed verbatim in `format_trust_warning`'s CLI panel as `Cryptographic signature: ✓` / `Source verified: ✓` — so a plugin with an arbitrary self-authored `.signature` file plus a three-line `pyproject.toml` got `risk_level="trusted"` and a green panel telling the operator its signature and provenance were verified. Neither was true.

## What this does — and doesn't do

**Not** implementing real cryptographic signature verification — that needs a trust-anchor/key-distribution story and is a much larger feature than this fix. This is a wording correction, same shape as issue #5034's `verify-export` "unmodified" → "chain-linked" fix (the reviewer feedback on that PR is the direct precedent for this class of fix in this repo):

- Corrected the `PluginTrust` docstring to state plainly what `signed`/`source_verified` actually check.
- Corrected the CLI panel's labels (`Signature file present:` / `Package metadata present:` instead of `Cryptographic signature:` / `Source verified:`), and added a one-line disclaimer to the panel itself.
- `risk_level` derivation and `trust_score` weighting are **completely unchanged** — no behavior change, only the claim made about what was checked.

## Testing

Added `test_panel_does_not_claim_cryptographic_or_provenance_verification`, and verified it actually catches a regression rather than just being written and trusted: reverted the panel-label fix locally, reran, confirmed the failure names exactly the leftover `'Cryptographic signature'` text in the panel output, then restored the fix.

```
uv run python -m pytest tests/unit/test_plugin_trust.py -v
uv run python -m ruff check src/bernstein/plugins/plugin_trust.py tests/unit/test_plugin_trust.py
uv run python -m pyright src/bernstein/plugins/plugin_trust.py
uv run lint-imports
```

28 tests pass; ruff and pyright are clean on the touched file; architecture-contract check clean.

Fixes #5676.
