### PR TITLE
docs: mirror the review roster in MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,4 +13,22 @@ UI, docs, and packaging — see [GOVERNANCE.md](GOVERNANCE.md) for how a name
 gets onto this table, and [CONTRIBUTING.md](CONTRIBUTING.md#areas) for the
 mechanics.
 
+## Review roster
+
+Approvals on a pull request are counted against
+[.github/quorum-roster.toml](.github/quorum-roster.toml). That file is the
+authoritative list; this table is its human-readable mirror, and if the two
+disagree the TOML wins. How the count works is in
+[docs/governance/review-charter.md](docs/governance/review-charter.md).
+
+| Role | Who | What it means on a pull request |
+|---|---|---|
+| Maintainer | [@chernistry](https://github.com/chernistry) | Own changes merge without approvals; approves protected paths and changes over 1,000 lines |
+| Core reviewers | [@vaibhav8a](https://github.com/vaibhav8a), [@thegoodengineer](https://github.com/thegoodengineer), [@tenequm](https://github.com/tenequm), [@Phoenix1504e](https://github.com/Phoenix1504e) | At least one of the two approvals a contributor's change needs comes from here |
+| Committers | [@Chirag6722](https://github.com/Chirag6722), [@Silentpartnercoding](https://github.com/Silentpartnercoding) | Approvals count toward the two; a standing "changes requested" blocks a merge, the maintainer's own included |
+| Automation | `bernstein-the-conductor[bot]`, `renovate[bot]`, `dependabot[bot]` | Own changes merge on green CI, except on sensitive paths, where the maintainer approves |
+
+A change to the roster is a pull request against the TOML file, following
+[GOVERNANCE.md](GOVERNANCE.md); this table is updated in the same pull request.
+
 Security reports do not go here. Use the channels in [SECURITY.md](SECURITY.md).


### PR DESCRIPTION
MAINTAINERS.md listed only the maintainer. The approval count on pull requests now reads `.github/quorum-roster.toml`, so the human-readable page should show the same names and say which file wins.

- Adds a "Review roster" section: maintainer, core reviewers, committers, automation, with one line each on what the role means for a pull request.
- States that the TOML is authoritative for approval counting and `CODEOWNERS` for review routing; the table is the mirror and is updated in the same pull request as any roster change.
- No change to the roster itself.

Protected path, so this waits out the 72-hour window before it merges.