### PR TITLE
governance: name the bare-approval queue rule in the charter

### DIFF
--- a/docs/governance/review-charter.md
+++ b/docs/governance/review-charter.md
@@ -56,6 +56,7 @@ Reserved to the maintainer: creating tags and releases, changing repository sett
 - `needs-committer-review` is set when CI is green, the request is not a draft, and nothing blocks it. That label is the work list. Oldest first.
 - When `main` is red, only fixes and reverts merge. Everything else waits.
 - A required check is re-run at most twice. If it fails again, the failure is treated as real or the test goes through the [flake process](../contributing/flake-handling.md); it is not re-run until green.
+- An approval on a change of more than forty lines that carries neither a line comment nor a sentence in its body is set aside by the queue sweep, with a note asking for one. Approving again with a sentence restores it. This is a request for evidence, not a finding: section 8 remains the only route to consequences, and the rule applies to every approver, the maintainer included.
 
 ## 6. When the maintainer is away
 

--- a/docs/governance/review-charter.md
+++ b/docs/governance/review-charter.md
@@ -56,7 +56,7 @@ Reserved to the maintainer: creating tags and releases, changing repository sett
 - `needs-committer-review` is set when CI is green, the request is not a draft, and nothing blocks it. That label is the work list. Oldest first.
 - When `main` is red, only fixes and reverts merge. Everything else waits.
 - A required check is re-run at most twice. If it fails again, the failure is treated as real or the test goes through the [flake process](../contributing/flake-handling.md); it is not re-run until green.
-- An approval on a change of more than forty lines that carries neither a line comment nor a sentence in its body is set aside by the queue sweep, with a note asking for one. Approving again with a sentence restores it. This is a request for evidence, not a finding: section 8 remains the only route to consequences, and the rule applies to every approver, the maintainer included.
+- An approval on a change of more than forty lines that carries neither a line comment nor a note in its body is set aside, with a note asking for one; approving again with the note restores it. Today reviewers apply this by reading; the queue sweep is written to apply it once it is armed, and asks each reviewer once per pull request. Drafts, automation accounts and pull requests labelled `pinned`, `do-not-close` or `work-in-progress` are outside it. This is a request for evidence, not a finding: section 8 remains the only route to consequences, and the rule applies to every approver, the maintainer included.
 
 ## 6. When the maintainer is away
 


### PR DESCRIPTION
## What

One bullet in section 5 of `docs/governance/review-charter.md`: an approval on a change of more than forty lines that carries neither a line comment nor a note in its body is set aside with a note asking for one; approving again with the note restores it. The bullet says reviewers apply this by reading today and that the queue sweep is written to apply it once armed, once per reviewer per pull request, with drafts, automation and the three exemption labels outside it; section 8 stays the only route to consequences; the rule applies to every approver, the maintainer included.

## Why

The sweep in #5739 implements this rule, and review there established that the charter does not contain it: section 3 uses timing as its proxy, section 8 reviews comment share monthly and privately first, and `scripts/` is not a protected path. Enforcing a governance rule the charter does not name, through a path the charter does not protect, is the wrong order. This puts the rule where the other queue rules live, in the shape it will take, before anything is armed.

## What this does not do

Nothing is switched on. `QUEUE_HYGIENE_ARMED` stays unset until this has landed and the objection window in section 10 has closed. The threshold and wording are open to objection here for that window.

## Related

- #5739 — the implementation, dormant.
- #5737 — `docs/CODE_REVIEW.md`, whose checklist item 4 states the same threshold and shape and points here.
