### PR TITLE
ci: move the release reconciliation and notify jobs onto the project's own runner

### DIFF
--- a/.github/workflows/ci-macos-nightly.yml
+++ b/.github/workflows/ci-macos-nightly.yml
@@ -119,7 +119,7 @@ jobs:
     name: Open / update macOS nightly failure issue
     needs: [test-macos-nightly]
     if: failure() && github.event_name != 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 5
     permissions:
       contents: read

--- a/.github/workflows/reconcile-release.yml
+++ b/.github/workflows/reconcile-release.yml
@@ -36,7 +36,7 @@ permissions: {}
 jobs:
   reconcile:
     name: Compare pyproject.toml vs published channels
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 5
     permissions:
       contents: read

--- a/.github/workflows/release-major-minor.yml
+++ b/.github/workflows/release-major-minor.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
   release:
     name: "${{ inputs.bump }} release"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     timeout-minutes: 60
     permissions:
       contents: write


### PR DESCRIPTION
Continues moving the repository's scheduled maintenance runs onto the project's own Linux runner, after #5763.

**Why.** These jobs run on a schedule, by hand, or on a push to `main`, and need only what the runner image ships (git, uv, Python, `jq`, the GitHub CLI) or what they provision themselves through `setup-node` / `setup-uv`. Running them on the project's own runner keeps the scheduled lane independent of hosted-runner availability.

**Scope.** `runs-on` only — no step, trigger or permission is touched.

**Guard.** `tests/unit/test_self_hosted_runner_scope.py` refuses any self-hosted job in a workflow with a trigger that can carry unmerged code (`pull_request`, `pull_request_target`, `merge_group`, `workflow_run`, `workflow_call`, or a `push` wider than `branches: [main]`). The runner group is additionally restricted to an explicit workflow allowlist, always pinned to `@refs/heads/main`.

The macOS test job of `ci-macos-nightly` stays on `macos-latest`; only the Linux notify job that follows it moves.
