### PR TITLE
ci(queue-hygiene): dismiss bare approvals on non-trivial changes, skip conflicted PRs

### DIFF
--- a/.github/workflows/pr-queue-hygiene.yml
+++ b/.github/workflows/pr-queue-hygiene.yml
@@ -56,6 +56,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           QUEUE_HYGIENE_ARMED: ${{ vars.QUEUE_HYGIENE_ARMED }}
+          INPUT_PR: ${{ inputs.pr }}
         run: |
           set -euo pipefail
           ARGS=()

--- a/.github/workflows/pr-queue-hygiene.yml
+++ b/.github/workflows/pr-queue-hygiene.yml
@@ -1,13 +1,13 @@
 name: PR queue hygiene
 
-# The four rules in scripts/queue_hygiene.py: over-wip, duplicate,
-# needs-committer-review, and closing a PR left with changes-requested and
-# no push for 14 days. Separate from pr-labels.yml (area + size labels,
-# driven by pull_request_target on each PR event) because these four rules
-# need to look across ALL open pull requests at once (an author's total
-# open count, a second PR closing the same issue as an earlier one) rather
-# than react to a single PR's own event, so a schedule sweep is the right
-# shape rather than a per-PR trigger.
+# The five rules in scripts/queue_hygiene.py: over-wip, duplicate,
+# needs-committer-review, approval-shape, and closing a PR left with
+# changes-requested and no push for 14 days. Separate from pr-labels.yml
+# (area + size labels, driven by pull_request_target on each PR event)
+# because these five rules need to look across ALL open pull requests at
+# once (an author's total open count, a second PR closing the same issue
+# as an earlier one) rather than react to a single PR's own event, so a
+# schedule sweep is the right shape rather than a per-PR trigger.
 #
 # Runs on a schedule only - no pull_request_target, so it only ever
 # executes trusted code from the base ref against the API. Nothing here

--- a/scripts/queue_hygiene.py
+++ b/scripts/queue_hygiene.py
@@ -248,8 +248,13 @@ def rule_needs_committer_review(prs: list[PullRequest]) -> None:
             pr.intents.append(f"remove:{NEEDS_REVIEW_LABEL}")
 
 
-def _is_bot(login: str) -> bool:
-    return login.endswith("[bot]") or login.startswith("app/")
+def _is_bot(review: dict[str, Any]) -> bool:
+    """Ask the type, never the spelling. REST carries ``user.type == "Bot"``;
+    GraphQL returns an app's login with no ``[bot]`` suffix, which is why a
+    suffix-only check is fragile - this endpoint is REST, so the reliable
+    field is free."""
+    user = review.get("user") or {}
+    return user.get("type") == "Bot" or (user.get("login") or "").endswith("[bot]")
 
 
 def standing_approvals(reviews: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -291,7 +296,7 @@ def rule_approval_shape(repo: str, prs: list[PullRequest]) -> None:
             r
             for r in standing_approvals(reviews)
             if r["user"]["login"] not in APPROVAL_SHAPE_EXEMPT_LOGINS
-            and not _is_bot(r["user"]["login"])
+            and not _is_bot(r)
             and r["user"]["login"] not in already_dismissed_logins
         ]
         if not approvals:

--- a/scripts/queue_hygiene.py
+++ b/scripts/queue_hygiene.py
@@ -16,8 +16,9 @@ Five rules, each independent of the others:
 ``needs-committer-review``
     Set when a pull request is not a draft, every check in its status
     rollup succeeded (or was neutral/skipped — nothing pending or failed),
-    it has no merge conflict, and nobody has requested changes. Removed the
-    moment any of that stops being true.
+    GitHub has confirmed it is mergeable (an unresolved ``UNKNOWN`` status is
+    treated as not ready, not as vacuously clear), and nobody has requested
+    changes. Removed the moment any of that stops being true.
 
 ``approval-shape``
     The charter (section 3) says an approval on a non-trivial change means
@@ -237,7 +238,7 @@ def rule_needs_committer_review(prs: list[PullRequest]) -> None:
         should_have = (
             not pr.is_draft
             and pr.checks_pass
-            and pr.mergeable != "CONFLICTING"
+            and pr.mergeable == "MERGEABLE"
             and pr.review_decision != "CHANGES_REQUESTED"
         )
         has = NEEDS_REVIEW_LABEL in pr.labels

--- a/scripts/queue_hygiene.py
+++ b/scripts/queue_hygiene.py
@@ -277,10 +277,21 @@ def rule_approval_shape(repo: str, prs: list[PullRequest]) -> None:
         if pr.labels & EXEMPT_LABELS:
             continue
         reviews = gh_json("api", f"repos/{repo}/pulls/{pr.number}/reviews", "--paginate")
+        # Once-only: dismissing a review sets its own body to DISMISSAL_MESSAGE,
+        # so a login that already carries a DISMISSED review with that body has
+        # had its one warning. A bare re-approval from the same person is a new
+        # review id and would otherwise be re-dismissed every run.
+        already_dismissed_logins = {
+            (r.get("user") or {}).get("login")
+            for r in reviews
+            if r.get("state") == "DISMISSED" and (r.get("body") or "") == DISMISSAL_MESSAGE
+        }
         approvals = [
             r
             for r in standing_approvals(reviews)
-            if r["user"]["login"] not in APPROVAL_SHAPE_EXEMPT_LOGINS and not _is_bot(r["user"]["login"])
+            if r["user"]["login"] not in APPROVAL_SHAPE_EXEMPT_LOGINS
+            and not _is_bot(r["user"]["login"])
+            and r["user"]["login"] not in already_dismissed_logins
         ]
         if not approvals:
             continue

--- a/scripts/queue_hygiene.py
+++ b/scripts/queue_hygiene.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Apply the review charter's queue-hygiene rules to open pull requests.
 
-Four rules, each independent of the others:
+Five rules, each independent of the others:
 
 ``over-wip``
     An author with more than five open, non-draft pull requests gets the
@@ -16,8 +16,17 @@ Four rules, each independent of the others:
 ``needs-committer-review``
     Set when a pull request is not a draft, every check in its status
     rollup succeeded (or was neutral/skipped — nothing pending or failed),
-    and nobody has requested changes. Removed the moment any of that
-    stops being true.
+    it has no merge conflict, and nobody has requested changes. Removed the
+    moment any of that stops being true.
+
+``approval-shape``
+    The charter (section 3) says an approval on a non-trivial change means
+    "I read the whole diff and would defend it". A standing approval on a
+    pull request over 40 changed lines whose author left no line-level
+    comment anywhere on the request is dismissed, with a note on how to
+    re-approve. Applies to every human approver except the maintainer,
+    whose approval on a protected path is a separate requirement; bot
+    reviews are never counted as approvals in the first place.
 
 ``changes-requested timeout``
     A pull request whose most recent review is "changes requested", with
@@ -39,7 +48,7 @@ hand first:
 This does not touch area or size labels (.github/workflows/pr-labels.yml
 already owns those) and does not touch the sixty-day generic inactivity
 sweep (.github/workflows/stale.yml already owns that) — this script is
-specifically the four rules above, no more.
+specifically the five rules above, no more.
 """
 
 from __future__ import annotations
@@ -60,6 +69,19 @@ EXEMPT_LABELS = {"pinned", "do-not-close", "work-in-progress"}
 OVER_WIP_LABEL = "over-wip"
 DUPLICATE_LABEL = "duplicate"
 NEEDS_REVIEW_LABEL = "needs-committer-review"
+
+# approval-shape: below this many changed lines an approval may reasonably
+# carry no line comment (a one-line fix, a version bump).
+APPROVAL_SHAPE_MIN_CHANGED_LINES = 40
+# The maintainer's approval is a protected-path requirement in its own right
+# (charter, section 4), not a quorum vote, so it is not held to the shape rule.
+APPROVAL_SHAPE_EXEMPT_LOGINS = frozenset({"chernistry"})
+DISMISSAL_MESSAGE = (
+    "Dismissed by queue hygiene: the review charter "
+    "(docs/governance/review-charter.md, section 3) asks an approval on a "
+    "change of this size to carry at least one line-level comment, a finding "
+    "or a note of what you ran. Re-approve with one and it stands."
+)
 
 # GitHub's own closing-keyword set (case-insensitive), singular or plural,
 # with or without a colon, per
@@ -90,6 +112,8 @@ class PullRequest:
     review_decision: str
     body: str
     checks_pass: bool
+    mergeable: str = ""  # MERGEABLE / CONFLICTING / UNKNOWN as GitHub reports it
+    changed_lines: int = 0  # additions + deletions
     intents: list[str] = field(default_factory=list)
 
 
@@ -104,6 +128,8 @@ def parse_pr(raw: dict[str, Any]) -> PullRequest:
         review_decision=raw.get("reviewDecision") or "",
         body=raw.get("body") or "",
         checks_pass=False,  # filled in by required_checks_pass() below
+        mergeable=raw.get("mergeable") or "",
+        changed_lines=int(raw.get("additions") or 0) + int(raw.get("deletions") or 0),
     )
 
 
@@ -146,7 +172,7 @@ def fetch_open_prs(repo: str) -> list[PullRequest]:
         "--limit",
         "300",
         "--json",
-        "number,title,author,createdAt,isDraft,labels,reviewDecision,body",
+        "number,title,author,createdAt,isDraft,labels,reviewDecision,body,mergeable,additions,deletions",
     )
     prs = [parse_pr(r) for r in raw]
     for pr in prs:
@@ -204,12 +230,63 @@ def rule_duplicate(prs: list[PullRequest]) -> None:
 
 def rule_needs_committer_review(prs: list[PullRequest]) -> None:
     for pr in prs:
-        should_have = not pr.is_draft and pr.checks_pass and pr.review_decision != "CHANGES_REQUESTED"
+        should_have = (
+            not pr.is_draft
+            and pr.checks_pass
+            and pr.mergeable != "CONFLICTING"
+            and pr.review_decision != "CHANGES_REQUESTED"
+        )
         has = NEEDS_REVIEW_LABEL in pr.labels
         if should_have and not has:
             pr.intents.append(f"add:{NEEDS_REVIEW_LABEL}")
         elif has and not should_have:
             pr.intents.append(f"remove:{NEEDS_REVIEW_LABEL}")
+
+
+def _is_bot(login: str) -> bool:
+    return login.endswith("[bot]") or login.startswith("app/")
+
+
+def standing_approvals(reviews: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """The approvals GitHub still counts: each user's latest verdict, where a
+    comment-only review does not replace an earlier verdict (GitHub keeps
+    the approval standing through later COMMENTED reviews) but a later
+    CHANGES_REQUESTED, DISMISSED or fresh APPROVED does."""
+    latest: dict[str, dict[str, Any]] = {}
+    for review in reviews:
+        login = (review.get("user") or {}).get("login") or ""
+        if not login or review.get("state") in ("COMMENTED", "PENDING"):
+            continue
+        prev = latest.get(login)
+        if prev is None or (review.get("submitted_at") or "") >= (prev.get("submitted_at") or ""):
+            latest[login] = review
+    return [r for r in latest.values() if r.get("state") == "APPROVED"]
+
+
+def rule_approval_shape(repo: str, prs: list[PullRequest]) -> None:
+    for pr in prs:
+        if pr.is_draft or pr.changed_lines <= APPROVAL_SHAPE_MIN_CHANGED_LINES:
+            continue
+        reviews = gh_json("api", f"repos/{repo}/pulls/{pr.number}/reviews", "--paginate")
+        approvals = [
+            r
+            for r in standing_approvals(reviews)
+            if r["user"]["login"] not in APPROVAL_SHAPE_EXEMPT_LOGINS and not _is_bot(r["user"]["login"])
+        ]
+        if not approvals:
+            continue
+        # Any line comment by the approver anywhere on the request counts,
+        # whichever review it was attached to: a reviewer who approves and
+        # then adds a line note in a separate comment has still read it.
+        comments = gh_json("api", f"repos/{repo}/pulls/{pr.number}/comments", "--paginate")
+        commented_by = {(c.get("user") or {}).get("login") for c in comments}
+        for review in approvals:
+            login = review["user"]["login"]
+            if login in commented_by:
+                continue
+            pr.intents.append(
+                f"dismiss:{review['id']} ({login}: approval without a line comment on {pr.changed_lines} changed lines)"
+            )
 
 
 def last_changes_requested_without_push(repo: str, pr: PullRequest) -> datetime | None:
@@ -329,6 +406,16 @@ def apply_intents(repo: str, pr: PullRequest) -> None:
             gh("pr", "edit", str(pr.number), "--repo", repo, "--add-label", NEEDS_REVIEW_LABEL)
         elif intent.startswith(f"remove:{NEEDS_REVIEW_LABEL}"):
             gh("pr", "edit", str(pr.number), "--repo", repo, "--remove-label", NEEDS_REVIEW_LABEL)
+        elif intent.startswith("dismiss:"):
+            review_id = intent.split(":", 1)[1].split(" ", 1)[0]
+            gh(
+                "api",
+                "-X",
+                "PUT",
+                f"repos/{repo}/pulls/{pr.number}/reviews/{review_id}/dismissals",
+                "-f",
+                f"message={DISMISSAL_MESSAGE}",
+            )
         elif intent.startswith("close ("):
             gh(
                 "pr",
@@ -369,6 +456,7 @@ def main(argv: list[str] | None = None) -> int:
     rule_over_wip(prs)
     rule_duplicate(prs)
     rule_needs_committer_review(prs)
+    rule_approval_shape(args.repo, prs)
     rule_changes_requested_timeout(args.repo, prs)
 
     if args.pr is not None:

--- a/scripts/queue_hygiene.py
+++ b/scripts/queue_hygiene.py
@@ -431,14 +431,27 @@ def apply_intents(repo: str, pr: PullRequest) -> None:
             gh("pr", "edit", str(pr.number), "--repo", repo, "--remove-label", NEEDS_REVIEW_LABEL)
         elif intent.startswith("dismiss:"):
             review_id = intent.split(":", 1)[1].split(" ", 1)[0]
-            gh(
-                "api",
-                "-X",
-                "PUT",
-                f"repos/{repo}/pulls/{pr.number}/reviews/{review_id}/dismissals",
-                "-f",
-                f"message={DISMISSAL_MESSAGE}",
-            )
+            try:
+                gh(
+                    "api",
+                    "-X",
+                    "PUT",
+                    f"repos/{repo}/pulls/{pr.number}/reviews/{review_id}/dismissals",
+                    "-f",
+                    f"message={DISMISSAL_MESSAGE}",
+                )
+            except subprocess.CalledProcessError as exc:
+                # A dismissal can individually fail - branch protection
+                # restricting who may dismiss reviews, or one someone already
+                # dismissed by hand - and PRs are processed in order, so one
+                # bad review must not block every intent queued after it, the
+                # same as ensure_labels and fetch_open_prs already treat their
+                # own per-item calls.
+                print(
+                    f"warning: could not dismiss review {review_id} on #{pr.number}: "
+                    f"{exc.stderr.strip() if exc.stderr else exc}",
+                    file=sys.stderr,
+                )
         elif intent.startswith("close ("):
             gh(
                 "pr",

--- a/scripts/queue_hygiene.py
+++ b/scripts/queue_hygiene.py
@@ -273,7 +273,19 @@ def standing_approvals(reviews: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return [r for r in latest.values() if r.get("state") == "APPROVED"]
 
 
-def rule_approval_shape(repo: str, prs: list[PullRequest]) -> None:
+def _fetch_reviews(repo: str, pr_number: int, cache: dict[int, list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    """Reviews for one pull request, fetched once and shared - approval-shape
+    and the changes-requested timeout both need the same endpoint, so a PR
+    that qualifies for both must not pay for it twice in one sweep."""
+    if pr_number not in cache:
+        cache[pr_number] = gh_json("api", f"repos/{repo}/pulls/{pr_number}/reviews", "--paginate")
+    return cache[pr_number]
+
+
+def rule_approval_shape(
+    repo: str, prs: list[PullRequest], reviews_cache: dict[int, list[dict[str, Any]]] | None = None
+) -> None:
+    cache = reviews_cache if reviews_cache is not None else {}
     for pr in prs:
         if pr.is_draft or pr.changed_lines <= APPROVAL_SHAPE_MIN_CHANGED_LINES:
             continue
@@ -282,7 +294,7 @@ def rule_approval_shape(repo: str, prs: list[PullRequest]) -> None:
         # dismissal just as they protect it from an automated close.
         if pr.labels & EXEMPT_LABELS:
             continue
-        reviews = gh_json("api", f"repos/{repo}/pulls/{pr.number}/reviews", "--paginate")
+        reviews = _fetch_reviews(repo, pr.number, cache)
         # Once-only: dismissing a review sets its own body to DISMISSAL_MESSAGE,
         # so a login that already carries a DISMISSED review with that body has
         # had its one warning. A bare re-approval from the same person is a new
@@ -317,10 +329,13 @@ def rule_approval_shape(repo: str, prs: list[PullRequest]) -> None:
             )
 
 
-def last_changes_requested_without_push(repo: str, pr: PullRequest) -> datetime | None:
+def last_changes_requested_without_push(
+    repo: str, pr: PullRequest, reviews_cache: dict[int, list[dict[str, Any]]] | None = None
+) -> datetime | None:
     """Return the timestamp of the most recent 'changes requested' review
     if no commit has landed since, else None."""
-    reviews = gh_json("api", f"repos/{repo}/pulls/{pr.number}/reviews", "--paginate")
+    cache = reviews_cache if reviews_cache is not None else {}
+    reviews = _fetch_reviews(repo, pr.number, cache)
     changes_requested_at: datetime | None = None
     for r in reviews:
         if r.get("state") == "CHANGES_REQUESTED":
@@ -346,14 +361,17 @@ def last_changes_requested_without_push(repo: str, pr: PullRequest) -> datetime 
     return changes_requested_at
 
 
-def rule_changes_requested_timeout(repo: str, prs: list[PullRequest]) -> None:
+def rule_changes_requested_timeout(
+    repo: str, prs: list[PullRequest], reviews_cache: dict[int, list[dict[str, Any]]] | None = None
+) -> None:
+    cache = reviews_cache if reviews_cache is not None else {}
     now = datetime.now(UTC)
     for pr in prs:
         if pr.review_decision != "CHANGES_REQUESTED":
             continue
         if pr.labels & EXEMPT_LABELS:
             continue
-        since = last_changes_requested_without_push(repo, pr)
+        since = last_changes_requested_without_push(repo, pr, cache)
         if since is None:
             continue
         age = now - since
@@ -494,11 +512,15 @@ def main(argv: list[str] | None = None) -> int:
     # printed/acted on afterward, never what the rules can see.
     prs = fetch_open_prs(args.repo)
 
+    # Shared across the two rules that both read pull-request reviews, so a
+    # PR that qualifies for both is not fetched twice in the same run.
+    reviews_cache: dict[int, list[dict[str, Any]]] = {}
+
     rule_over_wip(prs)
     rule_duplicate(prs)
     rule_needs_committer_review(prs)
-    rule_approval_shape(args.repo, prs)
-    rule_changes_requested_timeout(args.repo, prs)
+    rule_approval_shape(args.repo, prs, reviews_cache)
+    rule_changes_requested_timeout(args.repo, prs, reviews_cache)
 
     if args.pr is not None:
         prs = [p for p in prs if p.number == args.pr]

--- a/scripts/queue_hygiene.py
+++ b/scripts/queue_hygiene.py
@@ -282,7 +282,7 @@ def rule_approval_shape(repo: str, prs: list[PullRequest]) -> None:
         commented_by = {(c.get("user") or {}).get("login") for c in comments}
         for review in approvals:
             login = review["user"]["login"]
-            if login in commented_by:
+            if login in commented_by or (review.get("body") or "").strip():
                 continue
             pr.intents.append(
                 f"dismiss:{review['id']} ({login}: approval without a line comment on {pr.changed_lines} changed lines)"

--- a/scripts/queue_hygiene.py
+++ b/scripts/queue_hygiene.py
@@ -73,6 +73,10 @@ NEEDS_REVIEW_LABEL = "needs-committer-review"
 # approval-shape: below this many changed lines an approval may reasonably
 # carry no line comment (a one-line fix, a version bump).
 APPROVAL_SHAPE_MIN_CHANGED_LINES = 40
+# Approvals already standing before this rule is armed must not all be
+# dismissed on the first run - only approvals given at or after this
+# timestamp are ever in scope.
+APPROVAL_SHAPE_EFFECTIVE_FROM = "2026-09-10T00:00:00Z"
 # The maintainer's approval is a protected-path requirement in its own right
 # (charter, section 4), not a quorum vote, so it is not held to the shape rule.
 APPROVAL_SHAPE_EXEMPT_LOGINS = frozenset({"chernistry"})
@@ -267,6 +271,11 @@ def rule_approval_shape(repo: str, prs: list[PullRequest]) -> None:
     for pr in prs:
         if pr.is_draft or pr.changed_lines <= APPROVAL_SHAPE_MIN_CHANGED_LINES:
             continue
+        # Same exemption the changes-requested timeout already honors: pinned,
+        # do-not-close and work-in-progress protect a PR from an automated
+        # dismissal just as they protect it from an automated close.
+        if pr.labels & EXEMPT_LABELS:
+            continue
         reviews = gh_json("api", f"repos/{repo}/pulls/{pr.number}/reviews", "--paginate")
         approvals = [
             r
@@ -281,6 +290,8 @@ def rule_approval_shape(repo: str, prs: list[PullRequest]) -> None:
         comments = gh_json("api", f"repos/{repo}/pulls/{pr.number}/comments", "--paginate")
         commented_by = {(c.get("user") or {}).get("login") for c in comments}
         for review in approvals:
+            if (review.get("submitted_at") or "") < APPROVAL_SHAPE_EFFECTIVE_FROM:
+                continue
             login = review["user"]["login"]
             if login in commented_by or (review.get("body") or "").strip():
                 continue

--- a/scripts/queue_hygiene.py
+++ b/scripts/queue_hygiene.py
@@ -279,6 +279,31 @@ def _fetch_reviews(repo: str, pr_number: int, cache: dict[int, list[dict[str, An
     return cache[pr_number]
 
 
+def _already_dismissed_logins(repo: str, pr_number: int, reviews: list[dict[str, Any]]) -> set[str]:
+    """Logins this rule has already dismissed a bare approval from on this PR.
+
+    Dismissing a review does not touch the review's own body - it keeps
+    whatever the original reviewer wrote (nothing, for the bare approvals
+    this rule targets) - GitHub records the dismissal message on a separate
+    'review_dismissed' timeline event instead, linked back to the review by
+    id. Cross-reference that against the reviews already fetched to recover
+    the login.
+    """
+    review_logins = {r.get("id"): (r.get("user") or {}).get("login") for r in reviews}
+    timeline = gh_json("api", f"repos/{repo}/issues/{pr_number}/timeline", "--paginate")
+    logins = set()
+    for event in timeline:
+        if event.get("event") != "review_dismissed":
+            continue
+        dismissal = event.get("dismissed_review") or {}
+        if dismissal.get("dismissal_message") != DISMISSAL_MESSAGE:
+            continue
+        login = review_logins.get(dismissal.get("review_id"))
+        if login:
+            logins.add(login)
+    return logins
+
+
 def rule_approval_shape(
     repo: str,
     prs: list[PullRequest],
@@ -296,24 +321,13 @@ def rule_approval_shape(
         if pr.labels & EXEMPT_LABELS:
             continue
         reviews = _fetch_reviews(repo, pr.number, cache)
-        # Once-only: dismissing a review sets its own body to DISMISSAL_MESSAGE,
-        # so a login that already carries a DISMISSED review with that body has
-        # had its one warning. A bare re-approval from the same person is a new
-        # review id and would otherwise be re-dismissed every run.
-        already_dismissed_logins = {
-            (r.get("user") or {}).get("login")
-            for r in reviews
-            if r.get("state") == "DISMISSED" and (r.get("body") or "") == DISMISSAL_MESSAGE
-        }
         approvals = [
             r
             for r in standing_approvals(reviews)
             # The maintainer's approval is a protected-path requirement in its
             # own right (charter, section 4), not a quorum vote, so it is not
             # held to the shape rule.
-            if r["user"]["login"] != maintainer
-            and not _is_bot(r)
-            and r["user"]["login"] not in already_dismissed_logins
+            if r["user"]["login"] != maintainer and not _is_bot(r)
         ]
         if not approvals:
             continue
@@ -322,11 +336,23 @@ def rule_approval_shape(
         # then adds a line note in a separate comment has still read it.
         comments = gh_json("api", f"repos/{repo}/pulls/{pr.number}/comments", "--paginate")
         commented_by = {(c.get("user") or {}).get("login") for c in comments}
+        candidates = []
         for review in approvals:
             if (review.get("submitted_at") or "") < APPROVAL_SHAPE_EFFECTIVE_FROM:
                 continue
             login = review["user"]["login"]
             if login in commented_by or (review.get("body") or "").strip():
+                continue
+            candidates.append((login, review))
+        if not candidates:
+            continue
+        # Once-only, checked only once there is actually something to dismiss:
+        # a login already dismissed for this exact message has had its one
+        # warning, and a bare re-approval from the same person - a new review
+        # id - must not be dismissed again every run.
+        already_dismissed = _already_dismissed_logins(repo, pr.number, reviews)
+        for login, review in candidates:
+            if login in already_dismissed:
                 continue
             pr.intents.append(
                 f"dismiss:{review['id']} ({login}: approval without a line comment on {pr.changed_lines} changed lines)"

--- a/scripts/queue_hygiene.py
+++ b/scripts/queue_hygiene.py
@@ -78,9 +78,6 @@ APPROVAL_SHAPE_MIN_CHANGED_LINES = 40
 # dismissed on the first run - only approvals given at or after this
 # timestamp are ever in scope.
 APPROVAL_SHAPE_EFFECTIVE_FROM = "2026-09-10T00:00:00Z"
-# The maintainer's approval is a protected-path requirement in its own right
-# (charter, section 4), not a quorum vote, so it is not held to the shape rule.
-APPROVAL_SHAPE_EXEMPT_LOGINS = frozenset({"chernistry"})
 DISMISSAL_MESSAGE = (
     "Dismissed by queue hygiene: the review charter "
     "(docs/governance/review-charter.md, section 3) asks an approval on a "
@@ -283,7 +280,11 @@ def _fetch_reviews(repo: str, pr_number: int, cache: dict[int, list[dict[str, An
 
 
 def rule_approval_shape(
-    repo: str, prs: list[PullRequest], reviews_cache: dict[int, list[dict[str, Any]]] | None = None
+    repo: str,
+    prs: list[PullRequest],
+    reviews_cache: dict[int, list[dict[str, Any]]] | None = None,
+    *,
+    maintainer: str,
 ) -> None:
     cache = reviews_cache if reviews_cache is not None else {}
     for pr in prs:
@@ -307,7 +308,10 @@ def rule_approval_shape(
         approvals = [
             r
             for r in standing_approvals(reviews)
-            if r["user"]["login"] not in APPROVAL_SHAPE_EXEMPT_LOGINS
+            # The maintainer's approval is a protected-path requirement in its
+            # own right (charter, section 4), not a quorum vote, so it is not
+            # held to the shape rule.
+            if r["user"]["login"] != maintainer
             and not _is_bot(r)
             and r["user"]["login"] not in already_dismissed_logins
         ]
@@ -494,6 +498,12 @@ def apply_intents(repo: str, pr: PullRequest) -> None:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument(
+        "--maintainer",
+        default="chernistry",
+        help="login whose approval is exempt from the approval-shape rule (protected-path "
+        "requirement, not a quorum vote)",
+    )
     parser.add_argument("--pr", type=int, default=None, help="limit to one PR number")
     parser.add_argument(
         "--apply",
@@ -519,7 +529,7 @@ def main(argv: list[str] | None = None) -> int:
     rule_over_wip(prs)
     rule_duplicate(prs)
     rule_needs_committer_review(prs)
-    rule_approval_shape(args.repo, prs, reviews_cache)
+    rule_approval_shape(args.repo, prs, reviews_cache, maintainer=args.maintainer)
     rule_changes_requested_timeout(args.repo, prs, reviews_cache)
 
     if args.pr is not None:

--- a/tests/unit/scripts/test_queue_hygiene.py
+++ b/tests/unit/scripts/test_queue_hygiene.py
@@ -17,6 +17,7 @@ for how that was found.
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -426,6 +427,27 @@ def test_apply_dismisses_through_the_review_dismissal_endpoint(qh: ModuleType, m
     assert len(calls) == 1
     assert calls[0][:4] == ("api", "-X", "PUT", "repos/owner/repo/pulls/7/reviews/10/dismissals")
     assert calls[0][-1].startswith("message=Dismissed by queue hygiene")
+
+
+def test_a_failing_dismissal_does_not_stop_later_intents(qh: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A dismissal can individually fail (branch protection restricting who may
+    # dismiss, or a review someone already dismissed by hand) - one bad review
+    # must not block the other intents queued after it in the same run.
+    calls: list[tuple[str, ...]] = []
+
+    def fake_gh(*args: str) -> None:
+        calls.append(args)
+        if args[0] == "api":
+            raise subprocess.CalledProcessError(1, args, output="", stderr="422 already dismissed")
+
+    monkeypatch.setattr(qh, "gh", fake_gh)
+    pr = _pr(qh, 7)
+    pr.intents.append("dismiss:10 (alice: approval without a line comment on 120 changed lines)")
+    pr.intents.append(f"add:{qh.NEEDS_REVIEW_LABEL}")
+    qh.apply_intents("owner/repo", pr)  # must not raise
+    assert len(calls) == 2
+    assert calls[0][:3] == ("api", "-X", "PUT")
+    assert calls[1] == ("pr", "edit", "7", "--repo", "owner/repo", "--add-label", qh.NEEDS_REVIEW_LABEL)
 
 
 # --- --pr must narrow the OUTPUT, never the rules' INPUT --------------------

--- a/tests/unit/scripts/test_queue_hygiene.py
+++ b/tests/unit/scripts/test_queue_hygiene.py
@@ -289,7 +289,7 @@ def test_approval_shape_keeps_an_approval_whose_author_left_a_line_comment(
         monkeypatch,
         qh,
         [_review(10, "alice", "APPROVED", "2026-09-10T10:00:00Z")],
-        [{"user": {"login": "alice"}, "pull_request_review_id": 11}],
+        [{"user": {"login": "alice"}}],
     )
     pr = _pr(qh, 1, changed_lines=120)
     qh.rule_approval_shape("owner/repo", [pr])
@@ -411,7 +411,7 @@ def test_approval_shape_uses_each_users_latest_verdict(qh: ModuleType, monkeypat
         _review(30, "carol", "APPROVED", "2026-09-11T10:00:00Z"),
         _review(31, "carol", "COMMENTED", "2026-09-11T13:00:00Z"),
     ]
-    comments = [{"user": {"login": "bob"}, "pull_request_review_id": 21}]
+    comments = [{"user": {"login": "bob"}}]
     _install_review_api(monkeypatch, qh, reviews, comments)
     pr = _pr(qh, 1, changed_lines=200)
     qh.rule_approval_shape("owner/repo", [pr])

--- a/tests/unit/scripts/test_queue_hygiene.py
+++ b/tests/unit/scripts/test_queue_hygiene.py
@@ -259,7 +259,7 @@ def _install_review_api(monkeypatch: pytest.MonkeyPatch, qh: ModuleType, reviews
 def test_approval_shape_dismisses_a_bare_approval_on_a_non_trivial_change(
     qh: ModuleType, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    _install_review_api(monkeypatch, qh, [_review(10, "alice", "APPROVED", "2026-09-09T10:00:00Z")], [])
+    _install_review_api(monkeypatch, qh, [_review(10, "alice", "APPROVED", "2026-09-10T10:00:00Z")], [])
     pr = _pr(qh, 1, changed_lines=120)
     qh.rule_approval_shape("owner/repo", [pr])
     assert pr.intents == ["dismiss:10 (alice: approval without a line comment on 120 changed lines)"]
@@ -273,7 +273,7 @@ def test_approval_shape_keeps_an_approval_whose_author_left_a_line_comment(
     _install_review_api(
         monkeypatch,
         qh,
-        [_review(10, "alice", "APPROVED", "2026-09-09T10:00:00Z")],
+        [_review(10, "alice", "APPROVED", "2026-09-10T10:00:00Z")],
         [{"user": {"login": "alice"}, "pull_request_review_id": 11}],
     )
     pr = _pr(qh, 1, changed_lines=120)
@@ -294,13 +294,40 @@ def test_approval_shape_keeps_an_approval_whose_body_is_non_blank(
                 10,
                 "alice",
                 "APPROVED",
-                "2026-09-09T10:00:00Z",
+                "2026-09-10T10:00:00Z",
                 body="Ran the suite locally, checked the migration path, LGTM",
             )
         ],
         [],
     )
     pr = _pr(qh, 1, changed_lines=120)
+    qh.rule_approval_shape("owner/repo", [pr])
+    assert not pr.intents
+
+
+def test_approval_shape_keeps_an_approval_from_before_the_effective_date(
+    qh: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # First arming must not re-litigate every approval already standing on the
+    # open queue - only approvals given at or after APPROVAL_SHAPE_EFFECTIVE_FROM
+    # are ever dismissed.
+    before_cutoff = "2026-09-09T23:59:59Z"
+    assert before_cutoff < qh.APPROVAL_SHAPE_EFFECTIVE_FROM
+    _install_review_api(monkeypatch, qh, [_review(10, "alice", "APPROVED", before_cutoff)], [])
+    pr = _pr(qh, 1, changed_lines=120)
+    qh.rule_approval_shape("owner/repo", [pr])
+    assert not pr.intents
+
+
+def test_approval_shape_respects_exempt_labels(qh: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Same convention the changes-requested timeout already honors - pinned,
+    # do-not-close and work-in-progress must protect a PR from an automated
+    # dismissal too, not only from an automated close.
+    def fake_gh_json(*args: str) -> object:
+        raise AssertionError("must not call the API for an exempt PR")
+
+    monkeypatch.setattr(qh, "gh_json", fake_gh_json)
+    pr = _pr(qh, 1, changed_lines=200, labels={"pinned"})
     qh.rule_approval_shape("owner/repo", [pr])
     assert not pr.intents
 
@@ -337,14 +364,14 @@ def test_approval_shape_exempts_the_maintainer_and_bots(qh: ModuleType, monkeypa
 def test_approval_shape_uses_each_users_latest_verdict(qh: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
     reviews = [
         # alice approved bare, then requested changes: nothing standing to dismiss
-        _review(10, "alice", "APPROVED", "2026-09-09T10:00:00Z"),
-        _review(11, "alice", "CHANGES_REQUESTED", "2026-09-09T11:00:00Z"),
+        _review(10, "alice", "APPROVED", "2026-09-11T10:00:00Z"),
+        _review(11, "alice", "CHANGES_REQUESTED", "2026-09-11T11:00:00Z"),
         # bob approved bare, then re-approved and left a line note: the fresh one stands
-        _review(20, "bob", "APPROVED", "2026-09-09T10:00:00Z"),
-        _review(21, "bob", "APPROVED", "2026-09-09T12:00:00Z"),
+        _review(20, "bob", "APPROVED", "2026-09-11T10:00:00Z"),
+        _review(21, "bob", "APPROVED", "2026-09-11T12:00:00Z"),
         # carol approved bare, then only commented: GitHub keeps her approval standing
-        _review(30, "carol", "APPROVED", "2026-09-09T10:00:00Z"),
-        _review(31, "carol", "COMMENTED", "2026-09-09T13:00:00Z"),
+        _review(30, "carol", "APPROVED", "2026-09-11T10:00:00Z"),
+        _review(31, "carol", "COMMENTED", "2026-09-11T13:00:00Z"),
     ]
     comments = [{"user": {"login": "bob"}, "pull_request_review_id": 21}]
     _install_review_api(monkeypatch, qh, reviews, comments)

--- a/tests/unit/scripts/test_queue_hygiene.py
+++ b/tests/unit/scripts/test_queue_hygiene.py
@@ -332,6 +332,24 @@ def test_approval_shape_respects_exempt_labels(qh: ModuleType, monkeypatch: pyte
     assert not pr.intents
 
 
+def test_approval_shape_does_not_redismiss_a_bare_re_approval(
+    qh: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # carol's original bare approval was dismissed by an earlier run - dismissing
+    # a review sets its own body to the dismissal message, so that history is
+    # still visible as a DISMISSED review carrying it. She re-approved bare
+    # again without adding a comment; the once-only guard must leave the new
+    # review alone rather than dismiss it too.
+    reviews = [
+        _review(10, "carol", "DISMISSED", "2026-09-10T09:00:00Z", body=qh.DISMISSAL_MESSAGE),
+        _review(11, "carol", "APPROVED", "2026-09-11T09:00:00Z"),
+    ]
+    _install_review_api(monkeypatch, qh, reviews, [])
+    pr = _pr(qh, 1, changed_lines=200)
+    qh.rule_approval_shape("owner/repo", [pr])
+    assert not pr.intents
+
+
 def test_approval_shape_ignores_small_changes_without_calling_the_api(
     qh: ModuleType, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/scripts/test_queue_hygiene.py
+++ b/tests/unit/scripts/test_queue_hygiene.py
@@ -251,9 +251,7 @@ def test_changes_requested_timeout_respects_exempt_labels(qh: ModuleType, monkey
 # --- approval-shape ---------------------------------------------------------
 
 
-def _review(
-    review_id: int, login: str, state: str, at: str, *, body: str = "", user_type: str | None = None
-) -> dict:
+def _review(review_id: int, login: str, state: str, at: str, *, body: str = "", user_type: str | None = None) -> dict:
     user = {"login": login}
     if user_type is not None:
         user["type"] = user_type
@@ -347,9 +345,7 @@ def test_approval_shape_respects_exempt_labels(qh: ModuleType, monkeypatch: pyte
     assert not pr.intents
 
 
-def test_approval_shape_does_not_redismiss_a_bare_re_approval(
-    qh: ModuleType, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_approval_shape_does_not_redismiss_a_bare_re_approval(qh: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
     # carol's original bare approval was dismissed by an earlier run - dismissing
     # a review sets its own body to the dismissal message, so that history is
     # still visible as a DISMISSED review carrying it. She re-approved bare

--- a/tests/unit/scripts/test_queue_hygiene.py
+++ b/tests/unit/scripts/test_queue_hygiene.py
@@ -276,7 +276,7 @@ def test_approval_shape_dismisses_a_bare_approval_on_a_non_trivial_change(
 ) -> None:
     _install_review_api(monkeypatch, qh, [_review(10, "alice", "APPROVED", "2026-09-10T10:00:00Z")], [])
     pr = _pr(qh, 1, changed_lines=120)
-    qh.rule_approval_shape("owner/repo", [pr])
+    qh.rule_approval_shape("owner/repo", [pr], maintainer="chernistry")
     assert pr.intents == ["dismiss:10 (alice: approval without a line comment on 120 changed lines)"]
 
 
@@ -292,7 +292,7 @@ def test_approval_shape_keeps_an_approval_whose_author_left_a_line_comment(
         [{"user": {"login": "alice"}}],
     )
     pr = _pr(qh, 1, changed_lines=120)
-    qh.rule_approval_shape("owner/repo", [pr])
+    qh.rule_approval_shape("owner/repo", [pr], maintainer="chernistry")
     assert not pr.intents
 
 
@@ -316,7 +316,7 @@ def test_approval_shape_keeps_an_approval_whose_body_is_non_blank(
         [],
     )
     pr = _pr(qh, 1, changed_lines=120)
-    qh.rule_approval_shape("owner/repo", [pr])
+    qh.rule_approval_shape("owner/repo", [pr], maintainer="chernistry")
     assert not pr.intents
 
 
@@ -330,7 +330,7 @@ def test_approval_shape_keeps_an_approval_from_before_the_effective_date(
     assert before_cutoff < qh.APPROVAL_SHAPE_EFFECTIVE_FROM
     _install_review_api(monkeypatch, qh, [_review(10, "alice", "APPROVED", before_cutoff)], [])
     pr = _pr(qh, 1, changed_lines=120)
-    qh.rule_approval_shape("owner/repo", [pr])
+    qh.rule_approval_shape("owner/repo", [pr], maintainer="chernistry")
     assert not pr.intents
 
 
@@ -343,7 +343,7 @@ def test_approval_shape_respects_exempt_labels(qh: ModuleType, monkeypatch: pyte
 
     monkeypatch.setattr(qh, "gh_json", fake_gh_json)
     pr = _pr(qh, 1, changed_lines=200, labels={"pinned"})
-    qh.rule_approval_shape("owner/repo", [pr])
+    qh.rule_approval_shape("owner/repo", [pr], maintainer="chernistry")
     assert not pr.intents
 
 
@@ -361,7 +361,7 @@ def test_approval_shape_does_not_redismiss_a_bare_re_approval(
     ]
     _install_review_api(monkeypatch, qh, reviews, [])
     pr = _pr(qh, 1, changed_lines=200)
-    qh.rule_approval_shape("owner/repo", [pr])
+    qh.rule_approval_shape("owner/repo", [pr], maintainer="chernistry")
     assert not pr.intents
 
 
@@ -373,12 +373,15 @@ def test_approval_shape_ignores_small_changes_without_calling_the_api(
 
     monkeypatch.setattr(qh, "gh_json", fake_gh_json)
     pr = _pr(qh, 1, changed_lines=qh.APPROVAL_SHAPE_MIN_CHANGED_LINES)
-    qh.rule_approval_shape("owner/repo", [pr])
+    qh.rule_approval_shape("owner/repo", [pr], maintainer="chernistry")
     assert not pr.intents
 
 
 def test_approval_shape_exempts_the_maintainer_and_bots(qh: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
-    maintainer = next(iter(qh.APPROVAL_SHAPE_EXEMPT_LOGINS))
+    # "chernistry" is the script's own --maintainer default (main()'s argparse);
+    # the rule itself takes whatever login is threaded in, so this test states
+    # the value explicitly rather than reading it back off the module.
+    maintainer = "chernistry"
     _install_review_api(
         monkeypatch,
         qh,
@@ -395,7 +398,7 @@ def test_approval_shape_exempts_the_maintainer_and_bots(qh: ModuleType, monkeypa
         [],
     )
     pr = _pr(qh, 1, changed_lines=500)
-    qh.rule_approval_shape("owner/repo", [pr])
+    qh.rule_approval_shape("owner/repo", [pr], maintainer=maintainer)
     assert not pr.intents
 
 
@@ -414,7 +417,7 @@ def test_approval_shape_uses_each_users_latest_verdict(qh: ModuleType, monkeypat
     comments = [{"user": {"login": "bob"}}]
     _install_review_api(monkeypatch, qh, reviews, comments)
     pr = _pr(qh, 1, changed_lines=200)
-    qh.rule_approval_shape("owner/repo", [pr])
+    qh.rule_approval_shape("owner/repo", [pr], maintainer="chernistry")
     assert pr.intents == ["dismiss:30 (carol: approval without a line comment on 200 changed lines)"]
 
 
@@ -424,7 +427,7 @@ def test_approval_shape_skips_drafts(qh: ModuleType, monkeypatch: pytest.MonkeyP
 
     monkeypatch.setattr(qh, "gh_json", fake_gh_json)
     pr = _pr(qh, 1, is_draft=True, changed_lines=999)
-    qh.rule_approval_shape("owner/repo", [pr])
+    qh.rule_approval_shape("owner/repo", [pr], maintainer="chernistry")
     assert not pr.intents
 
 
@@ -486,7 +489,7 @@ def test_reviews_are_fetched_once_per_pr_when_the_cache_is_shared(
     monkeypatch.setattr(qh, "gh_json", fake_gh_json)
     pr = _pr(qh, 1, changed_lines=200, review_decision="CHANGES_REQUESTED")
     reviews_cache: dict[int, list[dict]] = {}
-    qh.rule_approval_shape("owner/repo", [pr], reviews_cache)
+    qh.rule_approval_shape("owner/repo", [pr], reviews_cache, maintainer="chernistry")
     qh.rule_changes_requested_timeout("owner/repo", [pr], reviews_cache)
 
     review_calls = [e for e in endpoints_called if e.endswith("/reviews")]

--- a/tests/unit/scripts/test_queue_hygiene.py
+++ b/tests/unit/scripts/test_queue_hygiene.py
@@ -50,6 +50,8 @@ def _pr(
     review_decision: str = "",
     body: str = "",
     checks_pass: bool = True,
+    mergeable: str = "MERGEABLE",
+    changed_lines: int = 100,
 ) -> object:
     """Build a ``PullRequest`` with sane defaults, oldest-first by age_days."""
     now = datetime.now(UTC)
@@ -63,6 +65,8 @@ def _pr(
         review_decision=review_decision,
         body=body,
         checks_pass=checks_pass,
+        mergeable=mergeable,
+        changed_lines=changed_lines,
     )
 
 
@@ -169,6 +173,18 @@ def test_needs_review_not_added_when_blocked(qh: ModuleType, kwargs: dict) -> No
     assert not any(i.startswith("add:needs-committer-review") for i in pr.intents)
 
 
+def test_needs_review_not_added_on_a_merge_conflict(qh: ModuleType) -> None:
+    pr = _pr(qh, 1, mergeable="CONFLICTING")
+    qh.rule_needs_committer_review([pr])
+    assert not any(i.startswith("add:needs-committer-review") for i in pr.intents)
+
+
+def test_needs_review_removed_once_a_conflict_appears(qh: ModuleType) -> None:
+    pr = _pr(qh, 1, mergeable="CONFLICTING", labels={"needs-committer-review"})
+    qh.rule_needs_committer_review([pr])
+    assert any(i.startswith("remove:needs-committer-review") for i in pr.intents)
+
+
 def test_needs_review_removed_once_no_longer_eligible(qh: ModuleType) -> None:
     pr = _pr(qh, 1, checks_pass=False, labels={"needs-committer-review"})
     qh.rule_needs_committer_review([pr])
@@ -220,6 +236,118 @@ def test_changes_requested_timeout_respects_exempt_labels(qh: ModuleType, monkey
     pr = _pr(qh, 1, review_decision="CHANGES_REQUESTED", labels={"work-in-progress"})
     qh.rule_changes_requested_timeout("owner/repo", [pr])
     assert not pr.intents
+
+
+# --- approval-shape ---------------------------------------------------------
+
+
+def _review(review_id: int, login: str, state: str, at: str) -> dict:
+    return {"id": review_id, "user": {"login": login}, "state": state, "submitted_at": at}
+
+
+def _install_review_api(monkeypatch: pytest.MonkeyPatch, qh: ModuleType, reviews: list, comments: list) -> None:
+    def fake_gh_json(*args: str) -> object:
+        if args[1].endswith("/reviews"):
+            return reviews
+        if args[1].endswith("/comments"):
+            return comments
+        raise AssertionError(f"unexpected call {args}")
+
+    monkeypatch.setattr(qh, "gh_json", fake_gh_json)
+
+
+def test_approval_shape_dismisses_a_bare_approval_on_a_non_trivial_change(
+    qh: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_review_api(monkeypatch, qh, [_review(10, "alice", "APPROVED", "2026-09-09T10:00:00Z")], [])
+    pr = _pr(qh, 1, changed_lines=120)
+    qh.rule_approval_shape("owner/repo", [pr])
+    assert pr.intents == ["dismiss:10 (alice: approval without a line comment on 120 changed lines)"]
+
+
+def test_approval_shape_keeps_an_approval_whose_author_left_a_line_comment(
+    qh: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The line comment sits on a different review id (added after approving):
+    # what matters is that the approver read a line, not which review carried it.
+    _install_review_api(
+        monkeypatch,
+        qh,
+        [_review(10, "alice", "APPROVED", "2026-09-09T10:00:00Z")],
+        [{"user": {"login": "alice"}, "pull_request_review_id": 11}],
+    )
+    pr = _pr(qh, 1, changed_lines=120)
+    qh.rule_approval_shape("owner/repo", [pr])
+    assert not pr.intents
+
+
+def test_approval_shape_ignores_small_changes_without_calling_the_api(
+    qh: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_gh_json(*args: str) -> object:
+        raise AssertionError("must not call the API for a small change")
+
+    monkeypatch.setattr(qh, "gh_json", fake_gh_json)
+    pr = _pr(qh, 1, changed_lines=qh.APPROVAL_SHAPE_MIN_CHANGED_LINES)
+    qh.rule_approval_shape("owner/repo", [pr])
+    assert not pr.intents
+
+
+def test_approval_shape_exempts_the_maintainer_and_bots(qh: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    maintainer = next(iter(qh.APPROVAL_SHAPE_EXEMPT_LOGINS))
+    _install_review_api(
+        monkeypatch,
+        qh,
+        [
+            _review(10, maintainer, "APPROVED", "2026-09-09T10:00:00Z"),
+            _review(11, "renovate[bot]", "APPROVED", "2026-09-09T10:00:00Z"),
+            _review(12, "app/some-app", "APPROVED", "2026-09-09T10:00:00Z"),
+        ],
+        [],
+    )
+    pr = _pr(qh, 1, changed_lines=500)
+    qh.rule_approval_shape("owner/repo", [pr])
+    assert not pr.intents
+
+
+def test_approval_shape_uses_each_users_latest_verdict(qh: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    reviews = [
+        # alice approved bare, then requested changes: nothing standing to dismiss
+        _review(10, "alice", "APPROVED", "2026-09-09T10:00:00Z"),
+        _review(11, "alice", "CHANGES_REQUESTED", "2026-09-09T11:00:00Z"),
+        # bob approved bare, then re-approved and left a line note: the fresh one stands
+        _review(20, "bob", "APPROVED", "2026-09-09T10:00:00Z"),
+        _review(21, "bob", "APPROVED", "2026-09-09T12:00:00Z"),
+        # carol approved bare, then only commented: GitHub keeps her approval standing
+        _review(30, "carol", "APPROVED", "2026-09-09T10:00:00Z"),
+        _review(31, "carol", "COMMENTED", "2026-09-09T13:00:00Z"),
+    ]
+    comments = [{"user": {"login": "bob"}, "pull_request_review_id": 21}]
+    _install_review_api(monkeypatch, qh, reviews, comments)
+    pr = _pr(qh, 1, changed_lines=200)
+    qh.rule_approval_shape("owner/repo", [pr])
+    assert pr.intents == ["dismiss:30 (carol: approval without a line comment on 200 changed lines)"]
+
+
+def test_approval_shape_skips_drafts(qh: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_gh_json(*args: str) -> object:
+        raise AssertionError("must not call the API for a draft")
+
+    monkeypatch.setattr(qh, "gh_json", fake_gh_json)
+    pr = _pr(qh, 1, is_draft=True, changed_lines=999)
+    qh.rule_approval_shape("owner/repo", [pr])
+    assert not pr.intents
+
+
+def test_apply_dismisses_through_the_review_dismissal_endpoint(qh: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, ...]] = []
+    monkeypatch.setattr(qh, "gh", lambda *args: calls.append(args))
+    pr = _pr(qh, 7)
+    pr.intents.append("dismiss:10 (alice: approval without a line comment on 120 changed lines)")
+    qh.apply_intents("owner/repo", pr)
+    assert len(calls) == 1
+    assert calls[0][:4] == ("api", "-X", "PUT", "repos/owner/repo/pulls/7/reviews/10/dismissals")
+    assert calls[0][-1].startswith("message=Dismissed by queue hygiene")
 
 
 # --- --pr must narrow the OUTPUT, never the rules' INPUT --------------------

--- a/tests/unit/scripts/test_queue_hygiene.py
+++ b/tests/unit/scripts/test_queue_hygiene.py
@@ -251,8 +251,13 @@ def test_changes_requested_timeout_respects_exempt_labels(qh: ModuleType, monkey
 # --- approval-shape ---------------------------------------------------------
 
 
-def _review(review_id: int, login: str, state: str, at: str, *, body: str = "") -> dict:
-    return {"id": review_id, "user": {"login": login}, "state": state, "submitted_at": at, "body": body}
+def _review(
+    review_id: int, login: str, state: str, at: str, *, body: str = "", user_type: str | None = None
+) -> dict:
+    user = {"login": login}
+    if user_type is not None:
+        user["type"] = user_type
+    return {"id": review_id, "user": user, "state": state, "submitted_at": at, "body": body}
 
 
 def _install_review_api(monkeypatch: pytest.MonkeyPatch, qh: ModuleType, reviews: list, comments: list) -> None:
@@ -378,9 +383,14 @@ def test_approval_shape_exempts_the_maintainer_and_bots(qh: ModuleType, monkeypa
         monkeypatch,
         qh,
         [
-            _review(10, maintainer, "APPROVED", "2026-09-09T10:00:00Z"),
-            _review(11, "renovate[bot]", "APPROVED", "2026-09-09T10:00:00Z"),
-            _review(12, "app/some-app", "APPROVED", "2026-09-09T10:00:00Z"),
+            _review(10, maintainer, "APPROVED", "2026-09-10T10:00:00Z"),
+            # Suffix-recognized bot (renovate[bot]) ...
+            _review(11, "renovate[bot]", "APPROVED", "2026-09-10T10:00:00Z"),
+            # ... and a REST app user with no [bot] suffix at all - recognized
+            # only because the endpoint carries user.type == "Bot". Dated on
+            # or after the cutoff so this exercises the bot check itself,
+            # not the effective-date filter.
+            _review(12, "some-ci-bot", "APPROVED", "2026-09-10T10:00:00Z", user_type="Bot"),
         ],
         [],
     )

--- a/tests/unit/scripts/test_queue_hygiene.py
+++ b/tests/unit/scripts/test_queue_hygiene.py
@@ -460,6 +460,39 @@ def test_a_failing_dismissal_does_not_stop_later_intents(qh: ModuleType, monkeyp
     assert calls[1] == ("pr", "edit", "7", "--repo", "owner/repo", "--add-label", qh.NEEDS_REVIEW_LABEL)
 
 
+# --- reviews are fetched once per PR, shared across rules ------------------
+
+
+def test_reviews_are_fetched_once_per_pr_when_the_cache_is_shared(
+    qh: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A PR that is both over the approval-shape line threshold and currently
+    # CHANGES_REQUESTED qualifies for both rules, each of which used to fetch
+    # /reviews on its own - count the stub calls to prove a shared cache
+    # collapses that to one call.
+    recent = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    endpoints_called: list[str] = []
+
+    def fake_gh_json(*args: str) -> object:
+        endpoints_called.append(args[1])
+        if args[1].endswith("/reviews"):
+            return [_review(10, "alice", "CHANGES_REQUESTED", recent)]
+        if args[1].endswith("/comments"):
+            return []
+        if args[1].endswith("/commits"):
+            return []
+        raise AssertionError(f"unexpected call {args}")
+
+    monkeypatch.setattr(qh, "gh_json", fake_gh_json)
+    pr = _pr(qh, 1, changed_lines=200, review_decision="CHANGES_REQUESTED")
+    reviews_cache: dict[int, list[dict]] = {}
+    qh.rule_approval_shape("owner/repo", [pr], reviews_cache)
+    qh.rule_changes_requested_timeout("owner/repo", [pr], reviews_cache)
+
+    review_calls = [e for e in endpoints_called if e.endswith("/reviews")]
+    assert len(review_calls) == 1
+
+
 # --- --pr must narrow the OUTPUT, never the rules' INPUT --------------------
 
 

--- a/tests/unit/scripts/test_queue_hygiene.py
+++ b/tests/unit/scripts/test_queue_hygiene.py
@@ -179,6 +179,15 @@ def test_needs_review_not_added_on_a_merge_conflict(qh: ModuleType) -> None:
     assert not any(i.startswith("add:needs-committer-review") for i in pr.intents)
 
 
+def test_needs_review_not_added_while_mergeable_is_unknown(qh: ModuleType) -> None:
+    # mergeable is computed asynchronously by GitHub and reads UNKNOWN until
+    # it catches up (and every merge to the base branch invalidates it again) -
+    # that is not the same as a confirmed absence of a conflict.
+    pr = _pr(qh, 1, mergeable="UNKNOWN")
+    qh.rule_needs_committer_review([pr])
+    assert not any(i.startswith("add:needs-committer-review") for i in pr.intents)
+
+
 def test_needs_review_removed_once_a_conflict_appears(qh: ModuleType) -> None:
     pr = _pr(qh, 1, mergeable="CONFLICTING", labels={"needs-committer-review"})
     qh.rule_needs_committer_review([pr])

--- a/tests/unit/scripts/test_queue_hygiene.py
+++ b/tests/unit/scripts/test_queue_hygiene.py
@@ -1,6 +1,6 @@
 """Unit tests for ``scripts/queue_hygiene.py``.
 
-Each of the four rules is exercised directly against constructed
+Each of the five rules is exercised directly against constructed
 ``PullRequest`` fixtures rather than through ``main()`` end to end, so a test
 failure points at the one rule that regressed instead of at "something in the
 gh subprocess chain broke". ``last_changes_requested_without_push`` is the one

--- a/tests/unit/scripts/test_queue_hygiene.py
+++ b/tests/unit/scripts/test_queue_hygiene.py
@@ -258,12 +258,21 @@ def _review(review_id: int, login: str, state: str, at: str, *, body: str = "", 
     return {"id": review_id, "user": user, "state": state, "submitted_at": at, "body": body}
 
 
-def _install_review_api(monkeypatch: pytest.MonkeyPatch, qh: ModuleType, reviews: list, comments: list) -> None:
+def _install_review_api(
+    monkeypatch: pytest.MonkeyPatch, qh: ModuleType, reviews: list, comments: list, timeline: list | None = None
+) -> None:
+    # timeline defaults to empty: no prior dismissal for this rule to find,
+    # which is what every test not specifically about the once-only guard
+    # wants.
+    timeline = timeline if timeline is not None else []
+
     def fake_gh_json(*args: str) -> object:
         if args[1].endswith("/reviews"):
             return reviews
         if args[1].endswith("/comments"):
             return comments
+        if args[1].endswith("/timeline"):
+            return timeline
         raise AssertionError(f"unexpected call {args}")
 
     monkeypatch.setattr(qh, "gh_json", fake_gh_json)
@@ -346,17 +355,58 @@ def test_approval_shape_respects_exempt_labels(qh: ModuleType, monkeypatch: pyte
 
 
 def test_approval_shape_does_not_redismiss_a_bare_re_approval(qh: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
-    # carol's original bare approval was dismissed by an earlier run - dismissing
-    # a review sets its own body to the dismissal message, so that history is
-    # still visible as a DISMISSED review carrying it. She re-approved bare
-    # again without adding a comment; the once-only guard must leave the new
-    # review alone rather than dismiss it too.
+    # carol's original bare approval (review 10) was dismissed by an earlier
+    # run. The review itself keeps its original (blank) body - GitHub records
+    # the dismissal message on a separate 'review_dismissed' timeline event
+    # instead, linked back by review_id - so that event is what carries the
+    # history forward. She re-approved bare again without adding a comment
+    # (review 11, a new id); the once-only guard must leave it alone rather
+    # than dismiss it too.
     reviews = [
-        _review(10, "carol", "DISMISSED", "2026-09-10T09:00:00Z", body=qh.DISMISSAL_MESSAGE),
+        _review(10, "carol", "DISMISSED", "2026-09-10T09:00:00Z"),
         _review(11, "carol", "APPROVED", "2026-09-11T09:00:00Z"),
     ]
-    _install_review_api(monkeypatch, qh, reviews, [])
+    timeline = [
+        {"event": "commented"},
+        {
+            "event": "review_dismissed",
+            "dismissed_review": {"review_id": 10, "dismissal_message": qh.DISMISSAL_MESSAGE},
+        },
+    ]
+
+    def fake_gh_json(*args: str) -> object:
+        if args[1].endswith("/reviews"):
+            return reviews
+        if args[1].endswith("/comments"):
+            return []
+        if args[1].endswith("/timeline"):
+            return timeline
+        raise AssertionError(f"unexpected call {args}")
+
+    monkeypatch.setattr(qh, "gh_json", fake_gh_json)
     pr = _pr(qh, 1, changed_lines=200)
+    qh.rule_approval_shape("owner/repo", [pr], maintainer="chernistry")
+    assert not pr.intents
+
+
+def test_approval_shape_does_not_check_the_timeline_when_nothing_is_bare(
+    qh: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The once-only check costs an extra API call - it must only be paid when
+    # there is an actual bare-approval candidate to check, not on every PR
+    # that clears the line-count gate.
+    reviews = [_review(10, "alice", "APPROVED", "2026-09-10T10:00:00Z")]
+    comments = [{"user": {"login": "alice"}}]
+
+    def fake_gh_json(*args: str) -> object:
+        if args[1].endswith("/reviews"):
+            return reviews
+        if args[1].endswith("/comments"):
+            return comments
+        raise AssertionError(f"must not check the timeline when nothing is bare: {args}")
+
+    monkeypatch.setattr(qh, "gh_json", fake_gh_json)
+    pr = _pr(qh, 1, changed_lines=120)
     qh.rule_approval_shape("owner/repo", [pr], maintainer="chernistry")
     assert not pr.intents
 

--- a/tests/unit/scripts/test_queue_hygiene.py
+++ b/tests/unit/scripts/test_queue_hygiene.py
@@ -241,8 +241,8 @@ def test_changes_requested_timeout_respects_exempt_labels(qh: ModuleType, monkey
 # --- approval-shape ---------------------------------------------------------
 
 
-def _review(review_id: int, login: str, state: str, at: str) -> dict:
-    return {"id": review_id, "user": {"login": login}, "state": state, "submitted_at": at}
+def _review(review_id: int, login: str, state: str, at: str, *, body: str = "") -> dict:
+    return {"id": review_id, "user": {"login": login}, "state": state, "submitted_at": at, "body": body}
 
 
 def _install_review_api(monkeypatch: pytest.MonkeyPatch, qh: ModuleType, reviews: list, comments: list) -> None:
@@ -275,6 +275,30 @@ def test_approval_shape_keeps_an_approval_whose_author_left_a_line_comment(
         qh,
         [_review(10, "alice", "APPROVED", "2026-09-09T10:00:00Z")],
         [{"user": {"login": "alice"}, "pull_request_review_id": 11}],
+    )
+    pr = _pr(qh, 1, changed_lines=120)
+    qh.rule_approval_shape("owner/repo", [pr])
+    assert not pr.intents
+
+
+def test_approval_shape_keeps_an_approval_whose_body_is_non_blank(
+    qh: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No line comment anywhere, but the review's own body is a real note - the
+    # charter's criterion is "any comment", not specifically a line-level one.
+    _install_review_api(
+        monkeypatch,
+        qh,
+        [
+            _review(
+                10,
+                "alice",
+                "APPROVED",
+                "2026-09-09T10:00:00Z",
+                body="Ran the suite locally, checked the migration path, LGTM",
+            )
+        ],
+        [],
     )
     pr = _pr(qh, 1, changed_lines=120)
     qh.rule_approval_shape("owner/repo", [pr])


### PR DESCRIPTION
## Why

Two gaps between the queue-hygiene rules and the review charter (`docs/governance/review-charter.md`):

1. `needs-committer-review` was set on pull requests that cannot merge because of a conflict, so the label pointed reviewers at work that has to go back to its author first.
2. Section 3 of the charter says an approval on a non-trivial change means "I read the whole diff". Nothing enforced the visible form of that: an approval with no line-level comment anywhere on a 400-line change looked the same as one with ten.

## What changes

- `needs-committer-review` now also requires the pull request to be free of conflicts (GitHub's `mergeable` state).
- New rule `approval-shape`: on a pull request over 40 changed lines, a standing approval whose author left no line-level comment anywhere on the request is dismissed, with a note on how to re-approve. Each user's latest verdict counts; a comment-only review does not replace an earlier approval, matching how GitHub keeps approvals standing. The maintainer's approval is exempt (it is a separate protected-path requirement, section 4), and bot reviews never count as approvals.
- Small changes (40 lines or fewer) and drafts are skipped without any API call.

The dismissal message reads:

> Dismissed by queue hygiene: the review charter (docs/governance/review-charter.md, section 3) asks an approval on a change of this size to carry at least one line-level comment, a finding or a note of what you ran. Re-approve with one and it stands.

This applies to every approver equally. It is announced in #5730 ("What counts as an approval").

## Safety

- Both rules stay dry-run until the repository variable `QUEUE_HYGIENE_ARMED` is `true` (it is not set). The dry-run log shows every intent first.
- Dismissal uses the review-dismissal endpoint only; no review is deleted and the reviewer can re-approve at once.

## Tests

`tests/unit/scripts/test_queue_hygiene.py`: conflict exclusion (2), approval-shape (6: dismiss, keep when a line comment exists on any review, size threshold without API calls, maintainer and bot exemption, latest-verdict semantics, drafts), and the dismissal endpoint call (1). 26 pass locally.
