### PR TITLE
fix(tui-snapshot): make the published terminal render independent of machine speed

### DIFF
--- a/scripts/render_tui_snapshot.py
+++ b/scripts/render_tui_snapshot.py
@@ -34,6 +34,7 @@ import asyncio
 import difflib
 import hashlib
 import html
+import itertools
 import json
 import re
 import sys
@@ -64,6 +65,11 @@ TERMINAL_SIZE = (120, 40)
 #: Panel titles the dashboard draws. Each is centred over its panel, so their
 #: coordinates are what a changed cell is attributed against.
 REGION_TITLES = ("AGENTS", "TASKS", "ACTIVITY")
+
+#: The one widget whose drawn shape depends on how much data has reached it
+#: rather than only on what the data says, so the wait before the export is
+#: expressed against it directly.
+_SPARKLINE_SELECTOR = "#spark"
 
 _TEXT_NODE = re.compile(r"<text[^>]*\bx=\"([\d.]+)\"[^>]*\by=\"([\d.]+)\"[^>]*>([^<]*)</text>")
 
@@ -124,6 +130,8 @@ class _FrozenDatetime(datetime):
 
 async def _export(payload: dict[str, object], frozen_now: float) -> str:
     """Drive the dashboard headless against *payload* and export its screen."""
+    from textual.widgets import Sparkline
+
     import bernstein.cli.dashboard_app as dashboard_app
     import bernstein.tui.agent_log as agent_log
 
@@ -131,6 +139,21 @@ async def _export(payload: dict[str, object], frozen_now: float) -> str:
     # fixture seam - no HTTP, no server, no task store.
     def fetch() -> dict[str, object]:
         return json.loads(json.dumps(payload))
+
+    # The dashboard re-polls once a second and every applied result appends a
+    # sample to the history the sparkline draws. Textual draws a one-sample
+    # series as a full bar in the max colour and two identical samples as the
+    # minimum bar in the min colour, so leaving the timer running would record
+    # in the exported bytes how many times a one-second timer happened to fire
+    # while the screen was being driven - that is, how busy the machine was.
+    # Letting exactly one poll through makes the frame a property of the
+    # fixture instead.
+    schedule_poll = dashboard_app.BernsteinApp._schedule_poll
+    polls_scheduled = itertools.count()
+
+    def schedule_first_poll_only(app_under_test: object) -> None:
+        if next(polls_scheduled) == 0:
+            schedule_poll(app_under_test)
 
     _FrozenDatetime._frozen = frozen_now
 
@@ -146,23 +169,22 @@ async def _export(payload: dict[str, object], frozen_now: float) -> str:
 
     with (
         patch.object(dashboard_app, "_fetch_all", fetch),
+        patch.object(dashboard_app.BernsteinApp, "_schedule_poll", schedule_first_poll_only),
         patch.object(agent_log, "datetime", _FrozenDatetime),
         patch("time.strftime", frozen_strftime),
         patch("time.time", lambda: frozen_now),
     ):
         app = dashboard_app.BernsteinApp()
         async with app.run_test(size=TERMINAL_SIZE) as pilot:
-            # The first pause starts the poll worker. How many more it takes
-            # for the result to land depends on the machine: six were enough
-            # here and not always on a busy CI runner, where the screen was
-            # captured with the sparkline still on its placeholder. Wait for
-            # the applied result itself, then let the widgets repaint. A poll
-            # that never lands is not an error here: the teardown test drives
-            # this same loop with a poll that completes after the screens close,
-            # and the freshness gate reports the resulting drift on its own.
+            # Wait for the state the export depends on rather than counting
+            # pauses: the poll has to have been applied, and the sparkline has
+            # to be holding the sample that poll produced. A poll that never
+            # lands is not an error here: the teardown test drives this same
+            # loop with a poll that completes after the screens close, and the
+            # freshness gate reports the resulting drift on its own.
             for _ in range(120):
                 await pilot.pause()
-                if app._history:
+                if app._history and app.query_one(_SPARKLINE_SELECTOR, Sparkline).data:
                     break
             for _ in range(3):
                 await pilot.pause()

--- a/tests/unit/test_tui_render_freshness.py
+++ b/tests/unit/test_tui_render_freshness.py
@@ -14,19 +14,27 @@ one implementation rather than two that agree today.
 
 from __future__ import annotations
 
+import asyncio
 import importlib.util
 import json
 import re
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 import yaml
+from textual.pilot import Pilot
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "render_tui_snapshot.py"
 RENDER_PATH = REPO_ROOT / "docs" / "assets" / "tui-live.svg"
 FIXTURE_PATH = REPO_ROOT / "tests" / "fixtures" / "tui_live_frame.json"
+
+#: The dashboard polls on a one-second interval. Two pauses this long straddle
+#: it, which is what makes the slow-machine render a second poll's worth of
+#: history behind rather than merely late.
+_LONGER_THAN_ONE_POLL = 0.8
 
 
 @pytest.fixture(scope="module")
@@ -70,6 +78,47 @@ def test_the_committed_render_matches_what_the_dashboard_draws(snapshot: Any) ->
         "docs/assets/tui-live.svg no longer matches the dashboard.\n"
         f"{snapshot.drift_report(committed, current)}\n"
         "Regenerate with: uv run python scripts/render_tui_snapshot.py --update"
+    )
+
+
+def test_two_renders_in_one_process_agree(snapshot: Any) -> None:
+    """A byte gate is only meaningful if the render is a function of the fixture.
+
+    Cheap half of the determinism check: anything left over from a previous
+    render inside the same interpreter shows up here.
+    """
+    assert snapshot.render() == snapshot.render()
+
+
+def test_the_render_does_not_depend_on_how_fast_the_machine_is(snapshot: Any) -> None:
+    """The render must not record how many times a background timer fired.
+
+    The dashboard re-polls once a second and every applied result appends a
+    sample to the history the sparkline draws. Textual draws a one-sample
+    series as a full bar in its max colour and two identical samples as the
+    minimum bar in its min colour, so a screen driven slowly enough for the
+    timer to fire twice exports different bytes - and different CSS class
+    numbering after it - than the same screen driven quickly. That is how this
+    gate failed on a loaded runner while passing on every developer machine.
+
+    Slowing every pause down past the poll interval is the cheapest way to be
+    that loaded runner on purpose. The assertion is on the published bytes,
+    because those are what the gate compares.
+    """
+    committed = RENDER_PATH.read_text(encoding="utf-8")
+    real_pause = Pilot.pause
+
+    async def pause_slower_than_the_poll_interval(self: Pilot, delay: float | None = None) -> None:
+        await real_pause(self, delay)
+        await asyncio.sleep(_LONGER_THAN_ONE_POLL / 2)
+
+    with patch.object(Pilot, "pause", pause_slower_than_the_poll_interval):
+        slow = snapshot.render()
+
+    assert slow == committed, (
+        "the render moved when the machine was slowed down, so the byte gate is "
+        "reporting machine speed rather than what the dashboard draws.\n"
+        f"{snapshot.drift_report(committed, slow)}"
     )
 
 


### PR DESCRIPTION
## What drifted

`tests/unit/test_tui_render_freshness.py::test_the_committed_render_matches_what_the_dashboard_draws`
went red on `main`. The gate re-renders `tests/fixtures/tui_live_frame.json`
through `scripts/render_tui_snapshot.py` and compares the bytes with
`docs/assets/tui-live.svg`.

The drift was one row, in the ACTIVITY region:

```
-██████████████████████████████████████ (118 cols)
+▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ (118 cols)
```

plus one extra CSS class (`fill: #153954`) which renumbered every class after
it.

## Why

Nothing in the five merges since the last green `main` changed an input: at
`origin/main` the render is byte-identical to the committed asset on a
developer machine, six runs out of six.

The cause is the snapshot itself. The dashboard re-polls once a second, and
every applied result appends a sample to the history the sparkline draws. The
sparkline draws a one-sample series as a full bar in its max colour, and two
identical samples as the minimum bar in its min colour (`$primary 30%`,
which is the `#153954` that appeared). The script waited for the first result
to be applied and then let the timer keep running, so the exported bytes
recorded how many times a one-second timer happened to fire while the screen
was being driven - i.e. how loaded the machine was. Fast machine: one sample,
full bar. Loaded runner: two samples, minimum bar.

## What changes

- `scripts/render_tui_snapshot.py`: let exactly one poll reach the widgets for
  the duration of the snapshot, and wait on the state the export depends on
  (the applied sample, and the sparkline holding it) rather than on a pause
  count.
- `tests/unit/test_tui_render_freshness.py`: two determinism assertions - two
  renders in one process agree, and the render does not move when every pause
  is slowed past the poll interval.

`docs/assets/tui-live.svg` is **not** regenerated. The one-poll frame is what
was already committed, so the fix restores the published asset's claim instead
of moving it. The byte comparison is untouched.

## How verified

- The new slow-machine test reproduces the runner's failure exactly - same
  region, same glyph, same inserted colour, same class renumbering - and fails
  without the script change.
- With the change: `scripts/render_tui_snapshot.py` reports
  `docs/assets/tui-live.svg matches what the dashboard draws` (exit 0), and all
  19 tests in the file pass.
- 585 `tui` unit tests pass.
- `ruff format` + `ruff check` clean on both files.
