### PR TITLE
ci: move six main-branch maintenance workflows onto the project's own runner

### DIFF
--- a/.github/workflows/ci-topology-heal.yml
+++ b/.github/workflows/ci-topology-heal.yml
@@ -59,7 +59,7 @@ permissions:
 jobs:
   heal:
     name: Regenerate topology report
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     environment: automation
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/eval-weekly.yml
+++ b/.github/workflows/eval-weekly.yml
@@ -36,7 +36,7 @@ concurrency:
 jobs:
   preflight:
     name: preflight (gate)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 1
     outputs:
       enabled: ${{ steps.gate.outputs.enabled }}
@@ -69,7 +69,7 @@ jobs:
     name: smoke (synthetic)
     needs: preflight
     if: needs.preflight.outputs.enabled == 'smoke'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 5
     steps:
       - name: Harden runner (audit mode)
@@ -110,7 +110,7 @@ jobs:
     name: bench (full)
     needs: preflight
     if: needs.preflight.outputs.enabled == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 240
     env:
       # Per-suite budget cap protects against runaway spend.

--- a/.github/workflows/hotfix-r-tracker.yml
+++ b/.github/workflows/hotfix-r-tracker.yml
@@ -26,7 +26,7 @@ permissions: {}
 jobs:
   track:
     name: Detect hotfix-begets-hotfix
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 5
     # Only run on commits that look like CI hotfixes. Conventional
     # commit prefix `fix(ci):` matches the established pattern used by

--- a/.github/workflows/main-sha-marker.yml
+++ b/.github/workflows/main-sha-marker.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   marker:
     name: Main SHA marker
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 2
     steps:
       - name: Record exact SHA marker

--- a/.github/workflows/mutation-fixed.yml
+++ b/.github/workflows/mutation-fixed.yml
@@ -55,7 +55,7 @@ concurrency:
 jobs:
   mutate:
     name: ${{ matrix.module }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     # Hard total cap; per-module budgets enforced inside the harness.
     timeout-minutes: 30
     # Per-module, driven by matrix.advisory below - not a blanket flag.

--- a/.github/workflows/soc2-evidence-weekly.yml
+++ b/.github/workflows/soc2-evidence-weekly.yml
@@ -37,7 +37,7 @@ concurrency:
 jobs:
   preflight:
     name: preflight (gate)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 1
     outputs:
       enabled: ${{ steps.gate.outputs.enabled }}
@@ -73,7 +73,7 @@ jobs:
     name: generate evidence pack
     needs: preflight
     if: needs.preflight.outputs.enabled == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 10
     steps:
       - name: Harden runner (audit mode)


### PR DESCRIPTION
Continues moving the repository's scheduled maintenance runs onto the project's own Linux runner, after #5763.

**Why.** These jobs run on a schedule, by hand, or on a push to `main`, and need only what the runner image ships (git, uv, Python, `jq`, the GitHub CLI) or what they provision themselves through `setup-node` / `setup-uv`. Running them on the project's own runner keeps the scheduled lane independent of hosted-runner availability.

**Scope.** `runs-on` only — no step, trigger or permission is touched.

**Guard.** `tests/unit/test_self_hosted_runner_scope.py` refuses any self-hosted job in a workflow with a trigger that can carry unmerged code (`pull_request`, `pull_request_target`, `merge_group`, `workflow_run`, `workflow_call`, or a `push` wider than `branches: [main]`). The runner group is additionally restricted to an explicit workflow allowlist, always pinned to `@refs/heads/main`.