### PR TITLE
fix(audit): verify fails when the grant sweep reports a finding

### DIFF
--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -921,7 +921,10 @@ def _verify_grant_chains() -> bool:
                 sweep_findings.append(f"run {run_id}: {finding['summary']}")
 
     console.print()
-    if not failures:
+    # A chain whose every signature and HMAC verifies can still carry a grant
+    # the sweep marks as revoked-but-present. That is a failing grant state,
+    # so the sweep findings block the pass verdict exactly like a chain error.
+    if not failures and not sweep_findings:
         console.print(
             Panel("[bold green]Grant Chain Verification Passed[/bold green]", border_style="green", expand=False)
         )

--- a/tests/unit/cli/test_audit_verify_grants.py
+++ b/tests/unit/cli/test_audit_verify_grants.py
@@ -3,6 +3,10 @@
 A tampered grant record makes ``bernstein audit verify`` fail with the run and
 record named, exactly like a tampered chain entry. When no grant chains exist
 the check is a silent no-op that does not affect the exit code.
+
+A cryptographically intact chain is not on its own a clean verdict: the grant
+sweep can still report that a revoked grant is present in the approved set, and
+a verdict that ignores that certifies a failing grant state as passing.
 """
 
 from __future__ import annotations
@@ -10,7 +14,8 @@ from __future__ import annotations
 import pytest
 
 from bernstein.cli.commands import audit_cmd
-from bernstein.core.identity import grants
+from bernstein.cli.helpers import console
+from bernstein.core.identity import grant_sweep, grants
 
 
 @pytest.fixture(autouse=True)
@@ -46,3 +51,47 @@ def test_verify_grant_chains_fails_for_tampered(tmp_path, monkeypatch) -> None:
 def test_verify_grant_chains_noop_when_absent(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(audit_cmd, "AUDIT_DIR", tmp_path)
     assert audit_cmd._verify_grant_chains() is True
+
+
+def test_verify_grant_chains_fails_when_the_sweep_reports_a_finding(tmp_path, monkeypatch) -> None:
+    """A valid chain plus a critical sweep finding is a failure, not a pass.
+
+    The chain signatures and the HMAC linkage all verify here - the only thing
+    wrong is what the sweep found - so this is the case a verdict keyed on
+    chain validity alone gets wrong. The command's return value is what
+    operators and automation branch on, so it is asserted alongside the panel.
+    """
+    monkeypatch.setattr(audit_cmd, "AUDIT_DIR", tmp_path)
+    _seed_grants(tmp_path)
+
+    summary = "revoked grant K is still present in the approved set"
+    monkeypatch.setattr(
+        grant_sweep,
+        "sweep_grants",
+        lambda result, **kwargs: {"severity": "critical", "category": "grant-sweep", "summary": summary},
+    )
+
+    with console.capture() as captured:
+        verdict = audit_cmd._verify_grant_chains()
+    output = captured.get()
+
+    assert verdict is False
+    assert "Grant Chain Verification Passed" not in output
+    assert "Grant Chain Verification FAILED" in output
+    assert summary in output
+
+
+def test_verify_grant_chains_still_passes_when_the_sweep_is_clean(tmp_path, monkeypatch) -> None:
+    """The sweep returning nothing must stay a pass, or the check is useless.
+
+    Guards the obvious over-correction: failing whenever the sweep runs at all.
+    """
+    monkeypatch.setattr(audit_cmd, "AUDIT_DIR", tmp_path)
+    _seed_grants(tmp_path)
+    monkeypatch.setattr(grant_sweep, "sweep_grants", lambda result, **kwargs: None)
+
+    with console.capture() as captured:
+        verdict = audit_cmd._verify_grant_chains()
+
+    assert verdict is True
+    assert "Grant Chain Verification Passed" in captured.get()


### PR DESCRIPTION
## What was wrong

`bernstein audit verify` could print `Grant Chain Verification Passed` and
return success while the grant sweep had reported a critical revoked-grant
overlap.

`_verify_grant_chains()` collects chain-validation errors in `failures` and
grant-sweep findings in `sweep_findings`. The success branch tested only
`failures`:

```python
if not failures:
    # green panel, return True
```

So a chain whose every Ed25519 signature and HMAC link verified, but which
carried a grant marked revoked that was still in the approved set, was
certified as clean. The findings were already rendered - but only on the path
taken when the chain itself had failed, which is unreachable when `failures`
is empty. The result an operator or a script branches on was the wrong one.

## What changes

`src/bernstein/cli/commands/audit_cmd.py` - the pass verdict now requires both
lists to be empty:

```python
if not failures and not sweep_findings:
```

A sweep finding therefore takes the existing failure panel and
finding-rendering path: the command exits non-zero and names the finding.
Chain verification, grant-sweep computation and remediation behaviour are
untouched, and a clean sweep still passes.

## How verified

`tests/unit/cli/test_audit_verify_grants.py` gains two tests:

- a valid signed chain plus a critical sweep finding must return `False`, must
  print the failure panel and the finding summary, and must not print the
  success panel. This test fails on the parent commit (`assert True is False`)
  and passes with the change.
- the over-correction guard: a clean sweep still returns `True` and still
  prints the success panel.

Runs on this branch:

- `tests/unit/cli/test_audit_verify_grants.py` - 5 passed
- `tests/unit/identity/test_grant_sweep.py` + `tests/unit/identity/test_grants_sweep.py` - 15 passed
- wider `audit`/`grant` unit selection - 308 passed
- `ruff check` and `ruff format --check` clean on both files

Reported by @Silentpartnercoding via GHSA-594x-5h3g-wj34.
