### PR TITLE
identity: escape the path when logging a corrupt identity file

### DIFF
--- a/src/bernstein/core/identity/agent_jwt.py
+++ b/src/bernstein/core/identity/agent_jwt.py
@@ -667,7 +667,7 @@ class AgentIdentityStore:
                 raise TypeError(msg)
             return AgentIdentity.from_dict(cast("dict[str, Any]", data))
         except (OSError, json.JSONDecodeError, AttributeError, KeyError, TypeError, ValueError):
-            logger.warning("Skipping corrupt identity file: %s", path)
+            logger.warning("Skipping corrupt identity file: %s", sanitize_log(str(path)))
             return None
 
     def _load(self, identity_id: str) -> AgentIdentity | None:


### PR DESCRIPTION
## What

One log line in `src/bernstein/core/identity/agent_jwt.py` now passes the identity file's path through `sanitize_log` before logging it.

## Why

The path is built from an identity id that arrives with the request. Every other log call in the module already escapes such values; this one did not, so an id containing a line break could end the log record early and start a fabricated one. Static analysis reported it as `py/log-injection` (alert on line 670).

## Note on the other 66 findings of the same kind

They are false positives: each flagged value already goes through `sanitize_log`, which strips `\x00-\x1f`, `\x7f-\x9f`, U+2028 and U+2029. The analyser does not model that function as a sanitiser, so it reports the call sites anyway. They are dismissed with that reason, and the modelling gap is tracked separately.