### PR TITLE
feat(skills): persist and journal declaration-init quarantines (#5108)

### DIFF
--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -8762,6 +8762,67 @@ def record_delegation_minted(
     )
 
 
+# ---------------------------------------------------------------------------
+# Declaration-init quarantine (#5108)
+# ---------------------------------------------------------------------------
+# A plugin, skill, adapter, or routine that fails to initialise is isolated
+# in-process (see e.g. ``bernstein.core.skills.loader.SkillLoader``) so the
+# rest of the set still loads. This event is the journaled half: the fact
+# that isolated the failure vanishes when the process exits unless it is
+# also anchored to the chain.
+
+#: A declaration (skill, plugin, adapter, or routine) failed to initialise
+#: and was quarantined rather than taking the rest of its set down. Records
+#: what failed and why; one event per quarantine, never batched, so the
+#: chain names exactly which declaration and when.
+EVENT_DECLARATION_QUARANTINED = "declaration.quarantined"
+
+
+def record_declaration_quarantined(
+    *,
+    chain: AuditChainStore,
+    kind: str,
+    source_name: str,
+    origin: str,
+    name: str,
+    reason: str,
+    error_type: str,
+    actor: str = "loader",
+) -> AuditEvent:
+    """Append a ``declaration.quarantined`` event into *chain* (#5108).
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        kind: Declaration kind (``"skill"`` today; a plugin/adapter/routine
+            kind once quarantine extends to them).
+        source_name: Label of the source the declaration came from.
+        origin: The declaration's origin, or the source label for a
+            whole-source failure.
+        name: The declaration's own name, or ``""`` when the failure never
+            got far enough to name one.
+        reason: The exception text.
+        error_type: The exception class name.
+        actor: Recorded actor; defaults to ``"loader"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_DECLARATION_QUARANTINED,
+        actor=actor,
+        resource_type="declaration",
+        resource_id=origin,
+        details={
+            "kind": kind,
+            "source_name": source_name,
+            "origin": origin,
+            "name": name,
+            "reason": reason,
+            "error_type": error_type,
+        },
+    )
+
+
 def record_pool_registered(
     *,
     chain: AuditChainStore,
@@ -9772,6 +9833,7 @@ __all__ = [
     "EVENT_COST_DISPATCH_RECEIPT",
     "EVENT_COST_PROFILE_REPORT",
     "EVENT_DASHBOARD_TOKEN_GRANT",
+    "EVENT_DECLARATION_QUARANTINED",
     "EVENT_DELEGATION_MINTED",
     "EVENT_ENDPOINT_CERTIFICATION",
     "EVENT_ESCALATION_LADDER_BUDGET_STOP",
@@ -9934,6 +9996,7 @@ __all__ = [
     "record_cost_dispatch_receipt",
     "record_cost_profile_report",
     "record_dashboard_token_grant",
+    "record_declaration_quarantined",
     "record_delegation_minted",
     "record_endpoint_certification",
     "record_escalation_ladder_budget_stop",

--- a/src/bernstein/core/skills/quarantine_store.py
+++ b/src/bernstein/core/skills/quarantine_store.py
@@ -1,0 +1,192 @@
+"""Persisted record of declaration-init quarantines (#5108, slice 2).
+
+``SkillLoader`` already isolates a source or artifact that fails to load: the
+rest of the set still registers, and the failure is available in-process as
+:class:`~bernstein.core.skills.loader.QuarantinedSkill` via the loader's
+``on_quarantine`` hook. What that isolation does not do on its own is leave
+anything behind for an operator to read later -- restart the process and the
+in-memory record is gone.
+
+This is a sibling of :class:`~bernstein.core.security.quarantine.QuarantineStore`,
+not a shared instance of it: that store is threshold-based (a task is
+quarantined after ``QUARANTINE_THRESHOLD`` repeated failures across runs), while
+a declaration that throws on init is quarantined on the first failure -- there
+is no "try it a few more times" for a source that cannot enumerate itself.
+
+:func:`journaled_quarantine_hook` composes the two things slice 2 needs into
+one ``on_quarantine`` callback: a persisted entry via :class:`DeclarationQuarantineStore`,
+and exactly one ``declaration.quarantined`` audit-chain event.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.persistence.atomic_write import write_atomic_json
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from bernstein.core.security.audit_chain import AuditChainStore
+    from bernstein.core.skills.loader import QuarantinedSkill
+
+#: Declaration kinds this store expects. Not enforced -- a caller extending
+#: quarantine to adapters or routines (issue #5108 slice 4) passes its own
+#: string, and the store persists whatever it is given.
+KIND_SKILL = "skill"
+
+
+@dataclass(frozen=True)
+class DeclarationQuarantineEntry:
+    """One declaration this install refused to load, and why.
+
+    Attributes:
+        kind: What was quarantined -- ``"skill"`` today; a plugin, adapter or
+            routine kind string once slice 4 extends this store to them.
+        source_name: Label of the source (module, plugin, source label) the
+            declaration came from.
+        origin: The declaration's origin (a path, plugin name, or entry
+            point), or the source label when the whole source failed before
+            producing anything to name.
+        name: The declaration's own name, or ``None`` for a whole-source
+            failure that never got far enough to name one.
+        reason: The exception text.
+        error_type: The exception class name.
+        at: Unix timestamp of the failure.
+    """
+
+    kind: str
+    source_name: str
+    origin: str
+    name: str | None
+    reason: str
+    error_type: str
+    at: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> DeclarationQuarantineEntry:
+        return cls(
+            kind=str(raw["kind"]),
+            source_name=str(raw["source_name"]),
+            origin=str(raw["origin"]),
+            name=raw.get("name"),
+            reason=str(raw["reason"]),
+            error_type=str(raw["error_type"]),
+            at=float(raw["at"]),
+        )
+
+
+class DeclarationQuarantineStore:
+    """Append-only, persisted log of declaration-init quarantines.
+
+    One-shot, unlike the threshold-based task quarantine: every failure
+    reported to :meth:`record` is written, with no dedup and no expiry --
+    each entry is a fact about a load that happened at a specific time, kept
+    for ``doctor``/``status``/re-enable (slices 3+) to read.
+
+    Args:
+        path: Full path to the quarantine JSON file.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    def load(self) -> list[DeclarationQuarantineEntry]:
+        """Return every persisted entry, oldest first.
+
+        Returns:
+            Entries in the file, or an empty list if it does not exist or is
+            unreadable -- a damaged file must not stop a load from
+            proceeding; it only means the operator loses the history of past
+            quarantines, not that this run's own isolation is affected.
+        """
+        if not self._path.exists():
+            return []
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+            return [DeclarationQuarantineEntry.from_dict(item) for item in raw]
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+            logger.error(
+                "declaration quarantine: %s is unreadable (%s); treating history as empty",
+                self._path,
+                exc,
+            )
+            return []
+
+    def record(self, entry: DeclarationQuarantineEntry) -> None:
+        """Append *entry* and persist the full list.
+
+        Args:
+            entry: The quarantine record to add.
+        """
+        entries = self.load()
+        entries.append(entry)
+        write_atomic_json(self._path, [e.to_dict() for e in entries])
+
+
+def journaled_quarantine_hook(
+    store: DeclarationQuarantineStore,
+    chain: AuditChainStore,
+    *,
+    kind: str = KIND_SKILL,
+    actor: str = "skill_loader",
+) -> Callable[[QuarantinedSkill], None]:
+    """Return an ``on_quarantine`` callback that persists and journals.
+
+    Composes the two things slice 2 needs into the one hook
+    :class:`~bernstein.core.skills.loader.SkillLoader` calls at the moment of
+    failure: a :class:`DeclarationQuarantineEntry` written to *store*, and
+    exactly one ``declaration.quarantined`` event appended to *chain*.
+
+    Args:
+        store: Where the persisted record is written.
+        chain: The audit chain store accepting the journal entry.
+        kind: Declaration kind to stamp on every entry this hook records.
+        actor: Recorded actor for the journal entry.
+
+    Returns:
+        A callable suitable for ``SkillLoader(..., on_quarantine=...)``.
+    """
+
+    def _on_quarantine(record: QuarantinedSkill) -> None:
+        from bernstein.core.security.audit_chain import record_declaration_quarantined
+
+        entry = DeclarationQuarantineEntry(
+            kind=kind,
+            source_name=record.source_name,
+            origin=record.origin,
+            name=record.skill_name,
+            reason=record.reason,
+            error_type=record.error_type,
+            at=record.at,
+        )
+        store.record(entry)
+        record_declaration_quarantined(
+            chain=chain,
+            kind=kind,
+            source_name=record.source_name,
+            origin=record.origin,
+            name=record.skill_name or "",
+            reason=record.reason,
+            error_type=record.error_type,
+            actor=actor,
+        )
+
+    return _on_quarantine
+
+
+__all__ = [
+    "KIND_SKILL",
+    "DeclarationQuarantineEntry",
+    "DeclarationQuarantineStore",
+    "journaled_quarantine_hook",
+]

--- a/tests/unit/skills/test_declaration_quarantine_store.py
+++ b/tests/unit/skills/test_declaration_quarantine_store.py
@@ -1,0 +1,164 @@
+"""Issue #5108 slice 2: a persisted record and one journaled event per quarantine.
+
+``SkillLoader``'s in-process isolation (tested in ``test_loader_quarantine.py``)
+already keeps one bad source from taking the rest down, and reports the
+failure through its ``on_quarantine`` hook. What vanishes when the process
+exits is the record of it -- nothing durable, nothing ``doctor`` or ``status``
+can read later. ``DeclarationQuarantineStore`` and ``journaled_quarantine_hook``
+are that missing half: a persisted entry, and one ``declaration.quarantined``
+audit-chain event, per quarantine.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from bernstein.core.security.audit_chain import AuditChainStore
+from bernstein.core.skills.loader import QuarantinedSkill
+from bernstein.core.skills.quarantine_store import (
+    KIND_SKILL,
+    DeclarationQuarantineEntry,
+    DeclarationQuarantineStore,
+    journaled_quarantine_hook,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_KEY = b"test-hmac-key-not-a-secret-0123456789"
+
+
+def _record(reason: str = "bad manifest", skill_name: str | None = "widget") -> QuarantinedSkill:
+    return QuarantinedSkill(
+        source_name="local",
+        origin="templates/skills/widget",
+        skill_name=skill_name,
+        reason=reason,
+        error_type="ValueError",
+        at=1234.5,
+    )
+
+
+class TestDeclarationQuarantineStore:
+    def test_a_fresh_store_has_no_history(self, tmp_path: Path) -> None:
+        store = DeclarationQuarantineStore(tmp_path / "quarantine.json")
+        assert store.load() == []
+
+    def test_record_persists_across_store_instances(self, tmp_path: Path) -> None:
+        path = tmp_path / "quarantine.json"
+        entry = DeclarationQuarantineEntry(
+            kind=KIND_SKILL,
+            source_name="local",
+            origin="templates/skills/widget",
+            name="widget",
+            reason="bad manifest",
+            error_type="ValueError",
+            at=100.0,
+        )
+        DeclarationQuarantineStore(path).record(entry)
+
+        reloaded = DeclarationQuarantineStore(path).load()
+        assert reloaded == [entry]
+
+    def test_record_appends_rather_than_replaces(self, tmp_path: Path) -> None:
+        path = tmp_path / "quarantine.json"
+        store = DeclarationQuarantineStore(path)
+        for i in range(3):
+            store.record(
+                DeclarationQuarantineEntry(
+                    kind=KIND_SKILL,
+                    source_name="local",
+                    origin=f"templates/skills/widget-{i}",
+                    name=f"widget-{i}",
+                    reason="bad manifest",
+                    error_type="ValueError",
+                    at=float(i),
+                )
+            )
+        assert [e.name for e in store.load()] == ["widget-0", "widget-1", "widget-2"]
+
+    def test_an_unreadable_file_degrades_to_empty_history(self, tmp_path: Path) -> None:
+        path = tmp_path / "quarantine.json"
+        path.write_text("not json at all", encoding="utf-8")
+        assert DeclarationQuarantineStore(path).load() == []
+
+
+class TestJournaledQuarantineHook:
+    def test_a_quarantine_produces_exactly_one_persisted_entry(self, tmp_path: Path) -> None:
+        store = DeclarationQuarantineStore(tmp_path / "quarantine.json")
+        chain = AuditChainStore(tmp_path / "audit", key=_KEY)
+        hook = journaled_quarantine_hook(store, chain)
+
+        hook(_record())
+
+        (entry,) = store.load()
+        assert entry.kind == KIND_SKILL
+        assert entry.name == "widget"
+        assert entry.reason == "bad manifest"
+        assert entry.error_type == "ValueError"
+        assert entry.at == 1234.5
+
+    def test_a_quarantine_journals_exactly_one_governance_event(self, tmp_path: Path) -> None:
+        store = DeclarationQuarantineStore(tmp_path / "quarantine.json")
+        chain = AuditChainStore(tmp_path / "audit", key=_KEY)
+        hook = journaled_quarantine_hook(store, chain)
+
+        hook(_record())
+
+        events = [e for e in chain.query() if e.event_type == "declaration.quarantined"]
+        assert len(events) == 1
+        assert events[0].details["name"] == "widget"
+        assert events[0].details["reason"] == "bad manifest"
+        assert events[0].details["kind"] == KIND_SKILL
+
+    def test_a_whole_source_failure_journals_an_empty_name_not_a_fabricated_one(self, tmp_path: Path) -> None:
+        """A source that throws in ``iter_skills`` never named a skill; nothing here should invent one."""
+        store = DeclarationQuarantineStore(tmp_path / "quarantine.json")
+        chain = AuditChainStore(tmp_path / "audit", key=_KEY)
+        hook = journaled_quarantine_hook(store, chain)
+
+        hook(_record(skill_name=None))
+
+        (entry,) = store.load()
+        assert entry.name is None
+        events = [e for e in chain.query() if e.event_type == "declaration.quarantined"]
+        assert events[0].details["name"] == ""
+
+    def test_two_quarantines_produce_two_entries_and_two_events(self, tmp_path: Path) -> None:
+        store = DeclarationQuarantineStore(tmp_path / "quarantine.json")
+        chain = AuditChainStore(tmp_path / "audit", key=_KEY)
+        hook = journaled_quarantine_hook(store, chain)
+
+        hook(_record(reason="first failure", skill_name="alpha"))
+        hook(_record(reason="second failure", skill_name="beta"))
+
+        assert [e.name for e in store.load()] == ["alpha", "beta"]
+        events = [e for e in chain.query() if e.event_type == "declaration.quarantined"]
+        assert len(events) == 2
+
+
+class TestLoaderWiredToTheJournaledHook:
+    """The end-to-end wiring the loader's own tests stop short of: a real store and chain."""
+
+    def test_a_loader_quarantine_reaches_the_store_and_the_chain(self, tmp_path: Path) -> None:
+        from bernstein.core.skills.loader import SkillLoader
+        from bernstein.core.skills.source import SkillSource
+
+        class _ThrowingSource(SkillSource):
+            @property
+            def name(self) -> str:
+                return "broken"
+
+            def iter_skills(self) -> list:  # type: ignore[type-arg]
+                raise RuntimeError("cannot enumerate")
+
+        store = DeclarationQuarantineStore(tmp_path / "quarantine.json")
+        chain = AuditChainStore(tmp_path / "audit", key=_KEY)
+
+        SkillLoader([_ThrowingSource()], on_quarantine=journaled_quarantine_hook(store, chain))
+
+        (entry,) = store.load()
+        assert entry.source_name == "broken"
+        assert entry.reason == "cannot enumerate"
+        events = [e for e in chain.query() if e.event_type == "declaration.quarantined"]
+        assert len(events) == 1


### PR DESCRIPTION
Slice 2 of #5108. Slice 1 already landed on \`main\`: \`SkillLoader._reload\` isolates a source or artifact that throws (or a \`DuplicateSkillError\`) so the rest of the set still loads, and \`on_quarantine\` reports each failure as it happens. What that isolation doesn't do is leave anything behind -- restart the process and the in-process \`QuarantinedSkill\` record is gone, so there's nothing for \`doctor\`/\`status\` to read and no governance trail. This PR is that missing half.

## What's new

- **\`DeclarationQuarantineStore\`** (\`src/bernstein/core/skills/quarantine_store.py\`) -- an append-only, persisted JSON log of \`DeclarationQuarantineEntry\` rows (kind, source, origin, name, reason, error type, timestamp). Deliberately a *sibling* of the existing threshold-based \`core/security/quarantine.py\` \`QuarantineStore\`, not a shared instance: that one quarantines a task after \`QUARANTINE_THRESHOLD\` repeated cross-run failures, while a declaration that throws on init is quarantined on the very first one -- there's no "try it a few more times" for a source that can't enumerate itself.
- **\`declaration.quarantined\`** audit-chain event (\`EVENT_DECLARATION_QUARANTINED\` / \`record_declaration_quarantined\` in \`audit_chain.py\`), placed directly after the existing \`delegation_minted\` event it's adjacent to structurally (one event, one resource, no batching).
- **\`journaled_quarantine_hook(store, chain)\`** -- composes both into the single \`on_quarantine\` callback \`SkillLoader\` already calls at the moment of failure: one persisted entry, one chain event, per quarantine.

## Why compose it as a hook rather than build it into the loader

\`SkillLoader\` is deliberately stateless and holds no audit key (see its own docstring on \`on_quarantine\`) -- it reports, callers write. \`journaled_quarantine_hook\` is exactly the seam slice 1 left for this: pass it as \`on_quarantine=journaled_quarantine_hook(store, chain)\` and every quarantine this load produces is both durable and chain-anchored, with zero changes to the loader itself.

## A correctness note carried over from the loader's own contract

A source that throws in \`iter_skills()\` never named a skill -- claiming one would be an invention. The hook preserves that: \`DeclarationQuarantineEntry.name\` stays \`None\` for a whole-source failure, and the audit event (whose \`details\` payload has no room for \`None\`) records \`""\` rather than fabricating a name.

## Tests

New file \`tests/unit/skills/test_declaration_quarantine_store.py\`: store round-trip and append-not-replace semantics, an unreadable file degrading to empty history (never blocking a load), one entry + one event per quarantine, the whole-source "no fabricated name" case, two quarantines producing two of each, and one end-to-end test wiring a real throwing \`SkillSource\` through \`SkillLoader(..., on_quarantine=journaled_quarantine_hook(...))\` into both the store and the chain.

```
uv run pytest tests/unit/skills/test_declaration_quarantine_store.py tests/unit/skills/test_loader_quarantine.py tests/unit/skills/test_loader.py -q   # 23 passed
uv run ruff check / ruff format --check   # clean
uv run lint-imports   # 3 contracts kept, 0 broken
```

## Out of scope (per the issue's own slicing)

- Slice 3: surfacing the quarantine count in \`status\`, listing entries as \`doctor\`/\`govern audit\` findings, and an explicit re-enable command.
- Slice 4: extending the same isolation + journaling to plugin tracker-adapter discovery and trigger/routine config loading -- the issue names this as a follow-up that needs this store to exist first.
- Wiring \`journaled_quarantine_hook\` into the real call sites that construct the default loader (\`role_resolver.py\`, \`load_skill_tool.py\`, the MCP server/transport) -- each currently constructs \`SkillLoader\` without an \`on_quarantine\`, and picking a default \`.sdd\` workdir + audit key at each of those four sites is its own piece of wiring work, separate from building the mechanism itself.