### PR TITLE
fix(git): consult the remote-tracking trunk before init.defaultBranch

### DIFF
--- a/src/bernstein/core/git/git_basic.py
+++ b/src/bernstein/core/git/git_basic.py
@@ -534,12 +534,17 @@ def resolve_default_branch(cwd: Path, remote: str = "origin") -> str:
     """Resolve the repository's default branch (the protected trunk).
 
     Resolution order: ``<remote>/HEAD`` first (the authoritative signal), then
-    ``init.defaultBranch`` from git config, then the ``<remote>/master``
-    remote-tracking ref, then the conventional ``main``/``master`` local probe,
-    and finally ``"main"`` as a last resort. Consulting ``init.defaultBranch``
-    and ``<remote>/master`` BEFORE the hard-coded ``main``-first local probe
-    means a repo whose real trunk is ``master`` is not mis-resolved to a stray
-    local ``main`` when ``<remote>/HEAD`` is unavailable. Never raises.
+    the ``<remote>/main`` / ``<remote>/master`` remote-tracking refs when
+    exactly one of them exists, then ``init.defaultBranch`` from git config,
+    then the conventional ``main``/``master`` local probe, and finally
+    ``"main"`` as a last resort. The remote-tracking refs are evidence from
+    the repository in hand, so they are consulted BEFORE ``init.defaultBranch``,
+    which is a machine-wide preference that says nothing about this clone: a
+    repo whose real trunk is ``master`` must not resolve to a stray local
+    ``main`` just because the machine's git config sets
+    ``init.defaultBranch=main``. When both remote-tracking refs exist the
+    trunk is genuinely ambiguous and resolution falls through to the config
+    and local probes as before. Never raises.
 
     Args:
         cwd: Repository root.
@@ -552,15 +557,19 @@ def resolve_default_branch(cwd: Path, remote: str = "origin") -> str:
     if from_head is not None:
         return from_head
 
+    tracked = [
+        candidate
+        for candidate in ("main", "master")
+        if _run_git_quiet(["rev-parse", "--verify", "--quiet", f"refs/remotes/{remote}/{candidate}"], cwd).ok
+    ]
+    if len(tracked) == 1:
+        return tracked[0]
+
     cfg = _run_git_quiet(["config", "--get", "init.defaultBranch"], cwd)
     if cfg.ok and cfg.stdout.strip():
         configured = cfg.stdout.strip()
         if _branch_exists(cwd, configured):
             return configured
-
-    master_tracking = _run_git_quiet(["rev-parse", "--verify", "--quiet", f"refs/remotes/{remote}/master"], cwd)
-    if master_tracking.ok:
-        return "master"
 
     for candidate in ("main", "master"):
         if _branch_exists(cwd, candidate):

--- a/tests/unit/test_issue_2178_default_branch_ambiguity.py
+++ b/tests/unit/test_issue_2178_default_branch_ambiguity.py
@@ -69,7 +69,63 @@ def master_default_clone(tmp_path: Path) -> Path:
     # Add a stray local ``main`` that is NOT the real trunk.
     _git(clone, "branch", "main")
 
+    # State the machine-wide default the regression depends on instead of
+    # inheriting it: the Apple-supplied git sets ``init.defaultBranch=main``
+    # system-wide, a Homebrew git leaves it unset.
+    _git(clone, "config", "init.defaultBranch", "main")
+
     # The real trunk (master) is checked out.
+    assert current_branch(clone) == "master"
+    return clone
+
+
+@pytest.fixture
+def main_default_clone(tmp_path: Path) -> Path:
+    """Mirror image: real default ``main``, origin/HEAD deleted, a stray local
+    ``master`` branch, and ``init.defaultBranch=master`` in the config.
+    """
+    upstream = tmp_path / "upstream"
+    upstream.mkdir()
+    _git(upstream, "init", "-q", "-b", "main")
+    _git(upstream, "config", "user.email", "test@example.com")
+    _git(upstream, "config", "user.name", "Test")
+    (upstream / "README.md").write_text("# upstream\n", encoding="utf-8")
+    _git(upstream, "add", "README.md")
+    _git(upstream, "commit", "-q", "-m", "initial")
+
+    clone = tmp_path / "clone"
+    _git(tmp_path, "clone", "-q", str(upstream), str(clone))
+    _git(clone, "config", "user.email", "test@example.com")
+    _git(clone, "config", "user.name", "Test")
+    _git(clone, "remote", "set-head", "origin", "-d")
+    _git(clone, "branch", "master")
+    _git(clone, "config", "init.defaultBranch", "master")
+    assert current_branch(clone) == "main"
+    return clone
+
+
+@pytest.fixture
+def two_trunks_clone(tmp_path: Path) -> Path:
+    """Genuinely ambiguous: the remote publishes BOTH ``main`` and ``master``,
+    origin/HEAD is deleted, both exist locally, ``init.defaultBranch=main``.
+    """
+    upstream = tmp_path / "upstream"
+    upstream.mkdir()
+    _git(upstream, "init", "-q", "-b", "master")
+    _git(upstream, "config", "user.email", "test@example.com")
+    _git(upstream, "config", "user.name", "Test")
+    (upstream / "README.md").write_text("# upstream\n", encoding="utf-8")
+    _git(upstream, "add", "README.md")
+    _git(upstream, "commit", "-q", "-m", "initial")
+    _git(upstream, "branch", "main")
+
+    clone = tmp_path / "clone"
+    _git(tmp_path, "clone", "-q", str(upstream), str(clone))
+    _git(clone, "config", "user.email", "test@example.com")
+    _git(clone, "config", "user.name", "Test")
+    _git(clone, "remote", "set-head", "origin", "-d")
+    _git(clone, "branch", "main", "origin/main")
+    _git(clone, "config", "init.defaultBranch", "main")
     assert current_branch(clone) == "master"
     return clone
 
@@ -80,6 +136,24 @@ def test_resolve_default_branch_prefers_master_when_origin_head_unset(
     # Prior behaviour resolved "main" (the stray local branch); now we resolve
     # the real trunk via the origin/master remote-tracking ref.
     assert resolve_default_branch(master_default_clone) == "master"
+
+
+def test_resolve_default_branch_prefers_main_when_origin_head_unset(
+    main_default_clone: Path,
+) -> None:
+    # Mirror image of the case above: the stray local ``master`` plus
+    # ``init.defaultBranch=master`` must not beat the real ``origin/main``.
+    assert resolve_default_branch(main_default_clone) == "main"
+
+
+def test_resolve_default_branch_falls_through_when_both_remote_refs_exist(
+    two_trunks_clone: Path,
+) -> None:
+    # Two remote-tracking trunks give no evidence either way, so resolution
+    # falls through to ``init.defaultBranch`` (set to ``main`` here) exactly as
+    # it did before the remote-tracking probe was added.
+    assert resolve_default_branch(two_trunks_clone) == "main"
+    assert protected_default_branches(two_trunks_clone) == frozenset({"main", "master"})
 
 
 def test_protected_branches_fail_closed_on_ambiguous_default(


### PR DESCRIPTION
`resolve_default_branch` names the trunk the merge guard protects. When `origin/HEAD` is unset (worktree checkouts, partial clones, anything where `git remote set-head` never ran) it consulted `init.defaultBranch` before the repository's own remote-tracking refs, so on a machine whose git config sets `init.defaultBranch=main` a stray local `main` beat a real `origin/master` and the guard protected the wrong branch. That is the default state of macOS with the Apple-supplied git, and the nightly macOS matrix reproduced it.

The resolver now probes `origin/main` and `origin/master` right after `origin/HEAD` and trusts them when exactly one exists. `init.defaultBranch` stays as the fallback it was meant to be, followed by the local probe and the hard-coded default.

**Decision:** when both remote-tracking trunks exist the trunk is genuinely ambiguous, so resolution falls through to `init.defaultBranch` and the local probe exactly as before, rather than preferring `origin/main`. `protected_default_branches` already fails closed on that state and is unchanged.

**Proof**
- The regression fixture now sets `init.defaultBranch=main` explicitly, so the test states the condition instead of inheriting it from the machine. With that line and without the fix the original test fails under both git 2.50.1 (Apple) and git 2.53 (Homebrew); with the fix all five tests pass under both.
- New: the mirror image (real `main`, stray local `master`, `init.defaultBranch=master`) resolves `main`.
- New: a remote publishing both `main` and `master` still falls through to `init.defaultBranch`, and `protected_default_branches` still returns both names.
- `pytest tests/unit -k "default_branch or git_basic or git_ops"`: 155 passed.

Closes #5776
