### PR TITLE
test(spawn): the BERNSTEIN_RUN_ID xfail was asserting a closed gap

### DIFF
--- a/tests/property/test_adapter_spawn_bughunt.py
+++ b/tests/property/test_adapter_spawn_bughunt.py
@@ -434,22 +434,40 @@ def test_fork_cache_key_stable_for_same_prefix() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    reason=(
-        "BERNSTEIN_RUN_ID is not currently part of the spawn contract - "
-        "the audit brief calls for an injected per-run identifier in the "
-        "child env-var set, but no adapter or env_isolation surface emits "
-        "it today.  Tracking via xfail until the contract is added."
-    ),
-    strict=True,
-)
-def test_xfail_bernstein_run_id_in_child_env() -> None:
-    """Audit brief item: every spawned process should see BERNSTEIN_RUN_ID."""
+def test_bernstein_run_id_reaches_the_child_env() -> None:
+    """FIXED: a filtered child env carries the run id the orchestrator set.
+
+    This was an ``xfail(strict=True)`` claiming "no adapter or env_isolation
+    surface emits it today". That stopped being true: ``BERNSTEIN_RUN_ID`` is
+    in ``env_isolation._BASE_ALLOWLIST`` with a comment explaining why an
+    agent that loses it writes its instrumentation under a literal
+    ``"unknown"`` run id.
+
+    The xfail never noticed, because the test could not pass either way. The
+    assertion sat *outside* the ``patch.dict`` block, so by the time it ran
+    the patch had been reverted and ``os.environ["BERNSTEIN_RUN_ID"]`` raised
+    ``KeyError`` - on a machine where the variable is not already set, which
+    is every machine that is not mid-run. A strict xfail turned that into a
+    green tick and kept asserting a gap that had been closed.
+    """
     import os
 
     with patch.dict("os.environ", {"BERNSTEIN_RUN_ID": "run-xyz"}, clear=False):
         env = build_filtered_env(["ANTHROPIC_API_KEY"])
-    assert env.get("BERNSTEIN_RUN_ID") == os.environ["BERNSTEIN_RUN_ID"]
+        assert env.get("BERNSTEIN_RUN_ID") == os.environ["BERNSTEIN_RUN_ID"]
+    assert env["BERNSTEIN_RUN_ID"] == "run-xyz"
+
+
+def test_a_child_env_has_no_run_id_when_the_orchestrator_set_none() -> None:
+    """The allowlist admits the variable; it does not invent one.
+
+    Without this, the test above would still pass against a
+    ``build_filtered_env`` that hard-coded the key.
+    """
+    with patch.dict("os.environ", {}, clear=True):
+        env = build_filtered_env([])
+
+    assert "BERNSTEIN_RUN_ID" not in env
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
## What the xfail claimed

```python
@pytest.mark.xfail(
    reason=(
        "BERNSTEIN_RUN_ID is not currently part of the spawn contract - "
        "... no adapter or env_isolation surface emits it today."
    ),
    strict=True,
)
```

That stopped being true. `BERNSTEIN_RUN_ID` is in `env_isolation._BASE_ALLOWLIST`, with a comment explaining that an agent which loses it falls back to a literal `"unknown"` run id and scatters its instrumentation outside the run it belongs to.

## Why nothing noticed

The test could not pass either way. Its assertion sat **outside** the `patch.dict` block:

```python
with patch.dict("os.environ", {"BERNSTEIN_RUN_ID": "run-xyz"}, clear=False):
    env = build_filtered_env(["ANTHROPIC_API_KEY"])
assert env.get("BERNSTEIN_RUN_ID") == os.environ["BERNSTEIN_RUN_ID"]
```

By the time the assertion ran, the patch had been reverted — so `os.environ["BERNSTEIN_RUN_ID"]` raised `KeyError` on any machine where the variable is not already set, which is every machine not mid-run. `strict=True` turned a test that could never pass into a green tick, and kept a false claim about the product sitting in the suite.

Verified directly:

```
inside  block: env BERNSTEIN_RUN_ID = run-xyz
inside  block: os.environ           = run-xyz
outside block: os.environ           = None
outside block: os.environ[...] raises KeyError -> 'BERNSTEIN_RUN_ID'
```

So the failure was the `KeyError`, not a missing env var — the exact shape a strict xfail is worst at: it records *that* a test fails, never *why*.

## The change

The assertion moves inside the block; the xfail goes. A second case pins the other half — a child env has **no** run id when the orchestrator set none — so the first cannot pass against a `build_filtered_env` that hard-codes the key.

```
tests/property/test_adapter_spawn_bughunt.py -k run_id   2 passed
```

## Not fixed here

`test_xfail_expected_version_propagation`, immediately below it, is a **genuine** gap: `build_worker_cmd` really has no `expected_version` parameter. I checked rather than assumed, and left it alone — implementing stale-spawn self-abort is a feature, not a test fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)