### PR TITLE
test(runner): give each parallel worker its own pytest temporary root

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -22,16 +22,20 @@ from __future__ import annotations
 
 import argparse
 import json
+import multiprocessing
 import os
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Mapping
+    from multiprocessing.sharedctypes import Synchronized
 
 # Changed paths for which an empty affected set is a coverage hole rather than
 # a legitimate no-op, so the shards fail closed instead of reporting green.
@@ -109,6 +113,65 @@ MEMORY_HEAVY_FILES: frozenset[str] = frozenset(
         "test_volunteer_sandbox_egress.py",
     }
 )
+
+# pytest builds every ``tmp_path`` under ``$PYTEST_DEBUG_TEMPROOT`` and keeps a
+# ``pytest-current`` symlink in the ``pytest-of-<user>`` directory it creates
+# there. Workers that inherit one root rewrite that symlink concurrently and
+# the loser fails on whichever test was building a ``tmp_path`` at the time
+# (issue #5777), so each worker is handed a root of its own instead.
+PYTEST_TEMPROOT_ENV = "PYTEST_DEBUG_TEMPROOT"
+
+#: Prefix of the run-unique parent directory holding one root per worker.
+TEMP_ROOT_PREFIX = "bernstein-tests-"
+
+#: This pool worker's own temporary root, claimed once by
+#: ``_bind_worker_temp_root`` and read by every ``run_file`` call it serves.
+_WORKER_TEMP_ROOT: Path | None = None
+
+
+def create_run_temp_parent() -> Path:
+    """Create the run-unique parent directory that holds every worker root."""
+    return Path(tempfile.mkdtemp(prefix=TEMP_ROOT_PREFIX))
+
+
+def worker_temp_root(parent: Path, index: int) -> Path:
+    """Create and return worker *index*'s own pytest temporary root."""
+    root = parent / f"w{index}"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def remove_run_temp_parent(parent: Path | None) -> None:
+    """Remove the run parent, and with it every worker root beneath it."""
+    if parent is None:
+        return
+    shutil.rmtree(parent, ignore_errors=True)
+
+
+def worker_env(temp_root: Path | None) -> dict[str, str]:
+    """Return the child environment for a worker owning *temp_root*.
+
+    A copy, never the live mapping: the parent process keeps whatever
+    ``PYTEST_DEBUG_TEMPROOT`` it was started with.
+    """
+    env = dict(os.environ)
+    if temp_root is not None:
+        env[PYTEST_TEMPROOT_ENV] = str(temp_root)
+    return env
+
+
+def _bind_worker_temp_root(parent: str, counter: Synchronized[int]) -> None:
+    """Pool initializer: claim the next worker index under *parent*.
+
+    ``counter`` is shared across the pool so the index is unique per worker
+    rather than per submitted file: a worker outlives the file it was started
+    for, so a per-file index would let two live workers share a root.
+    """
+    global _WORKER_TEMP_ROOT
+    with counter.get_lock():
+        index = counter.value
+        counter.value = index + 1
+    _WORKER_TEMP_ROOT = worker_temp_root(Path(parent), index)
 
 
 def split_memory_heavy(files: list[Path]) -> tuple[list[Path], list[Path]]:
@@ -385,11 +448,20 @@ def shard_files(
     return [f for j, f in enumerate(files) if j % shard_count == shard_index - 1]
 
 
-def run_file(path: Path, extra_args: list[str], coverage: bool = False) -> tuple[Path, int, float, str]:
+def run_file(
+    path: Path,
+    extra_args: list[str],
+    coverage: bool = False,
+    temp_root: Path | None = None,
+) -> tuple[Path, int, float, str]:
     """Run a single test file in a subprocess. Returns (path, exitcode, duration, output).
 
     When ``coverage`` is True, the process is wrapped in ``coverage run`` with a
     parallel-safe data file so that many subprocesses can be combined later.
+
+    ``temp_root`` overrides the pytest temporary root for this subprocess; it
+    defaults to the root bound to the calling pool worker, or to whatever the
+    parent inherited when there is none.
     """
     if coverage:
         cmd = [
@@ -424,7 +496,13 @@ def run_file(path: Path, extra_args: list[str], coverage: bool = False) -> tuple
             *extra_args,
         ]
     start = time.monotonic()
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=test_file_timeout_seconds())
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=test_file_timeout_seconds(),
+        env=worker_env(temp_root if temp_root is not None else _WORKER_TEMP_ROOT),
+    )
     duration = time.monotonic() - start
     output = result.stdout + result.stderr
     return path, result.returncode, duration, output
@@ -597,90 +675,101 @@ def run_parallel(
 
     print(f"  Workers: {workers}")
 
-    normal_files, heavy_files = split_memory_heavy(files)
-    total = len(files)
+    # One temporary root per worker, all under a single run-unique parent so
+    # the whole run is torn down by one rmtree below (issue #5777).
+    temp_parent = create_run_temp_parent()
+    try:
+        normal_files, heavy_files = split_memory_heavy(files)
+        total = len(files)
 
-    # Run normal files in parallel
-    with ProcessPoolExecutor(max_workers=workers) as pool:
-        futures = {pool.submit(run_file, f, extra_args, coverage): f for f in normal_files}
-        for future in as_completed(futures):
-            if abort:
-                future.cancel()
-                continue
-            try:
-                fpath, code, duration, output = future.result(timeout=360)
-            except Exception as exc:
-                fpath = futures[future]
+        # Run normal files in parallel
+        counter = multiprocessing.Value("i", 0)
+        with ProcessPoolExecutor(
+            max_workers=workers,
+            initializer=_bind_worker_temp_root,
+            initargs=(str(temp_parent), counter),
+        ) as pool:
+            futures = {pool.submit(run_file, f, extra_args, coverage): f for f in normal_files}
+            for future in as_completed(futures):
+                if abort:
+                    future.cancel()
+                    continue
+                try:
+                    fpath, code, duration, output = future.result(timeout=360)
+                except Exception as exc:
+                    fpath = futures[future]
+                    done += 1
+                    print(f"  ERROR [{done}/{total}] {durations_key(fpath)}: {exc}")
+                    failed += 1
+                    if fail_fast:
+                        abort = True
+                        for f in futures:
+                            f.cancel()
+                    continue
+
+                retry = retry_on_thread_exhaustion(fpath, extra_args, code, output, coverage=coverage)
+                if retry is not None:
+                    print(f"  RETRIED (thread exhaustion) {durations_key(fpath)}")
+                    code, duration, output = retry
+
                 done += 1
-                print(f"  ERROR [{done}/{total}] {durations_key(fpath)}: {exc}")
-                failed += 1
-                if fail_fast:
-                    abort = True
-                    for f in futures:
-                        f.cancel()
-                continue
+                label = f"[{done}/{total}] {durations_key(fpath)}"
+                if recorded_durations is not None:
+                    recorded_durations[durations_key(fpath)] = duration
+                outcome = _report_file_result(label, code, duration, output)
+                if outcome == OUTCOME_PASSED:
+                    passed += 1
+                elif outcome == OUTCOME_NO_TESTS:
+                    no_tests.append(fpath)
+                else:
+                    failed += 1
+                    if fail_fast:
+                        abort = True
+                        for f in futures:
+                            f.cancel()
 
-            retry = retry_on_thread_exhaustion(fpath, extra_args, code, output, coverage=coverage)
-            if retry is not None:
-                print(f"  RETRIED (thread exhaustion) {durations_key(fpath)}")
-                code, duration, output = retry
+        # Run memory-heavy files sequentially to avoid OOM
+        if heavy_files:
+            print("  Running memory-heavy files sequentially...")
+            for f in heavy_files:
+                if abort:
+                    break
+                try:
+                    fpath, code, duration, output = run_file(f, extra_args, coverage)
+                except Exception as exc:
+                    done += 1
+                    print(f"  ERROR [{done}/{total}] {durations_key(f)}: {exc}")
+                    failed += 1
+                    if fail_fast:
+                        abort = True
+                    continue
 
-            done += 1
-            label = f"[{done}/{total}] {durations_key(fpath)}"
-            if recorded_durations is not None:
-                recorded_durations[durations_key(fpath)] = duration
-            outcome = _report_file_result(label, code, duration, output)
-            if outcome == OUTCOME_PASSED:
-                passed += 1
-            elif outcome == OUTCOME_NO_TESTS:
-                no_tests.append(fpath)
-            else:
-                failed += 1
-                if fail_fast:
-                    abort = True
-                    for f in futures:
-                        f.cancel()
+                retry = retry_on_thread_exhaustion(fpath, extra_args, code, output, coverage=coverage)
+                if retry is not None:
+                    print(f"  RETRIED (thread exhaustion) {durations_key(fpath)}")
+                    code, duration, output = retry
 
-    # Run memory-heavy files sequentially to avoid OOM
-    if heavy_files:
-        print("  Running memory-heavy files sequentially...")
-        for f in heavy_files:
-            if abort:
-                break
-            try:
-                fpath, code, duration, output = run_file(f, extra_args, coverage)
-            except Exception as exc:
                 done += 1
-                print(f"  ERROR [{done}/{total}] {durations_key(f)}: {exc}")
-                failed += 1
-                if fail_fast:
-                    abort = True
-                continue
+                label = f"[{done}/{total}] {durations_key(f)}"
+                if recorded_durations is not None:
+                    recorded_durations[durations_key(fpath)] = duration
+                outcome = _report_file_result(label, code, duration, output)
+                if outcome == OUTCOME_PASSED:
+                    passed += 1
+                elif outcome == OUTCOME_NO_TESTS:
+                    no_tests.append(fpath)
+                else:
+                    failed += 1
+                    if fail_fast:
+                        abort = True
 
-            retry = retry_on_thread_exhaustion(fpath, extra_args, code, output, coverage=coverage)
-            if retry is not None:
-                print(f"  RETRIED (thread exhaustion) {durations_key(fpath)}")
-                code, duration, output = retry
-
-            done += 1
-            label = f"[{done}/{total}] {durations_key(f)}"
-            if recorded_durations is not None:
-                recorded_durations[durations_key(fpath)] = duration
-            outcome = _report_file_result(label, code, duration, output)
-            if outcome == OUTCOME_PASSED:
-                passed += 1
-            elif outcome == OUTCOME_NO_TESTS:
-                no_tests.append(fpath)
-            else:
-                failed += 1
-                if fail_fast:
-                    abort = True
-
-    wall_time = time.monotonic() - wall_start
-    print(f"\n{'=' * 60}")
-    _print_totals(passed, failed, no_tests, total)
-    print(f"Wall:  {wall_time:.1f}s ({workers} workers)")
-    return 1 if failed else 0
+        wall_time = time.monotonic() - wall_start
+        print(f"\n{'=' * 60}")
+        _print_totals(passed, failed, no_tests, total)
+        print(f"Wall:  {wall_time:.1f}s ({workers} workers)")
+        return 1 if failed else 0
+    finally:
+        remove_run_temp_parent(temp_parent)
 
 
 def _describe_rev(rev: str) -> str:

--- a/tests/unit/test_issue_5777_parallel_temp_root.py
+++ b/tests/unit/test_issue_5777_parallel_temp_root.py
@@ -1,0 +1,133 @@
+"""Each parallel worker gets its own pytest temporary root (issue #5777).
+
+pytest places ``tmp_path`` under ``$PYTEST_DEBUG_TEMPROOT/pytest-of-<user>``
+and keeps a ``pytest-current`` symlink inside that root. When every worker of
+``scripts/run_tests.py --parallel N`` inherits the same root, the workers race
+on that symlink and the loser fails on whichever test happened to be building
+a ``tmp_path``. These tests pin the per-worker root and its cleanup.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from scripts import run_tests
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture(autouse=True)
+def _restore_worker_binding() -> Iterator[None]:
+    """Keep a bound worker root from leaking into the next test."""
+    previous = run_tests._WORKER_TEMP_ROOT
+    try:
+        yield
+    finally:
+        run_tests._WORKER_TEMP_ROOT = previous
+
+
+def _bind_workers(parent: Path, count: int) -> list[Path]:
+    """Bind *count* workers against *parent* the way the pool initializer does."""
+    counter = multiprocessing.Value("i", 0)
+    roots: list[Path] = []
+    for _ in range(count):
+        run_tests._bind_worker_temp_root(str(parent), counter)
+        bound = run_tests._WORKER_TEMP_ROOT
+        assert bound is not None
+        roots.append(bound)
+    return roots
+
+
+class TestPerWorkerTempRoot:
+    def test_run_parent_is_unique_per_run(self) -> None:
+        first = run_tests.create_run_temp_parent()
+        second = run_tests.create_run_temp_parent()
+        try:
+            assert first != second
+            assert first.is_dir()
+            assert second.is_dir()
+            assert first.name.startswith("bernstein-tests-")
+        finally:
+            run_tests.remove_run_temp_parent(first)
+            run_tests.remove_run_temp_parent(second)
+
+    def test_workers_bind_distinct_roots_under_one_parent(self, tmp_path: Path) -> None:
+        parent = tmp_path / "bernstein-tests-run"
+        roots = _bind_workers(parent, 4)
+
+        assert len(set(roots)) == 4, f"workers share a temporary root: {roots}"
+        assert [r.name for r in roots] == ["w0", "w1", "w2", "w3"]
+        for root in roots:
+            assert root.parent == parent
+            assert root.is_dir()
+
+    def test_worker_env_exports_the_root_without_touching_the_parent_env(self, tmp_path: Path) -> None:
+        before = dict(os.environ)
+
+        env = run_tests.worker_env(tmp_path / "w0")
+
+        assert env["PYTEST_DEBUG_TEMPROOT"] == str(tmp_path / "w0")
+        assert dict(os.environ) == before
+        assert "PYTEST_DEBUG_TEMPROOT" not in before or before["PYTEST_DEBUG_TEMPROOT"] != str(tmp_path / "w0")
+
+    def test_run_file_exports_the_bound_root_to_the_pytest_subprocess(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: list[str | None] = []
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            env = kwargs["env"]
+            seen.append(env.get("PYTEST_DEBUG_TEMPROOT"))
+            return subprocess.CompletedProcess(cmd, 0, "1 passed", "")
+
+        monkeypatch.setattr(run_tests.subprocess, "run", fake_run)
+
+        parent = tmp_path / "bernstein-tests-run"
+        counter = multiprocessing.Value("i", 0)
+        for _ in range(2):
+            run_tests._bind_worker_temp_root(str(parent), counter)
+            run_tests.run_file(Path("tests/unit/test_example.py"), [])
+
+        assert seen == [str(parent / "w0"), str(parent / "w1")]
+
+
+class TestRunParentCleanup:
+    def _capture_parent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> list[Path]:
+        created: list[Path] = []
+
+        def fake_parent() -> Path:
+            parent = tmp_path / f"bernstein-tests-{len(created)}"
+            parent.mkdir()
+            created.append(parent)
+            return parent
+
+        monkeypatch.setattr(run_tests, "create_run_temp_parent", fake_parent)
+        return created
+
+    def test_parent_is_removed_after_the_run(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        created = self._capture_parent(tmp_path, monkeypatch)
+
+        assert run_tests.run_parallel([], [], 2, False) == 0
+
+        assert len(created) == 1
+        assert not created[0].exists(), "the run parent survived the run"
+
+    def test_parent_is_removed_on_keyboard_interrupt(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        created = self._capture_parent(tmp_path, monkeypatch)
+
+        def interrupt(*_args: object, **_kwargs: object) -> None:
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(run_tests, "split_memory_heavy", interrupt)
+
+        with pytest.raises(KeyboardInterrupt):
+            run_tests.run_parallel([Path("tests/unit/test_example.py")], [], 2, False)
+
+        assert len(created) == 1
+        assert not created[0].exists(), "the run parent survived a KeyboardInterrupt"


### PR DESCRIPTION
## What raced

Every worker of `scripts/run_tests.py --parallel N` inherited the same pytest temporary root, so all of them wrote into one `$TMPDIR/pytest-of-<user>` directory and each one recreated the `pytest-current` symlink pytest keeps there. Two workers recreating that symlink in the same instant lose the race, and the error lands on whichever test happened to be constructing a `tmp_path` — a red shard that does not reproduce when the same file is re-run alone. The nightly macOS matrix, which runs four shards on one machine, is where this showed up.

## What changes

Each pool worker now claims its own subdirectory and exports it as `PYTEST_DEBUG_TEMPROOT` in a copy of the environment handed to its pytest subprocess, so no two workers share a `pytest-of-<user>` directory or its symlink. The roots live under a run-unique parent (`tempfile.mkdtemp(prefix="bernstein-tests-")` under the normal temp directory) with one subdirectory per worker index (`w0`, `w1`, …): the parent is removed once at the end of the run, so cleanup covers every worker with a single `shutil.rmtree`, and the per-worker names stay readable in a failure log.

Nothing else moves. Tests keep using `tmp_path` as documented, the shard count and the parallel default are untouched, and the removal sits in the runner's `finally` block so it also runs after a `KeyboardInterrupt`.

## Proof

- New unit test `tests/unit/test_issue_5777_parallel_temp_root.py`: four workers bind four distinct roots named `w0`–`w3` under one parent; `run_file` exports the bound root to the pytest subprocess without touching the parent process environment; the parent is gone after a normal run and after a `KeyboardInterrupt`. Red before the change (the helpers did not exist), green after — `6 passed`.
- `python scripts/run_tests.py --parallel 4 tests/unit/test_issue_2178_default_branch_ambiguity.py tests/unit/test_run_tests_scheduler.py tests/unit/test_run_tests_selection.py tests/unit/test_issue_5777_parallel_temp_root.py` — `Files: 4 passed, 0 failed`. Polling the temp directory during the run showed exactly four roots, `bernstein-tests-<id>/w0` through `w3`, each holding its own `pytest-of-<user>` directory; nothing matching `bernstein-tests-*` remained afterwards.
- `ruff format` and `ruff check` clean on both touched files.

Closes #5777
