### PR TITLE
ci(macos): run the nightly macOS matrix on a project-owned runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,3 +3,4 @@
 self-hosted-runner:
   labels:
     - vps
+    - mac-night

--- a/.github/workflows/ci-macos-nightly.yml
+++ b/.github/workflows/ci-macos-nightly.yml
@@ -10,13 +10,27 @@ name: CI (macOS nightly)
 # release-train can demand an on-demand macOS check before cutting a
 # tag. The job mirrors the `test` matrix in ci.yml so the signal is
 # directly comparable.
+#
+# Runner split: the scheduled matrix runs on a project-owned macOS
+# runner during a fixed nightly window; push-to-main and on-demand runs
+# stay on the hosted pool so an operator can always get a macOS answer
+# outside that window. `workflow_dispatch` carries a `runner` input so
+# the owned lane can be exercised on demand without waiting for the
+# schedule.
 
 on:
   schedule:
-    # 06:00 UTC daily. Off-peak for both US/EU contributors so the
-    # macOS hosted-runner pool is least contended.
-    - cron: "0 6 * * *"
+    # 23:00 UTC daily. Chosen so the run starts inside the nightly
+    # maintenance window of the project-owned macOS runner in both
+    # daylight-saving seasons (02:00 IDT / 01:00 IST).
+    - cron: "0 23 * * *"
   workflow_dispatch:
+    inputs:
+      runner:
+        description: "Runner pool for the macOS matrix"
+        type: choice
+        options: [hosted, mac-night]
+        default: hosted
   push:
     branches: [main]
     paths:
@@ -54,8 +68,10 @@ permissions:
 
 jobs:
   test-macos-nightly:
-    name: Test (macos-latest, Python ${{ matrix.python-version }}, shard ${{ matrix.shard }})
-    runs-on: macos-latest
+    name: Test (macOS, Python ${{ matrix.python-version }}, shard ${{ matrix.shard }})
+    # Scheduled runs, and dispatches that ask for it, go to the
+    # project-owned macOS runner; everything else stays hosted.
+    runs-on: ${{ (github.event_name == 'schedule' || inputs.runner == 'mac-night') && fromJSON('["self-hosted","macOS","ARM64","mac-night"]') || 'macos-latest' }}
     timeout-minutes: 90
     permissions:
       contents: read
@@ -78,6 +94,9 @@ jobs:
         shard: [1, 2, 3, 4]
     steps:
       - name: Harden runner (audit mode)
+        # Not supported on self-hosted runners; the owned lane relies on
+        # the single-job ephemeral VM instead.
+        if: runner.environment == 'github-hosted'
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
           egress-policy: audit

--- a/.github/workflows/runner-canary.yml
+++ b/.github/workflows/runner-canary.yml
@@ -92,7 +92,7 @@ jobs:
           # directory that belongs to the machine hosting the VM.
           for entry in /Users/*; do
             case "$(basename "$entry")" in
-              admin|Shared|Guest|.localized) ;;
+              admin|runner|Shared|Guest|.localized) ;;
               \*) ;;
               *) echo "::error::an unexpected home directory is visible to the runner"; exit 1 ;;
             esac

--- a/.github/workflows/runner-canary.yml
+++ b/.github/workflows/runner-canary.yml
@@ -12,6 +12,15 @@
 # scheduled job moved onto the group has to keep both properties; this
 # file is the reference, and it deliberately prints nothing about the host
 # beyond pass or fail.
+#
+# A second job proves the macOS lane. That runner is a throwaway virtual
+# machine that exists only inside a nightly maintenance window, so the
+# job is dispatch-only: on a schedule it would queue against a machine
+# that is deliberately absent for most of the day. Its assertions are
+# containment assertions -- the job must be inside a VM, must not be the
+# account that owns the physical machine, must see no home directory but
+# its own, and must see no network share -- and, like the Linux canary,
+# it reports pass or fail rather than describing the host.
 name: Runner canary
 
 on:
@@ -45,6 +54,60 @@ jobs:
             echo "::error::runner is executing as root"
             exit 1
           fi
+      - name: Reach the API
+        run: |
+          set -o pipefail
+          curl -fsSI https://api.github.com | head -1
+
+  macos-canary:
+    name: macOS runner canary
+    # Dispatch only: see the note at the top of the file.
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: [self-hosted, macOS, ARM64, mac-night]
+    timeout-minutes: 15
+    steps:
+      - name: Assert the runner is a virtual machine
+        run: |
+          set -eu
+          model="$(sysctl -n hw.model)"
+          case "$model" in
+            *VirtualMac*) echo "virtualised" ;;
+            *) echo "::error::runner is not a virtual machine"; exit 1 ;;
+          esac
+      - name: Assert the runner account is the image account
+        run: |
+          set -eu
+          if [ "$(whoami)" != "admin" ]; then
+            echo "::error::runner is not executing as the image account"
+            exit 1
+          fi
+          if [ "$(id -u)" -eq 0 ]; then
+            echo "::error::runner is executing as root"
+            exit 1
+          fi
+      - name: Assert no home directory but the image account's is visible
+        run: |
+          set -eu
+          # Anything outside this set means the job can read a home
+          # directory that belongs to the machine hosting the VM.
+          for entry in /Users/*; do
+            case "$(basename "$entry")" in
+              admin|Shared|Guest|.localized) ;;
+              \*) ;;
+              *) echo "::error::an unexpected home directory is visible to the runner"; exit 1 ;;
+            esac
+          done
+          echo "home-directories-confined"
+      - name: Assert no network share is mounted
+        run: |
+          set -eu
+          # A share belonging to the machine that hosts the VM would
+          # appear here as one of these filesystem types.
+          if mount | grep -Eq '\((smbfs|nfs|afpfs|webdav|ftp)[,)]'; then
+            echo "::error::a network share is mounted inside the runner"
+            exit 1
+          fi
+          echo "no-network-share"
       - name: Reach the API
         run: |
           set -o pipefail

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -71,7 +71,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/release-major-minor.yml | Major/Minor Release | workflow_dispatch | {"cancel-in-progress": "false", "group": "release-major-minor-${{ github.ref }}"} | 1 |
 | .github/workflows/rendering-lane.yml | Rendering lane | pull_request, workflow_dispatch | {"cancel-in-progress": "true", "group": "rendering-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) \|\| format('branch-{0}-{1}', github.ref, github.sha) }}"} | 1 |
 | .github/workflows/required-check-canary.yml | Required-check name canary | pull_request, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "required-check-canary-${{ github.event.pull_request.number \|\| github.ref }}"} | 1 |
-| .github/workflows/runner-canary.yml | Runner canary | schedule, workflow_dispatch | - | 1 |
+| .github/workflows/runner-canary.yml | Runner canary | schedule, workflow_dispatch | - | 2 |
 | .github/workflows/sbom.yml | SBOM | release, workflow_dispatch | {"cancel-in-progress": "false", "group": "sbom-${{ github.ref }}"} | 1 |
 | .github/workflows/scorecard.yml | OSSF Scorecard | branch_protection_rule, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "scorecard-${{ github.ref }}"} | 2 |
 | .github/workflows/soc2-evidence-weekly.yml | soc2-evidence-weekly | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "soc2-evidence-${{ github.ref }}"} | 2 |
@@ -105,7 +105,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/bisect-on-red.yml | bisect: Identify culprit PR |
 | .github/workflows/branch-protection-audit.yml | audit: Branch protection audit |
 | .github/workflows/ci-gate-stub.yml | ci-gate: ${{ needs.classify.outputs.all_ignored == 'true' && 'CI gate' \|\| 'CI gate stub (not applicable)' }}<br>classify: Classify diff against ci.yml paths-ignore |
-| .github/workflows/ci-macos-nightly.yml | open-failure-issue: Open / update macOS nightly failure issue<br>test-macos-nightly: Test (macos-latest, Python ${{ matrix.python-version }}, shard ${{ matrix.shard }}) |
+| .github/workflows/ci-macos-nightly.yml | open-failure-issue: Open / update macOS nightly failure issue<br>test-macos-nightly: Test (macOS, Python ${{ matrix.python-version }}, shard ${{ matrix.shard }}) |
 | .github/workflows/ci-topology-heal.yml | heal: Regenerate topology report |
 | .github/workflows/ci-weekly-digest.yml | digest: Build and publish weekly digest |
 | .github/workflows/ci.yml | actionlint: Workflow lint<br>adapter-conformance-windows: Adapter conformance + e2e (windows)<br>adapter-integration: Adapter integration (fake-CLI)<br>adapter-integration-macos: Adapter integration (fake-CLI, macOS)<br>bandit: Bandit (security)<br>beartype: Beartype (type contracts)<br>ci-gate: CI gate<br>close-ci-issues: Close resolved CI issues<br>coverage-report: Coverage report<br>dead-code: Dead code (Vulture)<br>determine-changes: Determine changes<br>diff-coverage: Diff coverage report<br>dist-size: Package size check<br>install-smoke-pipx: Install smoke - pipx (${{ matrix.os }}, Python ${{ matrix.python-version }})<br>install-smoke-rpm: Install smoke - RPM (${{ matrix.image }})<br>install-smoke-uv: Install smoke - uv tool (${{ matrix.os }})<br>integration-tests: Integration tests<br>lineage-gate: Lineage Gate<br>lint: Lint<br>mutmut-diff: Mutation report (diff-only)<br>mypy-strict-zone: mypy strict (lineage substrate)<br>pip-audit: pip-audit (deps)<br>property-tests: Property tests (Hypothesis smoke)<br>proto-drift: Proto codegen drift<br>pyright-strict-zone: Pyright strict (security + cluster)<br>repo-hygiene: Repo hygiene<br>schemathesis-smoke: Schemathesis smoke<br>semgrep: Semgrep (custom rules)<br>snapshot-tests: Snapshot tests (syrupy)<br>spelling: Spelling (typos)<br>test: Test (${{ matrix.os }}, Python ${{ matrix.python-version }}, shard ${{ matrix.shard }})<br>test-macos: Test (macos-latest, Python 3.13, shard ${{ matrix.shard }})<br>typecheck: Type check report |
@@ -151,7 +151,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/release-major-minor.yml | release: ${{ inputs.bump }} release |
 | .github/workflows/rendering-lane.yml | rendering: Rendering fetcher (browser-backed) |
 | .github/workflows/required-check-canary.yml | verify: Required-check name canary |
-| .github/workflows/runner-canary.yml | canary: Runner canary |
+| .github/workflows/runner-canary.yml | canary: Runner canary<br>macos-canary: macOS runner canary |
 | .github/workflows/sbom.yml | sbom: Generate SBOM |
 | .github/workflows/scorecard.yml | analysis: Scorecard analysis<br>upload: Filter suppressions and upload to Code Scanning |
 | .github/workflows/soc2-evidence-weekly.yml | pack: generate evidence pack<br>preflight: preflight (gate) |


### PR DESCRIPTION
## What

The nightly macOS matrix runs on a project-owned macOS runner during a fixed nightly window; on-demand and push runs stay on the hosted pool.

## Why

`ci-macos-nightly.yml` is the largest scheduled consumer of hosted macOS capacity in this repository, and it draws from the same pool an operator needs when they ask for a macOS answer on demand. Splitting the two by event keeps the safety net running without the scheduled leg and the ad-hoc leg contending for the same capacity.

## Changes

| File | Change |
|---|---|
| `.github/workflows/ci-macos-nightly.yml` | `runs-on` chosen by event: `schedule` (or a dispatch that asks for it) uses the owned pool, everything else stays `macos-latest`. New `workflow_dispatch` input `runner: [hosted, mac-night]`. Cron moves `0 6 * * *` to `0 23 * * *` so the run starts inside the owned runner's window in both daylight-saving seasons. `step-security/harden-runner` gated on `runner.environment == 'github-hosted'`; the action does not support self-hosted runners. |
| `.github/workflows/runner-canary.yml` | New dispatch-only `macos-canary` job asserting the containment properties of the owned macOS runner: it is a virtual machine, runs as the image account rather than the account that owns the physical host, sees no home directory but its own, has no network share mounted, and can still reach the API. |
| `.github/actionlint.yaml` | Declare the new runner label so `actionlint` accepts the `runs-on` list. |
| `docs/operations/ci-topology.md` | Regenerated. |

## Safety

The runner is a throwaway virtual machine: one job per machine, one registration per job, machine destroyed afterwards. Its runner group is restricted to these two workflow files at `refs/heads/main` and to this repository.

Both edited workflows keep their triggers inside `schedule` / `workflow_dispatch` / `push` on `main`, so `tests/unit/test_self_hosted_runner_scope.py` continues to pass: no pull-request revision can reach the machine.

## Verification

- `actionlint` clean across the repository.
- `tests/unit/test_self_hosted_runner_scope.py`, `tests/unit/test_workflow_topology_report.py`, `tests/unit/test_required_check_canary_workflow_yaml.py`, `tests/unit/test_bot_pull_request_tokens_yaml.py` pass locally.
- After merge: `runner-canary.yml` dispatched so `macos-canary` exercises the assertions above, then `ci-macos-nightly.yml` dispatched with `runner=mac-night`.
