### PR TITLE
ci(quorum): a check that answers whether a pull request has its review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,3 +24,10 @@
 /AGENTS.md @chernistry
 /docs/governance/ @chernistry
 /docs/decisions/ @chernistry
+
+# The review roster and the two scripts that enforce this file and the
+# charter. `.github/` above already covers the roster; these are the pieces
+# that live outside it (charter, s10).
+/scripts/quorum_check.py @chernistry
+/scripts/queue_hygiene.py @chernistry
+/renovate.json @chernistry

--- a/.github/quorum-roster.toml
+++ b/.github/quorum-roster.toml
@@ -1,0 +1,23 @@
+# Who may approve, and what an approval from them is worth.
+#
+# `scripts/quorum_check.py` reads this file from the BASE branch of a pull
+# request, never from the branch under review, so a pull request cannot put
+# its own author on the roster. Changing this file needs the maintainer:
+# `.github/CODEOWNERS` routes it there.
+#
+# Roles are defined in docs/governance/review-charter.md, section 1. A person
+# belongs to exactly one list. Removing someone here removes their ability to
+# form a quorum; it does not touch their repository access, which lives in the
+# repository's collaborator settings and has to be changed there as well.
+
+maintainer = "chernistry"
+
+# Approve as a code owner; one core approval is part of every quorum.
+core_reviewers = ["vaibhav8a", "thegoodengineer", "tenequm", "Phoenix1504e"]
+
+# Approve; two approvals of any kind form the quorum when one is a core one.
+committers = ["Chirag6722", "Silentpartnercoding"]
+
+# Accounts that merge their own changes on green CI (charter, section 1).
+# Their reviews never count toward a human quorum.
+automation = ["bernstein-the-conductor[bot]", "renovate[bot]", "dependabot[bot]"]

--- a/.github/workflows/quorum-rerun.yml
+++ b/.github/workflows/quorum-rerun.yml
@@ -1,0 +1,83 @@
+name: quorum rerun
+
+# Re-runs the `quorum` check when its answer can have changed without a push.
+#
+# Two cases. A review is submitted, edited or dismissed: `pull_request` does
+# not fire for that, so the last quorum run still shows the old verdict and an
+# approval would otherwise sit unnoticed until the next push. And the 72-hour
+# objection window on governance files (charter, section 10) closes with the
+# clock rather than with an event, so an hourly sweep re-runs those - only
+# those, because they are the only pull requests whose verdict changes on its
+# own, and re-running everything hourly would spend runner slots the queue
+# needs.
+#
+# `pull_request_review` is a privileged trigger: it runs the workflow from the
+# base branch with a writable token, including for pull requests from forks.
+# That is safe here because nothing from the pull request is checked out or
+# executed - the job only asks the API to re-run an existing workflow run.
+
+on:
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch: {}
+
+concurrency:
+  group: quorum-rerun-${{ github.event.pull_request.number || 'sweep' }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  rerun:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: write
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
+      - name: Re-run quorum
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          REVIEWED_PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          rerun_for () {  # rerun_for <pr-number>
+            local pr="$1" head run
+            head=$(gh pr view "$pr" --repo "$REPO" --json headRefOid --jq .headRefOid)
+            run=$(gh run list --repo "$REPO" --workflow quorum.yml --commit "$head" \
+                    --limit 1 --json databaseId,conclusion --jq '.[0] | select(.conclusion != "success") | .databaseId')
+            if [ -n "${run:-}" ]; then
+              echo "re-running quorum for #$pr (run $run, head ${head:0:9})"
+              gh run rerun "$run" --repo "$REPO" || echo "  rerun refused; the next push will re-evaluate"
+            else
+              echo "#$pr: quorum already green or never ran; nothing to do"
+            fi
+          }
+
+          if [ -n "${REVIEWED_PR:-}" ]; then
+            rerun_for "$REVIEWED_PR"
+            exit 0
+          fi
+
+          # Hourly sweep: only the pull requests whose verdict moves with the
+          # clock, i.e. the ones inside the governance objection window.
+          gh pr list --repo "$REPO" --state open --limit 100 \
+              --json number,isDraft,files \
+              --jq '.[] | select(.isDraft | not)
+                        | select([.files[].path] | any(
+                            . == "docs/governance/review-charter.md" or . == "GOVERNANCE.md"
+                            or . == "MAINTAINERS.md" or . == ".github/CODEOWNERS"
+                            or . == ".github/quorum-roster.toml"
+                            or . == "scripts/quorum_check.py" or . == "scripts/queue_hygiene.py"))
+                        | .number' \
+            | while read -r pr; do rerun_for "$pr"; done

--- a/.github/workflows/quorum.yml
+++ b/.github/workflows/quorum.yml
@@ -1,0 +1,74 @@
+name: quorum
+
+# Does this pull request have the review the charter asks for?
+#
+# docs/governance/review-charter.md section 3 anticipated this check; the
+# reasoning for having it at all, and each rule it applies, is written at the
+# top of scripts/quorum_check.py. In short: GitHub's required-approvals rule
+# applies one number to everybody and ignores its own bypass list when a pull
+# request enters the merge queue, so it cannot express a charter that exempts
+# automation, lets the maintainer merge while committers keep their veto, and
+# asks for a third approval on large or sensitive changes.
+#
+# The check only reads. It takes no token beyond the read-only GITHUB_TOKEN
+# and never runs anything from the branch under review: the checkout below is
+# pinned to the BASE commit, so the roster and CODEOWNERS it reads are the
+# ones already on the target branch and a pull request cannot promote its own
+# author by editing them.
+#
+# This workflow is pinned by an organization ruleset as a required workflow,
+# which is what makes it non-forgeable: a branch cannot swap in its own
+# version of it.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+  merge_group: {}
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "Pull request number to check"
+        required: true
+        type: string
+
+concurrency:
+  group: quorum-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  quorum:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          # The base commit, never the pull request's own tree: the roster and
+          # CODEOWNERS have to be the ones already trusted on the target branch.
+          ref: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.sha }}
+          persist-credentials: false
+          sparse-checkout: |
+            scripts/quorum_check.py
+            .github/quorum-roster.toml
+            .github/CODEOWNERS
+          sparse-checkout-cone-mode: false
+      - name: Check the review quorum
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_PR: ${{ inputs.pr }}
+        run: |
+          set -euo pipefail
+          if [ "${INPUT_PR:-}" != "" ]; then
+            python3 scripts/quorum_check.py --pr "$INPUT_PR"
+          else
+            python3 scripts/quorum_check.py
+          fi

--- a/.github/workflows/quorum.yml
+++ b/.github/workflows/quorum.yml
@@ -67,6 +67,20 @@ jobs:
           INPUT_PR: ${{ inputs.pr }}
         run: |
           set -euo pipefail
+          # The checkout above is the base branch, so on the pull request that
+          # first adds this check -- and on any branch whose base predates it --
+          # there is nothing to run. Say so and pass: the rules in force on that
+          # base are whatever branch protection already enforces there, and this
+          # job cannot invent an opinion it has no code for. Once the script is
+          # on the base branch a pull request cannot remove it this way, because
+          # deleting it still has to pass the copy that is still on the base.
+          if [ ! -f scripts/quorum_check.py ]; then
+            echo "The base branch does not carry scripts/quorum_check.py yet; nothing to check."
+            echo "### quorum: not applicable" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "The base branch does not carry \`scripts/quorum_check.py\` yet, so this run has no rules to apply." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
           if [ "${INPUT_PR:-}" != "" ]; then
             python3 scripts/quorum_check.py --pr "$INPUT_PR"
           else

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -65,6 +65,8 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/publish-extension.yml | Publish VS Code Extension | push, workflow_dispatch | {"cancel-in-progress": "false", "group": "publish-extension-${{ github.ref }}"} | 1 |
 | .github/workflows/publish-homebrew.yml | Publish Homebrew Formula | release, workflow_dispatch | {"cancel-in-progress": "false", "group": "publish-homebrew-${{ github.ref }}"} | 1 |
 | .github/workflows/publish.yml | Publish | push, workflow_dispatch | - | 10 |
+| .github/workflows/quorum-rerun.yml | quorum rerun | pull_request_review, schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "quorum-rerun-${{ github.event.pull_request.number \|\| 'sweep' }}"} | 1 |
+| .github/workflows/quorum.yml | quorum | merge_group, pull_request, workflow_dispatch | {"cancel-in-progress": "true", "group": "quorum-${{ github.event.pull_request.number \|\| github.event.merge_group.head_ref \|\| github.ref }}"} | 1 |
 | .github/workflows/reconcile-release.yml | Reconcile release drift | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "reconcile-release"} | 1 |
 | .github/workflows/release-major-minor.yml | Major/Minor Release | workflow_dispatch | {"cancel-in-progress": "false", "group": "release-major-minor-${{ github.ref }}"} | 1 |
 | .github/workflows/rendering-lane.yml | Rendering lane | pull_request, workflow_dispatch | {"cancel-in-progress": "true", "group": "rendering-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) \|\| format('branch-{0}-{1}', github.ref, github.sha) }}"} | 1 |
@@ -142,6 +144,8 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/publish-extension.yml | publish |
 | .github/workflows/publish-homebrew.yml | update-formula: Update Homebrew formula |
 | .github/workflows/publish.yml | build: Build<br>github-release: Create GitHub Release<br>protocol-gate: Protocol Compatibility Gate<br>publish: Publish to PyPI<br>publish-copr: Publish RPM to Copr<br>publish-mcp-registry: Publish MCP registry listing<br>publish-npm: Publish npm wrapper<br>rpm-install-smoke: RPM install smoke (${{ matrix.image }})<br>test: Verify tests pass<br>version-check: Verify tag matches pyproject.toml |
+| .github/workflows/quorum-rerun.yml | rerun |
+| .github/workflows/quorum.yml | quorum |
 | .github/workflows/reconcile-release.yml | reconcile: Compare pyproject.toml vs published channels |
 | .github/workflows/release-major-minor.yml | release: ${{ inputs.bump }} release |
 | .github/workflows/rendering-lane.yml | rendering: Rendering fetcher (browser-backed) |
@@ -219,6 +223,8 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/publish-extension.yml | workflow: {"contents": "read"}<br>publish: {"contents": "read"} | OPEN_VSX_TOKEN, VS_MARKETPLACE_TOKEN |
 | .github/workflows/publish-homebrew.yml | workflow: {"contents": "read"}<br>update-formula: {"contents": "read"} | HOMEBREW_TAP_TOKEN |
 | .github/workflows/publish.yml | build: {"contents": "read"}<br>github-release: {"actions": "write", "contents": "write"}<br>protocol-gate: {"contents": "read"}<br>publish: {"attestations": "write", "contents": "read", "id-token": "write"}<br>publish-copr: {"contents": "read"}<br>publish-mcp-registry: {"contents": "read", "id-token": "write"}<br>publish-npm: {"contents": "read"}<br>rpm-install-smoke: {"contents": "read"}<br>test: {"contents": "read"}<br>version-check: {"contents": "read"} | COPR_CONFIG, GITHUB_TOKEN, NPM_TOKEN |
+| .github/workflows/quorum-rerun.yml | workflow: {"contents": "read"}<br>rerun: {"actions": "write", "contents": "read", "pull-requests": "read"} | GITHUB_TOKEN |
+| .github/workflows/quorum.yml | workflow: {"contents": "read"}<br>quorum: {"contents": "read", "pull-requests": "read"} | GITHUB_TOKEN |
 | .github/workflows/reconcile-release.yml | reconcile: {"contents": "read", "issues": "write"} | - |
 | .github/workflows/release-major-minor.yml | workflow: {"contents": "read"}<br>release: {"contents": "write", "pull-requests": "write"} | BERNSTEIN_AUTOSYNC_TOKEN, GITHUB_TOKEN |
 | .github/workflows/rendering-lane.yml | workflow: {"contents": "read"} | - |

--- a/docs/operations/merge-queue.md
+++ b/docs/operations/merge-queue.md
@@ -95,6 +95,18 @@ required-context coverage by
 | `typecheck (packages/vscode)` | `typecheck-ts.yml` :: `typecheck` | Yes - `merge_group: {}` | **No - see below** |
 | `typecheck (web)` | `typecheck-ts.yml` :: `typecheck` | Yes - `merge_group: {}` | **No - see below** |
 | `typecheck (templates/cloudflare-mcp-server)` | `typecheck-ts.yml` :: `typecheck` | Yes - `merge_group: {}` | **No - see below** |
+| `quorum` | `quorum.yml` :: `quorum` | Yes - `merge_group: {}` | **Through an organization ruleset, not a context name** |
+
+`quorum` is required differently from everything else in this table. A
+required *context* is matched by name, and a branch can publish that name
+from a workflow of its own; the review verdict is the one check where that
+would be the whole attack. So it is pinned as a required workflow in an
+organization ruleset instead: GitHub runs the file from the ref the ruleset
+names, and nothing on the branch can substitute for it. Requiring the
+`quorum` context by name as well would add nothing and could be satisfied by
+a branch, so this table lists it as reporting rather than requirable. What it
+decides, and why the branch rule cannot decide it instead, is written at the
+top of `scripts/quorum_check.py`.
 
 `typecheck-ts` occupies four rows because it publishes four contexts: its
 job is `typecheck (${{ matrix.package }})` and branch protection matches a

--- a/scripts/quorum_check.py
+++ b/scripts/quorum_check.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""Decide whether a pull request has the review the charter asks for.
+
+`docs/governance/review-charter.md` section 3 says an automated `quorum`
+check may enforce the review rules later; this is that check. It reports a
+pass or a failure with a table naming what is missing and who can supply it.
+
+Why a script and not the branch rule
+------------------------------------
+GitHub's "required approvals" rule applies the same number to everybody, and
+its bypass list does not apply when a pull request enters the merge queue. So
+the rule either blocks the maintainer's own infrastructure changes and every
+change the project's automation makes, or it is switched off for everyone.
+The charter does not say that: it exempts automation (section 1), it lets the
+maintainer merge while committers keep their veto (section 6), and it asks
+for MORE than two approvals on large or sensitive changes (section 3). All of
+that fits in a check; none of it fits in the rule. The branch rule keeps the
+parts GitHub does well - the queue, the required status checks, no force
+pushes - and this check owns the review question.
+
+What it reads, and from where
+-----------------------------
+The roster and CODEOWNERS come from the pull request's BASE branch, never
+from the branch under review, so a pull request cannot promote its own author
+or make itself unowned. The workflow checks out the base commit for the same
+reason. Everything else (reviews, commits, files) comes from the API, which
+reports the pull request as GitHub sees it.
+
+The rules, in the order they are applied
+----------------------------------------
+0. A draft is neutral: the queue does not take drafts, so there is nothing to
+   decide yet.
+1. A change to a governance path is held open for 72 hours after its last
+   push, so committers can object (section 10). This applies to every author,
+   the maintainer included.
+2. Automation merges its own changes on green CI (section 1), except on the
+   paths where a mistake is expensive - anything with `sandbox`, `security`,
+   `audit` or `auth` in it, plus `.github/`, `schemas/` and `proto/` - where
+   it needs the maintainer's approval.
+3. A pull request opened by `github-actions[bot]` needs the maintainer's
+   approval whatever it touches: anyone who can push a branch can open one.
+4. The maintainer's own pull requests merge without approvals, and any
+   standing `changes requested` from a committer blocks them (section 6).
+5. Everyone else needs the quorum: two approvals, at least one from a core
+   reviewer, none of them from anyone who wrote or pushed the change. Over
+   400 changed lines, or on a path containing `sandbox`, `security` or
+   `audit`, a third approval is required and two of the three must be core.
+   Over 1,000 changed lines the maintainer approves or the change is split.
+   A protected path (any CODEOWNERS entry that is not `*`) needs its owner.
+
+Approvals count only when they were given on the current head commit: a push
+after an approval means nobody has read what is about to merge. A `changes
+requested` survives a push, and stays counted until its author withdraws it.
+A review whose state is `commented` does not replace an earlier verdict,
+which is how GitHub itself treats it.
+
+Exit codes: 0 pass or neutral, 1 fail. The failure table is written to the
+job summary as well as stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import re
+import subprocess
+import sys
+import tomllib
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+ROSTER_PATH = ".github/quorum-roster.toml"
+CODEOWNERS_PATH = ".github/CODEOWNERS"
+
+# Section 3: over this many changed lines a third approval is required, and
+# over the second number the change is split or goes to the maintainer.
+THIRD_APPROVAL_LINES = 400
+MAINTAINER_OR_SPLIT_LINES = 1000
+
+# Section 3: these words in a path make a change sensitive whatever its size.
+SENSITIVE_WORDS = ("sandbox", "security", "audit")
+
+# Section 1 as decided for automation: the paths where automation stops being
+# allowed to merge its own work. Wider than SENSITIVE_WORDS because a change
+# to the workflows, the schemas or the wire protocol is not something the
+# project's automation should be able to land unseen.
+AUTOMATION_STOP_WORDS = (*SENSITIVE_WORDS, "auth")
+AUTOMATION_STOP_PREFIXES = (".github/", "schemas/", "proto/")
+
+# Section 10: an amendment stays open so committers can object. The charter
+# anchors the window on the approval; for a change that needs no approval the
+# equivalent anchor is the last push, which is what this check uses.
+GOVERNANCE_WINDOW = timedelta(hours=72)
+GOVERNANCE_PATHS = (
+    "docs/governance/review-charter.md",
+    "GOVERNANCE.md",
+    "MAINTAINERS.md",
+    ".github/CODEOWNERS",
+    ".github/quorum-roster.toml",
+    "scripts/quorum_check.py",
+    "scripts/queue_hygiene.py",
+)
+
+GITHUB_ACTIONS_BOT = "github-actions[bot]"
+
+
+def gh_json(*args: str) -> Any:
+    result = subprocess.run(["gh", *args], capture_output=True, text=True, check=True)
+    return json.loads(result.stdout)
+
+
+@dataclass(frozen=True)
+class Roster:
+    maintainer: str
+    core_reviewers: frozenset[str]
+    committers: frozenset[str]
+    automation: frozenset[str]
+
+    @property
+    def quorum_holders(self) -> frozenset[str]:
+        """Everyone whose approval counts toward a human quorum."""
+        return self.core_reviewers | self.committers | {self.maintainer}
+
+    @property
+    def core(self) -> frozenset[str]:
+        """Everyone who can supply the core reviewer's approval."""
+        return self.core_reviewers | {self.maintainer}
+
+
+def load_roster(root: str = ".") -> Roster:
+    with open(os.path.join(root, ROSTER_PATH), "rb") as handle:
+        raw = tomllib.load(handle)
+    return Roster(
+        maintainer=raw["maintainer"],
+        core_reviewers=frozenset(raw.get("core_reviewers", [])),
+        committers=frozenset(raw.get("committers", [])),
+        automation=frozenset(raw.get("automation", [])),
+    )
+
+
+def load_codeowners(root: str = ".") -> list[tuple[str, list[str]]]:
+    """CODEOWNERS as (pattern, owners) in file order. Last match wins."""
+    path = os.path.join(root, CODEOWNERS_PATH)
+    if not os.path.isfile(path):
+        return []
+    entries: list[tuple[str, list[str]]] = []
+    with open(path, encoding="utf-8") as handle:
+        for line in handle:
+            line = line.split("#", 1)[0].strip()
+            if not line:
+                continue
+            pattern, *owners = line.split()
+            if owners:
+                entries.append((pattern, [o.lstrip("@") for o in owners]))
+    return entries
+
+
+def path_matches(pattern: str, path: str) -> bool:
+    """CODEOWNERS matching, in the subset of the syntax this repository uses.
+
+    `*` matches everything; a pattern ending in `/` matches everything under
+    that directory; a leading `/` anchors at the repository root; anything
+    else is matched as a glob against the whole path and against its
+    basename, which is how GitHub treats an unanchored pattern.
+    """
+    if pattern == "*":
+        return True
+    anchored = pattern.startswith("/")
+    cleaned = pattern.lstrip("/")
+    if cleaned.endswith("/"):
+        return path.startswith(cleaned) if anchored else f"/{path}".find(f"/{cleaned}") >= 0
+    if anchored:
+        return path == cleaned or fnmatch.fnmatch(path, cleaned)
+    return fnmatch.fnmatch(path, cleaned) or fnmatch.fnmatch(os.path.basename(path), cleaned)
+
+
+def owners_for(path: str, entries: list[tuple[str, list[str]]]) -> tuple[list[str], bool]:
+    """Owners of a path and whether they come from a specific rule.
+
+    The boolean says the path is protected in the sense of charter section 4:
+    it matched a rule of its own rather than falling through to the catch-all.
+    """
+    owners: list[str] = []
+    specific = False
+    for pattern, entry_owners in entries:
+        if path_matches(pattern, path):
+            owners = entry_owners
+            specific = pattern != "*"
+    return owners, specific
+
+
+@dataclass
+class Review:
+    login: str
+    state: str
+    commit_id: str
+    submitted_at: str
+
+
+@dataclass
+class PullRequest:
+    number: int
+    author: str
+    is_draft: bool
+    head_sha: str
+    changed_lines: int
+    paths: list[str]
+    reviews: list[Review]
+    # Everyone who wrote or pushed any commit on the branch, plus anyone named
+    # in a Co-authored-by trailer: none of them can approve it (section 3).
+    contributors: set[str]
+    last_push: datetime
+
+
+def _logins_from_commit(raw: dict[str, Any]) -> set[str]:
+    logins: set[str] = set()
+    for role in ("author", "committer"):
+        login = ((raw.get(role) or {}).get("login")) or ""
+        if login:
+            logins.add(login)
+    message = (raw.get("commit") or {}).get("message") or ""
+    for match in re.finditer(r"Co-authored-by:[^<]*<([^>]+)>", message, re.IGNORECASE):
+        handle = match.group(1).split("@")[0]
+        # `12345+login@users.noreply.github.com` is the form GitHub writes.
+        logins.add(handle.split("+")[-1])
+    return logins
+
+
+def fetch_pull_request(repo: str, number: int) -> PullRequest:
+    raw = gh_json("api", f"repos/{repo}/pulls/{number}")
+    files = gh_json("api", f"repos/{repo}/pulls/{number}/files", "--paginate")
+    raw_reviews = gh_json("api", f"repos/{repo}/pulls/{number}/reviews", "--paginate")
+    commits = gh_json("api", f"repos/{repo}/pulls/{number}/commits", "--paginate")
+
+    contributors: set[str] = set()
+    pushed_at = None
+    for commit in commits:
+        contributors |= _logins_from_commit(commit)
+        date = ((commit.get("commit") or {}).get("committer") or {}).get("date")
+        if date:
+            moment = datetime.fromisoformat(date.replace("Z", "+00:00"))
+            pushed_at = moment if pushed_at is None or moment > pushed_at else pushed_at
+
+    return PullRequest(
+        number=number,
+        author=(raw.get("user") or {}).get("login", ""),
+        is_draft=bool(raw.get("draft")),
+        head_sha=(raw.get("head") or {}).get("sha", ""),
+        changed_lines=int(raw.get("additions") or 0) + int(raw.get("deletions") or 0),
+        paths=[f["filename"] for f in files],
+        reviews=[
+            Review(
+                login=(r.get("user") or {}).get("login", ""),
+                state=r.get("state", ""),
+                commit_id=r.get("commit_id") or "",
+                submitted_at=r.get("submitted_at") or "",
+            )
+            for r in raw_reviews
+        ],
+        contributors=contributors,
+        last_push=pushed_at or datetime.now(UTC),
+    )
+
+
+def standing_reviews(reviews: list[Review]) -> dict[str, Review]:
+    """Each person's current verdict.
+
+    A `commented` review does not replace an earlier approval or request for
+    changes - GitHub keeps the earlier verdict standing - so it is skipped
+    rather than treated as a newer state.
+    """
+    latest: dict[str, Review] = {}
+    for review in reviews:
+        if not review.login or review.state in ("COMMENTED", "PENDING", "DISMISSED"):
+            continue
+        current = latest.get(review.login)
+        if current is None or review.submitted_at >= current.submitted_at:
+            latest[review.login] = review
+    return latest
+
+
+@dataclass
+class Requirement:
+    text: str
+    met: bool
+    who: str
+
+
+@dataclass
+class Verdict:
+    passed: bool
+    title: str
+    requirements: list[Requirement] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def summary(self) -> str:
+        lines = [f"### `quorum`: {self.title}", ""]
+        if self.requirements:
+            lines += ["| Requirement | Met | Who can satisfy it |", "|---|---|---|"]
+            for req in self.requirements:
+                lines.append(f"| {req.text} | {'yes' if req.met else '**no**'} | {req.who} |")
+            lines.append("")
+        lines += self.notes
+        lines.append("")
+        lines.append(
+            "Rules: [`docs/governance/review-charter.md`](docs/governance/review-charter.md) "
+            "sections 1, 3, 4, 6 and 10. Roster: `.github/quorum-roster.toml`."
+        )
+        return "\n".join(lines)
+
+
+def _names(logins: set[str] | frozenset[str]) -> str:
+    return ", ".join(f"@{login}" for login in sorted(logins)) or "nobody on the roster"
+
+
+def evaluate(pr: PullRequest, roster: Roster, owners: list[tuple[str, list[str]]], now: datetime) -> Verdict:
+    if pr.is_draft:
+        return Verdict(True, "draft, nothing to decide yet")
+
+    standing = standing_reviews(pr.reviews)
+    approvals = {
+        login for login, review in standing.items() if review.state == "APPROVED" and review.commit_id == pr.head_sha
+    }
+    stale_approvals = {
+        login for login, review in standing.items() if review.state == "APPROVED" and review.commit_id != pr.head_sha
+    }
+    changes_requested = {login for login, review in standing.items() if review.state == "CHANGES_REQUESTED"}
+
+    verdict = Verdict(True, "")
+    blocking = changes_requested & (roster.quorum_holders | {roster.maintainer})
+    if blocking:
+        verdict.requirements.append(
+            Requirement(
+                f"no standing *changes requested* (open: {_names(blocking)})",
+                False,
+                "the reviewer who asked for changes, by approving or dismissing their review",
+            )
+        )
+
+    # 1. The objection window on governance changes, for every author.
+    governance = [p for p in pr.paths if p in GOVERNANCE_PATHS]
+    if governance:
+        elapsed = now - pr.last_push
+        met = elapsed >= GOVERNANCE_WINDOW
+        remaining = GOVERNANCE_WINDOW - elapsed
+        hours = max(0, int(remaining.total_seconds() // 3600))
+        verdict.requirements.append(
+            Requirement(
+                f"72 hours open for objections (touches {', '.join(f'`{p}`' for p in governance)})",
+                met,
+                "nobody - it merges once the window closes" + ("" if met else f", about {hours}h from now"),
+            )
+        )
+
+    if pr.author in roster.automation:
+        stops = sorted(
+            p
+            for p in pr.paths
+            if any(word in p for word in AUTOMATION_STOP_WORDS) or p.startswith(AUTOMATION_STOP_PREFIXES)
+        )
+        if stops:
+            met = roster.maintainer in approvals
+            verdict.requirements.append(
+                Requirement(
+                    f"maintainer approval: automation changing {', '.join(f'`{p}`' for p in stops[:4])}"
+                    + (" and others" if len(stops) > 4 else ""),
+                    met,
+                    f"@{roster.maintainer}",
+                )
+            )
+        else:
+            verdict.notes.append("Automation merging its own change on green CI (charter, section 1).")
+    elif pr.author == GITHUB_ACTIONS_BOT:
+        verdict.requirements.append(
+            Requirement(
+                "maintainer approval: a pull request opened by the workflow account",
+                roster.maintainer in approvals,
+                f"@{roster.maintainer}",
+            )
+        )
+    elif pr.author == roster.maintainer:
+        verdict.notes.append(
+            "The maintainer's own change merges without approvals; a committer's "
+            "*changes requested* blocks it (charter, section 6)."
+        )
+    else:
+        eligible = roster.quorum_holders - {pr.author} - pr.contributors
+        approving = approvals & eligible
+        approving_core = approving & roster.core
+
+        sensitive = sorted(p for p in pr.paths if any(word in p for word in SENSITIVE_WORDS))
+        large = pr.changed_lines > THIRD_APPROVAL_LINES
+        need_total, need_core = (3, 2) if (large or sensitive) else (2, 1)
+        reason = (
+            f"{pr.changed_lines} changed lines"
+            if large
+            else (f"touches `{sensitive[0]}`" if sensitive else f"{pr.changed_lines} changed lines")
+        )
+
+        verdict.requirements.append(
+            Requirement(
+                f"{need_total} approvals, {need_core} from a core reviewer ({reason})",
+                len(approving) >= need_total and len(approving_core) >= need_core,
+                _names(eligible - approving),
+            )
+        )
+
+        if pr.changed_lines > MAINTAINER_OR_SPLIT_LINES:
+            verdict.requirements.append(
+                Requirement(
+                    f"maintainer approval or a split ({pr.changed_lines} changed lines, "
+                    f"over {MAINTAINER_OR_SPLIT_LINES})",
+                    roster.maintainer in approvals,
+                    f"@{roster.maintainer}, or split the change",
+                )
+            )
+
+        protected: dict[str, list[str]] = {}
+        for path in pr.paths:
+            path_owners, specific = owners_for(path, owners)
+            if specific:
+                for owner in path_owners:
+                    protected.setdefault(owner, []).append(path)
+        for owner, paths in sorted(protected.items()):
+            verdict.requirements.append(
+                Requirement(
+                    f"approval from the owner of {', '.join(f'`{p}`' for p in paths[:3])}"
+                    + (" and others" if len(paths) > 3 else ""),
+                    owner in approvals,
+                    f"@{owner}",
+                )
+            )
+
+    if stale_approvals:
+        verdict.notes.append(
+            f"Approvals given before the last push do not count: {_names(stale_approvals)}. "
+            "A new push means nobody has read what is about to merge (charter, section 2)."
+        )
+
+    verdict.passed = all(req.met for req in verdict.requirements)
+    missing = sum(1 for req in verdict.requirements if not req.met)
+    verdict.title = "review requirements met" if verdict.passed else f"{missing} requirement(s) missing"
+    return verdict
+
+
+def pr_number_from_env(env: dict[str, str]) -> int | None:
+    """The pull request under test, for each event that can trigger this.
+
+    On `merge_group` the ref names the queued pull request, which is the one
+    whose reviews still have to hold at the moment it merges.
+    """
+    if env.get("GITHUB_EVENT_NAME") == "merge_group":
+        match = re.search(r"/pr-(\d+)-", env.get("GITHUB_REF", ""))
+        return int(match.group(1)) if match else None
+    event_path = env.get("GITHUB_EVENT_PATH")
+    if event_path and os.path.isfile(event_path):
+        with open(event_path, encoding="utf-8") as handle:
+            event = json.load(handle)
+        number = (event.get("pull_request") or {}).get("number")
+        if number:
+            return int(number)
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--pr", type=int, default=None)
+    parser.add_argument("--root", default=".", help="where to read the roster and CODEOWNERS from")
+    args = parser.parse_args(argv)
+
+    number = args.pr or pr_number_from_env(dict(os.environ))
+    if number is None:
+        print("quorum: no pull request in this event; nothing to check")
+        return 0
+
+    pr = fetch_pull_request(args.repo, number)
+    verdict = evaluate(pr, load_roster(args.root), load_codeowners(args.root), datetime.now(UTC))
+
+    summary = verdict.summary()
+    print(summary)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(summary + "\n")
+    if not verdict.passed:
+        print(f"::error title=quorum::{verdict.title} - see the job summary for what is missing")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/scripts/test_quorum_check.py
+++ b/tests/unit/scripts/test_quorum_check.py
@@ -1,0 +1,333 @@
+"""Unit tests for ``scripts/quorum_check.py``.
+
+Every rule is exercised against a constructed ``PullRequest`` through
+``evaluate()``, which is the whole decision: the network calls sit in
+``fetch_pull_request`` and are not part of what is being tested here, so a
+failure names the rule that regressed rather than a broken subprocess chain.
+
+The cases that matter most are the ones where a pass would be wrong: an
+approval given before the last push, an approval from someone who pushed to
+the branch, automation touching a path where it is not allowed to merge
+itself, and the objection window on governance files.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "quorum_check.py"
+NOW = datetime(2026, 9, 10, 12, 0, tzinfo=UTC)
+HEAD = "d" * 40
+
+
+@pytest.fixture(scope="module")
+def qc() -> ModuleType:
+    """Load ``scripts/quorum_check.py`` as an importable module."""
+    spec = importlib.util.spec_from_file_location("quorum_check_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    loaded = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = loaded
+    spec.loader.exec_module(loaded)
+    return loaded
+
+
+@pytest.fixture(scope="module")
+def roster(qc: ModuleType):
+    return qc.Roster(
+        maintainer="owner",
+        core_reviewers=frozenset({"core1", "core2"}),
+        committers=frozenset({"comm1", "comm2"}),
+        automation=frozenset({"the-conductor[bot]", "renovate[bot]"}),
+    )
+
+
+OWNERS = [("*", ["core1", "core2"]), ("/.github/", ["owner"]), ("/src/bernstein/core/", ["owner"])]
+
+
+def _review(qc: ModuleType, login: str, state: str, *, sha: str = HEAD, at: str = "2026-09-10T10:00:00Z"):
+    return qc.Review(login=login, state=state, commit_id=sha, submitted_at=at)
+
+
+def _pr(
+    qc: ModuleType,
+    *,
+    author: str = "outsider",
+    is_draft: bool = False,
+    changed_lines: int = 100,
+    paths: list[str] | None = None,
+    reviews: list | None = None,
+    contributors: set[str] | None = None,
+    pushed_hours_ago: float = 1.0,
+):
+    return qc.PullRequest(
+        number=1,
+        author=author,
+        is_draft=is_draft,
+        head_sha=HEAD,
+        changed_lines=changed_lines,
+        paths=paths if paths is not None else ["src/bernstein/adapters/aider.py"],
+        reviews=reviews or [],
+        contributors=contributors if contributors is not None else {author},
+        last_push=NOW - timedelta(hours=pushed_hours_ago),
+    )
+
+
+def _evaluate(qc: ModuleType, roster, pr):
+    return qc.evaluate(pr, roster, OWNERS, NOW)
+
+
+# --- the ordinary contributor path -----------------------------------------
+
+
+def test_two_approvals_with_one_core_pass(qc: ModuleType, roster) -> None:
+    pr = _pr(qc, reviews=[_review(qc, "core1", "APPROVED"), _review(qc, "comm1", "APPROVED")])
+    assert _evaluate(qc, roster, pr).passed
+
+
+def test_two_committer_approvals_without_a_core_one_fail(qc: ModuleType, roster) -> None:
+    pr = _pr(qc, reviews=[_review(qc, "comm1", "APPROVED"), _review(qc, "comm2", "APPROVED")])
+    verdict = _evaluate(qc, roster, pr)
+    assert not verdict.passed
+    assert "core reviewer" in verdict.requirements[0].text
+
+
+def test_a_single_approval_fails_and_names_who_can_close_it(qc: ModuleType, roster) -> None:
+    pr = _pr(qc, reviews=[_review(qc, "core1", "APPROVED")])
+    verdict = _evaluate(qc, roster, pr)
+    assert not verdict.passed
+    assert "@core2" in verdict.requirements[0].who
+    assert "@core1" not in verdict.requirements[0].who
+
+
+def test_an_approval_from_a_stranger_does_not_count(qc: ModuleType, roster) -> None:
+    pr = _pr(qc, reviews=[_review(qc, "core1", "APPROVED"), _review(qc, "passer-by", "APPROVED")])
+    assert not _evaluate(qc, roster, pr).passed
+
+
+def test_an_approval_given_before_the_last_push_does_not_count(qc: ModuleType, roster) -> None:
+    pr = _pr(
+        qc,
+        reviews=[_review(qc, "core1", "APPROVED", sha="0" * 40), _review(qc, "comm1", "APPROVED")],
+    )
+    verdict = _evaluate(qc, roster, pr)
+    assert not verdict.passed
+    assert any("before the last push" in note for note in verdict.notes)
+
+
+def test_an_approval_from_someone_who_pushed_to_the_branch_does_not_count(qc: ModuleType, roster) -> None:
+    pr = _pr(
+        qc,
+        reviews=[_review(qc, "core1", "APPROVED"), _review(qc, "comm1", "APPROVED")],
+        contributors={"outsider", "comm1"},
+    )
+    assert not _evaluate(qc, roster, pr).passed
+
+
+def test_changes_requested_blocks_even_with_a_full_quorum(qc: ModuleType, roster) -> None:
+    pr = _pr(
+        qc,
+        reviews=[
+            _review(qc, "core1", "APPROVED"),
+            _review(qc, "comm1", "APPROVED"),
+            _review(qc, "core2", "CHANGES_REQUESTED"),
+        ],
+    )
+    verdict = _evaluate(qc, roster, pr)
+    assert not verdict.passed
+    assert "changes requested" in verdict.requirements[0].text
+
+
+def test_a_comment_does_not_replace_an_earlier_verdict(qc: ModuleType, roster) -> None:
+    # GitHub keeps an approval standing through a later comment-only review.
+    pr = _pr(
+        qc,
+        reviews=[
+            _review(qc, "core1", "APPROVED", at="2026-09-10T10:00:00Z"),
+            _review(qc, "core1", "COMMENTED", at="2026-09-10T11:00:00Z"),
+            _review(qc, "comm1", "APPROVED"),
+        ],
+    )
+    assert _evaluate(qc, roster, pr).passed
+
+
+def test_a_later_approval_replaces_an_earlier_request_for_changes(qc: ModuleType, roster) -> None:
+    pr = _pr(
+        qc,
+        reviews=[
+            _review(qc, "core1", "CHANGES_REQUESTED", at="2026-09-10T09:00:00Z"),
+            _review(qc, "core1", "APPROVED", at="2026-09-10T11:00:00Z"),
+            _review(qc, "comm1", "APPROVED"),
+        ],
+    )
+    assert _evaluate(qc, roster, pr).passed
+
+
+# --- size and sensitivity (charter section 3) -------------------------------
+
+
+def test_over_four_hundred_lines_needs_a_third_approval_from_a_second_core(qc: ModuleType, roster) -> None:
+    reviews = [_review(qc, "core1", "APPROVED"), _review(qc, "comm1", "APPROVED"), _review(qc, "comm2", "APPROVED")]
+    pr = _pr(qc, changed_lines=401, reviews=reviews)
+    verdict = _evaluate(qc, roster, pr)
+    assert not verdict.passed
+    reviews.append(_review(qc, "core2", "APPROVED"))
+    assert _evaluate(qc, roster, _pr(qc, changed_lines=401, reviews=reviews)).passed
+
+
+def test_a_sensitive_path_needs_the_third_approval_at_any_size(qc: ModuleType, roster) -> None:
+    reviews = [_review(qc, "core1", "APPROVED"), _review(qc, "comm1", "APPROVED")]
+    pr = _pr(qc, changed_lines=12, paths=["src/bernstein/core/security/auth.py"], reviews=reviews)
+    verdict = _evaluate(qc, roster, pr)
+    assert not verdict.passed
+    assert "security" in verdict.requirements[0].text
+
+
+def test_over_a_thousand_lines_needs_the_maintainer(qc: ModuleType, roster) -> None:
+    reviews = [
+        _review(qc, "core1", "APPROVED"),
+        _review(qc, "core2", "APPROVED"),
+        _review(qc, "comm1", "APPROVED"),
+    ]
+    verdict = _evaluate(qc, roster, _pr(qc, changed_lines=1001, reviews=reviews))
+    assert not verdict.passed
+    assert any("maintainer approval or a split" in req.text for req in verdict.requirements)
+
+
+def test_a_protected_path_needs_its_owner(qc: ModuleType, roster) -> None:
+    reviews = [_review(qc, "core1", "APPROVED"), _review(qc, "core2", "APPROVED")]
+    verdict = _evaluate(qc, roster, _pr(qc, paths=["src/bernstein/core/tasks/claim.py"], reviews=reviews))
+    assert not verdict.passed
+    assert any("owner of" in req.text and "@owner" in req.who for req in verdict.requirements)
+
+
+def test_the_catch_all_owner_rule_is_not_treated_as_a_protected_path(qc: ModuleType, roster) -> None:
+    reviews = [_review(qc, "core1", "APPROVED"), _review(qc, "comm1", "APPROVED")]
+    verdict = _evaluate(qc, roster, _pr(qc, paths=["README.md"], reviews=reviews))
+    assert verdict.passed
+
+
+# --- automation, the workflow account and the maintainer --------------------
+
+
+def test_automation_merges_its_own_ordinary_change(qc: ModuleType, roster) -> None:
+    verdict = _evaluate(qc, roster, _pr(qc, author="the-conductor[bot]", contributors=set()))
+    assert verdict.passed
+    assert any("section 1" in note for note in verdict.notes)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ".github/workflows/ci.yml",
+        "schemas/task.json",
+        "proto/tasks.proto",
+        "src/bernstein/core/security/auth.py",
+        "tests/integration/test_sandbox_egress.py",
+    ],
+)
+def test_automation_needs_the_maintainer_on_a_path_it_must_not_land_alone(qc: ModuleType, roster, path: str) -> None:
+    pr = _pr(qc, author="renovate[bot]", paths=[path], contributors=set())
+    assert not _evaluate(qc, roster, pr).passed
+    approved = _pr(
+        qc,
+        author="renovate[bot]",
+        paths=[path],
+        contributors=set(),
+        reviews=[_review(qc, "owner", "APPROVED")],
+    )
+    assert _evaluate(qc, roster, approved).passed
+
+
+def test_a_pull_request_from_the_workflow_account_needs_the_maintainer(qc: ModuleType, roster) -> None:
+    pr = _pr(qc, author="github-actions[bot]", contributors=set())
+    verdict = _evaluate(qc, roster, pr)
+    assert not verdict.passed
+    assert "workflow account" in verdict.requirements[0].text
+
+
+def test_the_maintainers_own_change_merges_without_approvals(qc: ModuleType, roster) -> None:
+    assert _evaluate(qc, roster, _pr(qc, author="owner", contributors={"owner"})).passed
+
+
+def test_a_committer_can_block_the_maintainer(qc: ModuleType, roster) -> None:
+    pr = _pr(qc, author="owner", contributors={"owner"}, reviews=[_review(qc, "comm1", "CHANGES_REQUESTED")])
+    assert not _evaluate(qc, roster, pr).passed
+
+
+def test_a_stranger_cannot_block_the_maintainer(qc: ModuleType, roster) -> None:
+    pr = _pr(qc, author="owner", contributors={"owner"}, reviews=[_review(qc, "passer-by", "CHANGES_REQUESTED")])
+    assert _evaluate(qc, roster, pr).passed
+
+
+# --- the objection window on governance files (charter section 10) ----------
+
+
+def test_a_governance_change_waits_seventy_two_hours(qc: ModuleType, roster) -> None:
+    pr = _pr(qc, author="owner", contributors={"owner"}, paths=["GOVERNANCE.md"], pushed_hours_ago=1)
+    verdict = _evaluate(qc, roster, pr)
+    assert not verdict.passed
+    assert "71h from now" in verdict.requirements[0].who
+
+
+def test_a_governance_change_merges_once_the_window_closes(qc: ModuleType, roster) -> None:
+    pr = _pr(qc, author="owner", contributors={"owner"}, paths=["GOVERNANCE.md"], pushed_hours_ago=73)
+    assert _evaluate(qc, roster, pr).passed
+
+
+def test_the_window_applies_to_the_roster_and_to_this_script(qc: ModuleType, roster) -> None:
+    for path in (".github/quorum-roster.toml", "scripts/quorum_check.py"):
+        pr = _pr(qc, author="owner", contributors={"owner"}, paths=[path], pushed_hours_ago=2)
+        assert not _evaluate(qc, roster, pr).passed, path
+
+
+# --- drafts and plumbing ----------------------------------------------------
+
+
+def test_a_draft_is_neutral(qc: ModuleType, roster) -> None:
+    verdict = _evaluate(qc, roster, _pr(qc, is_draft=True))
+    assert verdict.passed
+    assert verdict.requirements == []
+
+
+def test_the_summary_names_the_charter_and_the_roster(qc: ModuleType, roster) -> None:
+    summary = _evaluate(qc, roster, _pr(qc)).summary()
+    assert "review-charter.md" in summary and "quorum-roster.toml" in summary
+    assert "| Requirement | Met | Who can satisfy it |" in summary
+
+
+def test_the_merge_group_ref_names_the_queued_pull_request(qc: ModuleType) -> None:
+    env = {
+        "GITHUB_EVENT_NAME": "merge_group",
+        "GITHUB_REF": "refs/heads/gh-readonly-queue/main/pr-5737-d45d2c3a9461916133c746dc91749d7f824706a6",
+    }
+    assert qc.pr_number_from_env(env) == 5737
+
+
+def test_no_pull_request_in_the_event_is_not_a_failure(qc: ModuleType) -> None:
+    assert qc.main(["--repo", "o/r", "--root", str(REPO_ROOT)]) == 0
+
+
+def test_co_authors_are_read_from_the_commit_trailer(qc: ModuleType) -> None:
+    commit = {
+        "author": {"login": "outsider"},
+        "committer": None,
+        "commit": {"message": "fix: thing\n\nCo-authored-by: Some One <12345+core1@users.noreply.github.com>"},
+    }
+    assert qc._logins_from_commit(commit) == {"outsider", "core1"}
+
+
+def test_the_roster_and_codeowners_on_this_branch_load(qc: ModuleType) -> None:
+    # Guards the shipped files themselves: a typo in either is a broken check.
+    loaded = qc.load_roster(str(REPO_ROOT))
+    assert loaded.maintainer
+    assert loaded.core_reviewers and loaded.committers
+    owners = qc.load_codeowners(str(REPO_ROOT))
+    assert owners and owners[0][0] == "*"
+    assert qc.owners_for(".github/workflows/ci.yml", owners) == ([loaded.maintainer], True)

--- a/tests/unit/scripts/test_quorum_check.py
+++ b/tests/unit/scripts/test_quorum_check.py
@@ -310,7 +310,11 @@ def test_the_merge_group_ref_names_the_queued_pull_request(qc: ModuleType) -> No
     assert qc.pr_number_from_env(env) == 5737
 
 
-def test_no_pull_request_in_the_event_is_not_a_failure(qc: ModuleType) -> None:
+def test_no_pull_request_in_the_event_is_not_a_failure(qc: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The variables have to go: this suite also runs inside Actions, where a
+    # real pull request event would otherwise be picked up and called.
+    for name in ("GITHUB_EVENT_NAME", "GITHUB_EVENT_PATH", "GITHUB_REF", "GITHUB_REPOSITORY"):
+        monkeypatch.delenv(name, raising=False)
     assert qc.main(["--repo", "o/r", "--root", str(REPO_ROOT)]) == 0
 
 

--- a/tests/unit/test_merge_queue_gate_coverage_yaml.py
+++ b/tests/unit/test_merge_queue_gate_coverage_yaml.py
@@ -62,6 +62,14 @@ MATCH_ANYTHING = ("*", "**")
 #: `test_queue_reporting_web_lanes_can_actually_be_required` re-reads the
 #: workflow and fails if the trigger is missing or filtered.
 QUEUE_REPORTING_WEB_LANES = {
+    "quorum.yml": (
+        "Answers whether a pull request has the review the charter asks for. It runs on "
+        "every pull request whatever it touches, `web/**` included, and on merge_group, so "
+        "the answer is re-checked against the queued state rather than only against the "
+        "branch. It is required through an organization ruleset that pins this workflow "
+        "rather than through a required-context name, which is what stops a branch from "
+        "substituting its own copy; the name it publishes is `quorum`."
+    ),
     "typecheck-ts.yml": (
         "`tsc --noEmit` over the TypeScript packages, `web/` among them. #4010's shape one "
         "directory over: ci.yml paths-ignores the TypeScript trees, `CI gate` is the only "


### PR DESCRIPTION
## Why

GitHub's required-approvals rule applies one number to everybody, and its bypass list does not apply when a pull request enters the merge queue. So the rule either blocks every change the maintainer and the project's automation make, or it is switched off for everyone.

Since the branch rule went on, the repository has been in the first state: an infrastructure change cannot be queued at all, because the rule waits for a code-owner review of a change whose code owner is its author. The charter describes something different from either state, and section 3 anticipated this check by name.

## What it does

`scripts/quorum_check.py` reads a pull request and reports a pass, or a table naming each missing requirement and who can supply it.

| Author | Requirement |
|---|---|
| Draft | neutral, nothing to decide yet |
| Automation | merges its own change on green CI; the maintainer approves on the paths in section 4 and anything naming `sandbox`, `security`, `audit`, `auth` |
| `github-actions[bot]` | the maintainer approves, whatever it touches: anyone who can push a branch can open one |
| Maintainer | no approvals; a committer's *changes requested* blocks |
| Everyone else | two approvals, one core; three with two core over 400 changed lines or on a sensitive path; the maintainer over 1,000; the owner of every protected path |

On top of that, every author waits out the 72-hour objection window on a governance file, approvals count only on the current head commit, and nobody who wrote, pushed to, or is a co-author of the change can approve it.

## Why it can be trusted

- The roster and CODEOWNERS are read from the **base** branch, and the workflow checks out the base commit. A pull request cannot promote its own author or make itself unowned.
- The job takes no token beyond the read-only `GITHUB_TOKEN`, and runs nothing from the branch under review.
- The organization ruleset pins this workflow as a required one, so a branch cannot substitute its own copy of it.
- The roster and both enforcing scripts are maintainer-owned in `.github/CODEOWNERS`, and sit inside the objection window.

## What decides while this is open

When this was written, the branch rule still decided and this check only reported. That changed at 20:32 today: the review requirement came off ruleset `22534399` so this pull request could enter the queue at all, and the pinned-workflow rule that replaces it cannot be created until the file is on the default branch. So between then and this landing, no rule requires review on `main`. That is deliberate, it is the only ordering the platform allows, and it is being tracked in #5744 rather than here, with the evidence and what is watching it in the meantime.

This pull request still switches nothing on by itself. The rule that makes the check load-bearing is created after it lands.

## Tests

`tests/unit/scripts/test_quorum_check.py`, 33 cases: quorum arithmetic, core requirement, stale approvals, self-approval through a push or a co-author trailer, the size and sensitivity thresholds, protected paths, automation with and without a stop path, the workflow account, the maintainer with and without a committer's block, the objection window, drafts, and the merge-queue ref parser. The shipped roster and CODEOWNERS are loaded by a test so a typo in either fails here rather than on a pull request.

Also green locally: `tests/unit/scripts` and `tests/unit/test_permissions.py` (477), the workflow YAML meta-tests (98), `ruff check`, `ruff format --check`.

## Related

The charter amendment that names these two exemptions is #5740, open for objections.

