### PR TITLE
docs(i18n): adopt the Vietnamese README translation (#5287)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -790,7 +790,7 @@ languages = ["zh-Hans", "zh-TW", "ja", "ko", "hi", "bn", "ru", "es", "pt", "de",
 "ar" = "@thegoodengineer"
 "he" = "@chernistry"
 "id" = "@thegoodengineer"
-"vi" = "@chernistry"
+"vi" = "@Bhumika-1432006"
 "th" = "@chernistry"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary

Resolves #5287.

Adopts the Vietnamese README translation (`docs/i18n/README.vi.md`) by listing `@Bhumika-1432006` as its owner in `[tool.bernstein.readme-l10n.owners]` in `pyproject.toml`.

## Verification

Ran `bernstein readme-l10n verify --workdir .` — all 23 translated READMEs in sync, exit code 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)