### PR TITLE
docs(i18n): adopt the Simplified Chinese README translation (#5258)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -769,7 +769,7 @@ languages = ["zh-Hans", "zh-TW", "ja", "ko", "hi", "bn", "ru", "es", "pt", "de",
 # standing obligation. Handing a language over is a one-line change to
 # this table, made by the person taking it on.
 [tool.bernstein.readme-l10n.owners]
-"zh-Hans" = "@chernistry"
+"zh-Hans" = "@7487"
 "zh-TW" = "@chernistry"
 "ja" = "@chernistry"
 "ko" = "@Bhumika-1432006"


### PR DESCRIPTION
## Summary

Fixes #5258.

Adopts the Simplified Chinese translation (`docs/i18n/README.zh-Hans.md`) by setting `"zh-Hans" = "@7487"` in `[tool.bernstein.readme-l10n.owners]`. It was listed against the maintainer, so a drift report on that file had nowhere useful to go. I read Chinese, so I can keep it current when `README.md` changes.

One line in `pyproject.toml`; no code change and no edit to `README.md`.

## Verification

```
uv run bernstein readme-l10n sync                 # done: 0 binding(s) updated
uv run bernstein readme-l10n verify --workdir .   # OK  all 23 translated README(s) in sync, exit 0
```

`sync` reporting zero updates confirms the translation is already current — adoption is the owner entry alone.

Also confirmed the entry is what the failure path actually reports: against a throwaway copy of the repo with the English README mutated, `verify` exits 1 with

```
OWNER    docs/i18n/README.zh-Hans.md is kept current by @7487
```

I read the translation end to end before taking it on; the content tracks the English, including the adapter counts (30 / 54 / 52) in "supported agents". One nit for a later PR rather than this one: a few sections (the intro paragraph, "what a run looks like") use halfwidth `,` where the rest of the file uses fullwidth `，`. Cosmetic, and mixing it into an ownership change would only make this diff harder to read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)