### PR TITLE
ci: move five heavy scheduled suites onto the project's own runner

### DIFF
--- a/.github/workflows/adapter-conformance-canary.yml
+++ b/.github/workflows/adapter-conformance-canary.yml
@@ -46,7 +46,7 @@ permissions:
 jobs:
   canary:
     name: Canary matrix
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     environment: automation
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/adapter-contract-drift.yml
+++ b/.github/workflows/adapter-contract-drift.yml
@@ -45,7 +45,7 @@ permissions:
 jobs:
   check:
     name: ${{ matrix.adapter }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 5
     strategy:
       fail-fast: false
@@ -215,7 +215,7 @@ jobs:
     name: Aggregate drift report
     needs: check
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 5
     permissions:
       contents: read

--- a/.github/workflows/nightly-deep-tests.yml
+++ b/.github/workflows/nightly-deep-tests.yml
@@ -52,7 +52,7 @@ jobs:
     # Sharded rather than a single job because a full unfiltered shard takes
     # roughly half an hour; one unsharded job would run about two.
     name: Unit tests (Python 3.14, shard ${{ matrix.shard }})
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 90
     permissions:
       contents: read
@@ -82,7 +82,7 @@ jobs:
 
   hypothesis-deep:
     name: Hypothesis (deep, 1000 examples)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 90
     permissions:
       contents: read
@@ -102,7 +102,7 @@ jobs:
 
   schemathesis-deep:
     name: Schemathesis (deep, full sweep)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 60
     permissions:
       contents: read
@@ -128,7 +128,7 @@ jobs:
     # in the smoke profile that PR-time would use once contracts are
     # added).
     name: CrossHair (concolic, deep)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 60
     permissions:
       contents: read
@@ -153,7 +153,7 @@ jobs:
 
   mutmut-full:
     name: Mutation (full repo, advisory)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 240
     permissions:
       contents: read
@@ -183,7 +183,7 @@ jobs:
 
   bandit-medium-and-high:
     name: Bandit (full -ll, advisory)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 10
     permissions:
       contents: read
@@ -211,7 +211,7 @@ jobs:
 
   pip-audit-deep:
     name: pip-audit (full closure)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 15
     permissions:
       contents: read
@@ -251,7 +251,7 @@ jobs:
     # Gated off the default CI run via the ``stress`` marker so PRs
     # don't pay the ~45 s wall-clock cost; runs once per day here.
     name: Stress + resource-leak suite (TC-C)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/pentest.yml
+++ b/.github/workflows/pentest.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   pentest:
     name: "Pen-test: ${{ github.event.inputs.suite || 'all' }}"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/static-analysis-extended.yml
+++ b/.github/workflows/static-analysis-extended.yml
@@ -76,7 +76,7 @@ jobs:
     # lane covers the broader community ruleset and uses the git
     # baseline so only NEW findings fail PRs.
     name: Semgrep (CE rules)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 10
     permissions:
       contents: read
@@ -162,7 +162,7 @@ jobs:
     # secrets across the repo. HIGH/CRITICAL fails the job; lower
     # severities surface in Code Scanning but do not block.
     name: Trivy (filesystem)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 15
     permissions:
       contents: read
@@ -245,7 +245,7 @@ jobs:
     # kustomize. Misconfigurations like missing USER directive,
     # privileged containers, latest tags, etc.
     name: Trivy (IaC)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 15
     permissions:
       contents: read
@@ -312,7 +312,7 @@ jobs:
     # Advisory lane: weekly schedule + manual dispatch only (#2764).
     name: vulture (dead code)
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 10
     permissions:
       contents: read
@@ -377,7 +377,7 @@ jobs:
     # Advisory lane: weekly schedule + manual dispatch only (#2764).
     name: refurb (idioms)
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 10
     permissions:
       contents: read
@@ -460,7 +460,7 @@ jobs:
     # Advisory lane: weekly schedule + manual dispatch only (#2764).
     name: perflint (hot-path antipatterns)
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 10
     permissions:
       contents: read


### PR DESCRIPTION
Continues moving the repository's scheduled maintenance runs onto the project's own Linux runner, after #5763.

**Why.** These jobs run on a schedule, by hand, or on a push to `main`, and need only what the runner image ships (git, uv, Python, `jq`, the GitHub CLI) or what they provision themselves through `setup-node` / `setup-uv`. Running them on the project's own runner keeps the scheduled lane independent of hosted-runner availability.

**Scope.** `runs-on` only — no step, trigger or permission is touched.

**Guard.** `tests/unit/test_self_hosted_runner_scope.py` refuses any self-hosted job in a workflow with a trigger that can carry unmerged code (`pull_request`, `pull_request_target`, `merge_group`, `workflow_run`, `workflow_call`, or a `push` wider than `branches: [main]`). The runner group is additionally restricted to an explicit workflow allowlist, always pinned to `@refs/heads/main`.