### PR TITLE
chore(governance): queue-hygiene labels, dry-run by default

### DIFF
--- a/.github/workflows/pr-queue-hygiene.yml
+++ b/.github/workflows/pr-queue-hygiene.yml
@@ -1,0 +1,70 @@
+name: PR queue hygiene
+
+# The four rules in scripts/queue_hygiene.py: over-wip, duplicate,
+# needs-committer-review, and closing a PR left with changes-requested and
+# no push for 14 days. Separate from pr-labels.yml (area + size labels,
+# driven by pull_request_target on each PR event) because these four rules
+# need to look across ALL open pull requests at once (an author's total
+# open count, a second PR closing the same issue as an earlier one) rather
+# than react to a single PR's own event, so a schedule sweep is the right
+# shape rather than a per-PR trigger.
+#
+# Runs on a schedule only - no pull_request_target, so it only ever
+# executes trusted code from the base ref against the API. Nothing here
+# checks out or runs anything from a PR head.
+#
+# Dry-run by default. Flip the repository variable QUEUE_HYGIENE_ARMED to
+# "true" to let it actually label/comment/close; until then it only prints
+# what it would do, in the job log, every run.
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "Limit to one PR number (optional)"
+        required: false
+        type: string
+
+concurrency:
+  group: pr-queue-hygiene
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  hygiene:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          sparse-checkout: |
+            scripts/queue_hygiene.py
+          sparse-checkout-cone-mode: false
+      - name: Run queue hygiene
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          QUEUE_HYGIENE_ARMED: ${{ vars.QUEUE_HYGIENE_ARMED }}
+        run: |
+          set -euo pipefail
+          ARGS=()
+          if [ "${{ inputs.pr }}" != "" ]; then
+            ARGS+=(--pr "${{ inputs.pr }}")
+          fi
+          if [ "${QUEUE_HYGIENE_ARMED}" = "true" ]; then
+            echo "QUEUE_HYGIENE_ARMED=true - running live."
+            python3 scripts/queue_hygiene.py --apply "${ARGS[@]}"
+          else
+            echo "QUEUE_HYGIENE_ARMED is not 'true' - dry run only. Nothing will be changed."
+            python3 scripts/queue_hygiene.py "${ARGS[@]}"
+          fi

--- a/.github/workflows/pr-queue-hygiene.yml
+++ b/.github/workflows/pr-queue-hygiene.yml
@@ -58,8 +58,8 @@ jobs:
         run: |
           set -euo pipefail
           ARGS=()
-          if [ "${{ inputs.pr }}" != "" ]; then
-            ARGS+=(--pr "${{ inputs.pr }}")
+          if [ "${INPUT_PR:-}" != "" ]; then
+            ARGS+=(--pr "$INPUT_PR")
           fi
           if [ "${QUEUE_HYGIENE_ARMED}" = "true" ]; then
             echo "QUEUE_HYGIENE_ARMED=true - running live."

--- a/.github/workflows/pr-queue-hygiene.yml
+++ b/.github/workflows/pr-queue-hygiene.yml
@@ -48,6 +48,7 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
+          persist-credentials: false
           sparse-checkout: |
             scripts/queue_hygiene.py
           sparse-checkout-cone-mode: false

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -59,6 +59,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/pr-labels.yml | PR labels | pull_request_target | {"cancel-in-progress": "true", "group": "pr-labels-${{ github.event.pull_request.number }}"} | 1 |
 | .github/workflows/pr-observability-summary.yml | PR observability summary | pull_request, workflow_dispatch | {"cancel-in-progress": "true", "group": "pr-observability-${{ github.event.pull_request.number \|\| github.event.inputs.pr_number }}"} | 1 |
 | .github/workflows/pr-policy.yml | PR policy | pull_request | {"cancel-in-progress": "${{ github.event_name == 'pull_request' }}", "group": "pr-policy-${{ github.event.pull_request.number }}"} | 1 |
+| .github/workflows/pr-queue-hygiene.yml | PR queue hygiene | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "pr-queue-hygiene"} | 1 |
 | .github/workflows/project-pulse.yml | Project pulse | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "project-pulse"} | 1 |
 | .github/workflows/publish-docker.yml | Publish Docker Image | release, workflow_dispatch | {"cancel-in-progress": "false", "group": "publish-docker-${{ github.ref }}"} | 1 |
 | .github/workflows/publish-extension.yml | Publish VS Code Extension | push, workflow_dispatch | {"cancel-in-progress": "false", "group": "publish-extension-${{ github.ref }}"} | 1 |
@@ -135,6 +136,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/pr-labels.yml | label |
 | .github/workflows/pr-observability-summary.yml | summary: Sticky observability comment |
 | .github/workflows/pr-policy.yml | pr-policy: PR policy |
+| .github/workflows/pr-queue-hygiene.yml | hygiene |
 | .github/workflows/project-pulse.yml | pulse: Collect and publish the project pulse |
 | .github/workflows/publish-docker.yml | publish: Build and push image to GHCR |
 | .github/workflows/publish-extension.yml | publish |
@@ -211,6 +213,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/pr-labels.yml | workflow: {"contents": "read"}<br>label: {"contents": "read", "issues": "write", "pull-requests": "write"} | GITHUB_TOKEN |
 | .github/workflows/pr-observability-summary.yml | workflow: {"contents": "read"}<br>summary: {"checks": "read", "contents": "read", "pull-requests": "write", "security-events": "read"} | GITHUB_TOKEN |
 | .github/workflows/pr-policy.yml | workflow: {"contents": "read"}<br>pr-policy: {"actions": "read", "contents": "write", "issues": "read", "pull-requests": "read"} | BERNSTEIN_AUTOSYNC_TOKEN |
+| .github/workflows/pr-queue-hygiene.yml | workflow: {"contents": "read"}<br>hygiene: {"contents": "read", "issues": "write", "pull-requests": "write"} | GITHUB_TOKEN |
 | .github/workflows/project-pulse.yml | pulse: {"contents": "write", "issues": "write", "pull-requests": "read"} | - |
 | .github/workflows/publish-docker.yml | publish: {"attestations": "write", "contents": "read", "id-token": "write", "packages": "write"} | GITHUB_TOKEN |
 | .github/workflows/publish-extension.yml | workflow: {"contents": "read"}<br>publish: {"contents": "read"} | OPEN_VSX_TOKEN, VS_MARKETPLACE_TOKEN |

--- a/scripts/queue_hygiene.py
+++ b/scripts/queue_hygiene.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""Apply the review charter's queue-hygiene rules to open pull requests.
+
+Four rules, each independent of the others:
+
+``over-wip``
+    An author with more than five open, non-draft pull requests gets the
+    label on every one past their oldest five. The oldest five are never
+    labelled, however many total the author has open.
+
+``duplicate``
+    A second (or later) open pull request that closes the same issue as an
+    earlier one gets the label plus a comment pointing at the earlier PR.
+    The earliest PR against a given issue is never the one labelled.
+
+``needs-committer-review``
+    Set when a pull request is not a draft, every check in its status
+    rollup succeeded (or was neutral/skipped — nothing pending or failed),
+    and nobody has requested changes. Removed the moment any of that
+    stops being true.
+
+``changes-requested timeout``
+    A pull request whose most recent review is "changes requested", with
+    no commit pushed since, for fourteen days or more, is closed with a
+    comment on how to reopen it. Exempt labels: pinned, do-not-close,
+    work-in-progress — the same convention stale.yml already uses.
+
+Dry-run by default: every rule always computes and prints what it WOULD do
+for every open pull request. Nothing is labelled, commented on, or closed
+unless ``--apply`` is passed. The workflow that calls this script only
+passes ``--apply`` when the repository variable QUEUE_HYGIENE_ARMED is
+exactly "true" — see .github/workflows/pr-queue-hygiene.yml. Run it by
+hand first:
+
+    python scripts/queue_hygiene.py                    # dry run, all PRs
+    python scripts/queue_hygiene.py --apply             # live
+    python scripts/queue_hygiene.py --pr 5701            # one PR, dry run
+
+This does not touch area or size labels (.github/workflows/pr-labels.yml
+already owns those) and does not touch the sixty-day generic inactivity
+sweep (.github/workflows/stale.yml already owns that) — this script is
+specifically the four rules above, no more.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+DEFAULT_REPO = "sipyourdrink-ltd/bernstein"
+WIP_CAP = 5
+CHANGES_REQUESTED_TIMEOUT_DAYS = 14
+EXEMPT_LABELS = {"pinned", "do-not-close", "work-in-progress"}
+OVER_WIP_LABEL = "over-wip"
+DUPLICATE_LABEL = "duplicate"
+NEEDS_REVIEW_LABEL = "needs-committer-review"
+
+# GitHub's own closing-keyword set (case-insensitive), singular or plural,
+# with or without a colon, per
+# https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
+_CLOSES_RE = re.compile(
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*#(\d+)",
+    re.IGNORECASE,
+)
+
+
+def gh_json(*args: str) -> Any:
+    result = subprocess.run(
+        ["gh", *args], capture_output=True, text=True, check=True
+    )
+    return json.loads(result.stdout)
+
+
+def gh(*args: str) -> None:
+    subprocess.run(["gh", *args], check=True, capture_output=True, text=True)
+
+
+@dataclass
+class PullRequest:
+    number: int
+    title: str
+    author: str
+    created_at: datetime
+    is_draft: bool
+    labels: set[str]
+    review_decision: str
+    body: str
+    checks_pass: bool
+    intents: list[str] = field(default_factory=list)
+
+
+def parse_pr(raw: dict[str, Any]) -> PullRequest:
+    return PullRequest(
+        number=raw["number"],
+        title=raw["title"],
+        author=(raw.get("author") or {}).get("login", "unknown"),
+        created_at=datetime.fromisoformat(raw["createdAt"].replace("Z", "+00:00")),
+        is_draft=raw["isDraft"],
+        labels={l["name"] for l in raw.get("labels", [])},
+        review_decision=raw.get("reviewDecision") or "",
+        body=raw.get("body") or "",
+        checks_pass=False,  # filled in by required_checks_pass() below
+    )
+
+
+def required_checks_pass(repo: str, pr_number: int) -> bool:
+    """True only when every REQUIRED check (not every job - this repo runs
+    27+ jobs and only two are required contexts) has reported and passed.
+
+    Deliberately per-PR rather than pulling statusCheckRollup in the bulk
+    `gh pr list` call: with ~90 open PRs and this many workflow jobs, the
+    rollup field on the list query is expensive enough on GitHub's side to
+    time out (HTTP 504) - confirmed against the live repo while building
+    this script, not a hypothetical. `gh pr checks --required` costs one
+    call per PR instead, which is slower but does not fall over.
+    """
+    checks = gh_json(
+        "pr", "checks", str(pr_number), "--repo", repo,
+        "--required", "--json", "bucket,name",
+    )
+    if not checks:
+        # Nothing required has reported yet - not the same as "nothing
+        # required exists". Treat as not ready rather than vacuously ready.
+        return False
+    return all(c.get("bucket") == "pass" for c in checks)
+
+
+def fetch_open_prs(repo: str) -> list[PullRequest]:
+    raw = gh_json(
+        "pr", "list", "--repo", repo, "--state", "open", "--limit", "300",
+        "--json",
+        "number,title,author,createdAt,isDraft,labels,reviewDecision,body",
+    )
+    prs = [parse_pr(r) for r in raw]
+    for pr in prs:
+        if pr.is_draft:
+            continue  # drafts never need needs-committer-review; skip the call
+        try:
+            pr.checks_pass = required_checks_pass(repo, pr.number)
+        except subprocess.CalledProcessError as exc:
+            print(
+                f"warning: could not read required checks for #{pr.number}: "
+                f"{exc.stderr.strip() if exc.stderr else exc}",
+                file=sys.stderr,
+            )
+            pr.checks_pass = False
+    return prs
+
+
+def rule_over_wip(prs: list[PullRequest]) -> None:
+    by_author: dict[str, list[PullRequest]] = {}
+    for pr in prs:
+        if pr.is_draft:
+            continue
+        by_author.setdefault(pr.author, []).append(pr)
+    for author, authored in by_author.items():
+        authored.sort(key=lambda p: p.created_at)
+        for pr in authored[:WIP_CAP]:
+            if OVER_WIP_LABEL in pr.labels:
+                pr.intents.append(f"remove:{OVER_WIP_LABEL} (within cap)")
+        for pr in authored[WIP_CAP:]:
+            if OVER_WIP_LABEL not in pr.labels:
+                pr.intents.append(
+                    f"add:{OVER_WIP_LABEL} ({author} has "
+                    f"{len(authored)} open, this is past the oldest {WIP_CAP})"
+                )
+
+
+def rule_duplicate(prs: list[PullRequest]) -> None:
+    by_issue: dict[int, list[PullRequest]] = {}
+    for pr in prs:
+        for m in _CLOSES_RE.finditer(pr.body):
+            by_issue.setdefault(int(m.group(1)), []).append(pr)
+    for issue_number, referring in by_issue.items():
+        if len(referring) < 2:
+            continue
+        deduped = {p.number: p for p in referring}
+        referring = sorted(deduped.values(), key=lambda p: p.created_at)
+        if len(referring) < 2:
+            continue
+        first, rest = referring[0], referring[1:]
+        for pr in rest:
+            if DUPLICATE_LABEL not in pr.labels:
+                pr.intents.append(
+                    f"add:{DUPLICATE_LABEL} + comment (closes #{issue_number}, "
+                    f"same as #{first.number} opened first)"
+                )
+
+
+def rule_needs_committer_review(prs: list[PullRequest]) -> None:
+    for pr in prs:
+        should_have = (
+            not pr.is_draft
+            and pr.checks_pass
+            and pr.review_decision != "CHANGES_REQUESTED"
+        )
+        has = NEEDS_REVIEW_LABEL in pr.labels
+        if should_have and not has:
+            pr.intents.append(f"add:{NEEDS_REVIEW_LABEL}")
+        elif has and not should_have:
+            pr.intents.append(f"remove:{NEEDS_REVIEW_LABEL}")
+
+
+def last_changes_requested_without_push(
+    repo: str, pr: PullRequest
+) -> datetime | None:
+    """Return the timestamp of the most recent 'changes requested' review
+    if no commit has landed since, else None."""
+    reviews = gh_json(
+        "api", f"repos/{repo}/pulls/{pr.number}/reviews", "--paginate"
+    )
+    changes_requested_at: datetime | None = None
+    for r in reviews:
+        if r.get("state") == "CHANGES_REQUESTED":
+            ts = datetime.fromisoformat(
+                r["submitted_at"].replace("Z", "+00:00")
+            )
+            if changes_requested_at is None or ts > changes_requested_at:
+                changes_requested_at = ts
+        elif r.get("state") == "APPROVED":
+            # An approval after the last changes-requested does not clear
+            # it by itself (the rule is about a *push*), but a later
+            # changes-requested from someone else supersedes an earlier one
+            # regardless - handled by the max() above since we scan all.
+            pass
+    if changes_requested_at is None:
+        return None
+    commits = gh_json(
+        "api", f"repos/{repo}/pulls/{pr.number}/commits", "--paginate"
+    )
+    for c in commits:
+        date_str = c.get("commit", {}).get("committer", {}).get("date")
+        if not date_str:
+            continue
+        pushed_at = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+        if pushed_at > changes_requested_at:
+            return None  # a push happened after the request - timer reset
+    return changes_requested_at
+
+
+def rule_changes_requested_timeout(repo: str, prs: list[PullRequest]) -> None:
+    now = datetime.now(timezone.utc)
+    for pr in prs:
+        if pr.review_decision != "CHANGES_REQUESTED":
+            continue
+        if pr.labels & EXEMPT_LABELS:
+            continue
+        since = last_changes_requested_without_push(repo, pr)
+        if since is None:
+            continue
+        age = now - since
+        if age >= timedelta(days=CHANGES_REQUESTED_TIMEOUT_DAYS):
+            pr.intents.append(
+                f"close ({age.days}d since changes-requested, no push)"
+            )
+
+
+# (name, color, description) for every label this script can apply that
+# does not already exist in the repo today (checked against the live
+# label list while building this script - `duplicate` already exists,
+# these five do not). Created idempotently on the first --apply run, not
+# by anyone running this PR's setup by hand, and not during a dry run.
+_LABELS_TO_ENSURE = (
+    (OVER_WIP_LABEL, "d4c5f9", "More than 5 open PRs by this author - past the oldest 5"),
+    (NEEDS_REVIEW_LABEL, "0e8a16", "CI green, not draft, nothing blocking - ready for a committer"),
+    # stale.yml already lists these three as exempt-pr-labels; they were
+    # never created, so that exemption has been a silent no-op. Creating
+    # them here makes stale.yml's existing config do what it already says.
+    ("pinned", "b60205", "Exempt from stale/queue-hygiene auto-close"),
+    ("do-not-close", "b60205", "Exempt from stale/queue-hygiene auto-close"),
+    ("work-in-progress", "fbca04", "Exempt from stale/queue-hygiene auto-close"),
+)
+
+
+def ensure_labels(repo: str) -> None:
+    existing = set(gh_json("label", "list", "--repo", repo, "--limit", "300", "--json", "name"))
+    existing_names = {e["name"] for e in existing} if existing and isinstance(existing, list) else set()
+    for name, color, description in _LABELS_TO_ENSURE:
+        if name in existing_names:
+            continue
+        try:
+            gh(
+                "label", "create", name, "--repo", repo,
+                "--color", color, "--description", description,
+            )
+            print(f"created missing label: {name}")
+        except subprocess.CalledProcessError as exc:
+            # Idempotent by design: a race with another run creating the
+            # same label between our list and our create is fine to ignore.
+            print(
+                f"warning: could not create label {name!r}: "
+                f"{exc.stderr.strip() if exc.stderr else exc}",
+                file=sys.stderr,
+            )
+
+
+def apply_intents(repo: str, pr: PullRequest) -> None:
+    for intent in pr.intents:
+        if intent.startswith(f"add:{OVER_WIP_LABEL}"):
+            gh("pr", "edit", str(pr.number), "--repo", repo, "--add-label", OVER_WIP_LABEL)
+        elif intent.startswith(f"remove:{OVER_WIP_LABEL}"):
+            gh("pr", "edit", str(pr.number), "--repo", repo, "--remove-label", OVER_WIP_LABEL)
+        elif intent.startswith(f"add:{DUPLICATE_LABEL}"):
+            gh("pr", "edit", str(pr.number), "--repo", repo, "--add-label", DUPLICATE_LABEL)
+            issue_ref = intent.split("closes #", 1)[1].split(",", 1)[0]
+            first_ref = intent.rsplit("#", 1)[1].rstrip(")")
+            gh(
+                "pr", "comment", str(pr.number), "--repo", repo, "--body",
+                f"This closes the same issue (#{issue_ref}) as #{first_ref}, "
+                "which was opened first. Marking as a duplicate per the "
+                "review charter's queue rules "
+                "(docs/governance/review-charter.md#5-queue-rules). If #"
+                f"{first_ref} is abandoned, say so here and a committer will "
+                "remove the label.",
+            )
+        elif intent.startswith(f"add:{NEEDS_REVIEW_LABEL}"):
+            gh("pr", "edit", str(pr.number), "--repo", repo, "--add-label", NEEDS_REVIEW_LABEL)
+        elif intent.startswith(f"remove:{NEEDS_REVIEW_LABEL}"):
+            gh("pr", "edit", str(pr.number), "--repo", repo, "--remove-label", NEEDS_REVIEW_LABEL)
+        elif intent.startswith("close ("):
+            gh(
+                "pr", "close", str(pr.number), "--repo", repo, "--comment",
+                "Closing per the review charter's queue rules: changes were "
+                "requested and there has been no push for "
+                f"{CHANGES_REQUESTED_TIMEOUT_DAYS} days "
+                "(docs/governance/review-charter.md#5-queue-rules). Push a "
+                "new commit and comment here to ask a committer to reopen.",
+            )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--pr", type=int, default=None, help="limit to one PR number")
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="actually label/comment/close instead of only printing intent",
+    )
+    args = parser.parse_args(argv)
+
+    if args.apply:
+        ensure_labels(args.repo)
+
+    prs = fetch_open_prs(args.repo)
+    if args.pr is not None:
+        prs = [p for p in prs if p.number == args.pr]
+        if not prs:
+            print(f"PR #{args.pr} not found among open PRs.", file=sys.stderr)
+            return 2
+
+    rule_over_wip(prs)
+    rule_duplicate(prs)
+    rule_needs_committer_review(prs)
+    rule_changes_requested_timeout(args.repo, prs)
+
+    acted = 0
+    for pr in sorted(prs, key=lambda p: p.number):
+        if not pr.intents:
+            continue
+        acted += 1
+        mode = "APPLY" if args.apply else "DRY-RUN"
+        print(f"[{mode}] #{pr.number} ({pr.author}) {pr.title!r}:")
+        for intent in pr.intents:
+            print(f"    {intent}")
+        if args.apply:
+            apply_intents(args.repo, pr)
+
+    print(f"\n{acted}/{len(prs)} open pull requests have an intent this run.")
+    if not args.apply:
+        print("Dry run only - nothing was changed. Pass --apply to act.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/queue_hygiene.py
+++ b/scripts/queue_hygiene.py
@@ -347,17 +347,23 @@ def main(argv: list[str] | None = None) -> int:
     if args.apply:
         ensure_labels(args.repo)
 
+    # Every rule runs over the FULL open-PR set, always - over-wip and
+    # duplicate are inherently cross-PR (an author's total count, a second
+    # PR against the same issue) and give a wrong, weaker answer if the
+    # input is pre-filtered to one PR. --pr only narrows what gets
+    # printed/acted on afterward, never what the rules can see.
     prs = fetch_open_prs(args.repo)
-    if args.pr is not None:
-        prs = [p for p in prs if p.number == args.pr]
-        if not prs:
-            print(f"PR #{args.pr} not found among open PRs.", file=sys.stderr)
-            return 2
 
     rule_over_wip(prs)
     rule_duplicate(prs)
     rule_needs_committer_review(prs)
     rule_changes_requested_timeout(args.repo, prs)
+
+    if args.pr is not None:
+        prs = [p for p in prs if p.number == args.pr]
+        if not prs:
+            print(f"PR #{args.pr} not found among open PRs.", file=sys.stderr)
+            return 2
 
     acted = 0
     for pr in sorted(prs, key=lambda p: p.number):

--- a/scripts/queue_hygiene.py
+++ b/scripts/queue_hygiene.py
@@ -50,7 +50,7 @@ import re
 import subprocess
 import sys
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 DEFAULT_REPO = "sipyourdrink-ltd/bernstein"
@@ -71,9 +71,7 @@ _CLOSES_RE = re.compile(
 
 
 def gh_json(*args: str) -> Any:
-    result = subprocess.run(
-        ["gh", *args], capture_output=True, text=True, check=True
-    )
+    result = subprocess.run(["gh", *args], capture_output=True, text=True, check=True)
     return json.loads(result.stdout)
 
 
@@ -102,7 +100,7 @@ def parse_pr(raw: dict[str, Any]) -> PullRequest:
         author=(raw.get("author") or {}).get("login", "unknown"),
         created_at=datetime.fromisoformat(raw["createdAt"].replace("Z", "+00:00")),
         is_draft=raw["isDraft"],
-        labels={l["name"] for l in raw.get("labels", [])},
+        labels={label["name"] for label in raw.get("labels", [])},
         review_decision=raw.get("reviewDecision") or "",
         body=raw.get("body") or "",
         checks_pass=False,  # filled in by required_checks_pass() below
@@ -121,8 +119,14 @@ def required_checks_pass(repo: str, pr_number: int) -> bool:
     call per PR instead, which is slower but does not fall over.
     """
     checks = gh_json(
-        "pr", "checks", str(pr_number), "--repo", repo,
-        "--required", "--json", "bucket,name",
+        "pr",
+        "checks",
+        str(pr_number),
+        "--repo",
+        repo,
+        "--required",
+        "--json",
+        "bucket,name",
     )
     if not checks:
         # Nothing required has reported yet - not the same as "nothing
@@ -133,7 +137,14 @@ def required_checks_pass(repo: str, pr_number: int) -> bool:
 
 def fetch_open_prs(repo: str) -> list[PullRequest]:
     raw = gh_json(
-        "pr", "list", "--repo", repo, "--state", "open", "--limit", "300",
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--limit",
+        "300",
         "--json",
         "number,title,author,createdAt,isDraft,labels,reviewDecision,body",
     )
@@ -167,8 +178,7 @@ def rule_over_wip(prs: list[PullRequest]) -> None:
         for pr in authored[WIP_CAP:]:
             if OVER_WIP_LABEL not in pr.labels:
                 pr.intents.append(
-                    f"add:{OVER_WIP_LABEL} ({author} has "
-                    f"{len(authored)} open, this is past the oldest {WIP_CAP})"
+                    f"add:{OVER_WIP_LABEL} ({author} has {len(authored)} open, this is past the oldest {WIP_CAP})"
                 )
 
 
@@ -188,18 +198,13 @@ def rule_duplicate(prs: list[PullRequest]) -> None:
         for pr in rest:
             if DUPLICATE_LABEL not in pr.labels:
                 pr.intents.append(
-                    f"add:{DUPLICATE_LABEL} + comment (closes #{issue_number}, "
-                    f"same as #{first.number} opened first)"
+                    f"add:{DUPLICATE_LABEL} + comment (closes #{issue_number}, same as #{first.number} opened first)"
                 )
 
 
 def rule_needs_committer_review(prs: list[PullRequest]) -> None:
     for pr in prs:
-        should_have = (
-            not pr.is_draft
-            and pr.checks_pass
-            and pr.review_decision != "CHANGES_REQUESTED"
-        )
+        should_have = not pr.is_draft and pr.checks_pass and pr.review_decision != "CHANGES_REQUESTED"
         has = NEEDS_REVIEW_LABEL in pr.labels
         if should_have and not has:
             pr.intents.append(f"add:{NEEDS_REVIEW_LABEL}")
@@ -207,20 +212,14 @@ def rule_needs_committer_review(prs: list[PullRequest]) -> None:
             pr.intents.append(f"remove:{NEEDS_REVIEW_LABEL}")
 
 
-def last_changes_requested_without_push(
-    repo: str, pr: PullRequest
-) -> datetime | None:
+def last_changes_requested_without_push(repo: str, pr: PullRequest) -> datetime | None:
     """Return the timestamp of the most recent 'changes requested' review
     if no commit has landed since, else None."""
-    reviews = gh_json(
-        "api", f"repos/{repo}/pulls/{pr.number}/reviews", "--paginate"
-    )
+    reviews = gh_json("api", f"repos/{repo}/pulls/{pr.number}/reviews", "--paginate")
     changes_requested_at: datetime | None = None
     for r in reviews:
         if r.get("state") == "CHANGES_REQUESTED":
-            ts = datetime.fromisoformat(
-                r["submitted_at"].replace("Z", "+00:00")
-            )
+            ts = datetime.fromisoformat(r["submitted_at"].replace("Z", "+00:00"))
             if changes_requested_at is None or ts > changes_requested_at:
                 changes_requested_at = ts
         elif r.get("state") == "APPROVED":
@@ -231,9 +230,7 @@ def last_changes_requested_without_push(
             pass
     if changes_requested_at is None:
         return None
-    commits = gh_json(
-        "api", f"repos/{repo}/pulls/{pr.number}/commits", "--paginate"
-    )
+    commits = gh_json("api", f"repos/{repo}/pulls/{pr.number}/commits", "--paginate")
     for c in commits:
         date_str = c.get("commit", {}).get("committer", {}).get("date")
         if not date_str:
@@ -245,7 +242,7 @@ def last_changes_requested_without_push(
 
 
 def rule_changes_requested_timeout(repo: str, prs: list[PullRequest]) -> None:
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     for pr in prs:
         if pr.review_decision != "CHANGES_REQUESTED":
             continue
@@ -256,9 +253,7 @@ def rule_changes_requested_timeout(repo: str, prs: list[PullRequest]) -> None:
             continue
         age = now - since
         if age >= timedelta(days=CHANGES_REQUESTED_TIMEOUT_DAYS):
-            pr.intents.append(
-                f"close ({age.days}d since changes-requested, no push)"
-            )
+            pr.intents.append(f"close ({age.days}d since changes-requested, no push)")
 
 
 # (name, color, description) for every label this script can apply that
@@ -286,16 +281,22 @@ def ensure_labels(repo: str) -> None:
             continue
         try:
             gh(
-                "label", "create", name, "--repo", repo,
-                "--color", color, "--description", description,
+                "label",
+                "create",
+                name,
+                "--repo",
+                repo,
+                "--color",
+                color,
+                "--description",
+                description,
             )
             print(f"created missing label: {name}")
         except subprocess.CalledProcessError as exc:
             # Idempotent by design: a race with another run creating the
             # same label between our list and our create is fine to ignore.
             print(
-                f"warning: could not create label {name!r}: "
-                f"{exc.stderr.strip() if exc.stderr else exc}",
+                f"warning: could not create label {name!r}: {exc.stderr.strip() if exc.stderr else exc}",
                 file=sys.stderr,
             )
 
@@ -311,7 +312,12 @@ def apply_intents(repo: str, pr: PullRequest) -> None:
             issue_ref = intent.split("closes #", 1)[1].split(",", 1)[0]
             first_ref = intent.rsplit("#", 1)[1].rstrip(")")
             gh(
-                "pr", "comment", str(pr.number), "--repo", repo, "--body",
+                "pr",
+                "comment",
+                str(pr.number),
+                "--repo",
+                repo,
+                "--body",
                 f"This closes the same issue (#{issue_ref}) as #{first_ref}, "
                 "which was opened first. Marking as a duplicate per the "
                 "review charter's queue rules "
@@ -325,7 +331,12 @@ def apply_intents(repo: str, pr: PullRequest) -> None:
             gh("pr", "edit", str(pr.number), "--repo", repo, "--remove-label", NEEDS_REVIEW_LABEL)
         elif intent.startswith("close ("):
             gh(
-                "pr", "close", str(pr.number), "--repo", repo, "--comment",
+                "pr",
+                "close",
+                str(pr.number),
+                "--repo",
+                repo,
+                "--comment",
                 "Closing per the review charter's queue rules: changes were "
                 "requested and there has been no push for "
                 f"{CHANGES_REQUESTED_TIMEOUT_DAYS} days "
@@ -339,7 +350,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--repo", default=DEFAULT_REPO)
     parser.add_argument("--pr", type=int, default=None, help="limit to one PR number")
     parser.add_argument(
-        "--apply", action="store_true",
+        "--apply",
+        action="store_true",
         help="actually label/comment/close instead of only printing intent",
     )
     args = parser.parse_args(argv)

--- a/tests/unit/scripts/test_queue_hygiene.py
+++ b/tests/unit/scripts/test_queue_hygiene.py
@@ -1,0 +1,252 @@
+"""Unit tests for ``scripts/queue_hygiene.py``.
+
+Each of the four rules is exercised directly against constructed
+``PullRequest`` fixtures rather than through ``main()`` end to end, so a test
+failure points at the one rule that regressed instead of at "something in the
+gh subprocess chain broke". ``last_changes_requested_without_push`` is the one
+function that talks to the network (via ``gh_json``); its two tests monkeypatch
+that call rather than mocking the ``gh`` binary itself.
+
+The full-PR-set-before-filtering test below pins a real bug found while this
+script was first exercised against the live repo: ``--pr`` narrowed the input
+list before the cross-PR rules ran, silently dropping both over-wip and
+duplicate detection for the one PR left in. See the fix's own commit message
+for how that was found.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "queue_hygiene.py"
+
+
+@pytest.fixture(scope="module")
+def qh() -> ModuleType:
+    """Load ``scripts/queue_hygiene.py`` as an importable module."""
+    spec = importlib.util.spec_from_file_location("queue_hygiene_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    loaded = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = loaded
+    spec.loader.exec_module(loaded)
+    return loaded
+
+
+def _pr(
+    qh: ModuleType,
+    number: int,
+    author: str = "someone",
+    *,
+    age_days: int = 0,
+    is_draft: bool = False,
+    labels: set[str] | None = None,
+    review_decision: str = "",
+    body: str = "",
+    checks_pass: bool = True,
+) -> object:
+    """Build a ``PullRequest`` with sane defaults, oldest-first by age_days."""
+    now = datetime.now(UTC)
+    return qh.PullRequest(
+        number=number,
+        title=f"pr {number}",
+        author=author,
+        created_at=now - timedelta(days=age_days),
+        is_draft=is_draft,
+        labels=set(labels or set()),
+        review_decision=review_decision,
+        body=body,
+        checks_pass=checks_pass,
+    )
+
+
+# --- over-wip -----------------------------------------------------------
+
+
+def test_over_wip_leaves_the_oldest_five_clean(qh: ModuleType) -> None:
+    # 7 PRs by the same author, oldest (highest age_days) first in creation
+    # order. The oldest 5 must never get the label; the newest 2 must.
+    prs = [_pr(qh, n, author="alice", age_days=10 - n) for n in range(1, 8)]
+    qh.rule_over_wip(prs)
+    by_number = {p.number: p for p in prs}
+    for n in range(1, 6):  # 5 oldest (ages 9..5)
+        assert not any(i.startswith("add:over-wip") for i in by_number[n].intents), n
+    for n in range(6, 8):  # 2 newest
+        assert any(i.startswith("add:over-wip") for i in by_number[n].intents), n
+
+
+def test_over_wip_does_not_fire_under_the_cap(qh: ModuleType) -> None:
+    prs = [_pr(qh, n, author="bob", age_days=n) for n in range(1, 5)]  # 4 open
+    qh.rule_over_wip(prs)
+    assert all(not p.intents for p in prs)
+
+
+def test_over_wip_removes_a_stale_label_once_back_under_cap(qh: ModuleType) -> None:
+    # Only 3 open PRs by this author now, but one still carries the label
+    # from when they had more - the rule must offer to remove it.
+    prs = [_pr(qh, n, author="carol", age_days=n, labels={"over-wip"} if n == 1 else set()) for n in range(1, 4)]
+    qh.rule_over_wip(prs)
+    by_number = {p.number: p for p in prs}
+    assert any(i.startswith("remove:over-wip") for i in by_number[1].intents)
+
+
+def test_over_wip_ignores_drafts_on_both_sides(qh: ModuleType) -> None:
+    # A draft does not count toward the cap, and is never itself labelled.
+    prs = [_pr(qh, n, author="dee", age_days=10 - n) for n in range(1, 6)]
+    prs.append(_pr(qh, 6, author="dee", age_days=0, is_draft=True))
+    qh.rule_over_wip(prs)
+    assert all(not p.intents for p in prs)  # exactly 5 non-draft, at the cap
+
+
+# --- duplicate ------------------------------------------------------------
+
+
+def test_duplicate_labels_only_the_later_pr(qh: ModuleType) -> None:
+    first = _pr(qh, 100, age_days=5, body="fixes #42")
+    second = _pr(qh, 101, age_days=1, body="Closes #42")  # newer, same issue
+    qh.rule_duplicate([first, second])
+    assert not first.intents
+    assert any(i.startswith("add:duplicate") for i in second.intents)
+    assert "#100" in second.intents[0]
+
+
+def test_duplicate_does_not_fire_on_a_single_referring_pr(qh: ModuleType) -> None:
+    only = _pr(qh, 200, body="resolves #7")
+    qh.rule_duplicate([only])
+    assert not only.intents
+
+
+def test_duplicate_matches_githubs_closing_keyword_set(qh: ModuleType) -> None:
+    # close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved, case
+    # insensitive, with or without a colon - the same set GitHub itself
+    # recognizes for issue auto-closing.
+    bodies = ["Fixes #9", "closed: #9", "This RESOLVES #9"]
+    prs = [_pr(qh, 300 + i, age_days=3 - i, body=b) for i, b in enumerate(bodies)]
+    qh.rule_duplicate(prs)
+    assert not prs[0].intents  # oldest (highest age_days) is first, never labelled
+    assert all(any(i.startswith("add:duplicate") for i in p.intents) for p in prs[1:])
+
+
+def test_duplicate_dedupes_a_pr_referencing_the_same_issue_twice(qh: ModuleType) -> None:
+    # A PullRequest is unhashable (mutable set/list fields) - rule_duplicate
+    # must dedupe by .number, not by putting PullRequest objects in a set.
+    # This is a regression test for exactly that TypeError.
+    first = _pr(qh, 400, age_days=2, body="fixes #1")
+    twice = _pr(qh, 401, age_days=1, body="fixes #1 and also fixes #1")
+    qh.rule_duplicate([first, twice])  # must not raise
+    assert any(i.startswith("add:duplicate") for i in twice.intents)
+    assert len(twice.intents) == 1  # not double-added for the double mention
+
+
+# --- needs-committer-review ------------------------------------------------
+
+
+def test_needs_review_added_when_green_and_unblocked(qh: ModuleType) -> None:
+    pr = _pr(qh, 1, checks_pass=True, review_decision="")
+    qh.rule_needs_committer_review([pr])
+    assert any(i.startswith("add:needs-committer-review") for i in pr.intents)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"is_draft": True},
+        {"checks_pass": False},
+        {"review_decision": "CHANGES_REQUESTED"},
+    ],
+)
+def test_needs_review_not_added_when_blocked(qh: ModuleType, kwargs: dict) -> None:
+    # _pr() already defaults checks_pass=True; kwargs overrides exactly the
+    # one condition each parametrized case is testing.
+    pr = _pr(qh, 1, **kwargs)
+    qh.rule_needs_committer_review([pr])
+    assert not any(i.startswith("add:needs-committer-review") for i in pr.intents)
+
+
+def test_needs_review_removed_once_no_longer_eligible(qh: ModuleType) -> None:
+    pr = _pr(qh, 1, checks_pass=False, labels={"needs-committer-review"})
+    qh.rule_needs_committer_review([pr])
+    assert any(i.startswith("remove:needs-committer-review") for i in pr.intents)
+
+
+# --- changes-requested timeout ---------------------------------------------
+
+
+def test_changes_requested_timeout_fires_after_14_days_no_push(qh: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    old = (datetime.now(UTC) - timedelta(days=20)).isoformat().replace("+00:00", "Z")
+    calls = {"reviews": [{"state": "CHANGES_REQUESTED", "submitted_at": old}], "commits": []}
+
+    def fake_gh_json(*args: str) -> object:
+        if "reviews" in args[1]:
+            return calls["reviews"]
+        return calls["commits"]
+
+    monkeypatch.setattr(qh, "gh_json", fake_gh_json)
+    pr = _pr(qh, 1, review_decision="CHANGES_REQUESTED")
+    qh.rule_changes_requested_timeout("owner/repo", [pr])
+    assert any(i.startswith("close (") for i in pr.intents)
+
+
+def test_changes_requested_timer_resets_on_a_later_push(qh: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    old = (datetime.now(UTC) - timedelta(days=20)).isoformat().replace("+00:00", "Z")
+    recent_push = (datetime.now(UTC) - timedelta(days=1)).isoformat().replace("+00:00", "Z")
+    calls = {
+        "reviews": [{"state": "CHANGES_REQUESTED", "submitted_at": old}],
+        "commits": [{"commit": {"committer": {"date": recent_push}}}],
+    }
+
+    def fake_gh_json(*args: str) -> object:
+        if "reviews" in args[1]:
+            return calls["reviews"]
+        return calls["commits"]
+
+    monkeypatch.setattr(qh, "gh_json", fake_gh_json)
+    pr = _pr(qh, 1, review_decision="CHANGES_REQUESTED")
+    qh.rule_changes_requested_timeout("owner/repo", [pr])
+    assert not pr.intents  # a push since the request resets the 14-day timer
+
+
+def test_changes_requested_timeout_respects_exempt_labels(qh: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_gh_json(*args: str) -> object:
+        raise AssertionError("must not call the API for an exempt PR")
+
+    monkeypatch.setattr(qh, "gh_json", fake_gh_json)
+    pr = _pr(qh, 1, review_decision="CHANGES_REQUESTED", labels={"work-in-progress"})
+    qh.rule_changes_requested_timeout("owner/repo", [pr])
+    assert not pr.intents
+
+
+# --- --pr must narrow the OUTPUT, never the rules' INPUT --------------------
+
+
+def test_pr_filter_does_not_weaken_cross_pr_rules(qh: ModuleType) -> None:
+    """Regression test for the bug fixed alongside this file: filtering to
+    one PR before the cross-PR rules ran silently dropped over-wip and
+    duplicate detection for it, because each rule needs the full open-PR set
+    to see an author's total count or a second PR against the same issue.
+    The contract main() must uphold: run every rule over the full set first,
+    filter what gets printed/acted on second.
+    """
+    # 6 PRs by the same author (1 over the cap of 5) - the target is the
+    # newest, so it should be flagged over-wip only if the rules saw all 6.
+    prs = [_pr(qh, n, author="eve", age_days=10 - n) for n in range(1, 7)]
+    target = next(p for p in prs if p.number == 6)  # newest = 6th open
+
+    qh.rule_over_wip(prs)
+    qh.rule_duplicate(prs)
+    qh.rule_needs_committer_review(prs)
+
+    # Simulate main()'s post-rule --pr narrowing.
+    filtered = [p for p in prs if p.number == 6]
+
+    assert filtered == [target]
+    assert any(i.startswith("add:over-wip") for i in target.intents), (
+        "over-wip must still fire for the filtered PR - the rule needed to "
+        "see all 6 of this author's PRs, not just the filtered-to-one list"
+    )

--- a/tests/unit/test_git_pr.py
+++ b/tests/unit/test_git_pr.py
@@ -182,9 +182,7 @@ def test_merge_with_conflict_detection_returns_the_commit_sha(
     orig_fake = fake
     expected_sha = "deadbeef" * 5
 
-    def _fake_with_commit_and_rev_parse(
-        args: list[str], cwd: Path, timeout: int = 30, **kwargs: object
-    ) -> GitResult:
+    def _fake_with_commit_and_rev_parse(args: list[str], cwd: Path, timeout: int = 30, **kwargs: object) -> GitResult:
         if args[:1] == ["commit"]:
             return GitResult(returncode=0, stdout="", stderr="")
         if args[:2] == ["rev-parse", "HEAD"]:


### PR DESCRIPTION
## Summary

Four small rules for the open pull-request queue, matched to the review
charter this repo is adopting (`docs/governance/review-charter.md`,
landing in a separate PR):

- `over-wip`: an author's open, non-draft PRs past their oldest five.
- `duplicate`: a second open PR closing the same issue as an earlier one
  (the label already exists in this repo; this just starts applying it
  automatically for this one case).
- `needs-committer-review`: not a draft, required checks pass, nothing
  requesting changes.
- Closes a PR that's sat with changes-requested and no push for 14 days,
  with a note on how to reopen it.

`scripts/queue_hygiene.py` implements all four. `.github/workflows/pr-queue-hygiene.yml`
runs it on a schedule (every 30 minutes) plus `workflow_dispatch`. It is a
separate file from `pr-labels.yml` on purpose: that workflow reacts to a
single PR's own event and owns area/size labels; these four rules need to
look across every open PR at once (an author's total count, a second PR
against the same issue), so a schedule sweep is the right shape rather
than forcing it onto a per-PR trigger.

**Dry-run by default.** The workflow only passes `--apply` to the script
when the repository variable `QUEUE_HYGIENE_ARMED` is exactly `true`.
That variable does not exist yet, so right now every run only prints what
it would have done, in the job log, and changes nothing. Someone with
repo-admin can create the variable when it's time to turn this on for
real; until then this is a no-op except for its own log output.

On the first `--apply` run it also creates the labels it needs if they
are missing (`over-wip`, `needs-committer-review`, plus `pinned` /
`do-not-close` / `work-in-progress` as exemptions for the 14-day close —
`stale.yml` already lists those three as `exempt-pr-labels`, but they
were never created, so that exemption has been a silent no-op; this PR
makes the existing config actually work rather than changing it).

## Verification

Ran the script with no `--apply` against every currently-open pull
request on this repo (`python scripts/queue_hygiene.py`, no repo
mutation possible in that mode): 78 open PRs, 66 with at least one
intent this run — mostly `needs-committer-review` and `over-wip` for
the two highest-volume authors, plus several real `duplicate` pairs
(PRs that do in fact close the same issue as an earlier open PR today).
Two bugs surfaced and were fixed before this PR: the bulk
`statusCheckRollup` field on `gh pr list` times out (HTTP 504) at this
repo's open-PR count and job count, replaced with a per-PR
`gh pr checks --required` call; and the duplicate-detection grouping
needs to dedupe by PR number, not hash the PR object.

`actionlint .github/workflows/pr-queue-hygiene.yml` is clean.

## Test plan

- [ ] CI green on this PR (workflow YAML validates, script has no syntax/import errors)
- [ ] After merge, a manual `workflow_dispatch` run (still unarmed) shows sane dry-run output in the job log
- [ ] When ready to arm: create repo variable `QUEUE_HYGIENE_ARMED=true`, then re-run once by hand and confirm the labels/comments it applies match what the prior dry-run predicted