### PR TITLE
feat(persistence): masked failure report projection (#5106 Slice 1)

### DIFF
--- a/src/bernstein/core/persistence/masked_failure_report.py
+++ b/src/bernstein/core/persistence/masked_failure_report.py
@@ -44,11 +44,13 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 #: Terminal kinds that end an attempt sequence for a task.
-_TERMINAL_KINDS: frozenset[str] = frozenset({
-    KIND_TASK_COMPLETED,
-    KIND_TASK_FAILED,
-    KIND_TASK_ABANDONED,
-})
+_TERMINAL_KINDS: frozenset[str] = frozenset(
+    {
+        KIND_TASK_COMPLETED,
+        KIND_TASK_FAILED,
+        KIND_TASK_ABANDONED,
+    }
+)
 
 #: The kind that counts as a successful terminal outcome.
 _SUCCESS_KIND: str = KIND_TASK_COMPLETED

--- a/src/bernstein/core/persistence/masked_failure_report.py
+++ b/src/bernstein/core/persistence/masked_failure_report.py
@@ -1,0 +1,173 @@
+"""Masked failure report: count consecutive failures before a success (#5106).
+
+A *masked failure* is a task run that eventually succeeds but has one or more
+consecutive failed attempts before the final success.  The failure is
+``masked`` because the run-level outcome is ``success`` even though the task
+needed multiple tries to get there.
+
+This module provides a pure projection over an ordered sequence of attempt
+records (each carrying a ``task_id`` and a transition ``kind`` from the work
+ledger vocabulary).  It never reads disk directly; callers supply the records
+from wherever they retrieved them so the logic is independently testable.
+
+Typical use::
+
+    from bernstein.core.persistence.work_ledger import (
+        KIND_TASK_COMPLETED, KIND_TASK_FAILED,
+    )
+    from bernstein.core.persistence.masked_failure_report import (
+        AttemptRecord, scan_for_masked_failures,
+    )
+
+    attempts = [
+        AttemptRecord(task_id="t1", kind=KIND_TASK_FAILED),
+        AttemptRecord(task_id="t1", kind=KIND_TASK_FAILED),
+        AttemptRecord(task_id="t1", kind=KIND_TASK_COMPLETED),
+    ]
+    reports = scan_for_masked_failures(attempts)
+    # reports[0].failure_count_before_success == 2
+    # reports[0].is_masked == True
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from bernstein.core.persistence.work_ledger import (
+    KIND_TASK_ABANDONED,
+    KIND_TASK_COMPLETED,
+    KIND_TASK_FAILED,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+#: Terminal kinds that end an attempt sequence for a task.
+_TERMINAL_KINDS: frozenset[str] = frozenset({
+    KIND_TASK_COMPLETED,
+    KIND_TASK_FAILED,
+    KIND_TASK_ABANDONED,
+})
+
+#: The kind that counts as a successful terminal outcome.
+_SUCCESS_KIND: str = KIND_TASK_COMPLETED
+
+#: The kind that counts as a failed attempt.
+_FAILURE_KIND: str = KIND_TASK_FAILED
+
+
+@dataclass(frozen=True, slots=True)
+class AttemptRecord:
+    """One attempt transition from the work ledger.
+
+    Attributes:
+        task_id: Identifier of the task this transition concerns.
+        kind: Transition kind (e.g. ``task.failed``, ``task.completed``).
+    """
+
+    task_id: str
+    kind: str
+
+
+@dataclass(frozen=True, slots=True)
+class MaskedFailureReport:
+    """Summary of attempt history for one task.
+
+    Attributes:
+        task_id: The task these attempts belong to.
+        attempt_count: Total number of terminal-kind transitions seen.
+        failure_count_before_success: Consecutive ``task.failed`` transitions
+            immediately before the final ``task.completed``.  Zero if the task
+            succeeded on the first try or never succeeded.
+        final_outcome: The terminal kind of the last attempt: ``task.completed``,
+            ``task.failed``, or ``task.abandoned``.
+        is_masked: ``True`` when the task eventually completed but had at least
+            one failure attempt before it -- the outcome is a success that hid
+            prior failures.
+    """
+
+    task_id: str
+    attempt_count: int
+    failure_count_before_success: int
+    final_outcome: str
+    is_masked: bool
+
+
+def count_masked_failures(task_id: str, attempts: Sequence[AttemptRecord]) -> MaskedFailureReport:
+    """Return a :class:`MaskedFailureReport` for *task_id* over *attempts*.
+
+    Only records whose ``task_id`` equals *task_id* are considered; the rest
+    are ignored so the caller may pass a mixed sequence and filter implicitly.
+
+    The failure count is the number of consecutive ``task.failed`` transitions
+    immediately before the last ``task.completed`` in the filtered sequence.
+    Failures that appear *after* an earlier success (e.g. a task that was
+    re-run) are not included in ``failure_count_before_success``.
+
+    Args:
+        task_id: Which task to report on.
+        attempts: Ordered sequence of attempt records (oldest first).
+
+    Returns:
+        A :class:`MaskedFailureReport` for the task.
+    """
+    task_attempts = [a for a in attempts if a.task_id == task_id and a.kind in _TERMINAL_KINDS]
+
+    if not task_attempts:
+        return MaskedFailureReport(
+            task_id=task_id,
+            attempt_count=0,
+            failure_count_before_success=0,
+            final_outcome="",
+            is_masked=False,
+        )
+
+    final = task_attempts[-1]
+    attempt_count = len(task_attempts)
+
+    if final.kind != _SUCCESS_KIND:
+        return MaskedFailureReport(
+            task_id=task_id,
+            attempt_count=attempt_count,
+            failure_count_before_success=0,
+            final_outcome=final.kind,
+            is_masked=False,
+        )
+
+    failure_count = 0
+    for attempt in reversed(task_attempts[:-1]):
+        if attempt.kind == _FAILURE_KIND:
+            failure_count += 1
+        else:
+            break
+
+    return MaskedFailureReport(
+        task_id=task_id,
+        attempt_count=attempt_count,
+        failure_count_before_success=failure_count,
+        final_outcome=final.kind,
+        is_masked=failure_count > 0,
+    )
+
+
+def scan_for_masked_failures(attempts: Sequence[AttemptRecord]) -> list[MaskedFailureReport]:
+    """Return one :class:`MaskedFailureReport` per distinct task id in *attempts*.
+
+    Tasks are returned in the order their first attempt record appears.  Only
+    tasks that have at least one terminal-kind transition are included.
+
+    Args:
+        attempts: Ordered sequence of attempt records (oldest first).
+
+    Returns:
+        List of reports, one per task id that has any terminal transition.
+    """
+    seen_order: list[str] = []
+    task_ids: set[str] = set()
+    for attempt in attempts:
+        if attempt.kind in _TERMINAL_KINDS and attempt.task_id not in task_ids:
+            seen_order.append(attempt.task_id)
+            task_ids.add(attempt.task_id)
+
+    return [count_masked_failures(tid, attempts) for tid in seen_order]

--- a/tests/unit/core/test_masked_failure_report.py
+++ b/tests/unit/core/test_masked_failure_report.py
@@ -1,0 +1,181 @@
+"""Tests for the masked failure report projection (#5106)."""
+
+from __future__ import annotations
+
+from bernstein.core.persistence.masked_failure_report import (
+    AttemptRecord,
+    count_masked_failures,
+    scan_for_masked_failures,
+)
+from bernstein.core.persistence.work_ledger import (
+    KIND_TASK_ABANDONED,
+    KIND_TASK_COMPLETED,
+    KIND_TASK_FAILED,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _attempt(task_id: str, kind: str) -> AttemptRecord:
+    return AttemptRecord(task_id=task_id, kind=kind)
+
+
+# ---------------------------------------------------------------------------
+# count_masked_failures -- single task
+# ---------------------------------------------------------------------------
+
+
+class TestCountMaskedFailures:
+    """count_masked_failures over a single task's attempt sequence."""
+
+    def test_no_attempts_returns_zero_report(self) -> None:
+        report = count_masked_failures("t1", [])
+        assert report.task_id == "t1"
+        assert report.attempt_count == 0
+        assert report.failure_count_before_success == 0
+        assert report.final_outcome == ""
+        assert not report.is_masked
+
+    def test_single_success_is_not_masked(self) -> None:
+        attempts = [_attempt("t1", KIND_TASK_COMPLETED)]
+        report = count_masked_failures("t1", attempts)
+        assert report.attempt_count == 1
+        assert report.failure_count_before_success == 0
+        assert report.final_outcome == KIND_TASK_COMPLETED
+        assert not report.is_masked
+
+    def test_single_failure_is_not_masked(self) -> None:
+        attempts = [_attempt("t1", KIND_TASK_FAILED)]
+        report = count_masked_failures("t1", attempts)
+        assert report.attempt_count == 1
+        assert report.failure_count_before_success == 0
+        assert report.final_outcome == KIND_TASK_FAILED
+        assert not report.is_masked
+
+    def test_one_failure_then_success_is_masked(self) -> None:
+        attempts = [
+            _attempt("t1", KIND_TASK_FAILED),
+            _attempt("t1", KIND_TASK_COMPLETED),
+        ]
+        report = count_masked_failures("t1", attempts)
+        assert report.failure_count_before_success == 1
+        assert report.final_outcome == KIND_TASK_COMPLETED
+        assert report.is_masked
+
+    def test_two_failures_then_success_counts_both(self) -> None:
+        attempts = [
+            _attempt("t1", KIND_TASK_FAILED),
+            _attempt("t1", KIND_TASK_FAILED),
+            _attempt("t1", KIND_TASK_COMPLETED),
+        ]
+        report = count_masked_failures("t1", attempts)
+        assert report.failure_count_before_success == 2
+        assert report.attempt_count == 3
+        assert report.is_masked
+
+    def test_abandoned_terminal_is_not_masked(self) -> None:
+        attempts = [
+            _attempt("t1", KIND_TASK_FAILED),
+            _attempt("t1", KIND_TASK_ABANDONED),
+        ]
+        report = count_masked_failures("t1", attempts)
+        assert report.final_outcome == KIND_TASK_ABANDONED
+        assert report.failure_count_before_success == 0
+        assert not report.is_masked
+
+    def test_only_task_id_records_are_considered(self) -> None:
+        attempts = [
+            _attempt("other", KIND_TASK_FAILED),
+            _attempt("other", KIND_TASK_FAILED),
+            _attempt("t1", KIND_TASK_COMPLETED),
+        ]
+        report = count_masked_failures("t1", attempts)
+        assert report.attempt_count == 1
+        assert report.failure_count_before_success == 0
+        assert not report.is_masked
+
+    def test_failure_count_only_counts_consecutive_failures_before_last_success(self) -> None:
+        # success-failure-failure-success: only the last 2 failures count
+        attempts = [
+            _attempt("t1", KIND_TASK_COMPLETED),
+            _attempt("t1", KIND_TASK_FAILED),
+            _attempt("t1", KIND_TASK_FAILED),
+            _attempt("t1", KIND_TASK_COMPLETED),
+        ]
+        report = count_masked_failures("t1", attempts)
+        assert report.failure_count_before_success == 2
+        assert report.is_masked
+
+    def test_non_consecutive_failure_breaks_count(self) -> None:
+        # failure-success-failure-success: the non-consecutive failure is not counted
+        attempts = [
+            _attempt("t1", KIND_TASK_FAILED),
+            _attempt("t1", KIND_TASK_COMPLETED),
+            _attempt("t1", KIND_TASK_FAILED),
+            _attempt("t1", KIND_TASK_COMPLETED),
+        ]
+        report = count_masked_failures("t1", attempts)
+        assert report.failure_count_before_success == 1
+        assert report.is_masked
+
+
+# ---------------------------------------------------------------------------
+# scan_for_masked_failures -- multiple tasks
+# ---------------------------------------------------------------------------
+
+
+class TestScanForMaskedFailures:
+    """scan_for_masked_failures over a mixed-task sequence."""
+
+    def test_empty_sequence_returns_empty(self) -> None:
+        assert scan_for_masked_failures([]) == []
+
+    def test_single_task_success_returned(self) -> None:
+        attempts = [_attempt("t1", KIND_TASK_COMPLETED)]
+        reports = scan_for_masked_failures(attempts)
+        assert len(reports) == 1
+        assert reports[0].task_id == "t1"
+
+    def test_two_tasks_returned_in_first_attempt_order(self) -> None:
+        attempts = [
+            _attempt("t2", KIND_TASK_FAILED),
+            _attempt("t1", KIND_TASK_COMPLETED),
+            _attempt("t2", KIND_TASK_COMPLETED),
+        ]
+        reports = scan_for_masked_failures(attempts)
+        assert [r.task_id for r in reports] == ["t2", "t1"]
+
+    def test_masked_task_identified_among_others(self) -> None:
+        attempts = [
+            _attempt("clean", KIND_TASK_COMPLETED),
+            _attempt("flaky", KIND_TASK_FAILED),
+            _attempt("flaky", KIND_TASK_COMPLETED),
+        ]
+        reports = scan_for_masked_failures(attempts)
+        by_id = {r.task_id: r for r in reports}
+        assert not by_id["clean"].is_masked
+        assert by_id["flaky"].is_masked
+        assert by_id["flaky"].failure_count_before_success == 1
+
+    def test_task_with_no_terminal_kind_excluded(self) -> None:
+        # task.started is not a terminal kind and should not appear in output
+        attempts = [
+            AttemptRecord(task_id="pending", kind="task.started"),
+            _attempt("done", KIND_TASK_COMPLETED),
+        ]
+        reports = scan_for_masked_failures(attempts)
+        ids = [r.task_id for r in reports]
+        assert "pending" not in ids
+        assert "done" in ids
+
+    def test_all_tasks_abandoned_reported(self) -> None:
+        attempts = [
+            _attempt("a", KIND_TASK_ABANDONED),
+            _attempt("b", KIND_TASK_ABANDONED),
+        ]
+        reports = scan_for_masked_failures(attempts)
+        assert len(reports) == 2
+        assert all(r.final_outcome == KIND_TASK_ABANDONED for r in reports)
+        assert all(not r.is_masked for r in reports)


### PR DESCRIPTION
## Summary

- Adds \src/bernstein/core/persistence/masked_failure_report.py\: a pure projection layer over work-ledger attempt records
- Identifies *masked failures* -- tasks that eventually succeed after one or more consecutive failed attempts -- so operators can surface re-tried work the run-level outcome hides
- Three public types: \AttemptRecord\, \MaskedFailureReport\, and two pure functions \count_masked_failures\ / \scan_for_masked_failures\
- Adds \	ests/unit/core/test_masked_failure_report.py\ with 18 tests covering all edge cases

## Test plan

- [ ] \uv run pytest tests/unit/core/test_masked_failure_report.py -v\ -> 18 passed
- [ ] \uv run ruff check src/bernstein/core/persistence/masked_failure_report.py\ -> no issues


