### PR TITLE
docs: align CONTRIBUTING, GOVERNANCE, CODE_REVIEW and CODEOWNERS with the review charter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -52,9 +52,16 @@
 /.cursor/ @chernistry
 /.qwen/ @chernistry
 
-# Container images are in scope in SECURITY.md (charter, s4).
+# The two published images, `bernstein:latest` and `bernstein:sandbox`, are
+# in scope in SECURITY.md (charter, s4), and the researcher sandbox is where
+# SECURITY.md promises egress blocking and an ephemeral filesystem - so the
+# files that build it are reserved too. The rigs under docker/demo/,
+# docker/volunteer-hub/ and docker/volunteer-rig/ publish no image and carry
+# no such promise; they stay on the normal quorum.
 /Dockerfile @chernistry
 /docker-compose.yaml @chernistry
+/docker/sandbox/ @chernistry
+/scripts/researcher_sandbox.sh @chernistry
 
 # The review roster and the two scripts that enforce this file and the
 # charter. `.github/` above already covers the roster; these are the pieces

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,6 +21,7 @@
 
 # Lockfiles outside the root, for the same reason as /uv.lock (charter, s4).
 /sdk/python/uv.lock @chernistry
+/sdk/python/pyproject.toml @chernistry
 /sdk/typescript/package-lock.json @chernistry
 /web/package-lock.json @chernistry
 /packages/vscode/package-lock.json @chernistry
@@ -31,10 +32,12 @@
 /.goosehints @chernistry
 /.mcp.json @chernistry
 /.cursor/ @chernistry
+/.qwen/ @chernistry
 
 # Container images are in scope in SECURITY.md (charter, s4).
 /Dockerfile @chernistry
 /docker-compose.yaml @chernistry
+
 /SECURITY.md @chernistry
 /GOVERNANCE.md @chernistry
 /MAINTAINERS.md @chernistry

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,10 +18,17 @@
 /proto/ @chernistry
 /pyproject.toml @chernistry
 /uv.lock @chernistry
+/SECURITY.md @chernistry
+/GOVERNANCE.md @chernistry
+/MAINTAINERS.md @chernistry
+/AGENTS.md @chernistry
+/docs/governance/ @chernistry
+/docs/decisions/ @chernistry
 
-# Lockfiles outside the root, for the same reason as /uv.lock (charter, s4).
-/sdk/python/uv.lock @chernistry
+# Manifests and lockfiles outside the root, for the same reason as
+# /pyproject.toml and /uv.lock above (charter, s4).
 /sdk/python/pyproject.toml @chernistry
+/sdk/python/uv.lock @chernistry
 /sdk/typescript/package-lock.json @chernistry
 /web/package-lock.json @chernistry
 /packages/vscode/package-lock.json @chernistry
@@ -37,13 +44,6 @@
 # Container images are in scope in SECURITY.md (charter, s4).
 /Dockerfile @chernistry
 /docker-compose.yaml @chernistry
-
-/SECURITY.md @chernistry
-/GOVERNANCE.md @chernistry
-/MAINTAINERS.md @chernistry
-/AGENTS.md @chernistry
-/docs/governance/ @chernistry
-/docs/decisions/ @chernistry
 
 # The review roster and the two scripts that enforce this file and the
 # charter. `.github/` above already covers the roster; these are the pieces

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,9 +35,11 @@
 
 # Agent configuration files at the repository root (charter, s4).
 /CLAUDE.md @chernistry
+/CONVENTIONS.md @chernistry
 /.aider.conf.yml @chernistry
 /.goosehints @chernistry
 /.mcp.json @chernistry
+/mcp.json @chernistry
 /.cursor/ @chernistry
 /.qwen/ @chernistry
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,6 +34,15 @@
 /packages/vscode/package-lock.json @chernistry
 
 # Agent configuration files at the repository root (charter, s4).
+#
+# CLAUDE.md, CONVENTIONS.md, .goosehints and .cursor/rules/*.mdc are written
+# by `bernstein agents-md sync`, which pr-policy.yml runs on every pull
+# request and pushes back onto the branch. So a change to the canonical
+# source under .sdd/agents-md/, or to the src/bernstein/ package layout it
+# derives from, regenerates them and picks up this requirement. That is
+# intended - the charter reserves these files whoever or whatever wrote
+# them - but it means a pull request can acquire the requirement without
+# naming any of these paths itself.
 /CLAUDE.md @chernistry
 /CONVENTIONS.md @chernistry
 /.aider.conf.yml @chernistry

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,23 @@
 /proto/ @chernistry
 /pyproject.toml @chernistry
 /uv.lock @chernistry
+
+# Lockfiles outside the root, for the same reason as /uv.lock (charter, s4).
+/sdk/python/uv.lock @chernistry
+/sdk/typescript/package-lock.json @chernistry
+/web/package-lock.json @chernistry
+/packages/vscode/package-lock.json @chernistry
+
+# Agent configuration files at the repository root (charter, s4).
+/CLAUDE.md @chernistry
+/.aider.conf.yml @chernistry
+/.goosehints @chernistry
+/.mcp.json @chernistry
+/.cursor/ @chernistry
+
+# Container images are in scope in SECURITY.md (charter, s4).
+/Dockerfile @chernistry
+/docker-compose.yaml @chernistry
 /SECURITY.md @chernistry
 /GOVERNANCE.md @chernistry
 /MAINTAINERS.md @chernistry

--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -46,6 +46,15 @@ on:
       - ".goosehints"
       - "README.md"
       - "CONTRIBUTING.md"
+      # Sources the playbook's governance rows name. Without these the
+      # deleted-source gate never starts for a change that removes one.
+      - "GOVERNANCE.md"
+      - "MAINTAINERS.md"
+      - "SECURITY.md"
+      - ".github/CODEOWNERS"
+      - ".github/quorum-roster.toml"
+      - "scripts/quorum_check.py"
+      - "scripts/queue_hygiene.py"
   push:
     branches: [main]
     paths:
@@ -63,6 +72,15 @@ on:
       - ".goosehints"
       - "README.md"
       - "CONTRIBUTING.md"
+      # Sources the playbook's governance rows name. Without these the
+      # deleted-source gate never starts for a change that removes one.
+      - "GOVERNANCE.md"
+      - "MAINTAINERS.md"
+      - "SECURITY.md"
+      - ".github/CODEOWNERS"
+      - ".github/quorum-roster.toml"
+      - "scripts/quorum_check.py"
+      - "scripts/queue_hygiene.py"
   schedule:
     # Weekly strict data-freshness sweep. Time-stamped markers drift purely
     # with the calendar, so the hard-threshold check runs on this cadence and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,8 +117,11 @@ All three must pass before committing. No exceptions, no "fix later."
 
 Every change lands through the merge queue with the approvals the
 [review charter](docs/governance/review-charter.md) requires: two, from
-committers who are not the author, at least one of them a code owner.
-Protected paths also need the maintainer. Reviewer checklist:
+committers who are not the author, at least one of them a core reviewer
+(the roster is `.github/quorum-roster.toml`). Ownership is separate: any
+path with a named owner in [CODEOWNERS](.github/CODEOWNERS) needs that
+owner's approval as well, rather than the core approval standing in for
+it. Protected paths also need the maintainer. Reviewer checklist:
 [docs/CODE_REVIEW.md](docs/CODE_REVIEW.md).
 
 ### If you cannot open a pull request

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ All three must pass before committing. No exceptions, no "fix later."
 Every change lands through the merge queue with the approvals the
 [review charter](docs/governance/review-charter.md) requires: two, from
 committers who are not the author, at least one of them a code owner.
-Protected paths also need the maintainer. Reviewer expectations:
+Protected paths also need the maintainer. Reviewer checklist:
 [docs/CODE_REVIEW.md](docs/CODE_REVIEW.md).
 
 ### If you cannot open a pull request

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,9 +68,12 @@ adapters, the web dashboard, the terminal UI, docs, and packaging.
 Stewardship starts at triage rather than write, because write access
 on this repository reaches the release workflows and their publishing
 credentials, and that surface is kept least-privilege. After a
-stretch of established stewardship the write grant follows, and with
-it your entry in [CODEOWNERS](.github/CODEOWNERS) - GitHub only
-honors code owners who hold write.
+stretch of established stewardship the maintainer can confirm you as a
+committer, which is the write grant, and on a record of reviews that
+found real problems as a core reviewer for the area, which is what an
+entry in [CODEOWNERS](.github/CODEOWNERS) means - GitHub only honors
+code owners who hold write. Both roles, and the floor for each, are
+defined in the [review charter](docs/governance/review-charter.md#7-becoming-and-remaining-a-committer).
 
 This is not ceremonial. An area with a name against it gets a second
 reader who knows it; an area with nobody against it accumulates
@@ -112,7 +115,11 @@ All three must pass before committing. No exceptions, no "fix later."
 4. Commit with a clear message
 5. Open a PR against `main`
 
-All non-trivial changes land via PR with at least one approving review. Security-touching changes need two approvals or operator-only push. Full process and reviewer expectations: [docs/CODE_REVIEW.md](docs/CODE_REVIEW.md).
+Every change lands through the merge queue with the approvals the
+[review charter](docs/governance/review-charter.md) requires: two, from
+committers who are not the author, at least one of them a code owner.
+Protected paths also need the maintainer. Reviewer expectations:
+[docs/CODE_REVIEW.md](docs/CODE_REVIEW.md).
 
 ### If you cannot open a pull request
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -30,9 +30,13 @@ confirms. Area stewardship
 ([CONTRIBUTING.md](CONTRIBUTING.md#areas)) is the triage-level path that
 usually comes first. Write access reaches the release workflows and their
 publishing credentials, so it follows an established record rather than
-arriving with a request. A [CODEOWNERS](.github/CODEOWNERS) entry is what
-core reviewer means in GitHub's terms, and GitHub only honors code owners
-who hold write. The project stays single-maintainer, as above.
+arriving with a request. Both roles are recorded in
+[.github/quorum-roster.toml](.github/quorum-roster.toml), which is the
+roster the merge gate reads and the one the charter's lapse rule is
+evaluated against; a core reviewer is additionally listed in
+[CODEOWNERS](.github/CODEOWNERS), which is how GitHub requests them on the
+paths they own, and GitHub only honors code owners who hold write. Adding
+someone means both files. The project stays single-maintainer, as above.
 
 **Licensing.** Apache-2.0 ([LICENSE](LICENSE)); by contributing you agree
 your contributions are licensed under it. There is no CLA and no sign-off

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -21,13 +21,16 @@ in-scope table). State the problem, the option chosen, and what it costs.
 Everything else — bug fixes, docs, tests, a new adapter — goes straight
 to a pull request.
 
-**Becoming a maintainer.** Stewardship is earned by sustained merged work
-in one area, not by application; the mechanics are in
-[CONTRIBUTING.md](CONTRIBUTING.md#areas). Write access follows a stretch
-of established stewardship rather than arriving with it, because write
-here reaches the release workflows and their publishing credentials. The
-[CODEOWNERS](.github/CODEOWNERS) entry comes with the write grant, since
-GitHub only honors code owners who hold write.
+**Becoming a committer or a core reviewer.** The roles, and the floor for
+each, are defined in the [review charter](docs/governance/review-charter.md#7-becoming-and-remaining-a-committer):
+anyone may nominate anyone, including themselves, in an issue, and the
+maintainer confirms. Area stewardship
+([CONTRIBUTING.md](CONTRIBUTING.md#areas)) is the triage-level path that
+usually comes first. Write access reaches the release workflows and their
+publishing credentials, so it follows an established record rather than
+arriving with a request. A [CODEOWNERS](.github/CODEOWNERS) entry is what
+core reviewer means in GitHub's terms, and GitHub only honors code owners
+who hold write. The project stays single-maintainer, as above.
 
 **Licensing.** Apache-2.0 ([LICENSE](LICENSE)); by contributing you agree
 your contributions are licensed under it. There is no CLA and no sign-off

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -21,10 +21,12 @@ in-scope table). State the problem, the option chosen, and what it costs.
 Everything else — bug fixes, docs, tests, a new adapter — goes straight
 to a pull request.
 
-**Becoming a committer or a core reviewer.** The roles, and the floor for
-each, are defined in the [review charter](docs/governance/review-charter.md#7-becoming-and-remaining-a-committer):
-anyone may nominate anyone, including themselves, in an issue, and the
-maintainer confirms. Area stewardship
+**Becoming a committer or a core reviewer.** Both roles are defined in the
+[review charter](docs/governance/review-charter.md#7-becoming-and-remaining-a-committer),
+which sets an objective floor for committer; core reviewer has no numeric
+floor, only a sustained record of reviews that found real problems. Anyone
+may nominate anyone, including themselves, in an issue, and the maintainer
+confirms. Area stewardship
 ([CONTRIBUTING.md](CONTRIBUTING.md#areas)) is the triage-level path that
 usually comes first. Write access reaches the release workflows and their
 publishing credentials, so it follows an established record rather than

--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -18,9 +18,10 @@ a core reviewer is `.github/quorum-roster.toml`. Ownership is a second, separate
 requirement: every path with a named owner in `.github/CODEOWNERS` needs that
 owner's approval too, so a core reviewer's approval does not stand in for a code
 owner's on a path the owner holds. A new push dismisses earlier approvals, and
-the person who pushed last cannot supply the final one. A change over 400 lines, or one touching a path with
-`sandbox`, `security`, or `audit` in it, needs a third approval from a core
-reviewer, and over 1,000 lines gets split or sent to the maintainer instead.
+the person who pushed last cannot supply the final one. A change over 400
+lines, or one touching a path with `sandbox`, `security`, or `audit` in it,
+needs three approvals, two of them from core reviewers, and over 1,000 lines
+gets split or sent to the maintainer instead.
 Protected paths (charter section 4, including the `.github/` directory, `core`,
 `evolution`, `adapters`, dependency lockfiles, schemas, the security and
 governance documents, agent configuration files) also need the maintainer's
@@ -28,7 +29,9 @@ approval. The project's own automation merges its own changes when CI is green;
 dependency bots merge under their own policy. Neither counts toward a human
 quorum, and neither self-merges a change whose paths carry `sandbox`,
 `security`, `audit` or `auth`, or sit under `.github/`, `schemas/` or `proto/`
-- those wait for the maintainer's approval like anyone else's.
+- those wait for the maintainer's approval like anyone else's. That carve-out
+is what the `quorum` check applies today; the charter's automation row does
+not carry it yet, and #5740 proposes it for section 1.
 
 ## Reviewer checklist
 
@@ -44,10 +47,10 @@ An approval says "I read the whole diff and would defend it". Before approving:
    still counts as an approval; the comment is what makes it reviewable by
    anyone reading the thread later.
 
-Item 4 is the one rule on this page that the charter does not yet carry.
-It is proposed for charter section 5 in #5746 with the same threshold and
-the same shape; until that lands, read it as guidance rather than a merge
-condition.
+Item 4 is the one rule on this page that neither the charter nor the check
+carries. It is proposed for charter section 5 in #5746 with the same
+threshold and the same shape; until that lands, read it as guidance rather
+than a merge condition.
 
 ## Escalation
 

--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -34,9 +34,8 @@ An approval says "I read the whole diff and would defend it". Before approving:
 3. Flag any new dependency, new outbound network call, or new credential read
    in the conversation before approving.
 4. Leave at least one line-level comment on a change over about 40 lines: a
-   finding, or a note of what you ran. Queue hygiene dismisses an approval that
-   carries none, for everyone equally, with a note on how to re-approve. A
-   summary without one is welcome as a comment.
+   finding, or a note of what you ran. A summary without one is welcome as a
+   comment.
 
 ## Escalation
 

--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -10,14 +10,15 @@ same answer.
 
 ## The rules, in one paragraph
 
-Every change goes through the merge queue; nobody pushes to `main` directly.
-A pull request merges with two approving reviews from committers who are not
-its author, at least one of them from a code owner (`.github/CODEOWNERS`),
-green required checks on the queued state, and no unresolved *changes
-requested*. A new push dismisses earlier approvals, and the person who pushed
-last cannot supply the final one. A change over 400 lines, or one touching a
-path with `sandbox`, `security`, or `audit` in it, needs a third approval from
-a core reviewer. Protected paths (charter section 4: workflows, `core`,
+Every change goes through the merge queue; nobody pushes to `main` directly. A
+pull request merges with two approving reviews from committers who are not its
+author, at least one of them from a code owner (`.github/CODEOWNERS`), green
+required checks on the queued state, and no unresolved *changes requested*. A
+new push dismisses earlier approvals, and the person who pushed last cannot
+supply the final one. A change over 400 lines, or one touching a path with
+`sandbox`, `security`, or `audit` in it, needs a third approval from a core
+reviewer, and over 1,000 lines gets split or sent to the maintainer instead.
+Protected paths (charter section 4, including the `.github/` directory, `core`,
 `evolution`, `adapters`, dependency lockfiles, schemas, the security and
 governance documents, agent configuration files) also need the maintainer's
 approval. The project's own automation merges its own changes when CI is green;

--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -12,10 +12,13 @@ same answer.
 
 Every change goes through the merge queue; nobody pushes to `main` directly. A
 pull request merges with two approving reviews from committers who are not its
-author, at least one of them from a code owner (`.github/CODEOWNERS`), green
-required checks on the queued state, and no unresolved *changes requested*. A
-new push dismisses earlier approvals, and the person who pushed last cannot
-supply the final one. A change over 400 lines, or one touching a path with
+author, at least one of them from a core reviewer, green required checks on the
+queued state, and no unresolved *changes requested*. The roster that says who is
+a core reviewer is `.github/quorum-roster.toml`. Ownership is a second, separate
+requirement: every path with a named owner in `.github/CODEOWNERS` needs that
+owner's approval too, so a core reviewer's approval does not stand in for a code
+owner's on a path the owner holds. A new push dismisses earlier approvals, and
+the person who pushed last cannot supply the final one. A change over 400 lines, or one touching a path with
 `sandbox`, `security`, or `audit` in it, needs a third approval from a core
 reviewer, and over 1,000 lines gets split or sent to the maintainer instead.
 Protected paths (charter section 4, including the `.github/` directory, `core`,

--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -26,7 +26,9 @@ Protected paths (charter section 4, including the `.github/` directory, `core`,
 governance documents, agent configuration files) also need the maintainer's
 approval. The project's own automation merges its own changes when CI is green;
 dependency bots merge under their own policy. Neither counts toward a human
-quorum.
+quorum, and neither self-merges a change whose paths carry `sandbox`,
+`security`, `audit` or `auth`, or sit under `.github/`, `schemas/` or `proto/`
+- those wait for the maintainer's approval like anyone else's.
 
 ## Reviewer checklist
 

--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -40,8 +40,14 @@ An approval says "I read the whole diff and would defend it". Before approving:
 3. Flag any new dependency, new outbound network call, or new credential read
    in the conversation before approving.
 4. Leave at least one line-level comment on a change over about 40 lines: a
-   finding, or a note of what you ran. A summary without one is welcome as a
-   comment.
+   finding, or a note of what you ran. A review that says only "looks good"
+   still counts as an approval; the comment is what makes it reviewable by
+   anyone reading the thread later.
+
+Item 4 is the one rule on this page that the charter does not yet carry.
+It is proposed for charter section 5 in #5746 with the same threshold and
+the same shape; until that lands, read it as guidance rather than a merge
+condition.
 
 ## Escalation
 

--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -1,73 +1,47 @@
-# Code Review Process
+# Code review
 
-Last reviewed: 2026-07-16.
+Last reviewed: 2026-09-09.
 
-This document describes how changes land in Bernstein. It exists so the OpenSSF
-Scorecard, regulated buyers, and new contributors can all read the same answer
-in one place.
+The rules for how a change reaches `main` live in one place, the
+[review charter](governance/review-charter.md). This page is the reviewer's
+checklist and defers to the charter for everything else, so that the OpenSSF
+Scorecard, operators evaluating the project, and new contributors all read the
+same answer.
 
-## Default rule
+## The rules, in one paragraph
 
-All non-trivial changes land via pull request against `main` with at least one
-approving review from a maintainer or designated reviewer. Direct pushes to
-`main` are reserved for the operator (repo owner) and limited to:
+Every change goes through the merge queue; nobody pushes to `main` directly.
+A pull request merges with two approving reviews from committers who are not
+its author, at least one of them from a code owner (`.github/CODEOWNERS`),
+green required checks on the queued state, and no unresolved *changes
+requested*. A new push dismisses earlier approvals, and the person who pushed
+last cannot supply the final one. A change over 400 lines, or one touching a
+path with `sandbox`, `security`, or `audit` in it, needs a third approval from
+a core reviewer. Protected paths (charter section 4: workflows, `core`,
+`evolution`, `adapters`, dependency lockfiles, schemas, the security and
+governance documents, agent configuration files) also need the maintainer's
+approval. The project's own automation merges its own changes when CI is green;
+dependency bots merge under their own policy. Neither counts toward a human
+quorum.
 
-- Release-cut commits produced by the auto-release workflow.
-- Documentation typo fixes and link repairs.
-- Emergency hotfixes for production-breaking issues, which are followed by a
-  retrospective PR within 24 hours.
+## Reviewer checklist
 
-## Security-sensitive changes
+An approval says "I read the whole diff and would defend it". Before approving:
 
-Changes that touch any of the following paths require **two** approving
-reviews, or operator-only push from a verified-signed commit:
-
-- `SECURITY.md`
-- `.github/workflows/**`
-- `src/bernstein/core/security/**`
-- `src/bernstein/core/identity/**`
-- Anything under `*signing*`, `*auth*`, `*credential*`, or `*token*` paths
-- Cryptographic key material, public keys, or signature verification logic
-
-## Required status checks
-
-Branch protection on `main` requires the following checks to pass before a PR
-can merge:
-
-- CI (`.github/workflows/ci.yml`)
-- CodeQL (`.github/workflows/codeql.yml`)
-- Architecture contracts (`lint-imports`)
-- Type checks (`pyright src/`)
-
-A green status from each is non-negotiable.
-
-## Reviewer expectations
-
-A reviewer is expected to:
-
-1. Pull the branch locally for any non-trivial change and run the affected
-   test files.
-2. Sanity-check that new public surface (CLI flags, MCP tools, HTTP routes,
-   adapter contracts) has corresponding tests and docs in the same PR.
+1. Pull the branch for any non-trivial change and run the affected tests.
+2. Check that new public surface (CLI flags, MCP tools, HTTP routes, adapter
+   contracts) has tests and docs in the same pull request.
 3. Flag any new dependency, new outbound network call, or new credential read
-   in the PR conversation before approving.
-
-## Auto-merged PRs
-
-The following PR classes are auto-merged when checks are green and one
-approving review is present:
-
-- Dependabot bumps in the `minor-and-patch` and `actions-minor-patch` groups.
-- Documentation-only changes (`docs:` prefix) from maintainers.
-
-Security-group Dependabot bumps (`cryptography`, `pyjwt`, `lxml`, etc.) are
-never auto-merged; they require a maintainer review even when the diff is
-trivial.
+   in the conversation before approving.
+4. Leave at least one line-level comment on a change over about 40 lines: a
+   finding, or a note of what you ran. Queue hygiene dismisses an approval that
+   carries none, for everyone equally, with a note on how to re-approve. A
+   summary without one is welcome as a comment.
 
 ## Escalation
 
-If a reviewer disagrees with the operator on a security-sensitive change, the
-change is blocked until a second maintainer weighs in or the disagreement is
-recorded in `docs/decisions/`. Disagreements about non-security changes are
-resolved by the operator after the reviewer's concerns are acknowledged in the
-PR conversation.
+A dispute, one approval against one *changes requested*, stays open until the
+requester is satisfied or seven days pass; then the thread gets
+`needs-maintainer`. Disagreements on security-sensitive changes are resolved by
+the maintainer, and when the outcome settles a boundary it is recorded in
+`docs/decisions/`.

--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -46,7 +46,8 @@ An approval says "I read the whole diff and would defend it". Before approving:
 ## Escalation
 
 A dispute, one approval against one *changes requested*, stays open until the
-requester is satisfied or seven days pass; then the thread gets
-`needs-maintainer`. Disagreements on security-sensitive changes are resolved by
+requester is satisfied or seven days pass; then anyone on the thread applies
+`needs-maintainer` by hand. No script sets that label today, so nothing marks
+the thread if nobody does. Disagreements on security-sensitive changes are resolved by
 the maintainer, and when the outcome settles a boundary it is recorded in
 `docs/decisions/`.

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -18,7 +18,7 @@ organized, and the contracts new adapters and hooks must satisfy.
 
     How review works and how the test suite is organized.
 
-    [:octicons-arrow-right-24: Code review process](../CODE_REVIEW.md)
+    [:octicons-arrow-right-24: Code review](../CODE_REVIEW.md)
     &middot;
     [Testing and CI hardening](testing.md)
     &middot;

--- a/docs/playbooks/docs-drift.md
+++ b/docs/playbooks/docs-drift.md
@@ -53,8 +53,9 @@ Drift remediation paths used by the rows below:
 | Doc | Source of truth | Drift signal | Remediation |
 |-----|-----------------|--------------|-------------|
 | `GOVERNANCE.md` | `docs/governance/`, `.github/CODEOWNERS`, `./MAINTAINERS.md` | Maintainer model changes, protected-path ownership changes, or the committer/maintainer roster changes | `manual-prose` |
-| `docs/governance/review-charter.md` | `.github/CODEOWNERS`, `.github/quorum-roster.toml`, `scripts/quorum_check.py`, `scripts/queue_hygiene.py`, `docs/CODE_REVIEW.md` | Ownership rules, the quorum roster, or the queue/quorum automation change without a matching charter update | `manual-prose` |
+| `docs/governance/review-charter.md` | `.github/CODEOWNERS`, `.github/quorum-roster.toml`, `scripts/quorum_check.py`, `scripts/queue_hygiene.py` | Ownership rules, the quorum roster, or the queue/quorum automation change without a matching charter update | `manual-prose` |
 | `.github/CODEOWNERS` | `./SECURITY.md`, `docs/governance/review-charter.md`, and any new top-level directory | The security scope changes, the charter's protected-paths list changes, or a new top-level directory needs an ownership decision | `manual-prose` |
+| `docs/CODE_REVIEW.md` | `docs/governance/review-charter.md`, `.github/quorum-roster.toml`, `scripts/quorum_check.py` | The charter's approval counts, size thresholds or protected-path list change without the checklist following | `manual-prose` |
 
 ### `docs/` top-level
 
@@ -65,7 +66,6 @@ Drift remediation paths used by the rows below:
 | `docs/agents-md.md` | `src/bernstein/cli/commands/agents_md_cmd.py`, `src/bernstein/core/knowledge/agents_md_bridge.py`, `src/bernstein/core/knowledge/agents_md_generator.py` | New target format added to the canonical IR, sync command options change | `manual-prose` |
 | `docs/playbooks/readme-l10n.md` | `src/bernstein/core/knowledge/readme_l10n.py`, `src/bernstein/cli/commands/readme_l10n_cmd.py`, `pyproject.toml` (`[tool.bernstein.readme-l10n]`) | Binding format change, verify/sync surface change, language config change | `manual-prose` |
 | `docs/CHANGELOG.md` | Pointer document for mkdocs; release history lives in `docs/release-notes/` | The release-notes location moves | `manual-prose` |
-| `docs/CODE_REVIEW.md` | `src/bernstein/core/quality/`, `src/bernstein/core/review/`, `src/bernstein/core/review_responder/` | Review pipeline stage added, reviewer-role policy change | `manual-prose` |
 | `docs/ENTERPRISE.md` | `src/bernstein/core/compliance/`, `src/bernstein/core/security/`, audit / lineage / air-gap surface | New regulator mapping, new compliance pack target, audit export schema change | `manual-prose` |
 | `docs/lineage.md` | `src/bernstein/core/lineage/`, `src/bernstein/core/persistence/lineage.py`, `src/bernstein/cli/commands/lineage_cmd.py` | Lineage record schema change, signature algorithm change, new verify CLI subcommand | `manual-prose` |
 | `docs/llm-citation-surface.md` | None (positioning note about how the project surfaces in LLM citations) | External citation pattern audited | `static` |

--- a/docs/playbooks/docs-drift.md
+++ b/docs/playbooks/docs-drift.md
@@ -48,6 +48,14 @@ Drift remediation paths used by the rows below:
 | `CHANGELOG.md` | Pointer document; release history lives in `docs/release-notes/` and release tags are cut by `.github/workflows/auto-release.yml` | The release-notes location moves, or the tag-cutting workflow changes | `manual-prose` |
 | `CONTRIBUTORS.md` | None (hand-curated list of named contributors) | New contributor merged a PR | `static` |
 
+### Governance
+
+| Doc | Source of truth | Drift signal | Remediation |
+|-----|-----------------|--------------|-------------|
+| `GOVERNANCE.md` | `docs/governance/`, `.github/CODEOWNERS`, `MAINTAINERS.md` | Maintainer model changes, protected-path ownership changes, or the committer/maintainer roster changes | `manual-prose` |
+| `docs/governance/review-charter.md` | `.github/CODEOWNERS`, `.github/quorum-roster.toml`, `scripts/quorum_check.py`, `scripts/queue_hygiene.py`, `docs/CODE_REVIEW.md` | Ownership rules, the quorum roster, or the queue/quorum automation change without a matching charter update | `manual-prose` |
+| `.github/CODEOWNERS` | `SECURITY.md`, `docs/governance/review-charter.md`, and any new top-level directory | The security scope changes, the charter's protected-paths list changes, or a new top-level directory needs an ownership decision | `manual-prose` |
+
 ### `docs/` top-level
 
 | Doc | Source of truth | Drift signal | Remediation |

--- a/docs/playbooks/docs-drift.md
+++ b/docs/playbooks/docs-drift.md
@@ -52,9 +52,9 @@ Drift remediation paths used by the rows below:
 
 | Doc | Source of truth | Drift signal | Remediation |
 |-----|-----------------|--------------|-------------|
-| `GOVERNANCE.md` | `docs/governance/`, `.github/CODEOWNERS`, `MAINTAINERS.md` | Maintainer model changes, protected-path ownership changes, or the committer/maintainer roster changes | `manual-prose` |
+| `GOVERNANCE.md` | `docs/governance/`, `.github/CODEOWNERS`, `./MAINTAINERS.md` | Maintainer model changes, protected-path ownership changes, or the committer/maintainer roster changes | `manual-prose` |
 | `docs/governance/review-charter.md` | `.github/CODEOWNERS`, `.github/quorum-roster.toml`, `scripts/quorum_check.py`, `scripts/queue_hygiene.py`, `docs/CODE_REVIEW.md` | Ownership rules, the quorum roster, or the queue/quorum automation change without a matching charter update | `manual-prose` |
-| `.github/CODEOWNERS` | `SECURITY.md`, `docs/governance/review-charter.md`, and any new top-level directory | The security scope changes, the charter's protected-paths list changes, or a new top-level directory needs an ownership decision | `manual-prose` |
+| `.github/CODEOWNERS` | `./SECURITY.md`, `docs/governance/review-charter.md`, and any new top-level directory | The security scope changes, the charter's protected-paths list changes, or a new top-level directory needs an ownership decision | `manual-prose` |
 
 ### `docs/` top-level
 

--- a/docs/playbooks/docs-drift.md
+++ b/docs/playbooks/docs-drift.md
@@ -50,6 +50,15 @@ Drift remediation paths used by the rows below:
 
 ### Governance
 
+`check_docs_drift.py` compares no content. Per row it asserts that each
+recognised source exists, that the doc exists, and it fails a pull request
+that deletes a recognised source. So editing a threshold in
+`scripts/quorum_check.py`, or adding a name to `.github/quorum-roster.toml`,
+leaves every file in place and reports clean. The drift signals below are
+the cue for the reviewer of that change, not something CI detects. "Any new
+top-level directory" on the `.github/CODEOWNERS` row has no detector at all
+- it is a standing instruction to decide ownership when one appears.
+
 | Doc | Source of truth | Drift signal | Remediation |
 |-----|-----------------|--------------|-------------|
 | `GOVERNANCE.md` | `docs/governance/`, `.github/CODEOWNERS`, `./MAINTAINERS.md` | Maintainer model changes, protected-path ownership changes, or the committer/maintainer roster changes | `manual-prose` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -680,7 +680,7 @@ nav:
   - Contribute:
       - contributing/index.md
       - Project pulse: project-pulse.md
-      - Code review process: CODE_REVIEW.md
+      - Code review: CODE_REVIEW.md
       - Testing & CI hardening: contributing/testing.md
       - Lifecycle hooks contract: contributing/hooks.md
       - Git hooks: contributing/git-hooks.md

--- a/scripts/check_docs_drift.py
+++ b/scripts/check_docs_drift.py
@@ -58,6 +58,11 @@ _ROW_RE = re.compile(r"^\|\s*`([^`|]+?)`\s*\|\s*(.+?)\s*\|\s*(.+?)\s*\|\s*`([a-z
 # ``backticked`` tokens. Any token that starts with src/, scripts/,
 # templates/, web/, pyproject.toml, .sdd/, .github/, .importlinter,
 # release-please-*, .cursor/, or a docs/ subdir is treated as a path.
+#
+# A root-level file with no directory component has to be written ``./NAME``
+# to survive that filter, so the leading ``./`` is stripped again here. Both
+# consumers compare against repo-relative paths - ``REPO_ROOT / src`` and the
+# output of ``git diff --name-only`` - and neither carries the prefix.
 _PATH_RE = re.compile(r"`([^`\s]+)`")
 
 
@@ -75,7 +80,7 @@ class DocRow:
         for match in _PATH_RE.finditer(self.sources_raw):
             tok = match.group(1)
             if tok.endswith(".py") or "/" in tok or tok.endswith(".toml"):
-                out.append(tok.rstrip("/"))
+                out.append(tok.removeprefix("./").rstrip("/"))
         return out
 
 

--- a/tests/unit/test_docs_drift_deleted_sources.py
+++ b/tests/unit/test_docs_drift_deleted_sources.py
@@ -67,6 +67,25 @@ def test_deleting_a_documented_source_is_reported() -> None:
     assert [src for _, src in hits] == [REAL_DELETED_SOURCE]
 
 
+def test_a_root_level_source_is_parsed_and_normalised() -> None:
+    """``./NAME`` is how a root file survives the path filter.
+
+    Without the prefix the token has no ``/`` and no ``.py``/``.toml``
+    suffix, so the parser drops it and the row's own source is invisible to
+    both checks. With it, the prefix has to come back off: ``git diff
+    --name-only`` prints ``MAINTAINERS.md``, not ``./MAINTAINERS.md``.
+    """
+    row = _row("`./MAINTAINERS.md`, `.github/CODEOWNERS`")
+    assert row.source_paths == ["MAINTAINERS.md", ".github/CODEOWNERS"]
+    hits = _script().sources_deleted_by(["MAINTAINERS.md"], [row])
+    assert [src for _, src in hits] == ["MAINTAINERS.md"]
+
+
+def test_a_bare_root_level_source_is_still_dropped() -> None:
+    """The filter is unchanged for tokens without the prefix."""
+    assert _row("`MAINTAINERS.md`").source_paths == []
+
+
 def test_deleting_an_undocumented_path_is_not_reported() -> None:
     """Deletions unrelated to any doc must not block the change."""
     mod = _script()


### PR DESCRIPTION
Three pages still described the review model that `docs/governance/review-charter.md` replaced in #5729:

| Page | Said | Now |
|---|---|---|
| `CONTRIBUTING.md` | one approving review is enough; security changes need two or an operator push | defers to the charter: two approvals, one from a code owner, protected paths need the maintainer |
| `docs/CODE_REVIEW.md` | direct pushes to `main` reserved for the operator; its own list of two-approval paths | one paragraph of rules pointing at the charter, plus the reviewer checklist |
| `GOVERNANCE.md` | write access follows area stewardship; the CODEOWNERS entry comes with it | committer and core reviewer are defined by the charter; stewardship is the triage-level path that usually comes first |

`.github/CODEOWNERS` gains the paths the charter's section 4 reserves but the file did not yet list: the lockfiles outside the root (`sdk/python/uv.lock`, `sdk/typescript/package-lock.json`, `web/package-lock.json`, `packages/vscode/package-lock.json`), the agent configuration files at the root (`CLAUDE.md`, `.aider.conf.yml`, `.goosehints`, `.mcp.json`, `.cursor/`), and the container images named in the SECURITY.md scope (`Dockerfile`, `docker-compose.yaml`).

Checks run locally: `tests/unit/test_constraint_manifest.py`, `tests/unit/test_area_steward_workflow_yaml.py`, `tests/unit/security/test_surface_grant_delta.py`, `tests/unit/test_naming_policy_docs.py`.

Part of #5730.
