### PR TITLE
fix(quality): correct GateRunnerCommandsMixin's docstring claims

### DIFF
--- a/src/bernstein/core/quality/gate_commands.py
+++ b/src/bernstein/core/quality/gate_commands.py
@@ -118,15 +118,34 @@ def _build_registry_from_config(config: Any) -> tuple[FormatterConfig, ...]:
 
 
 class GateRunnerCommandsMixin:
-    """Mixin providing all individual gate implementations for GateRunner.
+    """Named as a mixin for :class:`~bernstein.core.gate_pipeline.GateRunner`,
+    but not currently composed into it (#5682).
 
-    This mixin is combined with :class:`~bernstein.core.gate_pipeline.GateRunner`
-    at runtime.  Methods here reference ``self._config``, ``self._workdir``,
-    ``self._base_ref``, ``self._changed_files_resolved``, and helper methods
-    from the cache mixin via the GateRunner instance.
+    ``GateRunner.__mro__`` is ``(GateRunner, object)`` -- nothing inherits
+    this class or injects it dynamically, despite the name and the methods
+    here being written as instance methods that assume ``self._config``,
+    ``self._workdir``, ``self._base_ref``, ``self._changed_files_resolved``,
+    and cache-mixin helpers are available on ``self`` the way they are on a
+    real ``GateRunner`` instance. Calling most of these methods directly
+    (``GateRunnerCommandsMixin().some_gate(...)``) raises ``AttributeError``,
+    the same failure #5572 hit for ``_build_dead_code_result`` before that
+    fix qualified the one call actually needed
+    (``GateRunnerCommandsMixin._build_dead_code_result(...)``, a
+    ``@staticmethod`` with no dependency on ``self``) instead of assuming
+    composition that does not exist.
+
+    Twenty-three method names are independently defined in both this file
+    and ``gate_runner.py`` (``_run_tests_gate``, ``_run_complexity_gate_sync``,
+    and 21 more) -- resolving whether that duplication should become real
+    composition, a shared base, or is simply dead code is a separate,
+    larger question this docstring does not answer; see the issue for the
+    open investigation.
     """
 
-    # -- mixin initialiser (called from GateRunner.__init__) -----------------
+    # -- mixin initialiser: defined, but never called from anywhere --------
+    # No call site exists in src/ (checked: `grep -rn "__init_commands__"`
+    # finds only this definition), and GateRunner.__init__ does not
+    # reference it either.
 
     @staticmethod
     def __init_commands__(instance: object) -> None:


### PR DESCRIPTION
## Summary

`GateRunnerCommandsMixin`'s class docstring claimed "This mixin is combined with `GateRunner` at runtime", and its `__init_commands__` comment claimed it is "called from `GateRunner.__init__`". Neither is true:

```python
>>> from bernstein.core.quality.gate_runner import GateRunner
>>> GateRunner.__mro__
(<class '...GateRunner'>, <class 'object'>)
```

No class statement, decorator, or dynamic injection anywhere composes the two classes. `grep -rn "__init_commands__" src/` finds only the one definition — zero call sites, in this file or in `GateRunner.__init__`.

## Why this matters — it's not a hypothetical

This is exactly the trap issue #5572 fell into: `GateRunner._run_dead_code_gate_sync` called `self._build_dead_code_result`, a method that exists only on `GateRunnerCommandsMixin`, on the strength of this very docstring's claim that the two classes are combined. It crashed with `AttributeError` whenever the dead-code gate actually ran (off by default, `dead_code_check=False`, hence unnoticed). That fix (merged, PR #5599) deliberately did **not** try to make the composition real — qualifying the one call needed as `GateRunnerCommandsMixin._build_dead_code_result(...)` (a `@staticmethod` reference) instead — because a further check found **23 other method names independently defined in both files** (`_run_tests_gate`, `_run_complexity_gate_sync`, and 21 more). Composing the classes for real would silently swap in 22 other gates' duplicate implementations, which is a separate, larger question this fix doesn't attempt to resolve.

## What this fixes

Corrects both docstring claims to state the actual, current relationship between the two classes — so the next reader doesn't repeat #5572's mistake.

## Testing

```
uv run python -m pytest tests/unit/test_gate_runner.py -q
uv run python -m ruff check src/bernstein/core/quality/gate_commands.py
uv run lint-imports
```

18 tests pass; ruff and the architecture-contract check are clean. Docstring/comment-only change — pyright's error count on this file is unchanged (80, all pre-existing, unrelated debt).

Fixes #5682.
