### PR TITLE
fix(test-impact): resolve relative-import re-exports in the affected-test graph (#5111)

### DIFF
--- a/src/bernstein/core/quality/test_impact.py
+++ b/src/bernstein/core/quality/test_impact.py
@@ -24,8 +24,8 @@ logger = logging.getLogger(__name__)
 # lists are alias-resolved at write time, so a change to alias discovery makes
 # every existing entry potentially short of edges even though its file hashes
 # still match.
-_ANALYZER_CACHE_VERSION = "4"
-_COMPAT_CACHE_VERSION = "5"
+_ANALYZER_CACHE_VERSION = "5"
+_COMPAT_CACHE_VERSION = "6"
 _WORKFLOW_PATH_PREFIX = ".github/workflows/"
 
 # Upper bound on a harvested path literal. Long strings in a test are prose,
@@ -153,17 +153,21 @@ def _resolve_relative_import(
     Mirrors Python's own resolution: a package's ``__init__.py`` counts as the
     package itself for ``__package__`` purposes, so ``level=1`` there refers to
     the package's own directory rather than its parent. Returns ``None`` when
-    the import climbs above the project root (more ``.``s than the current
-    module has parent segments) -- undecidable, so the caller drops the edge
-    exactly as it already does for a module it cannot resolve at all.
+    the import climbs to or above the project root (as many ``.``s as, or more
+    than, the current module has parent segments) -- undecidable, so the
+    caller drops the edge exactly as it already does for a module it cannot
+    resolve at all. This also covers a bare top-level module (``package_parts``
+    empty even before stripping): Python has no package for it to import
+    relative to, so *every* relative import there is invalid, not only ones
+    that climb further.
     """
     package_parts = current_module.split(".") if current_module else []
     if not is_package_init:
         package_parts = package_parts[:-1]
     strip = level - 1
+    if strip >= len(package_parts):
+        return None
     if strip:
-        if strip > len(package_parts):
-            return None
         package_parts = package_parts[: len(package_parts) - strip]
     if module:
         return ".".join([*package_parts, module]) if package_parts else module
@@ -1066,7 +1070,23 @@ class TestImpactAnalyzer:
         return resolve_module_aliases(imports, self._aliases)
 
     def _parse_test_imports(self, test_file: Path) -> set[str]:
-        """Parse source dependencies imported by a test file."""
+        """Parse source dependencies imported by a test file.
+
+        Deliberately does not pass ``current_module`` -- a choice, not an
+        impossibility. Test directories are configured separately from
+        ``self._src_root`` (see ``self._test_dirs``) and are not usually
+        importable packages rooted the same way, so a test file has no
+        settled dotted module name to resolve a relative import against the
+        way :meth:`_parse_source_imports` does for source files. A test
+        helper imported relatively (``from .helpers import make_store``)
+        therefore still contributes no edge; that gap is real, but widening
+        this fix to cover it is out of scope here -- the source side is
+        where a relatively-imported facade silently drops selection edges
+        with nothing failing, which is the damage this fix addresses. If a
+        test tree ever gains a dotted root of its own (an ``__init__.py``
+        chain up to a known base), the same ``_path_to_module`` +
+        ``current_module`` technique would apply unchanged.
+        """
         return self._resolved_imports(test_file)
 
     def _parse_source_imports(self, source_file: Path) -> set[str]:

--- a/src/bernstein/core/quality/test_impact.py
+++ b/src/bernstein/core/quality/test_impact.py
@@ -141,8 +141,50 @@ def _normalize_mapping_list(raw: object) -> dict[str, list[str]]:
     return normalized
 
 
-def _collect_imports_from_node(node: ast.AST, package_prefixes: set[str]) -> set[str]:
-    """Collect project-scoped import names from a single AST node."""
+def _resolve_relative_import(
+    *,
+    current_module: str,
+    is_package_init: bool,
+    level: int,
+    module: str | None,
+) -> str | None:
+    """Resolve a relative ``from`` import to its absolute dotted module name.
+
+    Mirrors Python's own resolution: a package's ``__init__.py`` counts as the
+    package itself for ``__package__`` purposes, so ``level=1`` there refers to
+    the package's own directory rather than its parent. Returns ``None`` when
+    the import climbs above the project root (more ``.``s than the current
+    module has parent segments) -- undecidable, so the caller drops the edge
+    exactly as it already does for a module it cannot resolve at all.
+    """
+    package_parts = current_module.split(".") if current_module else []
+    if not is_package_init:
+        package_parts = package_parts[:-1]
+    strip = level - 1
+    if strip:
+        if strip > len(package_parts):
+            return None
+        package_parts = package_parts[: len(package_parts) - strip]
+    if module:
+        return ".".join([*package_parts, module]) if package_parts else module
+    return ".".join(package_parts) if package_parts else None
+
+
+def _collect_imports_from_node(
+    node: ast.AST,
+    package_prefixes: set[str],
+    *,
+    current_module: str | None = None,
+    is_package_init: bool = False,
+) -> set[str]:
+    """Collect project-scoped import names from a single AST node.
+
+    ``current_module`` (the dotted name of the file being parsed) resolves a
+    relative ``from .sibling import x`` / ``from ..pkg import x`` to the
+    absolute module it names. Without it, a relative import's edge is
+    silently dropped: ``node.module`` on a relative import never carries the
+    package prefix, so the plain prefix check below cannot see it either way.
+    """
     imports: set[str] = set()
     if isinstance(node, ast.Import):
         for alias in node.names:
@@ -151,23 +193,50 @@ def _collect_imports_from_node(node: ast.AST, package_prefixes: set[str]) -> set
                 imports.add(alias.name)
     elif isinstance(node, ast.ImportFrom):
         module = node.module or ""
-        if module:
+        if node.level and current_module:
+            resolved = _resolve_relative_import(
+                current_module=current_module,
+                is_package_init=is_package_init,
+                level=node.level,
+                module=module or None,
+            )
+            if resolved:
+                top = resolved.split(".", 1)[0]
+                if top in package_prefixes:
+                    imports.add(resolved)
+        elif module:
             top = module.split(".", 1)[0]
             if top in package_prefixes:
                 imports.add(module)
     return imports
 
 
-def extract_project_imports(path: Path, package_prefixes: set[str]) -> set[str]:
-    """Extract imported project module names from a Python file."""
+def extract_project_imports(path: Path, package_prefixes: set[str], *, current_module: str | None = None) -> set[str]:
+    """Extract imported project module names from a Python file.
+
+    ``current_module`` is the dotted module name ``path`` corresponds to
+    (e.g. from :func:`_path_to_module`); passing it lets a relative import be
+    resolved to the absolute module it names. Omitting it (the default)
+    preserves the prior behaviour of dropping relative-import edges, for
+    callers -- test files, the legacy CLI wrapper -- that have no module name
+    to resolve against.
+    """
     try:
         tree = ast.parse(path.read_text(encoding="utf-8"))
     except (OSError, SyntaxError, UnicodeDecodeError):
         return set()
 
+    is_package_init = path.name == "__init__.py"
     imports: set[str] = set()
     for node in ast.walk(tree):
-        imports.update(_collect_imports_from_node(node, package_prefixes))
+        imports.update(
+            _collect_imports_from_node(
+                node,
+                package_prefixes,
+                current_module=current_module,
+                is_package_init=is_package_init,
+            )
+        )
     return imports
 
 
@@ -399,7 +468,9 @@ def build_compat_dep_map(
                 continue
             source_imports[module] = {
                 "hash": _file_hash(src_file),
-                "imports": sorted(resolve_module_aliases(extract_project_imports(src_file, prefixes), aliases)),
+                "imports": sorted(
+                    resolve_module_aliases(extract_project_imports(src_file, prefixes, current_module=module), aliases)
+                ),
                 "paths": sorted(extract_path_literals(src_file)),
             }
 
@@ -987,19 +1058,28 @@ class TestImpactAnalyzer:
             tests.extend(sorted(path for path in test_dir.rglob("test_*.py") if path.is_file()))
         return tests
 
-    def _resolved_imports(self, path: Path) -> set[str]:
+    def _resolved_imports(self, path: Path, *, current_module: str | None = None) -> set[str]:
         """Parse project imports from ``path`` with legacy aliases resolved."""
         if self._aliases is None:
             self._aliases = discover_module_aliases(self._src_root)
-        return resolve_module_aliases(extract_project_imports(path, self._package_prefixes), self._aliases)
+        imports = extract_project_imports(path, self._package_prefixes, current_module=current_module)
+        return resolve_module_aliases(imports, self._aliases)
 
     def _parse_test_imports(self, test_file: Path) -> set[str]:
         """Parse source dependencies imported by a test file."""
         return self._resolved_imports(test_file)
 
     def _parse_source_imports(self, source_file: Path) -> set[str]:
-        """Parse project imports used by a source file."""
-        return self._resolved_imports(source_file)
+        """Parse project imports used by a source file.
+
+        Passes the file's own dotted module name so a relative
+        ``from .sibling import x`` resolves to the absolute module it names --
+        without it, a re-export written with a relative import has no edge to
+        its real definition, and a change there silently misses the tests that
+        import only the re-exporting module.
+        """
+        module = _path_to_module(source_file, self._src_root)
+        return self._resolved_imports(source_file, current_module=module or None)
 
     def _name_based_mapping(self, source_rel: str) -> list[str]:
         """Map a source file to likely test files by naming convention."""

--- a/tests/unit/test_test_impact_alias_edges.py
+++ b/tests/unit/test_test_impact_alias_edges.py
@@ -45,6 +45,7 @@ import bernstein.core  # noqa: F401
 from bernstein.core.quality.test_impact import TestImpactAnalyzer as ImpactAnalyzer
 from bernstein.core.quality.test_impact import (
     _real_module_names,
+    _resolve_relative_import,
     build_compat_dep_map,
     compat_get_affected_tests,
     discover_module_aliases,
@@ -450,3 +451,63 @@ def test_a_two_level_relative_reexport_makes_its_importers_affected(tmp_path: Pa
         "tests/unit/test_via_facade.py",
         "tests/unit/test_engine_direct.py",
     }
+
+
+# ---------------------------------------------------------------------------
+# _resolve_relative_import: direct unit coverage (review follow-up, #5111)
+# ---------------------------------------------------------------------------
+#
+# The fixtures above exercise this function only indirectly, through three
+# end-to-end selection tests that each build a tree, run the analyser, and
+# compare file sets -- the right *integration* coverage, but an expensive way
+# to pin pure arithmetic. A reviewer's manual trace caught a `>` that should
+# have been `>=`: when a relative import climbs exactly as many levels as the
+# current module has parent segments (not just past them), the old check let
+# it through and returned a fabricated top-level module name instead of
+# `None`. The same off-by-one made every relative import in a bare top-level
+# module (no enclosing package at all) resolve to a fabricated name too,
+# since an empty `package_parts` never satisfied the strict `>`.
+
+
+def test_level_one_resolves_against_the_full_package() -> None:
+    assert _resolve_relative_import(current_module="a.b.c", is_package_init=False, level=1, module="d") == "a.b.d"
+
+
+def test_level_two_climbs_one_parent() -> None:
+    assert _resolve_relative_import(current_module="a.b.c", is_package_init=False, level=2, module="e") == "a.e"
+
+
+def test_a_packages_own_init_is_its_own_package_for_level_one() -> None:
+    """``a/b/__init__.py``'s own package is ``a.b``, not ``a`` -- the case almost everyone gets wrong first time."""
+    assert _resolve_relative_import(current_module="a.b", is_package_init=True, level=1, module="c") == "a.b.c"
+
+
+def test_climbing_exactly_to_the_top_returns_none_not_a_fabricated_name() -> None:
+    """The off-by-one: ``strip == len(package_parts)`` must refuse, not silently succeed.
+
+    ``a/b/c.py``'s package is ``a.b`` (two segments). A level-3 import strips
+    two segments, landing exactly on nothing left to resolve against --
+    Python raises ``ImportError`` here, so this must not return a bare
+    ``"d"`` as if ``d`` were a real top-level module.
+    """
+    assert _resolve_relative_import(current_module="a.b.c", is_package_init=False, level=3, module="d") is None
+
+
+def test_climbing_past_the_top_returns_none() -> None:
+    assert _resolve_relative_import(current_module="a.b.c", is_package_init=False, level=4, module="d") is None
+
+
+def test_a_bare_top_level_module_has_no_package_to_resolve_against() -> None:
+    """``widget.py`` at the source root: even ``level=1`` has nothing to climb from.
+
+    Regression case for the same off-by-one: ``package_parts`` is already
+    empty here (a non-init file strips its own name, leaving nothing), so
+    the boundary check has to fire at ``strip == 0`` too, not only for a
+    deeper climb.
+    """
+    assert _resolve_relative_import(current_module="widget", is_package_init=False, level=1, module="sibling") is None
+
+
+def test_bare_from_dot_import_with_no_named_module() -> None:
+    """``from . import x`` -- ``module`` is ``None`` on the AST node, not empty string."""
+    assert _resolve_relative_import(current_module="a.b.c", is_package_init=False, level=1, module=None) == "a.b"

--- a/tests/unit/test_test_impact_alias_edges.py
+++ b/tests/unit/test_test_impact_alias_edges.py
@@ -373,3 +373,80 @@ def test_an_unrelated_module_does_not_select_the_facade_test(tmp_path: Path) -> 
     )
     _write(src / "proj" / "unrelated.py", "VALUE = 2\n")
     assert _selected_for(tmp_path, src, tests, "src/proj/unrelated.py") == set()
+
+
+# ---------------------------------------------------------------------------
+# Relative-import re-exports (#5111 slice 4, continued)
+# ---------------------------------------------------------------------------
+#
+# Every re-export fixture above writes the facade's import as an absolute
+# dotted path (``from proj.engine import compute``). That is not the form an
+# intra-package re-export is normally written in -- ``from .engine import
+# compute`` or, from a package's own ``__init__.py``, ``from .engine import
+# compute`` again with the package itself as the base -- and the analyser's
+# import extraction never resolved ``node.level``, so a relative import's
+# module name never carried the package prefix the selector matches on. The
+# edge from the defining module through a relatively-imported facade was
+# silently dropped: not routed to the full-suite fallback (a separate,
+# unrelated test already covers the facade module directly, so the "some
+# source changed maps to no test" fail-open path never triggers), just
+# missing from the precise selection with nothing failing.
+
+
+def test_a_relative_reexport_makes_its_importers_affected(tmp_path: Path) -> None:
+    """``from .engine import compute`` -- the ordinary sibling-module re-export."""
+    src, tests = _reexport_fixture(
+        tmp_path,
+        facade_body="from .engine import compute\n",
+        test_body="from proj.facade import compute\n\n\ndef test_it() -> None:\n    assert compute() == 1\n",
+    )
+    # A second, direct-import test so a change to engine.py is already mapped
+    # through it and the fail-open "unmapped source" fallback cannot mask the
+    # missing edge by selecting everything anyway.
+    _write(tests / "test_engine_direct.py", "from proj.engine import compute\n")
+    assert _selected_for(tmp_path, src, tests, "src/proj/engine.py") == {
+        "tests/unit/test_via_facade.py",
+        "tests/unit/test_engine_direct.py",
+    }
+
+
+def test_a_package_init_relative_reexport_makes_its_importers_affected(tmp_path: Path) -> None:
+    """``proj/__init__.py`` doing ``from .engine import compute``.
+
+    A package's own ``__init__.py`` is its own ``__package__`` for relative
+    resolution -- level 1 refers to ``proj`` itself, not ``proj``'s parent --
+    which is the distinction :func:`_resolve_relative_import` has to get
+    right for this, the commonest re-export shape in this codebase, to work.
+    """
+    src = tmp_path / "src"
+    tests = tmp_path / "tests" / "unit"
+    _write(src / "proj" / "__init__.py", "from .engine import compute\n")
+    _write(src / "proj" / "engine.py", "def compute() -> int:\n    return 1\n")
+    _write(
+        tests / "test_via_facade.py",
+        "from proj import compute\n\n\ndef test_it() -> None:\n    assert compute() == 1\n",
+    )
+    _write(tests / "test_engine_direct.py", "from proj.engine import compute\n")
+    assert _selected_for(tmp_path, src, tests, "src/proj/engine.py") == {
+        "tests/unit/test_via_facade.py",
+        "tests/unit/test_engine_direct.py",
+    }
+
+
+def test_a_two_level_relative_reexport_makes_its_importers_affected(tmp_path: Path) -> None:
+    """``from ..engine import compute`` -- climbing one level up from a subpackage."""
+    src = tmp_path / "src"
+    tests = tmp_path / "tests" / "unit"
+    _write(src / "proj" / "__init__.py", "")
+    _write(src / "proj" / "engine.py", "def compute() -> int:\n    return 1\n")
+    _write(src / "proj" / "sub" / "__init__.py", "")
+    _write(src / "proj" / "sub" / "facade.py", "from ..engine import compute\n")
+    _write(
+        tests / "test_via_facade.py",
+        "from proj.sub.facade import compute\n\n\ndef test_it() -> None:\n    assert compute() == 1\n",
+    )
+    _write(tests / "test_engine_direct.py", "from proj.engine import compute\n")
+    assert _selected_for(tmp_path, src, tests, "src/proj/engine.py") == {
+        "tests/unit/test_via_facade.py",
+        "tests/unit/test_engine_direct.py",
+    }


### PR DESCRIPTION
Slice 4 of #5111 (\"a re-exported module counts as affecting its importers\"), plus the real gap that slice exposed.

## What was already covered, and what wasn't

`tests/unit/test_test_impact_alias_edges.py` already has a "Re-exports" section pinning that an **absolute**-import facade (`from proj.engine import compute`) correctly carries the edge from the defining module through to a test that only imports the facade -- that case already worked, because the facade's own import statement names the real module directly and the transitive walk in `TestImpactAnalyzer._expand_impacted_modules` / `build_compat_dep_map`'s `source_imports` reaches it.

What wasn't covered, and doesn't work on `main`: the same re-export written the way it's actually written almost everywhere in this codebase -- as a **relative** import (`from .engine import compute`, or from a package's own `__init__.py`). `extract_project_imports()`'s `ast.ImportFrom` handling reads `node.module` and checks its top-level component against the project's package prefixes, but never looks at `node.level`. A relative import's `node.module` is the bare trailing segment (`"engine"`, or `""` for `from . import x`) with no package prefix at all, so the check silently rejects it -- the edge is dropped, not merely mis-resolved.

## Why this doesn't show up as a red CI run today

A changed source file that maps to *no* test triggers `test_impact`'s fail-open "unmapped source" fallback, which selects the entire suite -- so if the facade module happened to be the *only* thing depending on the changed file, you'd get a (wasteful but safe) full-suite run rather than a silent miss. The actual failure mode needs one more ingredient, which is also the common case: the defining module already has *some* other test that imports it directly. That test satisfies the "is this source mapped to anything" check, the fallback never fires, and the facade-only test is dropped from the precise selection with nothing turning red. Reproduced and confirmed locally before writing the fix:

```
source_imports: {'pkg': set(), 'pkg.a': set(), 'pkg.b': set()}   # pkg.a's relative import to pkg.b invisible
graph: {'pkg.a': {'tests/unit/test_a_consumer.py'}, 'pkg.b': {'tests/unit/test_b.py'}}
affected_tests: ['tests/unit/test_b.py']      # test_a_consumer.py silently missing
fallback_used: False                          # and no fallback catches it
```

## The fix

`_resolve_relative_import()` resolves `node.level` against the *importing file's own dotted module name*, mirroring Python's own `__package__` resolution: a package's `__init__.py` is its own package for this purpose (`level=1` there means the package itself, not its parent), while a regular module's package is its dirname. Both `TestImpactAnalyzer._parse_source_imports` and `build_compat_dep_map`'s source-file loop now pass that module name through; test files (which don't correspond to an importable dotted module in the same sense) keep passing `None`, preserving today's behaviour there.

## Tests

Extends the existing "Re-exports" section in `tests/unit/test_test_impact_alias_edges.py` with the three relative-import shapes the fix covers -- sibling (`from .engine import ...`), package-`__init__` (`from .engine import ...` inside `__init__.py`, the commonest form here), and two-level (`from ..engine import ...`) -- each asserting the exact selected set (not just membership), with a second, directly-covered test file in each fixture so the fail-open fallback can't paper over a still-broken edge.

```
uv run pytest tests/unit/test_test_impact_alias_edges.py -q                                    # 19 passed
uv run pytest tests/unit/test_test_impact.py tests/unit/test_test_impact_core.py tests/unit/test_impact_consolidation.py -q   # 83 passed
uv run ruff check / ruff format --check   # clean
uv run lint-imports   # 3 contracts kept, 0 broken
```

## Out of scope

The other #5111 slices (computing the affected set once per CI run instead of per matrix cell, and giving an empty set its own named step) -- those touch `.github/workflows/ci.yml` and `scripts/run_tests.py` directly and are a separate, larger piece of work from the selection-correctness bug this PR fixes.