### PR TITLE
ci: move six scheduled reporting workflows onto the project's own runner

### DIFF
--- a/.github/workflows/coverage-ratchet-weekly.yml
+++ b/.github/workflows/coverage-ratchet-weekly.yml
@@ -42,7 +42,7 @@ env:
 jobs:
   bump:
     name: Bump diff-coverage floor and open review PR
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     environment: automation
     timeout-minutes: 10
     if: >-

--- a/.github/workflows/detached-workflow-canary.yml
+++ b/.github/workflows/detached-workflow-canary.yml
@@ -41,7 +41,7 @@ permissions:
 jobs:
   canary:
     name: Detached workflow canary
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 10
     # Advisory: the action this reports is a settings change a human makes.
     continue-on-error: true

--- a/.github/workflows/docs-observability-snapshot.yml
+++ b/.github/workflows/docs-observability-snapshot.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   snapshot:
     name: Capture snapshot
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     environment: automation
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/docs-requirements-staleness-weekly.yml
+++ b/.github/workflows/docs-requirements-staleness-weekly.yml
@@ -35,7 +35,7 @@ concurrency:
 jobs:
   staleness:
     name: recompile and diff
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/nightly-canary.yml
+++ b/.github/workflows/nightly-canary.yml
@@ -38,7 +38,7 @@ concurrency:
 jobs:
   canary:
     name: Real-run canary
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 15
     steps:
       - name: Harden runner

--- a/.github/workflows/trunk-health-slo.yml
+++ b/.github/workflows/trunk-health-slo.yml
@@ -45,7 +45,7 @@ permissions: {}
 jobs:
   compute:
     name: Compute trunk red-rate and toggle the andon marker
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 10
     permissions:
       actions: read


### PR DESCRIPTION
Second step of moving the repository's scheduled maintenance runs onto the project's own Linux runner, after `nightly-drift-sweep` (#5763).

**Why.** These jobs run on a schedule or by hand against `main` and need only git, uv, Python, `jq` and the GitHub CLI, all of which the runner image ships. Running them on the project's own runner keeps the scheduled lane independent of hosted-runner availability.

**Scope.** `runs-on` only — no step, trigger or permission is touched.

**Guard.** `tests/unit/test_self_hosted_runner_scope.py` refuses any self-hosted job in a workflow with a trigger that can carry unmerged code (`pull_request`, `pull_request_target`, `merge_group`, `workflow_run`, `workflow_call`, or a `push` wider than `branches: [main]`). Every workflow here is `schedule` + `workflow_dispatch` only. The runner group is additionally restricted to an explicit workflow allowlist, always pinned to `@refs/heads/main`.