### PR TITLE
chore(vscode): require js-yaml 4.3.2 or later

### DIFF
--- a/packages/vscode/package-lock.json
+++ b/packages/vscode/package-lock.json
@@ -3350,29 +3350,6 @@
         "text-table": "^0.2.0"
       }
     },
-    "node_modules/@textlint/linter-formatter/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@textlint/linter-formatter/node_modules/pluralize": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-2.0.0.tgz",
@@ -8269,29 +8246,6 @@
         "js-yaml": "^4.1.1",
         "json5": "^2.2.3",
         "require-from-string": "^2.0.2"
-      }
-    },
-    "node_modules/rc-config-loader/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/rc/node_modules/strip-json-comments": {

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -113,7 +113,7 @@
   "overrides": {
     "uuid": "^14.0.0",
     "fast-uri": ">=4.1.2 <5",
-    "js-yaml": ">=4.3.1 <6",
+    "js-yaml": ">=4.3.2 <6",
     "@istanbuljs/load-nyc-config": {
       "js-yaml": ">=3.15.1 <6"
     }

--- a/tests/unit/test_context_compression.py
+++ b/tests/unit/test_context_compression.py
@@ -388,4 +388,3 @@ def test_context_compressor_has_no_embedding_scorer_attribute(project: Path) -> 
 
     compressor = ContextCompressor(project)
     assert not hasattr(compressor, "embedding_scorer")
-


### PR DESCRIPTION
Two nested copies of `js-yaml` in `packages/vscode` resolved to 4.3.1, which is inside the range GHSA-2883-xcg3-v3hh covers. The override floor moves to 4.3.2 and the lockfile is re-resolved; both copies dedupe onto the 5.x already in the tree. Lockfile-only change, no runtime code touched.