### PR TITLE
chore(auto): nightly mirror + format drift sweep

### DIFF
--- a/tests/unit/test_context_compression.py
+++ b/tests/unit/test_context_compression.py
@@ -388,4 +388,3 @@ def test_context_compressor_has_no_embedding_scorer_attribute(project: Path) -> 
 
     compressor = ContextCompressor(project)
     assert not hasattr(compressor, "embedding_scorer")
-

--- a/tests/unit/test_git_pr.py
+++ b/tests/unit/test_git_pr.py
@@ -182,9 +182,7 @@ def test_merge_with_conflict_detection_returns_the_commit_sha(
     orig_fake = fake
     expected_sha = "deadbeef" * 5
 
-    def _fake_with_commit_and_rev_parse(
-        args: list[str], cwd: Path, timeout: int = 30, **kwargs: object
-    ) -> GitResult:
+    def _fake_with_commit_and_rev_parse(args: list[str], cwd: Path, timeout: int = 30, **kwargs: object) -> GitResult:
         if args[:1] == ["commit"]:
             return GitResult(returncode=0, stdout="", stderr="")
         if args[:2] == ["rev-parse", "HEAD"]:


### PR DESCRIPTION
Nightly sweep regenerated AGENTS.md mirrors and ran ruff format on main. Diff is mechanical and may be merged after CI passes.

Source run: https://github.com/sipyourdrink-ltd/bernstein/actions/runs/34344531671