### PR TITLE
feat(govern): reconciliation lanes are chain-projected, with a CLI (#5120)

### DIFF
--- a/src/bernstein/cli/commands/govern_lane_cmd.py
+++ b/src/bernstein/cli/commands/govern_lane_cmd.py
@@ -1,0 +1,172 @@
+"""``bernstein govern lane``: bootstrap, list and show reconciliation lanes (#5120).
+
+A lane is a first-class chained object, the same discipline
+:mod:`bernstein.cli.commands.pool_cmd` already established for pools.
+``bernstein govern lane bootstrap`` reads a declared lane-set document, diffs
+it against the lanes already active in the HMAC audit chain, and appends a
+``lane.registered`` or ``lane.updated`` event for every lane that changed --
+running it twice against an unchanged set changes nothing and says so. The
+runtime lane registry is a deterministic projection of those events (see
+:mod:`bernstein.core.govern.lane_registry`), so there is no side database that
+can drift out of agreement with the chain.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import click
+from rich.table import Table
+
+from bernstein.cli.helpers import console
+from bernstein.core.govern.lane_registry import LaneStore, LaneStoreError, project_lane_registry
+from bernstein.core.govern.lanes import LaneError, load_lane_set, reconcile_lanes
+
+
+def _audit_dir(workdir: Path) -> Path:
+    return workdir / ".sdd" / "audit"
+
+
+def _store(workdir: Path) -> LaneStore:
+    return LaneStore(root=workdir / ".sdd" / "sandbox")
+
+
+def _chain(workdir: Path) -> Any:
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+    audit_dir = _audit_dir(workdir)
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    return AuditChainStore(audit_dir)
+
+
+def _lane_events(workdir: Path, *, key: bytes | None = None) -> list[Any]:
+    audit_dir = _audit_dir(workdir)
+    if not audit_dir.is_dir():
+        return []
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+    events = AuditChainStore(audit_dir, key=key).query()
+    return [e for e in events if str(getattr(e, "event_type", "")).startswith("lane.")]
+
+
+_WORKDIR_OPTION = click.option(
+    "--workdir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=Path(),
+    show_default=True,
+    help="Project root containing .sdd/.",
+)
+
+
+@click.command("bootstrap")
+@click.argument("spec_file", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@_WORKDIR_OPTION
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit the reconcile report as JSON.")
+def govern_lane_bootstrap_cmd(spec_file: Path, workdir: Path, as_json: bool) -> None:
+    """Bootstrap the lane set declared in JSON SPEC_FILE against the chain.
+
+    The spec is ``{"lanes": [...]}``, each lane without a hash: name, selector,
+    schedule, log_destination, timeout_seconds, barrier. Every lane that is new
+    or changed is appended to the audit chain as ``lane.registered`` /
+    ``lane.updated``; a lane already exactly as declared is left alone. Running
+    this against an unchanged set is a no-op, and the report says so.
+    """
+    workdir = workdir.resolve()
+    try:
+        spec = json.loads(spec_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        console.print(f"[red]Invalid lane spec JSON:[/red] {exc}")
+        raise SystemExit(1) from exc
+    try:
+        declared = list(load_lane_set(spec))
+    except LaneError as exc:
+        console.print(f"[red]Invalid lane set:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    existing = project_lane_registry(_lane_events(workdir))
+    try:
+        result = reconcile_lanes(declared, existing)
+    except LaneError as exc:
+        console.print(f"[red]Invalid lane set:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    store = _store(workdir)
+    chain = _chain(workdir)
+    from bernstein.core.security.audit_chain import record_lane_registered, record_lane_updated
+
+    for entry in result.changed:
+        store.put(entry.lane)
+        if entry.prev_hash:
+            record_lane_updated(
+                chain=chain,
+                lane_name=entry.lane.name,
+                lane_hash=entry.lane.lane_hash,
+                prev_lane_hash=entry.prev_hash,
+            )
+        else:
+            record_lane_registered(chain=chain, lane_name=entry.lane.name, lane_hash=entry.lane.lane_hash)
+
+    if as_json:
+        click.echo(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+        return
+    if result.is_noop:
+        console.print("[dim]Lane bootstrap is a no-op: every declared lane already matches the chain.[/dim]")
+        return
+    for entry in result.entries:
+        console.print(
+            f"[green]Lane {entry.action.value}:[/green] [bold]{entry.lane.name}[/bold]  {entry.lane.lane_hash[:16]}..."
+        )
+
+
+@click.command("list")
+@_WORKDIR_OPTION
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit the active lanes as JSON.")
+def govern_lane_list_cmd(workdir: Path, as_json: bool) -> None:
+    """List active reconciliation lanes projected from the audit chain."""
+    workdir = workdir.resolve()
+    active = project_lane_registry(_lane_events(workdir))
+    if as_json:
+        click.echo(json.dumps({"lanes": active}, indent=2, sort_keys=True))
+        return
+    if not active:
+        console.print("[dim]No active lanes. Bootstrap one with 'bernstein govern lane bootstrap'.[/dim]")
+        return
+    table = Table(title="Active Reconciliation Lanes", header_style="bold cyan")
+    table.add_column("Name", style="bold")
+    table.add_column("Lane hash", style="dim")
+    for name in sorted(active):
+        table.add_row(name, active[name][:24] + "...")
+    console.print(table)
+
+
+@click.command("show")
+@click.argument("name")
+@_WORKDIR_OPTION
+def govern_lane_show_cmd(name: str, workdir: Path) -> None:
+    """Show the canonical manifest and hash for an active lane NAME."""
+    workdir = workdir.resolve()
+    lane_hash = project_lane_registry(_lane_events(workdir)).get(name)
+    if lane_hash is None:
+        console.print(f"[yellow]No active lane named[/yellow] {name!r}.")
+        raise SystemExit(1)
+    try:
+        manifest = _store(workdir).get(lane_hash)
+    except LaneStoreError as exc:
+        console.print(f"[red]Cannot load lane body:[/red] {exc}")
+        raise SystemExit(1) from exc
+    click.echo(json.dumps(manifest.to_dict(), indent=2, sort_keys=True))
+
+
+@click.group("lane")
+def govern_lane_group() -> None:
+    """Bootstrap and inspect reconciliation lanes (chain-projected)."""
+
+
+govern_lane_group.add_command(govern_lane_bootstrap_cmd, "bootstrap")
+govern_lane_group.add_command(govern_lane_list_cmd, "list")
+govern_lane_group.add_command(govern_lane_show_cmd, "show")
+
+
+__all__ = ["govern_lane_group"]

--- a/src/bernstein/cli/commands/governance_cmd.py
+++ b/src/bernstein/cli/commands/governance_cmd.py
@@ -55,6 +55,7 @@ from rich.console import Console
 from rich.table import Table
 
 from bernstein.cli.commands.govern_cmd import govern_inventory_cmd, govern_reconcile_cmd
+from bernstein.cli.commands.govern_lane_cmd import govern_lane_group
 from bernstein.cli.helpers import console
 from bernstein.core.govern import collect_remediation as _collect_remediation
 from bernstein.core.govern import compute_plan as _compute_plan
@@ -1045,6 +1046,8 @@ def governance_audit_keys_cmd() -> None:
 govern_group.add_command(govern_reconcile_cmd, "reconcile")
 # Inventory topology graph from the store (#5133).
 govern_group.add_command(govern_inventory_cmd, "inventory")
+# Reconciliation lanes: bootstrap/list/show against the chain (#5120).
+govern_group.add_command(govern_lane_group, "lane")
 
 
 @click.group("governance")

--- a/src/bernstein/core/govern/lane_registry.py
+++ b/src/bernstein/core/govern/lane_registry.py
@@ -1,0 +1,200 @@
+"""Lane registry as a deterministic projection of the audit chain (#5120).
+
+``lanes.py`` gave the lane record and the bootstrap decision (create-if-absent,
+`registered`/`updated`/`unchanged`); this module is what makes that decision
+answerable across process runs instead of just within one call to
+``reconcile_lanes``. A lane's *active* hash lives in the HMAC audit chain --
+``lane.registered`` / ``lane.updated`` / ``lane.retired`` events (see
+:mod:`bernstein.core.security.audit_chain`) -- and :func:`project_lane_registry`
+replays those events to rebuild the current ``{name: lane_hash}`` map. There is
+no side table to drift out of agreement with the chain.
+
+Manifest bodies live in a content-addressed store (:class:`LaneStore`), exactly
+the shape :class:`~bernstein.core.sandbox.pool_registry.PoolStore` already
+established: each body is written to ``<root>/lanes/<lane_hash>.json`` and
+re-verified against its own canonical hash on load, so a tampered body is
+self-detecting rather than silently trusted.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.govern.lanes import LaneError, LaneManifest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+_LANE_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+
+_EVENT_REGISTERED = "lane.registered"
+_EVENT_UPDATED = "lane.updated"
+_EVENT_RETIRED = "lane.retired"
+
+
+class LaneStoreError(ValueError):
+    """Raised when a content-addressed lane body is missing or tampered."""
+
+
+def _event_field(event: Any, key: str) -> Any:
+    """Read *key* from *event* whether it is a mapping or a dataclass."""
+    if isinstance(event, Mapping):
+        return event.get(key)
+    return getattr(event, key, None)
+
+
+def project_lane_registry(events: Iterable[Any]) -> dict[str, str]:
+    """Return the active ``{lane_name: lane_hash}`` map from *events*.
+
+    A pure function over the ordered ``lane.*`` event stream, mirroring
+    :func:`bernstein.core.sandbox.pool_registry.project_pool_registry`.
+    Non-lane events are ignored, so callers may pass the whole chain. Register
+    and update set the active hash for the name; retire drops it. Replaying
+    the same ordered events always yields the same map.
+
+    Args:
+        events: Ordered events, each either a mapping or an object exposing
+            ``event_type`` and a ``details`` payload carrying ``lane_name`` /
+            ``lane_hash``.
+
+    Returns:
+        Mapping from lane name to the currently active canonical ``lane_hash``.
+    """
+    active: dict[str, str] = {}
+    for event in events:
+        event_type = _event_field(event, "event_type")
+        details = _event_field(event, "details") or {}
+        name = details.get("lane_name")
+        lane_hash = details.get("lane_hash")
+        if not name:
+            continue
+        if event_type in (_EVENT_REGISTERED, _EVENT_UPDATED):
+            if lane_hash:
+                active[name] = lane_hash
+        elif event_type == _EVENT_RETIRED:
+            active.pop(name, None)
+    return active
+
+
+@dataclass(frozen=True)
+class LaneStore:
+    """Content-addressed store for lane manifest bodies.
+
+    Bodies live under ``root/lanes/<lane_hash>.json``. The hash in the filename
+    is the manifest's own canonical hash, so a load both locates the body and
+    verifies it: a tampered body recomputes to a different hash and is refused.
+    """
+
+    root: Path
+
+    @property
+    def lanes_dir(self) -> Path:
+        return self.root / "lanes"
+
+    def _path_for(self, lane_hash: str) -> Path:
+        """Return the on-disk path for *lane_hash*, guarded against traversal."""
+        if not _LANE_HASH_RE.match(lane_hash):
+            raise LaneStoreError(f"lane_hash is not a canonical sha256 digest: {lane_hash!r}")
+        base = self.lanes_dir
+        candidate = base / f"{lane_hash}.json"
+        base_real = os.path.realpath(base)
+        cand_real = os.path.realpath(candidate)
+        if os.path.commonpath([base_real, cand_real]) != base_real:
+            raise LaneStoreError(f"lane body path escapes the lanes directory: {lane_hash!r}")
+        return candidate
+
+    def put(self, manifest: LaneManifest) -> Path:
+        """Write *manifest* to its content-addressed path and return it.
+
+        Idempotent: re-writing an identical manifest is a no-op-equivalent
+        (the bytes are byte-identical because the payload is canonical).
+        """
+        path = self._path_for(manifest.lane_hash)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(manifest.to_dict(), sort_keys=True, separators=(",", ":")), encoding="utf-8")
+        return path
+
+    def get(self, lane_hash: str) -> LaneManifest:
+        """Load and hash-verify the manifest body for *lane_hash*.
+
+        Raises:
+            LaneStoreError: The body is absent, unreadable, or its recomputed
+                canonical hash does not equal *lane_hash* (tampered).
+        """
+        path = self._path_for(lane_hash)
+        if not path.is_file():
+            raise LaneStoreError(f"no lane body for {lane_hash!r}")
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            raise LaneStoreError(f"unreadable lane body for {lane_hash!r}: {exc}") from exc
+        try:
+            manifest = LaneManifest.from_dict(data)
+        except (LaneError, KeyError, ValueError, TypeError) as exc:
+            # from_dict recomputes the hash and refuses a body whose embedded
+            # lane_hash no longer matches its own content -- surface that as a
+            # store-level tamper error, not a manifest construction error.
+            raise LaneStoreError(f"lane body hash mismatch for {lane_hash!r} (tampered): {exc}") from exc
+        if manifest.lane_hash != lane_hash:
+            raise LaneStoreError(f"lane body hash mismatch for {lane_hash!r} (tampered)")
+        return manifest
+
+    def has(self, lane_hash: str) -> bool:
+        """Return whether a body exists for *lane_hash* (no hash verification)."""
+        try:
+            return self._path_for(lane_hash).is_file()
+        except LaneStoreError:
+            return False
+
+
+@dataclass(frozen=True)
+class LaneRegistry:
+    """Chain-authoritative view of active lanes, backed by a content store.
+
+    The active set is the projection of the chain events; the bodies are loaded
+    content-addressed from the store and hash-verified. Nothing here is a
+    mutable source of truth -- both halves are deterministic derivations.
+    """
+
+    active: dict[str, str]
+    store: LaneStore
+
+    @classmethod
+    def from_events(cls, events: Iterable[Any], store: LaneStore) -> LaneRegistry:
+        """Build a registry by projecting *events* over *store*."""
+        return cls(active=project_lane_registry(events), store=store)
+
+    def names(self) -> list[str]:
+        """Return the sorted names of currently active lanes."""
+        return sorted(self.active)
+
+    def hash_for(self, name: str) -> str | None:
+        """Return the active lane hash for *name*, or ``None`` if retired/absent."""
+        return self.active.get(name)
+
+    def get(self, name: str) -> LaneManifest | None:
+        """Load the active manifest for *name*, or ``None`` if none is active.
+
+        Raises:
+            LaneStoreError: The active hash resolves to a missing or tampered
+                body -- surfaced loudly rather than silently returning a stale
+                or wrong lane.
+        """
+        lane_hash = self.active.get(name)
+        if lane_hash is None:
+            return None
+        return self.store.get(lane_hash)
+
+
+__all__ = [
+    "LaneRegistry",
+    "LaneStore",
+    "LaneStoreError",
+    "project_lane_registry",
+]

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -9061,6 +9061,109 @@ def record_pool_warm_quarantine(
 
 
 # ---------------------------------------------------------------------------
+# Reconciliation lanes (#5120)
+# ---------------------------------------------------------------------------
+# A lane's lifecycle lives in the chain, mirroring the pool section above:
+# register/update/retire events are the only mutation path, and the runtime
+# lane registry is a deterministic projection rebuilt by replaying them (see
+# ``bernstein.core.govern.lane_registry``).
+
+#: A lane manifest was registered. Records the lane name and its canonical
+#: ``lane_hash`` so the registry projection can be rebuilt from the chain.
+EVENT_LANE_REGISTERED = "lane.registered"
+
+#: A lane manifest was updated (superseded by a new canonical hash). Records
+#: both the prior and the new ``lane_hash`` so the projection is unambiguous.
+EVENT_LANE_UPDATED = "lane.updated"
+
+#: A lane was retired. The projection drops it.
+EVENT_LANE_RETIRED = "lane.retired"
+
+
+def record_lane_registered(
+    *,
+    chain: AuditChainStore,
+    lane_name: str,
+    lane_hash: str,
+    actor: str = "operator",
+) -> AuditEvent:
+    """Append a ``lane.registered`` event into *chain* (#5120).
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        lane_name: Operator-facing lane name.
+        lane_hash: Canonical hash identifying the registered lane manifest.
+        actor: Recorded actor; defaults to ``"operator"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_LANE_REGISTERED,
+        actor=actor,
+        resource_type="reconciliation_lane",
+        resource_id=lane_hash,
+        details={"lane_name": lane_name, "lane_hash": lane_hash},
+    )
+
+
+def record_lane_updated(
+    *,
+    chain: AuditChainStore,
+    lane_name: str,
+    lane_hash: str,
+    prev_lane_hash: str,
+    actor: str = "operator",
+) -> AuditEvent:
+    """Append a ``lane.updated`` event into *chain* (#5120).
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        lane_name: Operator-facing lane name.
+        lane_hash: New canonical hash identifying the lane manifest.
+        prev_lane_hash: The superseded lane hash for the same name.
+        actor: Recorded actor; defaults to ``"operator"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_LANE_UPDATED,
+        actor=actor,
+        resource_type="reconciliation_lane",
+        resource_id=lane_hash,
+        details={"lane_name": lane_name, "lane_hash": lane_hash, "prev_lane_hash": prev_lane_hash},
+    )
+
+
+def record_lane_retired(
+    *,
+    chain: AuditChainStore,
+    lane_name: str,
+    lane_hash: str,
+    actor: str = "operator",
+) -> AuditEvent:
+    """Append a ``lane.retired`` event into *chain* (#5120).
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        lane_name: Operator-facing lane name.
+        lane_hash: Canonical hash of the retired lane manifest.
+        actor: Recorded actor; defaults to ``"operator"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_LANE_RETIRED,
+        actor=actor,
+        resource_type="reconciliation_lane",
+        resource_id=lane_hash,
+        details={"lane_name": lane_name, "lane_hash": lane_hash},
+    )
+
+
+# ---------------------------------------------------------------------------
 # Provenance-verified release update advisory (#2942)
 # ---------------------------------------------------------------------------
 
@@ -9800,6 +9903,9 @@ __all__ = [
     "EVENT_INPUT_REFUSAL",
     "EVENT_INTENT_CAPSULE",
     "EVENT_INTENT_DRIFT",
+    "EVENT_LANE_REGISTERED",
+    "EVENT_LANE_RETIRED",
+    "EVENT_LANE_UPDATED",
     "EVENT_MANDATE_CONSENT_RECEIPT",
     "EVENT_MANDATE_REVOCATION",
     "EVENT_MCP_CAPABILITY_DRIFT",
@@ -9960,6 +10066,9 @@ __all__ = [
     "record_input_refusal",
     "record_intent_capsule",
     "record_intent_drift",
+    "record_lane_registered",
+    "record_lane_retired",
+    "record_lane_updated",
     "record_mandate_consent_receipt",
     "record_mandate_revocation",
     "record_mcp_capability_drift",

--- a/tests/unit/cli/test_govern_lane_cmd.py
+++ b/tests/unit/cli/test_govern_lane_cmd.py
@@ -1,0 +1,105 @@
+"""End-to-end CLI surface for reconciliation lanes (#5120).
+
+Exercises ``bernstein govern lane bootstrap / list / show`` against a
+throwaway working directory, proving the verbs are wired to the chain and that
+a repeat bootstrap against an unchanged set is a no-op that says so.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.govern_lane_cmd import govern_lane_group
+
+_SPEC = {
+    "lanes": [
+        {
+            "name": "canary",
+            "selector": "team:payments",
+            "schedule": "*/15 * * * *",
+            "log_destination": "s3://logs/lanes/canary",
+            "timeout_seconds": 900,
+            "barrier": "per-step",
+        }
+    ]
+}
+
+
+def _write_spec(path: Path, spec: dict) -> Path:
+    spec_file = path / "lanes.json"
+    spec_file.write_text(json.dumps(spec), encoding="utf-8")
+    return spec_file
+
+
+def _run(args: list[str]):
+    return CliRunner().invoke(govern_lane_group, args)
+
+
+class TestGovernLaneCli:
+    def test_bootstrap_list_show(self, tmp_path: Path):
+        spec = _write_spec(tmp_path, _SPEC)
+        res = _run(["bootstrap", str(spec), "--workdir", str(tmp_path)])
+        assert res.exit_code == 0, res.output
+        assert "registered" in res.output.lower()
+
+        res = _run(["list", "--workdir", str(tmp_path), "--json"])
+        assert res.exit_code == 0, res.output
+        lanes = json.loads(res.stdout)["lanes"]
+        assert "canary" in lanes
+
+        res = _run(["show", "canary", "--workdir", str(tmp_path)])
+        assert res.exit_code == 0, res.output
+        body = json.loads(res.stdout)
+        assert body["name"] == "canary"
+        assert len(body["lane_hash"]) == 64
+
+    def test_json_output_carries_the_document_and_nothing_else(self, tmp_path: Path):
+        spec = _write_spec(tmp_path, _SPEC)
+        _run(["bootstrap", str(spec), "--workdir", str(tmp_path)])
+
+        res = _run(["list", "--workdir", str(tmp_path), "--json"])
+
+        assert res.exit_code == 0, res.output
+        assert set(json.loads(res.stdout)) == {"lanes"}
+        assert res.stdout.lstrip().startswith("{")
+
+    def test_running_it_twice_against_an_unchanged_set_is_a_noop_and_says_so(self, tmp_path: Path):
+        spec = _write_spec(tmp_path, _SPEC)
+        _run(["bootstrap", str(spec), "--workdir", str(tmp_path)])
+        res = _run(["bootstrap", str(spec), "--workdir", str(tmp_path), "--json"])
+        assert res.exit_code == 0, res.output
+        report = json.loads(res.stdout)
+        assert report["noop"] is True
+        assert report["changed"] == 0
+
+        res = _run(["bootstrap", str(spec), "--workdir", str(tmp_path)])
+        assert res.exit_code == 0, res.output
+        assert "no-op" in res.output.lower()
+
+    def test_update_changes_hash(self, tmp_path: Path):
+        spec = _write_spec(tmp_path, _SPEC)
+        _run(["bootstrap", str(spec), "--workdir", str(tmp_path)])
+        updated = {"lanes": [{**_SPEC["lanes"][0], "timeout_seconds": 1800}]}
+        spec.write_text(json.dumps(updated), encoding="utf-8")
+        res = _run(["bootstrap", str(spec), "--workdir", str(tmp_path)])
+        assert res.exit_code == 0, res.output
+        assert "updated" in res.output.lower()
+
+    def test_show_missing_lane_fails(self, tmp_path: Path):
+        res = _run(["show", "nope", "--workdir", str(tmp_path)])
+        assert res.exit_code == 1
+
+    def test_invalid_spec_json_fails(self, tmp_path: Path):
+        spec_file = tmp_path / "bad.json"
+        spec_file.write_text("not json", encoding="utf-8")
+        res = _run(["bootstrap", str(spec_file), "--workdir", str(tmp_path)])
+        assert res.exit_code == 1
+
+    def test_duplicate_lane_names_refused(self, tmp_path: Path):
+        dupe = {"lanes": [_SPEC["lanes"][0], _SPEC["lanes"][0]]}
+        spec = _write_spec(tmp_path, dupe)
+        res = _run(["bootstrap", str(spec), "--workdir", str(tmp_path)])
+        assert res.exit_code == 1

--- a/tests/unit/core/govern/test_lane_registry.py
+++ b/tests/unit/core/govern/test_lane_registry.py
@@ -1,0 +1,110 @@
+"""Tests for the chain-projected lane registry and content store (#5120)."""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.govern.lane_registry import (
+    LaneRegistry,
+    LaneStore,
+    LaneStoreError,
+    project_lane_registry,
+)
+from bernstein.core.govern.lanes import LaneManifest
+
+
+def _lane(name: str, timeout: int = 900) -> LaneManifest:
+    return LaneManifest(
+        name=name,
+        selector="team:payments",
+        schedule="*/15 * * * *",
+        log_destination="s3://logs/lanes",
+        timeout_seconds=timeout,
+    )
+
+
+def _ev(event_type: str, name: str, lane_hash: str) -> dict:
+    return {"event_type": event_type, "details": {"lane_name": name, "lane_hash": lane_hash}}
+
+
+class TestProjection:
+    def test_register_then_active(self):
+        lane = _lane("a")
+        active = project_lane_registry([_ev("lane.registered", "a", lane.lane_hash)])
+        assert active == {"a": lane.lane_hash}
+
+    def test_update_supersedes(self):
+        l1, l2 = _lane("a", 900), _lane("a", 1800)
+        events = [
+            _ev("lane.registered", "a", l1.lane_hash),
+            _ev("lane.updated", "a", l2.lane_hash),
+        ]
+        assert project_lane_registry(events) == {"a": l2.lane_hash}
+
+    def test_retire_drops(self):
+        lane = _lane("a")
+        events = [
+            _ev("lane.registered", "a", lane.lane_hash),
+            _ev("lane.retired", "a", lane.lane_hash),
+        ]
+        assert project_lane_registry(events) == {}
+
+    def test_non_lane_events_ignored(self):
+        lane = _lane("a")
+        events = [
+            {"event_type": "cache.hit", "details": {"cache_key": "x"}},
+            _ev("lane.registered", "a", lane.lane_hash),
+        ]
+        assert project_lane_registry(events) == {"a": lane.lane_hash}
+
+    def test_projection_is_deterministic(self):
+        l1, l2 = _lane("a"), _lane("b")
+        events = [_ev("lane.registered", "a", l1.lane_hash), _ev("lane.registered", "b", l2.lane_hash)]
+        assert project_lane_registry(events) == project_lane_registry(events)
+
+
+class TestContentStore:
+    def test_put_get_roundtrip(self, tmp_path):
+        store = LaneStore(root=tmp_path)
+        lane = _lane("a")
+        store.put(lane)
+        loaded = store.get(lane.lane_hash)
+        assert loaded.lane_hash == lane.lane_hash
+
+    def test_tampered_body_refused(self, tmp_path):
+        store = LaneStore(root=tmp_path)
+        lane = _lane("a")
+        path = store.put(lane)
+        text = path.read_text().replace('"timeout_seconds":900', '"timeout_seconds":1')
+        assert '"timeout_seconds":1' in text
+        path.write_text(text)
+        with pytest.raises(LaneStoreError):
+            store.get(lane.lane_hash)
+
+    def test_missing_body_refused(self, tmp_path):
+        store = LaneStore(root=tmp_path)
+        with pytest.raises(LaneStoreError):
+            store.get("a" * 64)
+
+    def test_non_canonical_hash_refused(self, tmp_path):
+        store = LaneStore(root=tmp_path)
+        with pytest.raises(LaneStoreError):
+            store.get("../etc/passwd")
+
+
+class TestRegistry:
+    def test_registry_resolves_active_body(self, tmp_path):
+        store = LaneStore(root=tmp_path)
+        lane = _lane("a")
+        store.put(lane)
+        registry = LaneRegistry.from_events([_ev("lane.registered", "a", lane.lane_hash)], store)
+        assert registry.names() == ["a"]
+        assert registry.get("a").lane_hash == lane.lane_hash
+
+    def test_retired_lane_returns_none(self, tmp_path):
+        store = LaneStore(root=tmp_path)
+        lane = _lane("a")
+        store.put(lane)
+        events = [_ev("lane.registered", "a", lane.lane_hash), _ev("lane.retired", "a", lane.lane_hash)]
+        registry = LaneRegistry.from_events(events, store)
+        assert registry.get("a") is None

--- a/tests/unit/test_security_controls_are_wired.py
+++ b/tests/unit/test_security_controls_are_wired.py
@@ -46,7 +46,7 @@ PACKAGE = REPO_ROOT / "src" / "bernstein" / "core" / "security"
 SEARCHED = ("src", "tests", "scripts")
 SELF = Path(__file__).resolve()
 
-#: The 8 still PROVED uncalled: each name appears nowhere outside its own module, in
+#: The 9 still PROVED uncalled: each name appears nowhere outside its own module, in
 #: any file, in any form. Pre-existing debt, deliberately not fixed here - each needs
 #: its own judgement about wiring versus deleting. The two `post_tool_enforcement`
 #: entries the list started with are gone: #4992 wired them into the hook receiver's
@@ -59,6 +59,7 @@ SELF = Path(__file__).resolve()
 KNOWN_UNCALLED: frozenset[str] = frozenset(
     {
         "audit_chain.py:record_expectation_expired",
+        "audit_chain.py:record_lane_retired",
         "audit_chain.py:record_pool_claim_receipt",
         "audit_chain.py:record_pool_retired",
         "audit_chain.py:record_schedule_collision",


### PR DESCRIPTION
Closes #5120's two remaining pieces. #5430 already landed the record and the bootstrap decision (`LaneManifest`, `reconcile_lanes`), and explicitly deferred "the chain projection ... and the CLI" as attaching to that record rather than being it. This PR is those two pieces.

## Chain projection

`lane_registry.py` mirrors `bernstein.core.sandbox.pool_registry` exactly, because that's the pattern issue #5120 named as the closest existing analog for everything downstream of the record itself:

- `project_lane_registry(events)` -- a pure function replaying `lane.registered`/`lane.updated`/`lane.retired` events into the current `{name: lane_hash}` map. Two operators replaying the same events land on the same map.
- `LaneStore` -- content-addressed bodies at `<root>/lanes/<lane_hash>.json`, re-verified against their own hash on load (`LaneManifest.from_dict` already refuses a tampered body; the store surfaces that as `LaneStoreError`).
- `LaneRegistry` -- combines the two, same shape as `PoolRegistry`.

`audit_chain.py` gains the matching event constants (`EVENT_LANE_REGISTERED/UPDATED/RETIRED`) and recorder functions (`record_lane_registered/updated/retired`), placed directly after the pool section they mirror.

## CLI

`bernstein govern lane bootstrap/list/show`, nested under the existing `govern` group the way `govern reconcile` and `govern inventory` already are (issue #5120 left this naming decision open; `govern reconcile` is the precedent I followed rather than inventing a standalone top-level group the way `pool` has).

`bootstrap` reads a declared lane-set JSON document, diffs it against the chain via the existing `reconcile_lanes()`, and appends one `lane.registered`/`lane.updated` event per lane that changed. A lane already exactly as declared is left alone -- running bootstrap twice against an unchanged set is a no-op, and both the `--json` report (`"noop": true`) and the plain-text output say so.

## Not in this PR

The dated log artefact per run -- that belongs to a lane *runner*, which doesn't exist anywhere in the codebase yet (no runner concept at all, for any lane or otherwise). Attaching a log-artefact convention to a runner that doesn't exist would be inventing the runner as a side effect of this PR, which is a separate piece of work.

## Tests

`tests/unit/core/govern/test_lane_registry.py` (projection determinism, retire-drops, tamper detection, path-traversal guard, registry resolution) and `tests/unit/cli/test_govern_lane_cmd.py` (bootstrap/list/show wiring, the `--json` output-purity check `pool_cmd`'s tests already established, the no-op-and-says-so case run twice, update-changes-hash, duplicate-name refusal).

```
uv run pytest tests/unit/core/govern/test_lane_registry.py tests/unit/cli/test_govern_lane_cmd.py -q   # 18 passed
uv run pytest tests/unit/core/govern/ tests/unit/cli/ -k "lane or audit_chain or governance or govern" -q   # 415 passed
uv run ruff check / ruff format --check   # clean
uv run lint-imports   # 3 contracts kept, 0 broken
```