### PR TITLE
fix(replay): extract read paths nested in args and frame payloads (#5646)

### DIFF
--- a/docs/release-notes/fragments/5646-derive-read-paths-nested-payloads.md
+++ b/docs/release-notes/fragments/5646-derive-read-paths-nested-payloads.md
@@ -1,0 +1,7 @@
+## Recover read paths nested under tool call args and protocol frames
+
+`derive_read_paths` previously scanned only top-level `path` and `file_path`
+fields in journal rows. Real tool calls (such as `fs.read`) and protocol frames
+nest their path arguments under `args` or `frame`. The derivation now descends
+into these known payload carriers to extract all accessed paths, ensuring
+the read-set merge gate accurately reflects files accessed during runs (#5646).

--- a/src/bernstein/core/replay/read_paths.py
+++ b/src/bernstein/core/replay/read_paths.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from bernstein.core.replay.journal import (
     PATH_FIELDS,
@@ -33,6 +33,7 @@ from bernstein.core.replay.journal import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
 
@@ -145,10 +146,7 @@ def derive_read_paths(journal_path: Path, worktree_root: Path) -> ReadPathSet:
     read_paths: set[str] = set()
     out_of_tree: set[str] = set()
     for row in loaded.events:
-        for field in PATH_FIELDS:
-            raw = row.get(field)
-            if not isinstance(raw, str) or not raw:
-                continue
+        for raw in _extract_raw_paths(row):
             candidate = os.path.normpath(raw if os.path.isabs(raw) else os.path.join(root_norm, raw))
             try:
                 relative = os.path.relpath(candidate, root_norm)
@@ -168,6 +166,35 @@ def derive_read_paths(journal_path: Path, worktree_root: Path) -> ReadPathSet:
         read_paths=frozenset(read_paths),
         out_of_tree=frozenset(out_of_tree),
     )
+
+
+def _extract_raw_paths(row: Mapping[str, Any]) -> list[str]:
+    """Extract accessed filesystem path strings from a journal row.
+
+    Inspects top-level fields (``path``, ``file_path``) as well as known
+    payload carriers (``args``, ``frame``) where tool calls and protocol frames
+    nest path parameters (#5646).
+    """
+    raw_paths: list[str] = []
+
+    def _collect(obj: Any) -> None:
+        if not isinstance(obj, dict):
+            return
+        for field in PATH_FIELDS:
+            val = obj.get(field)
+            if isinstance(val, str) and val:
+                raw_paths.append(val)
+
+    _collect(row)
+    for container_key in ("args", "frame"):
+        container = row.get(container_key)
+        if isinstance(container, dict):
+            _collect(container)
+            sub = container.get("args")
+            if isinstance(sub, dict):
+                _collect(sub)
+
+    return raw_paths
 
 
 def _posix(path: str) -> str:

--- a/tests/unit/core/replay/test_read_paths.py
+++ b/tests/unit/core/replay/test_read_paths.py
@@ -196,7 +196,32 @@ def test_out_of_tree_path_lands_in_separate_set(tmp_path: Path) -> None:
     result = derive_read_paths(path, tmp_path)
 
     assert result.read_paths == frozenset({"src/foo.py"})
-    assert result.out_of_tree == frozenset({str(outside)})
+    assert result.out_of_tree == frozenset({outside.as_posix()})
+
+
+def test_nested_payload_carriers_args_and_frame_are_extracted(tmp_path: Path) -> None:
+    """Tool calls and protocol frames nesting paths under args/frame are extracted (#5646)."""
+    path = _journal(
+        tmp_path,
+        [
+            {"event": "tool_call", "tool": "fs.read", "args": {"path": "README.md"}},
+            {"event": "tool_call", "tool": "editor.open", "args": {"file_path": "src/app.py"}},
+            {"event": "acp_event", "frame": {"path": "docs/guide.md"}},
+            {"event": "acp_event", "frame": {"args": {"path": "config/settings.yaml"}}},
+            {"event": "read", "path": "src/alpha.py"},
+        ],
+    )
+
+    result = derive_read_paths(path, tmp_path)
+
+    assert result.read_paths == frozenset({
+        "README.md",
+        "src/app.py",
+        "docs/guide.md",
+        "config/settings.yaml",
+        "src/alpha.py",
+    })
+    assert result.out_of_tree == frozenset()
 
 
 def test_determinism_across_insertion_orders(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Resolves #5646.

`derive_read_paths` previously extracted paths only from top-level `path` and `file_path` fields. In production and test journals, tool calls (e.g., `fs.read`, `editor.open`) and protocol frames (e.g. ACP) nest target paths under `args` or `frame`. Because no production code recorded paths at the top level, `derive_read_paths` consistently derived empty read sets, rendering the read-set merge gate ineffective.

This PR:
- Adds `_extract_raw_paths` in `src/bernstein/core/replay/read_paths.py` to descend into known payload carriers (`args` and `frame`) as well as top-level fields.
- Leaves existing event record structure and payload hashes untouched and verifying without breakage.
- Adds test `test_nested_payload_carriers_args_and_frame_are_extracted` to verify extraction from `args`, `frame`, and nested `frame.args`.
- Uses POSIX normalization in `test_out_of_tree_path_lands_in_separate_set` for cross-platform test reliability.
- Adds release notes fragment `docs/release-notes/fragments/5646-derive-read-paths-nested-payloads.md`.

## Verification
- `pytest tests/unit/core/replay/test_read_paths.py`: 12 passed, 1 skipped (0 failures)
- `ruff check src/bernstein/core/replay/read_paths.py tests/unit/core/replay/test_read_paths.py`: clean
