### PR TITLE
fix(ci): align macOS test file timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2175,6 +2175,7 @@ jobs:
       # Single source of truth for the shard count, mirrors
       # TEST_SHARD_COUNT in the `test` job above.
       MACOS_SHARD_COUNT: "4"
+      BERNSTEIN_TEST_FILE_TIMEOUT_SECONDS: "600"
     strategy:
       fail-fast: false
       matrix:

--- a/tests/unit/test_cross_platform_ci.py
+++ b/tests/unit/test_cross_platform_ci.py
@@ -101,6 +101,18 @@ class TestCIWorkflowExists:
         assert "name" in data
         assert "jobs" in data
 
+    def test_main_and_macos_test_jobs_share_per_file_timeout(self) -> None:
+        data = _load_ci_workflow()
+        jobs = cast("dict[str, Any]", data["jobs"])
+        test_job = cast("dict[str, Any]", jobs["test"])
+        macos_job = cast("dict[str, Any]", jobs["test-macos"])
+        test_env = cast("dict[str, Any]", test_job.get("env", {}))
+        macos_env = cast("dict[str, Any]", macos_job.get("env", {}))
+
+        timeout_key = "BERNSTEIN_TEST_FILE_TIMEOUT_SECONDS"
+        assert test_env.get(timeout_key) == "600"
+        assert macos_env.get(timeout_key) == test_env[timeout_key]
+
     def test_ci_runs_on_ubuntu(self) -> None:
         data = _load_ci_workflow()
         # At least one job should run on ubuntu


### PR DESCRIPTION
## What

Give the macOS test shards the same 600-second per-file timeout as the main CI test job and pin that parity with a structural regression test.

## Why

`test-macos` was falling back to `scripts/run_tests.py`'s 300-second default even though the main `test` job already allows 600 seconds for heavier CI files. Fixes #5653.

## How

Set `BERNSTEIN_TEST_FILE_TIMEOUT_SECONDS` to `"600"` in the `test-macos` job environment and assert that the main and macOS jobs retain the same value. Focused workflow, runner, lint, formatting, and actionlint checks pass, including the affected security-controls test through the isolated runner.

## Checklist

- [ ] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` passes
- [ ] `uv run python scripts/run_tests.py -x` passes
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (N/A — internal CI configuration only)
- [x] `docs/operations/<area>.md` updated (N/A — no operator workflow changed)
- [x] `docs/api/` schema regenerated if a public surface changed (N/A — no public surface changed)
- [x] `uv run bernstein agents-md sync` run so AGENTS.md, CLAUDE.md, `.goosehints`, `CONVENTIONS.md`, and `.cursor/rules/*.mdc` reflect any new module (N/A — no module added)
- [x] Tests cover the changed behaviour