### PR TITLE
ci(quorum): evaluate the review rules from the default branch

### DIFF
--- a/.github/workflows/quorum.yml
+++ b/.github/workflows/quorum.yml
@@ -12,9 +12,17 @@ name: quorum
 #
 # The check only reads. It takes no token beyond the read-only GITHUB_TOKEN
 # and never runs anything from the branch under review: the checkout below is
-# pinned to the BASE commit, so the roster and CODEOWNERS it reads are the
-# ones already on the target branch and a pull request cannot promote its own
-# author by editing them.
+# pinned to the default branch, so the script, the roster and CODEOWNERS it
+# reads are the ones in force on the target branch and a pull request cannot
+# promote its own author, unown a path, or delete the script by editing its
+# own tree.
+#
+# The default branch, and not the commit a pull request records as its base:
+# a base commit older than the rules carries no copy of the script at all, so
+# the job had no rules to apply and said so. A check that applies no rule must
+# not read as a review that happened, so a missing script now fails the job
+# instead of passing it. The rules a pull request is measured against are
+# therefore always the current ones, whenever it was opened.
 #
 # This workflow is pinned by an organization ruleset as a required workflow,
 # which is what makes it non-forgeable: a branch cannot swap in its own
@@ -52,9 +60,11 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          # The base commit, never the pull request's own tree: the roster and
-          # CODEOWNERS have to be the ones already trusted on the target branch.
-          ref: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.sha }}
+          # The default branch, never the pull request's own tree: the script,
+          # the roster and CODEOWNERS have to be the ones in force on the
+          # target branch, and they have to be the current ones rather than
+          # whatever the pull request happens to record as its base commit.
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
           sparse-checkout: |
             scripts/quorum_check.py
@@ -67,19 +77,19 @@ jobs:
           INPUT_PR: ${{ inputs.pr }}
         run: |
           set -euo pipefail
-          # The checkout above is the base branch, so on the pull request that
-          # first adds this check -- and on any branch whose base predates it --
-          # there is nothing to run. Say so and pass: the rules in force on that
-          # base are whatever branch protection already enforces there, and this
-          # job cannot invent an opinion it has no code for. Once the script is
-          # on the base branch a pull request cannot remove it this way, because
-          # deleting it still has to pass the copy that is still on the base.
+          # The checkout above is the default branch, so the script is there
+          # whenever the rules are in force. If it is not, this job has no
+          # rules to apply and cannot answer the review question -- and a
+          # green check that applied no rule is worse than a red one, because
+          # it is indistinguishable from a review that happened. Fail closed.
           if [ ! -f scripts/quorum_check.py ]; then
-            echo "The base branch does not carry scripts/quorum_check.py yet; nothing to check."
-            echo "### quorum: not applicable" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "The base branch does not carry \`scripts/quorum_check.py\` yet, so this run has no rules to apply." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
+            echo "scripts/quorum_check.py is not present in the default branch checkout; no rule could be applied."
+            {
+              echo "### quorum: not evaluated"
+              echo ""
+              echo "\`scripts/quorum_check.py\` is not present in the default branch checkout, so this run had no rules to apply and fails rather than passing without applying any."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
           fi
           if [ "${INPUT_PR:-}" != "" ]; then
             python3 scripts/quorum_check.py --pr "$INPUT_PR"

--- a/tests/unit/test_quorum_workflow_yaml.py
+++ b/tests/unit/test_quorum_workflow_yaml.py
@@ -1,0 +1,194 @@
+"""Structural assertions for the review-quorum check.
+
+The `quorum` check is the only gate that answers the review question: the
+branch ruleset on the default branch asks for zero native approvals, so a
+green `quorum` is the whole approval signal a merge is allowed to rely on.
+That makes two properties of the workflow file load-bearing, and neither one
+shows up as a red check when it regresses:
+
+*Stale rules.* The rules the check applies -- the script, the roster,
+CODEOWNERS -- come from a checkout. If that checkout is the commit a pull
+request records as its base, then a pull request opened before a rule existed
+is measured against a tree that does not carry it, and the answer is a green
+check for a state the current rules reject. A pull request that sits open long
+enough decides for itself which rules it is judged by.
+
+*Passing without applying a rule.* A run that finds no script has no rules to
+apply. Reporting that as success makes "no rule was applied" and "the review
+happened" the same check result, which is the failure the gate exists to
+prevent; the same shape reappears whenever the missing-script branch is
+allowed to exit zero.
+
+Both are decided by static structure, so they are asserted statically here.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
+    pytest.skip("pyyaml not installed", allow_module_level=True)
+
+QUORUM = Path(".github/workflows/quorum.yml")
+SCRIPT = Path("scripts/quorum_check.py")
+
+#: The expression that has to decide the checkout. Anything derived from the
+#: pull request's recorded base pins the rules to the moment it was opened.
+DEFAULT_BRANCH_EXPR = "github.event.repository.default_branch"
+STALE_BASE_EXPRS = (
+    "github.event.pull_request.base.sha",
+    "github.event.merge_group.base_sha",
+)
+
+#: The three files the check reads. A sparse checkout that drops one of them
+#: reads a missing roster or a missing CODEOWNERS as "no rule here".
+READS = (
+    "scripts/quorum_check.py",
+    ".github/quorum-roster.toml",
+    ".github/CODEOWNERS",
+)
+
+SHA_PIN = re.compile(r"^[^@]+@[0-9a-f]{40}$")
+
+
+def _load() -> dict[str, Any]:
+    doc = yaml.safe_load(QUORUM.read_text(encoding="utf-8"))
+    assert isinstance(doc, dict), f"{QUORUM} is not a mapping"
+    return cast("dict[str, Any]", doc)
+
+
+def _on(doc: dict[str, Any]) -> dict[str, Any]:
+    # PyYAML 1.1 parses a bare ``on:`` key as the boolean True.
+    on = cast("dict[Any, Any]", doc).get(True, doc.get("on"))
+    assert isinstance(on, dict), "the workflow must have an `on:` mapping"
+    return cast("dict[str, Any]", on)
+
+
+def _job(doc: dict[str, Any]) -> dict[str, Any]:
+    jobs = doc.get("jobs")
+    assert isinstance(jobs, dict), "the workflow must define jobs"
+    job = jobs.get("quorum")
+    assert isinstance(job, dict), "the workflow must define the `quorum` job"
+    return cast("dict[str, Any]", job)
+
+
+def _steps(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    steps = _job(doc).get("steps")
+    assert isinstance(steps, list), "the `quorum` job must define steps"
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def _checkout(doc: dict[str, Any]) -> dict[str, Any]:
+    matches = [step for step in _steps(doc) if str(step.get("uses", "")).startswith("actions/checkout@")]
+    assert len(matches) == 1, "the job must check out exactly once"
+    return matches[0]
+
+
+def _check_step(doc: dict[str, Any]) -> dict[str, Any]:
+    matches = [step for step in _steps(doc) if "run" in step]
+    assert len(matches) == 1, "the job must have exactly one `run` step"
+    return matches[0]
+
+
+def test_the_rules_are_read_from_the_default_branch() -> None:
+    """The checkout is the default branch, not the pull request's recorded base.
+
+    A base commit older than a rule does not carry it, so measuring a pull
+    request against its own recorded base lets an old pull request pass rules
+    it never saw. The default branch is where the ruleset pins this workflow
+    from, and it is where the rules in force live.
+    """
+    checkout = _checkout(_load())
+    with_ = checkout.get("with")
+    assert isinstance(with_, dict), "the checkout step must have a `with:` mapping"
+    ref = with_.get("ref")
+    assert isinstance(ref, str), "the checkout step must pin `ref`"
+
+    assert DEFAULT_BRANCH_EXPR in ref, f"the checkout must read `{DEFAULT_BRANCH_EXPR}`; got {ref!r}"
+    for expr in STALE_BASE_EXPRS:
+        assert expr not in ref, f"the checkout must not fall back to `{expr}`: it pins the rules to the pull request"
+
+
+def test_the_checkout_cannot_run_the_branch_under_review() -> None:
+    """Read-only, credential-free, and limited to the three files it reads."""
+    doc = _load()
+    with_ = _checkout(doc).get("with")
+    assert isinstance(with_, dict)
+
+    assert with_.get("persist-credentials") is False, "the checkout must not leave a token behind"
+    assert with_.get("sparse-checkout-cone-mode") is False
+
+    sparse = with_.get("sparse-checkout")
+    assert isinstance(sparse, str), "the checkout must stay sparse"
+    listed = [line.strip() for line in sparse.splitlines() if line.strip()]
+    assert listed == list(READS), f"the sparse checkout must be exactly the files the check reads; got {listed}"
+
+    assert doc.get("permissions") == {"contents": "read"}
+    assert _job(doc).get("permissions") == {"contents": "read", "pull-requests": "read"}
+
+
+def test_a_run_that_applied_no_rule_fails() -> None:
+    """The missing-script branch fails; nothing in the step can exit zero early.
+
+    `exit 0` there is the shape that turns "no rule was applied" into a green
+    review check, which is the one answer this gate must never give.
+    """
+    run = _check_step(_load()).get("run")
+    assert isinstance(run, str), "the check step must have a `run:` body"
+
+    assert "exit 1" in run, "the missing-script branch must fail the job"
+    assert "exit 0" not in run, "the check step must not exit zero without applying a rule"
+    assert f"[ ! -f {READS[0]} ]" in run, "the step must still guard on the script being present"
+    assert "set -euo pipefail" in run
+
+
+def test_the_check_still_answers_for_every_event_that_can_gate_a_merge() -> None:
+    """Pull requests, queued groups, and a manual run against one pull request."""
+    doc = _load()
+    on = _on(doc)
+
+    pull_request = on.get("pull_request")
+    assert isinstance(pull_request, dict)
+    types = pull_request.get("types")
+    assert isinstance(types, list)
+    assert {"opened", "synchronize", "reopened", "ready_for_review"} <= set(types)
+    assert "paths" not in pull_request and "paths-ignore" not in pull_request, (
+        "the review question is asked whatever the pull request touches"
+    )
+
+    assert "merge_group" in on, "the queued state has to be re-checked before it merges"
+
+    dispatch = on.get("workflow_dispatch")
+    assert isinstance(dispatch, dict)
+    inputs = dispatch.get("inputs")
+    assert isinstance(inputs, dict)
+    assert "pr" in inputs, "a manual run has to name the pull request it answers for"
+
+
+def test_every_action_stays_pinned_to_a_commit() -> None:
+    """A tag is movable; the gate's own steps cannot be."""
+    for step in _steps(_load()):
+        uses = step.get("uses")
+        if uses is None:
+            continue
+        assert isinstance(uses, str)
+        assert SHA_PIN.match(uses), f"`{uses}` must be pinned to a full commit sha"
+
+
+def test_the_file_records_why_the_rules_come_from_the_default_branch() -> None:
+    """The reason is in the file, next to the line it explains.
+
+    Both properties above were regressions somebody could introduce while
+    reading the old comment and believing it, so the comment is asserted.
+    """
+    text = QUORUM.read_text(encoding="utf-8")
+    assert "default branch" in text
+    assert "organization ruleset" in text, "the file must keep naming what makes it non-forgeable"
+    assert "BASE commit" not in text, "the comment must not still describe the recorded base commit"
+    assert SCRIPT.exists(), "the script the gate runs must be on the default branch"


### PR DESCRIPTION
## What was wrong

`quorum` answers whether a pull request has the review the charter asks for. It read the rules it applies — `scripts/quorum_check.py`, `.github/quorum-roster.toml`, `.github/CODEOWNERS` — out of a checkout of `github.event.pull_request.base.sha`: the commit a pull request records as its base, not the branch it targets.

A pull request whose recorded base predates a rule is therefore measured against a tree that does not carry it. Where the base predates the script itself, the run found nothing to run, printed `The base branch does not carry scripts/quorum_check.py yet; nothing to check.` and exited zero — a **green review check on a pull request that no rule had been applied to**, indistinguishable from a review that happened.

That is not theoretical here. The branch ruleset on the default branch asks for **0** native approvals, so a green `quorum` is the whole approval signal a merge relies on; and the script was added on 2026-09-09, so every pull request opened before then is in this state. On one of them GitHub reported `CLEAN` and `quorum: success` while the shipped script, run against the same data, reported the pull request two approvals short.

## What this changes

1. **The checkout is the default branch.** That is where the rules in force live, and where the organization ruleset pins this workflow from, so a pull request is measured against the current rules whatever its base and however long it has been open. The security property is unchanged: still the target branch and never the branch under review, still `persist-credentials: false`, still the same three files sparsely checked out — a pull request still cannot promote its own author, unown a path, or delete the script by editing its own tree.
2. **A run that applied no rule fails.** If the script is not in the checkout the job cannot answer the review question, so it fails rather than passing. Fail closed.

Triggers, permissions, concurrency and the commit-pinned actions are untouched. No ruleset, roster, CODEOWNERS or script change: the fix is this file, on the branch the ruleset already pins.

## Tests

`tests/unit/test_quorum_workflow_yaml.py` (new, follows the `test_*_workflow_yaml.py` convention) pins:

- the checkout reads `github.event.repository.default_branch` and does **not** fall back to either recorded-base expression;
- the missing-script branch exits non-zero, and no `exit 0` remains in the step;
- the checkout stays read-only, credential-free and limited to exactly the three files;
- the check still runs on `pull_request`, `merge_group` and `workflow_dispatch`, unfiltered by paths;
- every action stays pinned to a full commit sha;
- the header comment no longer describes the recorded base commit.

Three of those cases fail against the previous version of the file.

Local: `ruff check .` clean · `pytest tests/unit -k quorum` 68 passed · `test_merge_queue_gate_coverage_yaml.py` and the other workflow-structure suites pass · `actionlint .github/workflows/quorum.yml` clean.

## Reviewers

`.github/` is a protected path, so this needs three approvals. It is also the check that decides your own pull requests, which is why the review is worth the interruption.
