### PR TITLE
feat(govern): idempotency_key and is_already_satisfied in change_receipt (#5086 slice 1)

### DIFF
--- a/src/bernstein/core/security/change_receipt.py
+++ b/src/bernstein/core/security/change_receipt.py
@@ -76,6 +76,41 @@ def _sha256_hex(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
+def idempotency_key(entity_id: str, desired_value: str) -> str:
+    """Derive a stable idempotency key from an entity id and a desired value.
+
+    The key is ``sha256(entity_id + ":" + sha256(desired_value))`` so the
+    desired value is never stored in the key and the key is stable across
+    callers who hold the same entity_id and desired_value pair.
+
+    Args:
+        entity_id: The resource being changed (e.g. ``"iam.User:alice"``).
+        desired_value: The target value to write (pre-image; not stored).
+
+    Returns:
+        A hex-encoded SHA-256 digest string.
+    """
+    value_digest = _sha256_hex(desired_value.encode("utf-8"))
+    raw = f"{entity_id}:{value_digest}".encode("utf-8")
+    return _sha256_hex(raw)
+
+
+def is_already_satisfied(observed_value: str, desired_value: str) -> bool:
+    """Return True when the observed value already equals the desired value.
+
+    A caller that finds ``True`` should record a ``ChangeAttempt`` with
+    ``outcome="skipped"`` and perform no side effect.
+
+    Args:
+        observed_value: The value currently on the target resource.
+        desired_value: The value the change would write.
+
+    Returns:
+        ``True`` when no write is needed, ``False`` otherwise.
+    """
+    return observed_value == desired_value
+
+
 def _sort_recursive(value: Any) -> Any:
     """Recursively reorder dict keys so canonical JSON is byte-stable."""
     if isinstance(value, dict):

--- a/src/bernstein/core/security/change_receipt.py
+++ b/src/bernstein/core/security/change_receipt.py
@@ -90,8 +90,8 @@ def idempotency_key(entity_id: str, desired_value: str) -> str:
     Returns:
         A hex-encoded SHA-256 digest string.
     """
-    value_digest = _sha256_hex(desired_value.encode("utf-8"))
-    raw = f"{entity_id}:{value_digest}".encode("utf-8")
+    value_digest = _sha256_hex(desired_value.encode())
+    raw = f"{entity_id}:{value_digest}".encode()
     return _sha256_hex(raw)
 
 

--- a/tests/unit/core/security/test_change_receipt.py
+++ b/tests/unit/core/security/test_change_receipt.py
@@ -29,6 +29,8 @@ from bernstein.core.security.change_receipt import (
     ChangeReceipt,
     canonical_bytes,
     change_receipt_payload_errors,
+    idempotency_key,
+    is_already_satisfied,
 )
 from bernstein.core.skills.catalog.signature import generate_signer_keypair
 
@@ -335,6 +337,61 @@ class TestVerifyReceipt:
 # ---------------------------------------------------------------------------
 # canonical_bytes
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# idempotency_key and is_already_satisfied  (#5086 Slice 1)
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotencyFunctions:
+    """Pure-function idempotency primitives for the apply loop (#5086)."""
+
+    def test_idempotency_key_is_stable_for_same_entity_and_desired_value(self) -> None:
+        """Same inputs always produce the same key."""
+        k1 = idempotency_key("iam.User:alice", "role:admin")
+        k2 = idempotency_key("iam.User:alice", "role:admin")
+        assert k1 == k2
+
+    def test_idempotency_key_changes_when_entity_id_changes(self) -> None:
+        """Different entity_id → different key even with the same desired value."""
+        k1 = idempotency_key("iam.User:alice", "role:admin")
+        k2 = idempotency_key("iam.User:bob", "role:admin")
+        assert k1 != k2
+
+    def test_idempotency_key_changes_when_desired_value_changes(self) -> None:
+        """Different desired_value → different key for the same entity."""
+        k1 = idempotency_key("iam.User:alice", "role:admin")
+        k2 = idempotency_key("iam.User:alice", "role:viewer")
+        assert k1 != k2
+
+    def test_idempotency_key_is_hex_string(self) -> None:
+        """The key is a 64-character lower-case hex string (SHA-256 output)."""
+        k = idempotency_key("target:x", "value")
+        assert len(k) == 64
+        assert all(c in "0123456789abcdef" for c in k)
+
+    def test_idempotency_key_does_not_contain_desired_value(self) -> None:
+        """The desired value is not embedded in the key (it is hashed, not concatenated)."""
+        desired = "super-secret-value"
+        k = idempotency_key("res:1", desired)
+        assert desired not in k
+
+    def test_is_already_satisfied_true_when_equal(self) -> None:
+        """Returns True when observed equals desired — no write needed."""
+        assert is_already_satisfied("role:admin", "role:admin") is True
+
+    def test_is_already_satisfied_false_when_different(self) -> None:
+        """Returns False when observed differs from desired — a write is needed."""
+        assert is_already_satisfied("role:viewer", "role:admin") is False
+
+    def test_is_already_satisfied_false_for_empty_vs_nonempty(self) -> None:
+        """A missing observed value is not the same as a non-empty desired value."""
+        assert is_already_satisfied("", "some-value") is False
+
+    def test_is_already_satisfied_true_for_both_empty(self) -> None:
+        """Two empty strings are equal — already satisfied."""
+        assert is_already_satisfied("", "") is True
 
 
 class TestCanonicalBytes:


### PR DESCRIPTION
Closes #5086 (Slice 1)

## Summary

Adds two pure idempotency primitives to `src/bernstein/core/security/change_receipt.py` so the apply loop (Slice 2) has a stable, well-tested foundation to build on.

### `idempotency_key(entity_id, desired_value) -> str`

Derives a stable SHA-256 key from `(entity_id, sha256(desired_value))`.  The desired value is hashed before inclusion so the raw value is not embedded in the key, and two callers holding the same `(entity_id, desired_value)` pair always produce the same key.

```python
key = idempotency_key("iam.User:alice", "role:admin")
# → "7a4512dba68437d6..."  (64-char hex, stable across callers and restarts)
```

### `is_already_satisfied(observed_value, desired_value) -> bool`

Returns `True` when the observed value equals the desired value — the signal to the apply loop to record a `ChangeAttempt(outcome="skipped")` and perform no side effect.

```python
if is_already_satisfied(current, desired):
    # record ChangeAttempt(outcome="skipped") — no write
```

## Tests added (`tests/unit/core/security/test_change_receipt.py`)

Nine new tests in `TestIdempotencyFunctions`:

| Test | What it pins |
|---|---|
| `test_idempotency_key_is_stable_for_same_entity_and_desired_value` | Same inputs → same key (stability) |
| `test_idempotency_key_changes_when_entity_id_changes` | Entity scope: different entity → different key |
| `test_idempotency_key_changes_when_desired_value_changes` | Value sensitivity: different desired → different key |
| `test_idempotency_key_is_hex_string` | Output shape: 64-char lowercase hex (SHA-256) |
| `test_idempotency_key_does_not_contain_desired_value` | Pre-image hiding: raw value is hashed, not embedded |
| `test_is_already_satisfied_true_when_equal` | Returns True when already converged |
| `test_is_already_satisfied_false_when_different` | Returns False when a write is still needed |
| `test_is_already_satisfied_false_for_empty_vs_nonempty` | Empty observed ≠ non-empty desired |
| `test_is_already_satisfied_true_for_both_empty` | Two empty strings satisfy each other |

## Out of scope (Slice 2)

The apply loop that calls `idempotency_key` and `is_already_satisfied`, constructs `ChangeAttempt`/`ChangeReceipt`, and runs the run-twice integration test is Slice 2 of #5086 and is not part of this PR.

