### PR TITLE
ci(quorum): say in the red check what is being waited for

### DIFF
--- a/scripts/quorum_check.py
+++ b/scripts/quorum_check.py
@@ -446,6 +446,21 @@ def evaluate(pr: PullRequest, roster: Roster, owners: list[tuple[str, list[str]]
     return verdict
 
 
+def annotation(verdict: Verdict) -> str:
+    """The one line GitHub shows next to the red check.
+
+    It names the first unmet requirement and who can meet it, so a contributor
+    reads "waiting for two approvals" rather than "something is missing". The
+    full table stays in the job summary.
+    """
+    unmet = [req for req in verdict.requirements if not req.met]
+    if not unmet:
+        return verdict.title
+    first = unmet[0]
+    rest = f" (+{len(unmet) - 1} more in the job summary)" if len(unmet) > 1 else ""
+    return f"waiting for: {first.text} - {first.who}{rest}".replace("`", "")
+
+
 def pr_number_from_env(env: dict[str, str]) -> int | None:
     """The pull request under test, for each event that can trigger this.
 
@@ -487,7 +502,7 @@ def main(argv: list[str] | None = None) -> int:
         with open(summary_path, "a", encoding="utf-8") as handle:
             handle.write(summary + "\n")
     if not verdict.passed:
-        print(f"::error title=quorum::{verdict.title} - see the job summary for what is missing")
+        print(f"::error title=quorum::{annotation(verdict)}")
         return 1
     return 0
 

--- a/tests/unit/scripts/test_quorum_check.py
+++ b/tests/unit/scripts/test_quorum_check.py
@@ -335,3 +335,22 @@ def test_the_roster_and_codeowners_on_this_branch_load(qc: ModuleType) -> None:
     owners = qc.load_codeowners(str(REPO_ROOT))
     assert owners and owners[0][0] == "*"
     assert qc.owners_for(".github/workflows/ci.yml", owners) == ([loaded.maintainer], True)
+
+
+def test_annotation_names_the_first_unmet_requirement(qc: ModuleType) -> None:
+    verdict = qc.Verdict(passed=False, title="2 requirement(s) missing")
+    verdict.requirements.append(
+        qc.Requirement("2 approvals, 1 from a core reviewer (40 changed lines)", False, "@a, @b")
+    )
+    verdict.requirements.append(qc.Requirement("approval from the owner of `x.py`", False, "@m"))
+    assert qc.annotation(verdict) == (
+        "waiting for: 2 approvals, 1 from a core reviewer (40 changed lines) - @a, @b (+1 more in the job summary)"
+    )
+
+
+def test_annotation_strips_backticks_and_handles_a_single_gap(qc: ModuleType) -> None:
+    verdict = qc.Verdict(passed=False, title="1 requirement(s) missing")
+    verdict.requirements.append(
+        qc.Requirement("72 hours open for objections (touches `GOVERNANCE.md`)", False, "nobody")
+    )
+    assert qc.annotation(verdict) == "waiting for: 72 hours open for objections (touches GOVERNANCE.md) - nobody"


### PR DESCRIPTION
The red `quorum` check reads "1 requirement(s) missing - see the job summary". Contributors read that as "something is broken" and open the logs; the actual state is usually "waiting for two approvals".

- The annotation now names the first unmet requirement and who can meet it, e.g. `waiting for: 2 approvals, 1 from a core reviewer (263 changed lines) - @a, @b, @c`, with `(+N more in the job summary)` when there are several.
- The job summary table is unchanged.
- Two tests pin the line shape, including the backtick strip.

Protected path, so this waits out the 72-hour window.