### PR TITLE
ci: move six scheduled repository-hygiene workflows onto the project's own runner

### DIFF
--- a/.github/workflows/branch-protection-audit.yml
+++ b/.github/workflows/branch-protection-audit.yml
@@ -45,7 +45,7 @@ permissions: {}
 jobs:
   audit:
     name: Branch protection audit
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     environment: automation
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/ci-weekly-digest.yml
+++ b/.github/workflows/ci-weekly-digest.yml
@@ -46,7 +46,7 @@ permissions: {}
 jobs:
   digest:
     name: Build and publish weekly digest
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/cleanup-runs.yml
+++ b/.github/workflows/cleanup-runs.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 30
     permissions:
       actions: write

--- a/.github/workflows/pr-queue-hygiene.yml
+++ b/.github/workflows/pr-queue-hygiene.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   hygiene:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/project-pulse.yml
+++ b/.github/workflows/project-pulse.yml
@@ -53,7 +53,7 @@ env:
 jobs:
   pulse:
     name: Collect and publish the project pulse
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 20
     permissions:
       # contents: write is what pushing to the data branch needs. main is

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
Second step of moving the repository's scheduled maintenance runs onto the project's own Linux runner, after `nightly-drift-sweep` (#5763).

**Why.** These jobs run on a schedule or by hand against `main` and need only git, uv, Python, `jq` and the GitHub CLI, all of which the runner image ships. Running them on the project's own runner keeps the scheduled lane independent of hosted-runner availability.

**Scope.** `runs-on` only — no step, trigger or permission is touched.

**Guard.** `tests/unit/test_self_hosted_runner_scope.py` refuses any self-hosted job in a workflow with a trigger that can carry unmerged code (`pull_request`, `pull_request_target`, `merge_group`, `workflow_run`, `workflow_call`, or a `push` wider than `branches: [main]`). Every workflow here is `schedule` + `workflow_dispatch` only. The runner group is additionally restricted to an explicit workflow allowlist, always pinned to `@refs/heads/main`.