### PR TITLE
ci: scope workflow secrets to deployment environments

### DIFF
--- a/.github/workflows/adapter-conformance-canary.yml
+++ b/.github/workflows/adapter-conformance-canary.yml
@@ -47,6 +47,7 @@ jobs:
   canary:
     name: Canary matrix
     runs-on: ubuntu-latest
+    environment: automation
     timeout-minutes: 20
     permissions:
       contents: write        # push the last-green regeneration branch

--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -280,6 +280,7 @@ jobs:
       needs.triage.outputs.should_heal == 'true' &&
       needs.triage.outputs.idempotent_skip != 'true'
     runs-on: ubuntu-latest
+    environment: automation
     timeout-minutes: 25
     permissions:
       contents: write

--- a/.github/workflows/bernstein-ci-fix.yml
+++ b/.github/workflows/bernstein-ci-fix.yml
@@ -213,6 +213,7 @@ jobs:
     needs: triage
     if: needs.triage.outputs.existing_pr == '' && needs.triage.outputs.safe_for_gemini == 'true'
     runs-on: ubuntu-latest
+    environment: automation
     timeout-minutes: 20
     permissions:
       contents: write

--- a/.github/workflows/bernstein-issues-decompose.yml
+++ b/.github/workflows/bernstein-issues-decompose.yml
@@ -200,6 +200,7 @@ jobs:
   decompose:
     name: Implement approved issue plan
     runs-on: ubuntu-latest
+    environment: automation
     timeout-minutes: 60
     needs:
       - plan

--- a/.github/workflows/branch-protection-audit.yml
+++ b/.github/workflows/branch-protection-audit.yml
@@ -46,6 +46,7 @@ jobs:
   audit:
     name: Branch protection audit
     runs-on: ubuntu-latest
+    environment: automation
     timeout-minutes: 5
     permissions:
       contents: read

--- a/.github/workflows/ci-topology-heal.yml
+++ b/.github/workflows/ci-topology-heal.yml
@@ -60,6 +60,7 @@ jobs:
   heal:
     name: Regenerate topology report
     runs-on: ubuntu-latest
+    environment: automation
     timeout-minutes: 10
     permissions:
       contents: write

--- a/.github/workflows/coverage-ratchet-weekly.yml
+++ b/.github/workflows/coverage-ratchet-weekly.yml
@@ -43,6 +43,7 @@ jobs:
   bump:
     name: Bump diff-coverage floor and open review PR
     runs-on: ubuntu-latest
+    environment: automation
     timeout-minutes: 10
     if: >-
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/coverage-ratchet.yml
+++ b/.github/workflows/coverage-ratchet.yml
@@ -95,6 +95,7 @@ jobs:
   ratchet:
     name: Total coverage ratchet
     runs-on: ubuntu-latest
+    environment: automation
     timeout-minutes: 10
     # Two guards, and they answer different questions.
     #

--- a/.github/workflows/docs-observability-snapshot.yml
+++ b/.github/workflows/docs-observability-snapshot.yml
@@ -14,6 +14,7 @@ jobs:
   snapshot:
     name: Capture snapshot
     runs-on: ubuntu-latest
+    environment: automation
     timeout-minutes: 15
     permissions:
       contents: write

--- a/.github/workflows/nightly-drift-sweep.yml
+++ b/.github/workflows/nightly-drift-sweep.yml
@@ -28,6 +28,7 @@ jobs:
   sweep:
     name: Open drift-sweep PR if mirrors drifted
     runs-on: ubuntu-latest
+    environment: automation
     timeout-minutes: 15
     permissions:
       contents: write

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -23,6 +23,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: pypi
     timeout-minutes: 30
     permissions:
       # Read-only: the job packages a VSIX and publishes to external

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -23,6 +23,7 @@ jobs:
   update-formula:
     name: Update Homebrew formula
     runs-on: ubuntu-latest
+    environment: pypi
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -337,6 +337,7 @@ jobs:
   publish-npm:
     name: Publish npm wrapper
     runs-on: ubuntu-latest
+    environment: pypi
     needs: build
     timeout-minutes: 15
     permissions:
@@ -494,6 +495,7 @@ jobs:
   publish-copr:
     name: Publish RPM to Copr
     runs-on: ubuntu-latest
+    environment: pypi
     needs: [publish, rpm-install-smoke]
     # `always()` so a channel-only republish still runs with the upstream
     # release graph skipped; the PyPI result still gates the normal tag path.

--- a/.github/workflows/release-major-minor.yml
+++ b/.github/workflows/release-major-minor.yml
@@ -34,7 +34,6 @@ jobs:
   release:
     name: "${{ inputs.bump }} release"
     runs-on: ubuntu-latest
-    environment: automation
     timeout-minutes: 60
     permissions:
       contents: write

--- a/.github/workflows/release-major-minor.yml
+++ b/.github/workflows/release-major-minor.yml
@@ -34,6 +34,7 @@ jobs:
   release:
     name: "${{ inputs.bump }} release"
     runs-on: ubuntu-latest
+    environment: automation
     timeout-minutes: 60
     permissions:
       contents: write

--- a/tests/unit/test_git_pr.py
+++ b/tests/unit/test_git_pr.py
@@ -182,9 +182,7 @@ def test_merge_with_conflict_detection_returns_the_commit_sha(
     orig_fake = fake
     expected_sha = "deadbeef" * 5
 
-    def _fake_with_commit_and_rev_parse(
-        args: list[str], cwd: Path, timeout: int = 30, **kwargs: object
-    ) -> GitResult:
+    def _fake_with_commit_and_rev_parse(args: list[str], cwd: Path, timeout: int = 30, **kwargs: object) -> GitResult:
         if args[:1] == ["commit"]:
             return GitResult(returncode=0, stdout="", stderr="")
         if args[:2] == ["rev-parse", "HEAD"]:


### PR DESCRIPTION
Every job that reads a repository secret now declares a deployment environment, so the secret is
only readable on the refs that environment allows.

Repository secrets are available to any workflow in the repository, including one added on a
branch. Scoping each consumer to an environment moves that boundary from "anyone who can push a
workflow" to "the refs the environment lists".

- `automation` (branch policy: `main`) — jobs that run from the default branch on a schedule, a
  `workflow_run`, a `workflow_call` or a dispatch.
- `pypi` (branch policy: `main`, `v*`, `ext-v*`; one approval per run) — the publishing jobs. A
  release now waits for a single approval in the Actions tab before any package is pushed; one
  approval covers every job in that run.

`ci.yml` is untouched, so merge-queue behaviour is unchanged. `pr-policy.yml` is deliberately out
of scope: its autosync job has to run on pull-request refs, so an environment cannot cover it, and
that path needs a different change.

Before this merges, each secret named below has to exist in its environment, otherwise the job
reads an empty value: `automation` — BERNSTEIN_AUTOSYNC_TOKEN, BRANCH_PROTECTION_AUDIT_TOKEN,
GEMINI_API_KEY; `pypi` — NPM_TOKEN, COPR_CONFIG, OPEN_VSX_TOKEN, VS_MARKETPLACE_TOKEN,
HOMEBREW_TAP_TOKEN.
