### PR TITLE
ci: ask the roster for the reviews a pull request still needs

### DIFF
--- a/.github/workflows/quorum-rerun.yml
+++ b/.github/workflows/quorum-rerun.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       actions: write
     steps:
       - name: Harden runner (audit mode)
@@ -81,3 +81,18 @@ jobs:
                             or . == "scripts/quorum_check.py" or . == "scripts/queue_hygiene.py"))
                         | .number' \
             | while read -r pr; do rerun_for "$pr"; done
+
+      # The sweep also asks for what the check says is missing. Only the base
+      # branch is checked out, so this stays safe under the privileged trigger.
+      - name: Check out the scripts
+        if: github.event_name != 'pull_request_review'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Ask the roster for the reviews still missing
+        if: github.event_name != 'pull_request_review'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          QUORUM_REQUEST_REVIEWS: ${{ vars.QUORUM_REQUEST_REVIEWS }}
+        run: python3 scripts/quorum_request_reviews.py

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -223,7 +223,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/publish-extension.yml | workflow: {"contents": "read"}<br>publish: {"contents": "read"} | OPEN_VSX_TOKEN, VS_MARKETPLACE_TOKEN |
 | .github/workflows/publish-homebrew.yml | workflow: {"contents": "read"}<br>update-formula: {"contents": "read"} | HOMEBREW_TAP_TOKEN |
 | .github/workflows/publish.yml | build: {"contents": "read"}<br>github-release: {"actions": "write", "contents": "write"}<br>protocol-gate: {"contents": "read"}<br>publish: {"attestations": "write", "contents": "read", "id-token": "write"}<br>publish-copr: {"contents": "read"}<br>publish-mcp-registry: {"contents": "read", "id-token": "write"}<br>publish-npm: {"contents": "read"}<br>rpm-install-smoke: {"contents": "read"}<br>test: {"contents": "read"}<br>version-check: {"contents": "read"} | COPR_CONFIG, GITHUB_TOKEN, NPM_TOKEN |
-| .github/workflows/quorum-rerun.yml | workflow: {"contents": "read"}<br>rerun: {"actions": "write", "contents": "read", "pull-requests": "read"} | GITHUB_TOKEN |
+| .github/workflows/quorum-rerun.yml | workflow: {"contents": "read"}<br>rerun: {"actions": "write", "contents": "read", "pull-requests": "write"} | GITHUB_TOKEN |
 | .github/workflows/quorum.yml | workflow: {"contents": "read"}<br>quorum: {"contents": "read", "pull-requests": "read"} | GITHUB_TOKEN |
 | .github/workflows/reconcile-release.yml | reconcile: {"contents": "read", "issues": "write"} | - |
 | .github/workflows/release-major-minor.yml | workflow: {"contents": "read"}<br>release: {"contents": "write", "pull-requests": "write"} | BERNSTEIN_AUTOSYNC_TOKEN, GITHUB_TOKEN |

--- a/scripts/quorum_request_reviews.py
+++ b/scripts/quorum_request_reviews.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Ask the roster for the reviews a pull request is still missing.
+
+The `quorum` check says what a pull request waits for; nothing asks anyone.
+GitHub requests reviews from CODEOWNERS only, and the `*` owner is the
+maintainer, so every contributor pull request waits on one person by default.
+This script runs from the hourly sweep and, for each open pull request that
+still needs approvals, requests them from roster members who may give them:
+
+- never the author, anyone who pushed to the branch, or a co-author, and
+  never the maintainer (CODEOWNERS already requests them where it matters);
+- never someone who already has a standing review on the current head;
+- core reviewers first while a core approval is still missing;
+- the least-loaded eligible person first (fewest open review requests in the
+  repository), ties broken by login, so two sweeps agree on the same answer;
+- at most REQUESTS_PER_SWEEP new requests per run and at most
+  OPEN_REQUESTS_PER_REVIEWER standing requests per person, so a backlog is
+  spread over hours rather than dumped on six people at once.
+
+Nothing is requested while a roster member's *changes requested* stands: the
+author has something to do first. Automation and maintainer pull requests are
+skipped for the same reason as the maintainer: what they wait for is not a
+roster approval.
+
+Dry run when QUORUM_REQUEST_REVIEWS is "0" or `--dry-run` is given; the plan
+is printed either way, one line per pull request.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+REQUESTS_PER_SWEEP = 6
+OPEN_REQUESTS_PER_REVIEWER = 3
+
+
+def _load_quorum_check() -> ModuleType:
+    """`scripts/` is not a package; load the sibling module by path."""
+    path = Path(__file__).resolve().with_name("quorum_check.py")
+    spec = importlib.util.spec_from_file_location("quorum_check", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault(spec.name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+qc = _load_quorum_check()
+
+
+def approvals_needed(pr: Any) -> tuple[int, int]:
+    """(total, core) approvals a contributor change needs, as in the quorum check.
+
+    Same rule as `quorum_check.evaluate` (charter, section 3): three with two
+    core over 400 changed lines or on a sensitive path, otherwise two with one.
+    """
+    large = pr.changed_lines > qc.THIRD_APPROVAL_LINES
+    sensitive = any(word in path for path in pr.paths for word in qc.SENSITIVE_WORDS)
+    return (3, 2) if (large or sensitive) else (2, 1)
+
+
+def plan_requests(
+    pr: Any,
+    roster: Any,
+    requested: set[str],
+    load: dict[str, int],
+    *,
+    per_reviewer_cap: int = OPEN_REQUESTS_PER_REVIEWER,
+) -> list[str]:
+    """Who to ask for a review on this pull request, in order. Empty means nobody."""
+    if pr.is_draft or pr.author == roster.maintainer or pr.author in roster.automation:
+        return []
+    if pr.author == qc.GITHUB_ACTIONS_BOT:
+        return []
+
+    standing = qc.standing_reviews(pr.reviews)
+    holders = roster.quorum_holders | {roster.maintainer}
+    if any(r.state == "CHANGES_REQUESTED" and login in holders for login, r in standing.items()):
+        return []
+
+    may_approve = roster.quorum_holders - {roster.maintainer} - {pr.author} - pr.contributors
+    approving = {login for login, r in standing.items() if r.state == "APPROVED" and r.commit_id == pr.head_sha}
+    approving &= may_approve
+    need_total, need_core = approvals_needed(pr)
+    pending = requested & may_approve
+    missing_total = need_total - len(approving) - len(pending)
+    missing_core = need_core - len(approving & roster.core) - len(pending & roster.core)
+    if missing_total <= 0:
+        return []
+
+    reviewed_at_head = {login for login, r in standing.items() if r.commit_id == pr.head_sha}
+    candidates = sorted(
+        (login for login in may_approve - requested - reviewed_at_head if load.get(login, 0) < per_reviewer_cap),
+        key=lambda login: (load.get(login, 0), login),
+    )
+    picks: list[str] = []
+    for login in [c for c in candidates if c in roster.core]:
+        if missing_core <= 0 or len(picks) >= missing_total:
+            break
+        picks.append(login)
+        missing_core -= 1
+    for login in candidates:
+        if len(picks) >= missing_total:
+            break
+        if login not in picks:
+            picks.append(login)
+    return picks
+
+
+def open_pull_requests(repo: str) -> list[dict[str, Any]]:
+    pages = qc.gh_json("api", f"repos/{repo}/pulls?state=open&per_page=100", "--paginate", "--slurp")
+    return [pr for page in pages for pr in page]
+
+
+def needs_a_look(raw: dict[str, Any], roster: Any) -> bool:
+    """Cheap pre-filter on the list payload, before the four calls a full evaluation costs."""
+    author = (raw.get("user") or {}).get("login") or ""
+    if raw.get("draft") or not author:
+        return False
+    return author != roster.maintainer and author not in roster.automation and author != qc.GITHUB_ACTIONS_BOT
+
+
+def request_load(open_prs: list[dict[str, Any]]) -> dict[str, int]:
+    load: dict[str, int] = {}
+    for raw in open_prs:
+        for reviewer in raw.get("requested_reviewers") or []:
+            login = reviewer.get("login") or ""
+            if login:
+                load[login] = load.get(login, 0) + 1
+    return load
+
+
+def request_reviews(repo: str, number: int, logins: list[str]) -> bool:
+    payload = json.dumps({"reviewers": logins})
+    result = subprocess.run(
+        ["gh", "api", "--method", "POST", f"repos/{repo}/pulls/{number}/requested_reviewers", "--input", "-"],
+        input=payload,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        print(f"#{number}: request failed: {result.stderr.strip()[:200]}")
+        return False
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--root", default=".", help="where to read the roster and CODEOWNERS from")
+    parser.add_argument("--dry-run", action="store_true", help="print the plan, request nothing")
+    parser.add_argument("--limit", type=int, default=REQUESTS_PER_SWEEP, help="new requests per run")
+    args = parser.parse_args(argv)
+    if not args.repo:
+        parser.error("--repo owner/name is required (or GITHUB_REPOSITORY)")
+    dry_run = args.dry_run or os.environ.get("QUORUM_REQUEST_REVIEWS", "1") == "0"
+
+    roster = qc.load_roster(args.root)
+    owners = qc.load_codeowners(args.root)
+    now = datetime.now(UTC)
+    raw_prs = open_pull_requests(args.repo)
+    load = request_load(raw_prs)
+    budget = args.limit
+
+    for raw in sorted(raw_prs, key=lambda r: r.get("number") or 0):
+        if budget <= 0:
+            print(f"sweep budget of {args.limit} requests used; the rest waits for the next hour")
+            break
+        number = int(raw["number"])
+        if not needs_a_look(raw, roster):
+            continue
+        pr = qc.fetch_pull_request(args.repo, number)
+        if qc.evaluate(pr, roster, owners, now).passed:
+            continue
+        requested = {(r.get("login") or "") for r in raw.get("requested_reviewers") or []}
+        picks = plan_requests(pr, roster, requested, load)[:budget]
+        if not picks:
+            continue
+        names = ", ".join(f"@{login}" for login in picks)
+        if dry_run:
+            print(f"#{number}: would request {names}")
+        elif request_reviews(args.repo, number, picks):
+            print(f"#{number}: requested {names}")
+        else:
+            continue
+        budget -= len(picks)
+        for login in picks:
+            load[login] = load.get(login, 0) + 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/scripts/test_quorum_request_reviews.py
+++ b/tests/unit/scripts/test_quorum_request_reviews.py
@@ -1,0 +1,119 @@
+"""`scripts/quorum_request_reviews.py`: who gets asked for the reviews a change still needs."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "quorum_request_reviews.py"
+HEAD = "d" * 40
+OLD = "e" * 40
+
+
+@pytest.fixture(scope="module")
+def rr() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("quorum_request_reviews_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    loaded = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = loaded
+    spec.loader.exec_module(loaded)
+    return loaded
+
+
+@pytest.fixture(scope="module")
+def roster(rr: ModuleType):
+    return rr.qc.Roster(
+        maintainer="owner",
+        core_reviewers=frozenset({"core1", "core2"}),
+        committers=frozenset({"comm1", "comm2"}),
+        automation=frozenset({"the-conductor[bot]"}),
+    )
+
+
+def _review(rr: ModuleType, login: str, state: str, *, sha: str = HEAD):
+    return rr.qc.Review(login=login, state=state, commit_id=sha, submitted_at="2026-09-10T10:00:00Z")
+
+
+def _pr(
+    rr: ModuleType, *, author: str = "outsider", reviews=None, paths=None, changed_lines: int = 100, contributors=None
+):
+    return rr.qc.PullRequest(
+        number=7,
+        author=author,
+        is_draft=False,
+        head_sha=HEAD,
+        changed_lines=changed_lines,
+        paths=paths or ["src/bernstein/adapters/aider.py"],
+        reviews=reviews or [],
+        contributors=contributors if contributors is not None else {author},
+        last_push=datetime(2026, 9, 10, 11, 0, tzinfo=UTC) - timedelta(hours=1),
+    )
+
+
+def test_asks_two_with_a_core_reviewer_first_and_lowest_load(rr, roster) -> None:
+    load = {"core1": 2, "core2": 0, "comm1": 0, "comm2": 1}
+    assert rr.plan_requests(_pr(rr), roster, set(), load) == ["core2", "comm1"]
+
+
+def test_a_core_approval_leaves_one_more_to_ask_from_anyone(rr, roster) -> None:
+    pr = _pr(rr, reviews=[_review(rr, "core1", "APPROVED")])
+    assert rr.plan_requests(pr, roster, set(), {}) == ["comm1"]
+
+
+def test_a_committer_approval_still_needs_a_core_reviewer(rr, roster) -> None:
+    pr = _pr(rr, reviews=[_review(rr, "comm1", "APPROVED")])
+    assert rr.plan_requests(pr, roster, set(), {"core1": 1}) == ["core2"]
+
+
+def test_a_standing_request_counts_and_is_not_repeated(rr, roster) -> None:
+    assert rr.plan_requests(_pr(rr), roster, {"core1"}, {}) == ["comm1"]
+    assert rr.plan_requests(_pr(rr), roster, {"core1", "comm2"}, {}) == []
+
+
+def test_author_pushers_coauthors_and_the_maintainer_are_never_asked(rr, roster) -> None:
+    pr = _pr(rr, contributors={"outsider", "core1", "comm1"})
+    assert rr.plan_requests(pr, roster, set(), {}) == ["core2", "comm2"]
+
+
+def test_maintainer_and_automation_changes_ask_nobody(rr, roster) -> None:
+    assert rr.plan_requests(_pr(rr, author="owner", contributors={"owner"}), roster, set(), {}) == []
+    assert rr.plan_requests(_pr(rr, author="the-conductor[bot]"), roster, set(), {}) == []
+
+
+def test_a_standing_changes_requested_pauses_the_asking(rr, roster) -> None:
+    pr = _pr(rr, reviews=[_review(rr, "comm2", "CHANGES_REQUESTED")])
+    assert rr.plan_requests(pr, roster, set(), {}) == []
+
+
+def test_a_stale_approval_means_that_reviewer_is_asked_again(rr, roster) -> None:
+    pr = _pr(rr, reviews=[_review(rr, "core1", "APPROVED", sha=OLD)])
+    assert rr.plan_requests(pr, roster, set(), {"core2": 1, "comm1": 1, "comm2": 1}) == ["core1", "comm1"]
+
+
+def test_a_sensitive_change_asks_for_three_with_two_core(rr, roster) -> None:
+    pr = _pr(rr, paths=["src/bernstein/core/security/policy.py"])
+    assert rr.plan_requests(pr, roster, set(), {}) == ["core1", "core2", "comm1"]
+
+
+def test_the_per_reviewer_cap_skips_the_overloaded(rr, roster) -> None:
+    load = {"core1": 3, "core2": 3, "comm1": 0, "comm2": 0}
+    assert rr.plan_requests(_pr(rr), roster, set(), load) == ["comm1", "comm2"]
+
+
+def test_request_load_counts_standing_requests(rr) -> None:
+    prs = [{"requested_reviewers": [{"login": "a"}, {"login": "b"}]}, {"requested_reviewers": [{"login": "a"}]}]
+    assert rr.request_load(prs) == {"a": 2, "b": 1}
+
+
+def test_only_contributor_changes_get_the_full_evaluation(rr, roster) -> None:
+    assert rr.needs_a_look({"user": {"login": "outsider"}, "draft": False}, roster)
+    assert not rr.needs_a_look({"user": {"login": "outsider"}, "draft": True}, roster)
+    assert not rr.needs_a_look({"user": {"login": "owner"}, "draft": False}, roster)
+    assert not rr.needs_a_look({"user": {"login": "the-conductor[bot]"}, "draft": False}, roster)
+    assert not rr.needs_a_look({"user": {"login": "github-actions[bot]"}, "draft": False}, roster)


### PR DESCRIPTION
## What

The hourly quorum sweep now requests the approvals a contributor pull request is still missing from roster members who may give them.

## Why

The \`quorum\` check reports what a change waits for, but nothing asks anyone. CODEOWNERS routes every review request to the maintainer, so a contributor pull request sits until someone notices it by hand.

## Rules

- never the author, anyone who pushed to the branch, or a co-author; never the maintainer
- never someone who already reviewed the current head
- core reviewers first while a core approval is still missing
- the least-loaded eligible person first (fewest open requests in the repository), ties by login
- at most 6 new requests per sweep, at most 3 open requests per person
- nothing is requested while a roster member's *changes requested* stands
- maintainer, automation and draft pull requests are skipped

## Safety

- the sweep step runs only on \`schedule\` and \`workflow_dispatch\`, never on the \`pull_request_review\` trigger
- only the base branch is checked out, with \`persist-credentials: false\`
- repository variable \`QUORUM_REQUEST_REVIEWS=0\` (or \`--dry-run\`) prints the plan and requests nothing

## Verification

- 12 unit tests in \`tests/unit/scripts/test_quorum_request_reviews.py\` cover the selection rules
- a dry run against the live repository planned three requests, one per waiting pull request