### PR TITLE
feat(trace): follow joins the work ledger, not just the trace store (#5114)

### DIFF
--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -1195,6 +1195,35 @@ def trace_show_cmd(ctx: click.Context, task_id: str, as_json: bool) -> None:
     _trace_show_task(task_id, traces_dir=traces_dir, as_json=as_json)
 
 
+def _ledger_entries_for_entity(sdd_dir: Path, entity_id: str) -> list[tuple[str, Any]]:
+    """Return ``(run_id, LedgerEntry)`` pairs from every run ledger referencing ``entity_id``.
+
+    A work ledger is scoped per run, under ``<sdd_dir>/runtime/ledger/<run_id>/``.
+    ``entity_id`` may name the run itself (the ledger directory) or a task
+    inside it (``LedgerEntry.task_id``), so both are checked. Deliberately
+    reads the ledger root path directly rather than going through
+    :func:`bernstein.core.persistence.work_ledger.default_ledger_root`, which
+    creates it on first use -- a read-only ``follow`` must not create a
+    ``.sdd/runtime/ledger/`` directory as a side effect of a query that finds
+    nothing.
+    """
+    from bernstein.core.persistence.work_ledger import LedgerReader
+
+    ledger_root = sdd_dir / "runtime" / "ledger"
+    if not ledger_root.is_dir():
+        return []
+    found: list[tuple[str, Any]] = []
+    for run_dir in sorted(p for p in ledger_root.iterdir() if p.is_dir()):
+        reader = LedgerReader(run_dir)
+        if not reader.exists():
+            continue
+        run_matches = run_dir.name == entity_id
+        for entry in reader.entries():
+            if run_matches or entry.task_id == entity_id:
+                found.append((run_dir.name, entry))
+    return found
+
+
 @trace_cmd.command("follow")
 @click.argument("entity_id")
 @click.option(
@@ -1206,13 +1235,15 @@ def trace_show_cmd(ctx: click.Context, task_id: str, as_json: bool) -> None:
 )
 @click.pass_context
 def trace_follow_cmd(ctx: click.Context, entity_id: str, as_json: bool) -> None:
-    """Show every trace entry that references ENTITY_ID, oldest first.
+    """Show every trace or ledger entry that references ENTITY_ID, oldest first.
 
     `trace show` globs filenames for one task id and prints whichever file
     matches, once. An entity id -- a task, a run, a grant -- appears across
-    several traces, and following it meant exporting and grepping.
+    several journals, and following it meant exporting and grepping each one
+    separately. This joins two of them by that id: the trace store and the
+    work ledger.
 
-    Ordering is by start time, and ties break on trace id, so a finished run
+    Ordering is by timestamp, with a total tie-break, so a finished run
     prints byte-identically on every invocation.
     """
     from bernstein.core.observability.trace_store import ContentAddressedTraceStore
@@ -1232,37 +1263,79 @@ def trace_follow_cmd(ctx: click.Context, entity_id: str, as_json: bool) -> None:
     # same finished run print differently after a rebuild.
     matches.sort(key=lambda entry: (entry.started_at, entry.trace_id))
 
-    if not matches:
+    ledger_entries = _ledger_entries_for_entity(traces_path.parent, entity_id)
+
+    if not matches and not ledger_entries:
         console.print(f"[yellow]No trace entries reference:[/yellow] {entity_id}")
         raise SystemExit(1)
 
     if as_json:
-        console.print_json(json.dumps([entry.to_dict() for entry in matches]))
+        rows: list[tuple[float, str, dict[str, Any]]] = [
+            (entry.started_at, f"trace:{entry.trace_id}", {**entry.to_dict(), "source": "trace"})
+            for entry in matches
+        ]
+        rows.extend(
+            (entry.ts, f"ledger:{run_id}:{entry.seq}", {**entry.to_dict(), "source": "ledger", "run_id": run_id})
+            for run_id, entry in ledger_entries
+        )
+        rows.sort(key=lambda row: (row[0], row[1]))
+        console.print_json(json.dumps([row[2] for row in rows]))
         return
 
     from rich.table import Table
 
-    table = Table(
-        title=f"Traces referencing {entity_id}",
-        show_header=True,
-        header_style="bold cyan",
-    )
-    table.add_column("Started")
-    table.add_column("Trace")
-    table.add_column("Task")
-    table.add_column("Model")
-    table.add_column("Bytes", justify="right")
-    for entry in matches:
-        table.add_row(
-            _trace_timestamp(entry.started_at),
-            entry.trace_id,
-            entry.task_id or "-",
-            entry.model or "-",
-            str(entry.byte_size),
+    if matches:
+        table = Table(
+            title=f"Traces referencing {entity_id}",
+            show_header=True,
+            header_style="bold cyan",
         )
-    console.print(table)
-    suffix = "y" if len(matches) == 1 else "ies"
-    console.print(f"[dim]{len(matches)} entr{suffix}[/dim]")
+        table.add_column("Started")
+        table.add_column("Trace")
+        table.add_column("Task")
+        table.add_column("Model")
+        table.add_column("Bytes", justify="right")
+        for entry in matches:
+            table.add_row(
+                _trace_timestamp(entry.started_at),
+                entry.trace_id,
+                entry.task_id or "-",
+                entry.model or "-",
+                str(entry.byte_size),
+            )
+        console.print(table)
+
+    if ledger_entries:
+        ledger_entries_sorted = sorted(ledger_entries, key=lambda pair: (pair[1].ts, pair[0], pair[1].seq))
+        ledger_table = Table(
+            title=f"Ledger entries referencing {entity_id}",
+            show_header=True,
+            header_style="bold cyan",
+        )
+        ledger_table.add_column("Time")
+        ledger_table.add_column("Run")
+        ledger_table.add_column("Seq", justify="right")
+        ledger_table.add_column("Kind")
+        ledger_table.add_column("Task")
+        for run_id, entry in ledger_entries_sorted:
+            ledger_table.add_row(
+                _trace_timestamp(entry.ts),
+                run_id,
+                str(entry.seq),
+                entry.kind,
+                entry.task_id or "-",
+            )
+        console.print(ledger_table)
+
+    if ledger_entries:
+        trace_suffix = "y" if len(matches) == 1 else "ies"
+        ledger_suffix = "y" if len(ledger_entries) == 1 else "ies"
+        console.print(
+            f"[dim]{len(matches)} trace entr{trace_suffix}, {len(ledger_entries)} ledger entr{ledger_suffix}[/dim]"
+        )
+    else:
+        suffix = "y" if len(matches) == 1 else "ies"
+        console.print(f"[dim]{len(matches)} entr{suffix}[/dim]")
 
 
 def _trace_timestamp(epoch: float) -> str:

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -1271,8 +1271,7 @@ def trace_follow_cmd(ctx: click.Context, entity_id: str, as_json: bool) -> None:
 
     if as_json:
         rows: list[tuple[float, str, dict[str, Any]]] = [
-            (entry.started_at, f"trace:{entry.trace_id}", {**entry.to_dict(), "source": "trace"})
-            for entry in matches
+            (entry.started_at, f"trace:{entry.trace_id}", {**entry.to_dict(), "source": "trace"}) for entry in matches
         ]
         rows.extend(
             (entry.ts, f"ledger:{run_id}:{entry.seq}", {**entry.to_dict(), "source": "ledger", "run_id": run_id})

--- a/tests/unit/cli/test_trace_follow_ledger_join.py
+++ b/tests/unit/cli/test_trace_follow_ledger_join.py
@@ -1,0 +1,140 @@
+"""`bernstein trace follow <entity-id>`: the cross-source join (#5114 slice 2).
+
+Slice 1 (`tests/unit/cli/test_trace_follow.py`) covers `follow` over the trace
+store alone. An entity id -- a task, a run, a grant -- is meaningful across
+more than the trace store: the work ledger records the same run's task-graph
+transitions under the same ids. This extends `follow` to also read the work
+ledger and merge its entries into the same ordered output, so "which of these
+journals mention this entity" stays one command instead of turning back into
+export-and-grep for every journal beyond the first.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.advanced_cmd import trace_cmd
+from bernstein.core.observability.trace_store import (
+    ContentAddressedTraceStore,
+    TraceMetadataHints,
+)
+from bernstein.core.persistence.work_ledger import WorkLedger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _follow(traces_dir: Path, *args: str) -> tuple[int, str]:
+    result = CliRunner().invoke(trace_cmd, ["--traces-dir", str(traces_dir), "follow", *args])
+    return result.exit_code, result.output
+
+
+@pytest.fixture
+def sdd_dir(tmp_path: Path) -> Path:
+    return tmp_path / ".sdd"
+
+
+@pytest.fixture
+def traces_dir(sdd_dir: Path) -> Path:
+    traces = sdd_dir / "traces"
+    traces.mkdir(parents=True)
+    return traces
+
+
+def _ledger_dir(sdd_dir: Path, run_id: str) -> Path:
+    path = sdd_dir / "runtime" / "ledger" / run_id
+    path.mkdir(parents=True)
+    return path
+
+
+def test_follow_merges_ledger_entries_naming_the_same_task_id(sdd_dir: Path, traces_dir: Path) -> None:
+    store = ContentAddressedTraceStore(traces_dir)
+    store.put(b'{"event": "trace"}', hints=TraceMetadataHints(trace_id="trace-a", task_id="T-100", started_at=100.0))
+
+    ledger = WorkLedger.open(_ledger_dir(sdd_dir, "run-1"))
+    ledger.append(kind="agent.claimed", task_id="T-100", payload={"note": "claimed"})
+    ledger.close()
+
+    code, output = _follow(traces_dir, "T-100", "--as-json")
+    assert code == 0
+    rows = json.loads(output)
+    sources = {row["source"] for row in rows}
+    assert sources == {"trace", "ledger"}
+    ledger_row = next(row for row in rows if row["source"] == "ledger")
+    assert ledger_row["task_id"] == "T-100"
+    assert ledger_row["kind"] == "agent.claimed"
+    assert ledger_row["run_id"] == "run-1"
+
+
+def test_follow_finds_ledger_entries_by_run_id_even_without_a_matching_task(sdd_dir: Path, traces_dir: Path) -> None:
+    """The entity id can name the run (the ledger directory) rather than a task inside it."""
+    ledger = WorkLedger.open(_ledger_dir(sdd_dir, "run-42"))
+    ledger.append(kind="agent.claimed", task_id="T-1", payload={})
+    ledger.append(kind="agent.completed", task_id="T-2", payload={})
+    ledger.close()
+
+    code, output = _follow(traces_dir, "run-42", "--as-json")
+    assert code == 0
+    rows = json.loads(output)
+    assert {row["task_id"] for row in rows} == {"T-1", "T-2"}
+    assert all(row["run_id"] == "run-42" for row in rows)
+
+
+def test_merged_output_is_ordered_by_timestamp_across_sources(sdd_dir: Path, traces_dir: Path) -> None:
+    store = ContentAddressedTraceStore(traces_dir)
+    store.put(b'{"event": "late"}', hints=TraceMetadataHints(trace_id="trace-late", task_id="T-5", started_at=300.0))
+
+    run_dir = _ledger_dir(sdd_dir, "run-9")
+    ledger = WorkLedger.open(run_dir)
+    ledger.append(kind="agent.claimed", task_id="T-5", payload={})
+    ledger.close()
+    # Force the ledger entry's timestamp earlier than the trace's, so a
+    # source-blind (rather than timestamp-blind) sort would get this wrong.
+    bucket = run_dir / "000000.jsonl"
+    text = bucket.read_text(encoding="utf-8")
+    row = json.loads(text.strip())
+    row["ts"] = 50.0
+    bucket.write_text(json.dumps(row) + "\n", encoding="utf-8")
+
+    code, output = _follow(traces_dir, "T-5", "--as-json")
+    assert code == 0
+    rows = json.loads(output)
+    assert [row["source"] for row in rows] == ["ledger", "trace"]
+
+
+def test_an_entity_with_only_ledger_entries_and_no_traces_still_succeeds(sdd_dir: Path, traces_dir: Path) -> None:
+    ledger = WorkLedger.open(_ledger_dir(sdd_dir, "run-only"))
+    ledger.append(kind="agent.claimed", task_id="T-lonely", payload={})
+    ledger.close()
+
+    code, output = _follow(traces_dir, "T-lonely", "--as-json")
+    assert code == 0
+    rows = json.loads(output)
+    assert len(rows) == 1
+    assert rows[0]["source"] == "ledger"
+
+
+def test_follow_is_read_only_and_never_creates_a_ledger_root(traces_dir: Path, sdd_dir: Path) -> None:
+    """A query that finds nothing must not create `.sdd/runtime/ledger/`."""
+    code, _ = _follow(traces_dir, "nothing-anywhere")
+    assert code == 1
+    assert not (sdd_dir / "runtime" / "ledger").exists()
+
+
+def test_human_readable_output_names_both_sources_when_both_have_matches(sdd_dir: Path, traces_dir: Path) -> None:
+    store = ContentAddressedTraceStore(traces_dir)
+    store.put(b'{"event": "x"}', hints=TraceMetadataHints(trace_id="trace-a", task_id="T-7", started_at=1.0))
+    ledger = WorkLedger.open(_ledger_dir(sdd_dir, "run-7"))
+    ledger.append(kind="agent.claimed", task_id="T-7", payload={})
+    ledger.close()
+
+    code, output = _follow(traces_dir, "T-7")
+    assert code == 0
+    condensed = " ".join(output.split())
+    assert "Traces referencing T-7" in condensed
+    assert "Ledger entries referencing T-7" in condensed
+    assert "1 trace entry, 1 ledger entry" in condensed


### PR DESCRIPTION
Slice 2 of #5114. Slice 1 (#5527) already landed \`trace follow <entity-id>\` over the trace store alone -- every trace entry naming the entity, in order, byte-identical across invocations. This PR is the cross-source join slice 1 deliberately left out: the work ledger.

## What changed

\`trace follow\` now also reads every run's work ledger under \`.sdd/runtime/ledger/<run-id>/\`, matching \`entity-id\` against either:

- the ledger directory name itself (the entity is a **run**), or
- \`LedgerEntry.task_id\` on an entry inside it (the entity is a **task**).

Matches from both sources are merged into one stream, sorted by timestamp with a total tie-break (\`(trace|ledger):<id>\`), so the determinism guarantee slice 1 established (byte-identical output for a finished run) extends to the merged output.

\`--as-json\` rows carry a \`"source": "trace" | "ledger"\` discriminator; a ledger row additionally carries \`run_id\`. The human-readable form prints a second table (\`Ledger entries referencing <id>\`) alongside the existing trace table when there are ledger matches, and the summary line becomes \`"N trace entries, M ledger entries"\` only when \`M > 0\` -- with no ledger matches (every existing fixture), the output is byte-for-byte what slice 1 already produced.

## The one thing worth calling out

\`bernstein.core.persistence.work_ledger.default_ledger_root()\` creates \`.sdd/runtime/ledger/\` on first use -- fine for a writer, wrong for a read-only \`follow\` that finds nothing. The new \`_ledger_entries_for_entity()\` helper reads the ledger-root path directly and only calls \`is_dir()\` on it, so a \`follow\` for an entity with no ledger anywhere never creates the directory it was about to conclude doesn't exist. There's a regression test for exactly this (\`test_follow_is_read_only_and_never_creates_a_ledger_root\`).

## Tests

New file \`tests/unit/cli/test_trace_follow_ledger_join.py\`: merging by task id, matching by run id (no task match needed), cross-source ordering by timestamp (not source), an entity with only ledger entries and no traces, the read-only/no-side-effect guarantee, and the human-readable two-table output. All of slice 1's existing tests (\`tests/unit/cli/test_trace_follow.py\`) still pass unchanged, since none of their fixtures create a ledger.

```
uv run pytest tests/unit/cli/test_trace_follow.py tests/unit/cli/test_advanced_cmd_trace.py tests/unit/cli/test_trace_follow_ledger_join.py -q   # 25 passed
uv run ruff check / ruff format --check   # clean
uv run lint-imports   # 3 contracts kept, 0 broken
```

## Out of scope

The audit chain (also named in the issue as a source \`follow\` could eventually join, "where relevant") and slice 3 (\`--since\`, \`--out\`, live-follow mode) -- both are separate, larger pieces of work from this join.