### PR TITLE
fix(env_isolation): preserve PYTHONUTF8 and PYTHONIOENCODING in _BASE_ALLOWLIST for Windows UTF-8 compatibility

### DIFF
--- a/docs/operations/env-isolation.md
+++ b/docs/operations/env-isolation.md
@@ -55,7 +55,7 @@ function in a Unix-like environment:
 | Group               | Vars |
 |---------------------|------|
 | Shell basics        | `PATH`, `HOME`, `USER`, `LOGNAME`, `SHELL` |
-| Locale              | `LANG`, `LC_ALL`, `LC_CTYPE`, `LC_MESSAGES` |
+| Locale / text encoding | `LANG`, `LC_ALL`, `LC_CTYPE`, `LC_MESSAGES`, `PYTHONUTF8`, `PYTHONIOENCODING` |
 | Terminal            | `TERM`, `COLORTERM`, `COLUMNS`, `LINES` |
 | Temp dirs           | `TMPDIR`, `TMP`, `TEMP` |
 | XDG                 | `XDG_RUNTIME_DIR`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_CACHE_HOME` |
@@ -63,6 +63,10 @@ function in a Unix-like environment:
 | SSH / git transport | `SSH_AUTH_SOCK`, `GIT_SSH_COMMAND`, `GIT_SSH` |
 | Python              | `PYTHONPATH`, `VIRTUAL_ENV`, `CONDA_DEFAULT_ENV`, `CONDA_PREFIX` |
 | Node                | `NVM_DIR`, `NVM_BIN`, `NVM_PATH`, `NODE_PATH` |
+
+`PYTHONUTF8` and `PYTHONIOENCODING` are passthrough settings: Bernstein
+preserves the operator-supplied values when present, but does not create,
+normalise, or otherwise force an encoding when they are absent.
 
 There is no built-in proxy entry. If you run behind a corporate proxy
 you probably want `HTTPS_PROXY`, `HTTP_PROXY`, and `NO_PROXY` -

--- a/docs/release-notes/fragments/5718-windows-python-utf8-env.md
+++ b/docs/release-notes/fragments/5718-windows-python-utf8-env.md
@@ -1,0 +1,7 @@
+## Preserve Python encoding settings across filtered Windows spawns
+
+Filtered agent and worker subprocesses now preserve operator-set `PYTHONUTF8`
+and `PYTHONIOENCODING` values, so Windows Python processes do not lose their
+configured UTF-8 or standard-stream encoding at the environment-isolation
+boundary. Bernstein passes the existing values through unchanged and does not
+set either variable when the operator has not configured it (#5718).

--- a/src/bernstein/adapters/env_isolation.py
+++ b/src/bernstein/adapters/env_isolation.py
@@ -65,6 +65,8 @@ _BASE_ALLOWLIST: frozenset[str] = frozenset(
         "LC_ALL",
         "LC_CTYPE",
         "LC_MESSAGES",
+        "PYTHONUTF8",
+        "PYTHONIOENCODING",
         # --- User identity ---
         # git uses USER/LOGNAME as fallback for commit authorship
         "USER",

--- a/tests/unit/test_env_isolation.py
+++ b/tests/unit/test_env_isolation.py
@@ -52,6 +52,33 @@ class TestBuildFilteredEnv:
         # unrelated secret still stripped
         assert "DATABASE_URL" not in result
 
+    def test_python_encoding_vars_in_allowlist(self) -> None:
+        """Python UTF-8/stdio encoding controls are preserved across filtered spawns."""
+        assert "PYTHONUTF8" in _BASE_ALLOWLIST
+        assert "PYTHONIOENCODING" in _BASE_ALLOWLIST
+
+    def test_python_encoding_vars_pass_through_build_filtered_env(self) -> None:
+        """Operator-set Python encoding values pass through unchanged."""
+        for python_utf8, python_io_encoding in (("1", "utf-8"), ("0", "cp1252:replace")):
+            fake_env = {
+                "PATH": r"C:\Python312",
+                "PYTHONUTF8": python_utf8,
+                "PYTHONIOENCODING": python_io_encoding,
+                "DATABASE_URL": "postgres://user:pass@host/db",
+            }
+            with patch("bernstein.adapters.env_isolation.os.environ", fake_env):
+                result = build_filtered_env()
+            assert result["PYTHONUTF8"] == python_utf8
+            assert result["PYTHONIOENCODING"] == python_io_encoding
+            assert "DATABASE_URL" not in result
+
+    def test_python_encoding_vars_are_not_synthesized(self) -> None:
+        """Missing Python encoding controls stay absent from the filtered env."""
+        with patch("bernstein.adapters.env_isolation.os.environ", {"PATH": r"C:\Python312"}):
+            result = build_filtered_env()
+        assert "PYTHONUTF8" not in result
+        assert "PYTHONIOENCODING" not in result
+
     def test_secrets_excluded(self) -> None:
         """Database credentials, CI tokens and unrelated keys are stripped."""
         sensitive = {


### PR DESCRIPTION
## What

Preserve operator-set `PYTHONUTF8` and `PYTHONIOENCODING` values across Bernstein's filtered subprocess environment.

## Why

Windows Python child processes could lose explicit UTF-8 or standard-stream encoding settings at the environment-isolation boundary and fall back to legacy code pages.

Fixes #5718

## How

- Add `PYTHONUTF8` and `PYTHONIOENCODING` to the locale/text-encoding base allowlist without creating, validating, or normalizing their values.
- Add regression coverage for allowlist membership, exact passthrough including non-default values, absence when unset, and continued filtering of unrelated secrets.
- Document the passthrough behavior and add the #5718 release-note fragment.

Focused env-isolation tests, Ruff, formatting, and the release-notes gate pass. Focused comparison confirms the touched-file pyright diagnostics are pre-existing, while the broader unit suite was not completed.

## Checklist

- [x] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` passes
- [ ] `uv run python scripts/run_tests.py -x` passes
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (or N/A if internal-only)
  - N/A: there is no relevant README section for this environment-isolation passthrough behavior.
- [x] `docs/operations/<area>.md` updated (or N/A)
- [x] `docs/api/` schema regenerated if a public surface changed (or N/A)
  - N/A: no public API surface changed.
- [x] `uv run bernstein agents-md sync` run so AGENTS.md, CLAUDE.md, `.goosehints`, `CONVENTIONS.md`, and `.cursor/rules/*.mdc` reflect any new module (or N/A)
  - N/A: no module was added.
- [x] Tests cover the documented behaviour