### PR TITLE
perf(ci): run the macOS legs only where they can observe something new

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1722,12 +1722,20 @@ jobs:
     #      cross-platform work that the path filter cannot detect).
     # Otherwise this job is skipped on PRs and ci-macos-nightly.yml
     # provides the safety net.
+    #
+    # `merge_group` is excluded outright. A queued group re-checks the
+    # same platform surface that the post-merge push to `main` checks
+    # minutes later on the very same tree, so the queue copy cannot
+    # observe a regression the push copy does not. The `CI gate` roll-up
+    # tolerates the skip unconditionally on that event
+    # (MACOS_UNCONDITIONAL_SKIP_EVENTS).
     name: Adapter integration (fake-CLI, macOS)
     needs: [lint, determine-changes]
     if: >-
-      github.event_name == 'push' ||
-      needs.determine-changes.outputs.macos_sensitive == 'true' ||
-      contains(github.event.pull_request.labels.*.name, 'macos-needed')
+      github.event_name != 'merge_group' &&
+      (github.event_name == 'push' ||
+       needs.determine-changes.outputs.macos_sensitive == 'true' ||
+       contains(github.event.pull_request.labels.*.name, 'macos-needed'))
     runs-on: macos-latest
     timeout-minutes: 15
     permissions:
@@ -2126,9 +2134,10 @@ jobs:
 
   test-macos:
     # macOS half of the test matrix, split out for #1468 (macOS hosted
-    # runner saturation). Runs unconditionally on push (so every commit
-    # that reaches main has a fresh macOS signal), and on PRs only when
-    # one of the gate conditions is met:
+    # runner saturation). Four sharded macOS runners, so this is the
+    # most expensive leg in the workflow; it runs only where it can
+    # observe something the cheaper legs cannot. The gate is the same
+    # on every event that runs it:
     #   - the planner classified the diff as macos_sensitive (touched
     #     a module with `sys.platform == "darwin"` branches, the
     #     tunnels driver layer, the daemon installer, the runtime
@@ -2136,11 +2145,16 @@ jobs:
     #     ci.yml / ci-macos-nightly.yml themselves);
     #   - the PR carries the `macos-needed` label (operator opt-in for
     #     cross-platform work the path filter cannot detect).
-    # Otherwise this job is skipped on the PR and ci-macos-nightly.yml
-    # provides the safety-net coverage at 06:00 UTC each day. The merge
-    # queue (merge_group) skips this job entirely (see the ci-gate
-    # MACOS_SKIP_EVENTS handling) - the post-merge push carries the
-    # macOS signal for a queued group.
+    # A push to `main` whose diff touches none of the platform paths no
+    # longer runs these shards: the non-platform diff is already covered
+    # by the ubuntu/windows `test` matrix on the same commit, and
+    # ci-macos-nightly.yml re-runs the whole macOS suite at 06:00 UTC
+    # daily, so the shards were re-asserting a result nothing in the
+    # diff could have changed. `CI gate` tolerates that skip through
+    # MACOS_PUSH_GATED.
+    # The merge queue (merge_group) never runs this job: the `if:`
+    # excludes the event, and the post-merge push carries whatever macOS
+    # signal a queued group's diff earns.
     #
     # Coverage / JUnit / Codecov uploads are NOT mirrored here; they
     # remain ubuntu-only (matches the previous matrix gating).
@@ -2164,9 +2178,9 @@ jobs:
     name: Test (macos-latest, Python 3.13, shard ${{ matrix.shard }})
     needs: [lint, determine-changes]
     if: >-
-      github.event_name == 'push' ||
-      needs.determine-changes.outputs.macos_sensitive == 'true' ||
-      contains(github.event.pull_request.labels.*.name, 'macos-needed')
+      github.event_name != 'merge_group' &&
+      (needs.determine-changes.outputs.macos_sensitive == 'true' ||
+       contains(github.event.pull_request.labels.*.name, 'macos-needed'))
     runs-on: macos-latest
     timeout-minutes: 90
     permissions:
@@ -2416,8 +2430,19 @@ jobs:
           }
           # macOS-gated jobs (see #1468): on PRs these are skipped unless
           # the diff is macos_sensitive or the PR carries the
-          # `macos-needed` label. Always run on push events.
+          # `macos-needed` label.
           MACOS_GATED = {"test-macos", "adapter-integration-macos"}
+          # `test-macos` is the four-shard macOS test matrix, and it is
+          # gated on `push` too: it runs on a push to `main` only when the
+          # planner flags the diff as macos_sensitive. A push whose diff
+          # touches none of the platform paths cannot regress what those
+          # shards check that the ubuntu/windows `test` matrix on the same
+          # commit does not already check, and ci-macos-nightly.yml re-runs
+          # the full macOS suite daily. adapter-integration-macos is
+          # deliberately not in this set: it is one short job, so it keeps
+          # running on every push and every merged commit still gets a
+          # macOS signal.
+          MACOS_PUSH_GATED = {"test-macos"}
           # Push-only jobs are required on native main pushes but skip
           # intentionally on PR, workflow_dispatch, and merge_group runs.
           PUSH_ONLY = {"coverage-report"}
@@ -2431,21 +2456,21 @@ jobs:
           # install-smoke-rpm-nightly.yml is the safety net that still
           # exercises the released artifact on days nothing here changes.
           RPM_SMOKE_SKIPPABLE = {"install-smoke-rpm"}
-          # Events under which a macOS-gated skip is intentional. PRs and
-          # manual dispatch already gate macOS behind macos_sensitive /
-          # label. merge_group must be included too: a merge queue runs CI
-          # on a synthetic merge_group ref where `github.event.pull_request`
-          # is null, so the `macos-needed` label and `push`-only branches of
-          # the job `if:` can never be true there. The remaining branch,
-          # `macos_sensitive`, is computed by `determine-changes` from the
-          # group's combined diff, so a macOS-sensitive group still runs the
-          # macOS jobs in the queue and this tolerance does not apply. A group
-          # that touches nothing macOS-sensitive skips them: the merged commit
-          # still triggers a native `push` to main that runs the full macOS
-          # suite un-gated, and ci-macos-nightly.yml covers regression -- so
-          # tolerating that skip is what keeps the queue from wedging without
-          # losing macOS coverage on what actually lands.
+          # Events under which a macOS-gated skip can be intentional. PRs
+          # and manual dispatch gate macOS behind macos_sensitive / label;
+          # merge_group excludes the macOS jobs outright.
           MACOS_SKIP_EVENTS = ("pull_request", "workflow_dispatch", "merge_group")
+          # The subset of the above where the skip needs no further
+          # justification, because the job `if:` refuses the event whatever
+          # the planner said. Both macOS jobs carry
+          # `github.event_name != 'merge_group'`: a queued group re-checks
+          # the same platform surface the post-merge push to `main` checks
+          # minutes later on the very same tree, so the queue copy cannot
+          # observe a regression the push copy does not. Coverage on what
+          # actually lands is unchanged -- the merged commit triggers a
+          # native `push` to main, and ci-macos-nightly.yml is the daily
+          # safety net for the rest.
+          MACOS_UNCONDITIONAL_SKIP_EVENTS = ("merge_group",)
 
           docs_only = plan.get("docs_only") == "true"
           macos_sensitive = plan.get("macos_sensitive") == "true"
@@ -2478,20 +2503,26 @@ jobs:
                   if name in RPM_SMOKE_SKIPPABLE and not rpm_relevant_changed:
                       continue
                   # macOS-gated jobs are allowed to skip on:
+                  #  - merge_group (merge-queue ref), unconditionally: the
+                  #    job `if:` excludes the event, and the post-merge
+                  #    push re-checks the same tree.
                   #  - PRs when diff is not macos_sensitive AND no
                   #    `macos-needed` label.
                   #  - workflow_dispatch (manual re-runs from hotfix
                   #    agents) when diff is not macos_sensitive.
-                  #  - merge_group (merge-queue ref) where the label/push
-                  #    branches of the job `if:` cannot be true; the
-                  #    post-merge push to main runs macOS un-gated.
-                  # On native push events macOS must run.
                   # Nightly ci-macos-nightly.yml covers regression.
+                  if name in MACOS_GATED and event in MACOS_SKIP_EVENTS:
+                      if event in MACOS_UNCONDITIONAL_SKIP_EVENTS:
+                          continue
+                      if not macos_sensitive and not macos_labelled:
+                          continue
+                  # On a native push, adapter-integration-macos must run,
+                  # but the test-macos shards run only for a
+                  # macos_sensitive diff (see MACOS_PUSH_GATED).
                   if (
-                      name in MACOS_GATED
-                      and event in MACOS_SKIP_EVENTS
+                      name in MACOS_PUSH_GATED
+                      and event == "push"
                       and not macos_sensitive
-                      and not macos_labelled
                   ):
                       continue
               bad.append((name, r))

--- a/docs/operations/ci.md
+++ b/docs/operations/ci.md
@@ -109,11 +109,16 @@ with `sys.platform == "darwin"` branches).
 
 ### What runs when
 
+The two macOS jobs are `test-macos` (four sharded macOS runners, the
+whole suite) and `adapter-integration-macos` (one short job).
+
 | Event | macOS jobs trigger? | Notes |
 |-------|---------------------|-------|
-| `push` to `main` | Always | Every merged commit gets a fresh macOS signal |
-| PR with `macos-needed` label | Always | Operator opt-in for cross-platform work |
-| PR touching macOS-sensitive paths | Always | Path filter in `determine-changes` |
+| `push` to `main`, macOS-sensitive diff | Both | Path filter in `determine-changes` |
+| `push` to `main`, any other diff | `adapter-integration-macos` only | Every merged commit still gets a macOS signal; the `test-macos` shards would only re-assert what the ubuntu/windows `test` matrix already checked on the same commit |
+| Merge queue (`merge_group`) | Neither | The post-merge `push` re-checks the same tree minutes later |
+| PR with `macos-needed` label | Both | Operator opt-in for cross-platform work |
+| PR touching macOS-sensitive paths | Both | Path filter in `determine-changes` |
 | Other PRs | Skipped | Nightly catches drift within 24h |
 | Daily 06:00 UTC schedule | Full macOS matrix | `ci-macos-nightly.yml` |
 
@@ -481,7 +486,11 @@ intentional-skip allow-lists. The aggregator understands:
 
 - `docs_only` skips for content-only changes
 - `PR_ONLY` / `PUSH_ONLY` event-gated jobs
-- `MACOS_GATED` jobs that legitimately skip on non-macOS-sensitive PRs
+- `MACOS_GATED` jobs that legitimately skip on non-macOS-sensitive PRs,
+  and unconditionally on a `merge_group` ref
+  (`MACOS_UNCONDITIONAL_SKIP_EVENTS`)
+- `MACOS_PUSH_GATED` - the `test-macos` shards, which also skip on a push
+  to `main` whose diff is not macOS-sensitive
 
 If you add a new conditionally-gated job, register it in the
 appropriate allow-list inside the `roll-up` step of `ci-gate`.

--- a/docs/operations/merge-queue.md
+++ b/docs/operations/merge-queue.md
@@ -235,16 +235,25 @@ docs-only.
 
 ## macOS coverage under the queue
 
-The macOS matrix (`test-macos`, `adapter-integration-macos`) is **gated**:
-it runs on `push` to `main`, on macOS-sensitive diffs, and on the
-`macos-needed` label. On a queued group the label and `push` branches cannot
-fire, so `macos_sensitive` - computed from the group's combined diff - is what
-decides: a group touching a macOS-sensitive path runs the macOS cells in the
-queue, and a group that does not skips them. The `CI gate` roll-up tolerates
-exactly that skip (see `MACOS_SKIP_EVENTS` in `ci.yml`). Coverage is preserved
-because the **post-merge `push` to `main`** runs the full macOS suite
-un-gated, and `ci-macos-nightly.yml` is the daily safety net. The queue
-validates the integrated combination; the merged commit validates macOS.
+The macOS matrix (`test-macos`, `adapter-integration-macos`) **never runs in
+the queue**. Both jobs carry `github.event_name != 'merge_group'`.
+
+The reason is that a queue build cannot observe anything new on that surface.
+The group's merge commit is the tree that lands on `main`, and the
+**post-merge `push` to `main`** re-runs the same platform checks against it
+minutes later. Running them inside the group buys a duplicate of a result the
+push produces anyway, while the group sits at the head of the queue and every
+entry behind it waits.
+
+The `CI gate` roll-up tolerates the skip unconditionally on this event -- see
+`MACOS_UNCONDITIONAL_SKIP_EVENTS` in `ci.yml`, a subset of `MACOS_SKIP_EVENTS`
+-- so a queued group is never wedged waiting on a job that cannot start.
+
+Coverage on what actually lands: the post-merge push runs
+`adapter-integration-macos` on every commit and the `test-macos` shards
+whenever the diff touches a macOS-sensitive path, and `ci-macos-nightly.yml`
+re-runs the whole macOS suite at 06:00 UTC daily. The queue validates the
+integrated combination; the merged commit validates macOS.
 
 ## Auto-release through the queue
 

--- a/tests/unit/test_merge_queue_gate_coverage_yaml.py
+++ b/tests/unit/test_merge_queue_gate_coverage_yaml.py
@@ -849,18 +849,82 @@ def test_macos_tolerance_covers_the_merge_group_event(
 ) -> None:
     """The roll-up must tolerate the macOS skip on a queued group.
 
-    The macOS jobs gate on ``push``, on a ``macos-needed`` label, or on
-    the planner's ``macos_sensitive`` verdict. On a merge group there is
-    no pull request payload, so the label branch cannot fire and only the
-    planner's verdict can start them. Without ``merge_group`` in the
-    tolerated-skip events, every non-macOS-sensitive group fails
+    Both macOS jobs carry ``github.event_name != 'merge_group'``, so they
+    skip on every queued group whatever the planner said. Without
+    ``merge_group`` in the tolerated-skip events, every group fails
     ``CI gate`` and nothing ever merges.
     """
     events = rollup_constants.get("MACOS_SKIP_EVENTS")
     assert events, "the roll-up no longer declares MACOS_SKIP_EVENTS"
     assert "merge_group" in events, (
-        f"MACOS_SKIP_EVENTS is {events!r}. A queued group cannot set the `macos-needed` label branch, so the "
-        "macOS cells skip and `CI gate` fails on every group whose diff is not macOS-sensitive."
+        f"MACOS_SKIP_EVENTS is {events!r}. The macOS jobs never start on a queued group, so the macOS cells "
+        "skip and `CI gate` fails on every group."
+    )
+
+
+def test_merge_group_macos_tolerance_does_not_depend_on_the_planner(
+    rollup_constants: dict[str, Any],
+) -> None:
+    """The queued-group tolerance must be unconditional, not planner-gated.
+
+    The macOS jobs refuse the ``merge_group`` event outright, so a group
+    whose combined diff *is* macOS-sensitive skips them exactly like any
+    other group. A tolerance still keyed on ``macos_sensitive`` would flag
+    that skip and wedge the queue on precisely the groups that touch the
+    platform paths.
+    """
+    unconditional = rollup_constants.get("MACOS_UNCONDITIONAL_SKIP_EVENTS")
+    assert unconditional, "the roll-up no longer declares MACOS_UNCONDITIONAL_SKIP_EVENTS"
+    assert "merge_group" in unconditional, (
+        f"MACOS_UNCONDITIONAL_SKIP_EVENTS is {unconditional!r}. A macOS-sensitive group would then have to "
+        "produce macOS results it can never produce, and the queue wedges."
+    )
+    events = rollup_constants.get("MACOS_SKIP_EVENTS") or ()
+    assert set(unconditional) <= set(events), (
+        f"MACOS_UNCONDITIONAL_SKIP_EVENTS {unconditional!r} is not a subset of MACOS_SKIP_EVENTS {events!r}. "
+        "The unconditional branch is only reached for events the outer check already admits."
+    )
+
+
+def test_macos_jobs_refuse_the_merge_group_event(ci_jobs: dict[str, Any]) -> None:
+    """The job `if:`s must be what actually keeps macOS out of the queue.
+
+    The roll-up tolerance above is only safe while the jobs really cannot
+    start on a queued group. If an `if:` regains a branch that fires on
+    ``merge_group``, the queue pays for macOS again and the tolerance
+    silently becomes a hole that would accept a genuine skip.
+    """
+    for key in ("test-macos", "adapter-integration-macos"):
+        job = ci_jobs.get(key)
+        assert isinstance(job, dict), f"ci.yml must keep a `{key}` job"
+        condition = " ".join(str(job.get("if", "")).split())
+        assert "github.event_name != 'merge_group'" in condition, (
+            f"`{key}.if` is {condition!r}; it no longer excludes the merge queue, but the roll-up still "
+            "tolerates its skip on that event unconditionally."
+        )
+
+
+def test_test_macos_has_no_unconditional_push_branch(ci_jobs: dict[str, Any]) -> None:
+    """The macOS shards must be planner-gated on push, not automatic.
+
+    ``test-macos`` fans out over four macOS runners. On a push whose diff
+    touches none of the platform paths those shards re-assert what the
+    ubuntu/windows ``test`` matrix already checked on the same commit, so
+    the job gates on ``macos_sensitive`` there too and the roll-up carries
+    the matching ``MACOS_PUSH_GATED`` tolerance. A bare
+    ``github.event_name == 'push'`` branch would put them back on every
+    merge while that tolerance quietly accepts a real skip.
+    """
+    job = ci_jobs.get("test-macos")
+    assert isinstance(job, dict), "ci.yml must keep a `test-macos` job"
+    condition = " ".join(str(job.get("if", "")).split())
+    assert "github.event_name == 'push'" not in condition, (
+        f"`test-macos.if` is {condition!r}; the push branch is back, so every merge to main pays for the "
+        "macOS shards again."
+    )
+    assert "macos_sensitive" in condition, (
+        f"`test-macos.if` is {condition!r}; without the planner's verdict the job can no longer run on a "
+        "push that does touch a macOS-sensitive path."
     )
 
 

--- a/tests/unit/test_required_check_canary_workflow_yaml.py
+++ b/tests/unit/test_required_check_canary_workflow_yaml.py
@@ -446,10 +446,10 @@ def _run_rollup(
     )
 
 
-# A typical (non-macOS-sensitive) merge_group entry: every required job
-# succeeds except the ones whose `if:` excludes merge_group. Under
-# merge_group: macOS-gated jobs skip (if: only fires on push / sensitive /
-# label), and PR-only jobs skip (if: pull_request).
+# A typical merge_group entry: every required job succeeds except the ones
+# whose `if:` excludes merge_group. Under merge_group: the macOS jobs skip
+# (both carry `github.event_name != 'merge_group'`), and PR-only jobs skip
+# (if: pull_request).
 _MERGE_GROUP_NEEDS = {
     "determine-changes": {"result": "success"},
     "repo-hygiene": {"result": "success"},
@@ -471,9 +471,9 @@ _MERGE_GROUP_NEEDS = {
     "beartype": {"result": "success"},
     "pyright-strict-zone": {"result": "success"},
     "adapter-integration": {"result": "success"},
-    "adapter-integration-macos": {"result": "skipped"},  # if: push/sensitive/label
+    "adapter-integration-macos": {"result": "skipped"},  # if: != merge_group
     "test": {"result": "success"},
-    "test-macos": {"result": "skipped"},  # if: push/sensitive/label
+    "test-macos": {"result": "skipped"},  # if: != merge_group
 }
 
 
@@ -481,9 +481,9 @@ def test_ci_gate_rollup_passes_on_merge_group(ci_doc: dict[str, object], tmp_pat
     """The shipped roll-up must PASS on a merge_group event whose only
     non-success jobs are the ones legitimately skipped under merge_group.
 
-    If this fails, a GitHub merge queue would wedge: the first queued entry
-    with a non-macOS-sensitive diff makes test-macos / adapter-integration-macos
-    skip, and an intolerant gate reads that as a failure -> nothing merges.
+    If this fails, a GitHub merge queue would wedge: every queued entry
+    makes test-macos / adapter-integration-macos skip, and an intolerant
+    gate reads that as a failure -> nothing merges.
     """
     script = _ci_gate_rollup_script(ci_doc)
     proc = _run_rollup(
@@ -539,6 +539,109 @@ def test_ci_gate_rollup_passes_on_push(ci_doc: dict[str, object], tmp_path: Path
         plan={"docs_only": "false", "macos_sensitive": "false"},
     )
     assert proc.returncode == 0, f"CI gate roll-up must pass on push.\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+
+
+def test_ci_gate_rollup_passes_on_a_macos_sensitive_merge_group(ci_doc: dict[str, object], tmp_path: Path) -> None:
+    """A queued group that touches macOS paths must pass too.
+
+    Both macOS jobs carry `github.event_name != 'merge_group'`, so they
+    skip on every group -- including one whose combined diff is
+    macOS-sensitive. A tolerance still keyed on `macos_sensitive` would
+    flag that skip and wedge the queue on exactly the entries that touch
+    the platform surface. The post-merge push to `main` re-checks the same
+    tree minutes later.
+    """
+    script = _ci_gate_rollup_script(ci_doc)
+    proc = _run_rollup(
+        tmp_path,
+        script,
+        needs=_MERGE_GROUP_NEEDS,
+        event="merge_group",
+        plan={"docs_only": "false", "macos_sensitive": "true"},
+    )
+    assert proc.returncode == 0, (
+        "CI gate roll-up FAILED on a macOS-sensitive merge_group -- the queue would wedge on every entry "
+        f"that touches a platform path.\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+
+
+def test_ci_gate_rollup_tolerates_the_macos_shards_skipping_on_a_plain_push(
+    ci_doc: dict[str, object], tmp_path: Path
+) -> None:
+    """`test-macos` skips on a push whose diff is not macOS-sensitive.
+
+    Four sharded macOS runners cannot observe anything on such a push that
+    the ubuntu/windows `test` matrix does not already observe on the same
+    commit, and ci-macos-nightly.yml re-runs the whole macOS suite daily.
+    Pins MACOS_PUSH_GATED: without it every merge to `main` red-gates.
+    """
+    script = _ci_gate_rollup_script(ci_doc)
+    needs = dict(_MERGE_GROUP_NEEDS)
+    needs["test-macos"] = {"result": "skipped"}
+    needs["adapter-integration-macos"] = {"result": "success"}
+    proc = _run_rollup(
+        tmp_path,
+        script,
+        needs=needs,
+        event="push",
+        plan={"docs_only": "false", "macos_sensitive": "false"},
+    )
+    assert proc.returncode == 0, (
+        "CI gate roll-up FAILED to tolerate a test-macos skip on a non-macOS-sensitive push to main."
+        f"\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+
+
+def test_ci_gate_rollup_fails_when_the_macos_shards_skip_a_macos_sensitive_push(
+    ci_doc: dict[str, object], tmp_path: Path
+) -> None:
+    """The push tolerance must not become a rubber stamp.
+
+    When the planner says the pushed diff touched a macOS-sensitive path,
+    `test-macos` has to produce a result. A skip there is the silent hole
+    the tolerance must not cover.
+    """
+    script = _ci_gate_rollup_script(ci_doc)
+    needs = dict(_MERGE_GROUP_NEEDS)
+    needs["test-macos"] = {"result": "skipped"}
+    needs["adapter-integration-macos"] = {"result": "success"}
+    proc = _run_rollup(
+        tmp_path,
+        script,
+        needs=needs,
+        event="push",
+        plan={"docs_only": "false", "macos_sensitive": "true"},
+    )
+    assert proc.returncode == 1, (
+        "CI gate roll-up must FAIL when test-macos skips on a macOS-sensitive push to main."
+        f"\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+
+
+def test_ci_gate_rollup_still_requires_adapter_integration_macos_on_push(
+    ci_doc: dict[str, object], tmp_path: Path
+) -> None:
+    """Only the sharded job is push-gated; the short one still runs.
+
+    `adapter-integration-macos` is a single job, so every merged commit
+    keeps a macOS signal. It is deliberately absent from MACOS_PUSH_GATED,
+    and a skip on push must still fail the gate.
+    """
+    script = _ci_gate_rollup_script(ci_doc)
+    needs = dict(_MERGE_GROUP_NEEDS)
+    needs["test-macos"] = {"result": "skipped"}
+    needs["adapter-integration-macos"] = {"result": "skipped"}
+    proc = _run_rollup(
+        tmp_path,
+        script,
+        needs=needs,
+        event="push",
+        plan={"docs_only": "false", "macos_sensitive": "false"},
+    )
+    assert proc.returncode == 1, (
+        "CI gate roll-up must FAIL when adapter-integration-macos skips on a push to main -- otherwise a "
+        f"merged commit can land with no macOS signal at all.\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
 
 
 def test_ci_gate_rollup_tolerates_rpm_smoke_skip_when_diff_is_rpm_irrelevant(


### PR DESCRIPTION
## What

The macOS legs stop running on the two paths where they cannot observe anything new:

| Job | `merge_group` | `push` to `main` | Pull request |
|---|---|---|---|
| `test-macos` (4 macOS shards) | **never** (was: when the group diff was macOS-sensitive) | **only when the diff is macOS-sensitive** (was: always) | unchanged - macOS-sensitive diff or `macos-needed` label |
| `adapter-integration-macos` (1 short job) | **never** (was: when the group diff was macOS-sensitive) | unchanged - always | unchanged |
| `install-smoke-pipx` / `install-smoke-uv` | unchanged | unchanged | unchanged |

## Why

Both legs were being asked to certify a tree that another run certifies on its own.

**In the queue.** A queued group's merge commit is the tree that lands on `main`, and
the post-merge `push` re-runs the same platform checks against it minutes later. The
queue copy therefore cannot see a regression the push copy does not - it just sits at
the head of the queue while every entry behind it waits. The gate comment already
described `merge_group` as skipped, but the job `if:` still let a macOS-sensitive
group start them, and the workflow file itself is a macOS-sensitive path, so any CI
change put four macOS shards on the critical path of the queue.

**On push.** `test-macos` ran unconditionally on every commit reaching `main`. For a
diff that touches none of the platform paths, those four shards re-assert what the
ubuntu/windows `test` matrix already checked on the very same commit. The same
`macos_sensitive` gate that decides this on a pull request now decides it on push.

`adapter-integration-macos` is a single ~1-minute job, so it keeps running on every
push and every merged commit still carries a macOS signal.
`ci-macos-nightly.yml` (cron `0 6 * * *`) is unchanged and remains the safety net for
regressions outside the platform paths.

## How

- Both jobs gain `github.event_name != 'merge_group'` in their `if:`.
- `test-macos` loses its unconditional `github.event_name == 'push'` branch; the
  planner's `macos_sensitive` verdict and the `macos-needed` label are the only ways
  in. `determine-changes` already computes `macos_sensitive` on `push` (diffing
  against `github.event.before`), so no planner change was needed.
- The `CI gate` roll-up grows the two matching tolerances:
  - `MACOS_UNCONDITIONAL_SKIP_EVENTS = ("merge_group",)` - a subset of
    `MACOS_SKIP_EVENTS`, so a queued group is tolerated whatever the planner said.
    Without this the queue would wedge on exactly the groups that touch a platform
    path, including this PR.
  - `MACOS_PUSH_GATED = {"test-macos"}` - tolerates the shard skip on a
    non-macOS-sensitive push. `adapter-integration-macos` is deliberately not in it.
- `docs/operations/ci.md` and `docs/operations/merge-queue.md` updated to match.

### Tests

Seven new tests; five of them fail against `main`'s workflow (verified by running the
new tests with the pre-change `ci.yml` in place), and the other two are the
rubber-stamp guards.

| Test | Pins |
|---|---|
| `test_merge_group_macos_tolerance_does_not_depend_on_the_planner` | queued-group tolerance is unconditional and a subset of `MACOS_SKIP_EVENTS` |
| `test_macos_jobs_refuse_the_merge_group_event` | the `if:`s are what actually keep macOS out of the queue |
| `test_test_macos_has_no_unconditional_push_branch` | the push branch cannot come back while the tolerance stands |
| `test_ci_gate_rollup_passes_on_a_macos_sensitive_merge_group` | the queue does not wedge on a platform-touching group |
| `test_ci_gate_rollup_tolerates_the_macos_shards_skipping_on_a_plain_push` | a plain push to `main` stays green |
| `test_ci_gate_rollup_fails_when_the_macos_shards_skip_a_macos_sensitive_push` | the push tolerance is not a rubber stamp |
| `test_ci_gate_rollup_still_requires_adapter_integration_macos_on_push` | no merged commit lands with zero macOS signal |

Existing coverage in `test_merge_queue_gate_coverage_yaml.py` and
`test_required_check_canary_workflow_yaml.py` updated in the same change (108 tests
green in those two files plus `tests/unit/scripts/test_ci_establishes_origin_head.py`);
all 796 workflow-YAML unit tests pass. `actionlint`, `ruff check`, `ruff format --check`
and `typos` clean.

### Overlap with open CI work

Test-merged locally against #5760 (`ci/merge-queue-lane-ubuntu-only`) and #5761
(`ci/merge-queue-lane-eight-shards`): both merge cleanly. They touch the `test` job's
matrix; this touches the two macOS jobs and the roll-up.

## Checklist

- [x] `ruff check` passes
- [x] `actionlint` clean on `.github/workflows/ci.yml`
- [x] Tests cover the documented behaviour
- [x] `docs/operations/ci.md` and `docs/operations/merge-queue.md` updated
- [ ] N/A - no `src/` change, so no pyright / type hints / README / `docs/api/` / `agents-md sync` duty
