### PR TITLE
ci: add a smoke check for the project's own scheduled-job runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+# Labels of the project's own runners. Without this, actionlint rejects any
+# `runs-on` label it does not recognise as a hosted-runner label.
+self-hosted-runner:
+  labels:
+    - vps

--- a/.github/workflows/runner-canary.yml
+++ b/.github/workflows/runner-canary.yml
@@ -1,0 +1,41 @@
+# Smoke check for the project's own scheduled-job runner.
+#
+# Runs only on schedule or by hand, never on pull-request events, and
+# checks out nothing: it exists to prove that the runner picks up a
+# job quickly, runs as an unprivileged user, and has no access to a
+# container socket. Job-level `permissions: {}` keeps the token inert.
+name: Runner canary
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 5 * * *"
+
+permissions: {}
+
+jobs:
+  canary:
+    name: Runner canary
+    runs-on: [self-hosted, linux, vps]
+    timeout-minutes: 5
+    steps:
+      - name: Report host facts
+        run: |
+          uname -a
+          id
+          echo "work=$(pwd)"
+      - name: Assert no container socket
+        run: |
+          if [ -e /var/run/docker.sock ]; then
+            echo "::error::container socket is visible inside the runner"
+            exit 1
+          fi
+          echo "no-docker-sock"
+      - name: Assert unprivileged user
+        run: |
+          if [ "$(id -u)" -eq 0 ]; then
+            echo "::error::runner is executing as root"
+            exit 1
+          fi
+      - name: Reach the API
+        run: curl -sSI https://api.github.com | head -1

--- a/.github/workflows/runner-canary.yml
+++ b/.github/workflows/runner-canary.yml
@@ -4,6 +4,14 @@
 # checks out nothing: it exists to prove that the runner picks up a
 # job quickly, runs as an unprivileged user, and has no access to a
 # container socket. Job-level `permissions: {}` keeps the token inert.
+#
+# The rule for the runner group this job proves out: a workflow may run
+# there only if it has no pull-request trigger of any kind and checks out
+# no ref it did not author. A self-hosted runner executes whatever a pull
+# request carries, and on a public repository that is anyone's code. Every
+# scheduled job moved onto the group has to keep both properties; this
+# file is the reference, and it deliberately prints nothing about the host
+# beyond pass or fail.
 name: Runner canary
 
 on:
@@ -19,18 +27,18 @@ jobs:
     runs-on: [self-hosted, linux, vps]
     timeout-minutes: 5
     steps:
-      - name: Report host facts
-        run: |
-          uname -a
-          id
-          echo "work=$(pwd)"
       - name: Assert no container socket
         run: |
-          if [ -e /var/run/docker.sock ]; then
-            echo "::error::container socket is visible inside the runner"
-            exit 1
-          fi
-          echo "no-docker-sock"
+          for sock in /var/run/docker.sock /run/docker.sock \
+                      /run/podman/podman.sock /run/containerd/containerd.sock \
+                      "${XDG_RUNTIME_DIR:-/nonexistent}/docker.sock" \
+                      "${XDG_RUNTIME_DIR:-/nonexistent}/podman/podman.sock"; do
+            if [ -e "$sock" ]; then
+              echo "::error::container socket is visible inside the runner: $sock"
+              exit 1
+            fi
+          done
+          echo "no-container-socket"
       - name: Assert unprivileged user
         run: |
           if [ "$(id -u)" -eq 0 ]; then
@@ -38,4 +46,6 @@ jobs:
             exit 1
           fi
       - name: Reach the API
-        run: curl -sSI https://api.github.com | head -1
+        run: |
+          set -o pipefail
+          curl -fsSI https://api.github.com | head -1

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -69,6 +69,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/release-major-minor.yml | Major/Minor Release | workflow_dispatch | {"cancel-in-progress": "false", "group": "release-major-minor-${{ github.ref }}"} | 1 |
 | .github/workflows/rendering-lane.yml | Rendering lane | pull_request, workflow_dispatch | {"cancel-in-progress": "true", "group": "rendering-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) \|\| format('branch-{0}-{1}', github.ref, github.sha) }}"} | 1 |
 | .github/workflows/required-check-canary.yml | Required-check name canary | pull_request, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "required-check-canary-${{ github.event.pull_request.number \|\| github.ref }}"} | 1 |
+| .github/workflows/runner-canary.yml | Runner canary | schedule, workflow_dispatch | - | 1 |
 | .github/workflows/sbom.yml | SBOM | release, workflow_dispatch | {"cancel-in-progress": "false", "group": "sbom-${{ github.ref }}"} | 1 |
 | .github/workflows/scorecard.yml | OSSF Scorecard | branch_protection_rule, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "scorecard-${{ github.ref }}"} | 2 |
 | .github/workflows/soc2-evidence-weekly.yml | soc2-evidence-weekly | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "soc2-evidence-${{ github.ref }}"} | 2 |
@@ -146,6 +147,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/release-major-minor.yml | release: ${{ inputs.bump }} release |
 | .github/workflows/rendering-lane.yml | rendering: Rendering fetcher (browser-backed) |
 | .github/workflows/required-check-canary.yml | verify: Required-check name canary |
+| .github/workflows/runner-canary.yml | canary: Runner canary |
 | .github/workflows/sbom.yml | sbom: Generate SBOM |
 | .github/workflows/scorecard.yml | analysis: Scorecard analysis<br>upload: Filter suppressions and upload to Code Scanning |
 | .github/workflows/soc2-evidence-weekly.yml | pack: generate evidence pack<br>preflight: preflight (gate) |
@@ -223,6 +225,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/release-major-minor.yml | workflow: {"contents": "read"}<br>release: {"contents": "write", "pull-requests": "write"} | BERNSTEIN_AUTOSYNC_TOKEN, GITHUB_TOKEN |
 | .github/workflows/rendering-lane.yml | workflow: {"contents": "read"} | - |
 | .github/workflows/required-check-canary.yml | verify: {"contents": "read"} | - |
+| .github/workflows/runner-canary.yml | - | - |
 | .github/workflows/sbom.yml | workflow: {"contents": "read"}<br>sbom: {"contents": "write"} | - |
 | .github/workflows/scorecard.yml | workflow: {"contents": "read"}<br>analysis: {"actions": "read", "contents": "read", "id-token": "write", "security-events": "write"}<br>upload: {"contents": "read", "security-events": "write"} | - |
 | .github/workflows/soc2-evidence-weekly.yml | workflow: {"contents": "read"} | SOC2_EVIDENCE_ENABLED, SOC2_EVIDENCE_SINK |

--- a/tests/unit/test_context_compression.py
+++ b/tests/unit/test_context_compression.py
@@ -388,3 +388,4 @@ def test_context_compressor_has_no_embedding_scorer_attribute(project: Path) -> 
 
     compressor = ContextCompressor(project)
     assert not hasattr(compressor, "embedding_scorer")
+

--- a/tests/unit/test_context_compression.py
+++ b/tests/unit/test_context_compression.py
@@ -388,4 +388,3 @@ def test_context_compressor_has_no_embedding_scorer_attribute(project: Path) -> 
 
     compressor = ContextCompressor(project)
     assert not hasattr(compressor, "embedding_scorer")
-


### PR DESCRIPTION
Adds a workflow that runs only on schedule or by hand, checks out nothing, and asserts the runner executes as an unprivileged user without access to a container socket. It is the first workflow admitted to the dedicated runner group; scheduled maintenance jobs move over one at a time once it stays green.