### PR TITLE
ci: run the merge-queue lane on ubuntu cells only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1842,7 +1842,14 @@ jobs:
         # macOS-sensitive, the PR carries the `macos-needed` label, or
         # the event is a push. ci-macos-nightly.yml provides a daily
         # safety-net run of the full macOS matrix.
-        os: [ubuntu-latest, windows-latest]
+        # The merge-queue lane runs the ubuntu cells only. Every entry in the
+        # queue already passed the Windows cells on its own pull request, and
+        # push-to-main runs them again minutes after the merge, so the queue
+        # build was paying four Windows jobs per entry to re-check a
+        # combination the push run checks anyway. A Windows-only regression
+        # that only appears in the combination surfaces one merge later and
+        # is answered with a revert.
+        os: ${{ github.event_name == 'merge_group' && fromJSON('["ubuntu-latest"]') || fromJSON('["ubuntu-latest", "windows-latest"]') }}
         # Only push-to-main runs the full interpreter matrix; PR and
         # merge-queue lanes run the primary interpreter (3.13) alone. The
         # queue ran both rows, which doubled its ubuntu shard fan-out to


### PR DESCRIPTION
## What

The `test` matrix drops the Windows cells on `merge_group` events only. Pull requests and pushes to `main` keep the full matrix.

## Why

Every queue entry already passed the Windows cells on its own pull request, and the push to `main` runs them again minutes after the merge. The queue build was paying four Windows jobs per entry to re-check a combination the push run checks anyway; with several entries building in parallel those jobs were most of the hosted-runner load.

## Risk

A Windows-only regression that appears only in the combined diff surfaces one merge later, on the push run, and is answered with a revert. The standalone Windows adapter-conformance job still runs in the queue.