### PR TITLE
ci: run the nightly drift sweep on the project's own runner

### DIFF
--- a/.github/workflows/nightly-drift-sweep.yml
+++ b/.github/workflows/nightly-drift-sweep.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   sweep:
     name: Open drift-sweep PR if mirrors drifted
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     environment: automation
     timeout-minutes: 15
     permissions:

--- a/tests/unit/test_self_hosted_runner_scope.py
+++ b/tests/unit/test_self_hosted_runner_scope.py
@@ -8,8 +8,9 @@ triggers a job may combine with a self-hosted ``runs-on`` are ``schedule``,
 ``workflow_call``, ``issue_comment`` -- can carry a contributor's revision and
 is refused here, so the mistake is caught in review rather than on the box.
 
-No workflow uses a self-hosted runner today; this pins the rule for the first
-one that does.
+Every workflow moved onto the project's own runner is covered here, so a
+later edit that widens its triggers reddens this test instead of silently
+exposing the box.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Moves `nightly-drift-sweep.yml` onto the project's own Linux runner.

**Why.** The sweep is a scheduled maintenance run on `main`. It needs git, uv, Python and the GitHub CLI, all of which the runner image ships, so it does not depend on a hosted image. Running it on the project's own runner keeps the scheduled lane independent of hosted-runner availability.

**Scope.** `runs-on` only. Triggers stay `schedule` + `workflow_dispatch`, so the job still only ever executes code that is already merged.

**Guard.** `tests/unit/test_self_hosted_runner_scope.py` already refuses any self-hosted job in a workflow with a trigger that can carry unmerged code (`pull_request`, `pull_request_target`, `merge_group`, `workflow_run`, `workflow_call`, or a `push` wider than `branches: [main]`). It now covers this workflow; the only change to it is a module docstring line that said no workflow used a self-hosted runner yet.

The runner group is additionally restricted to an explicit workflow allowlist, always pinned to `@refs/heads/main`.