### PR TITLE
fix(adapters): normalize scanner paths to POSIX for cross-platform consistency

### DIFF
--- a/src/bernstein/adapters/gitleaks.py
+++ b/src/bernstein/adapters/gitleaks.py
@@ -291,7 +291,7 @@ def _normalize_path(path: str, target_root: Path | None) -> str:
     candidate = PurePosixPath(path.replace("\\", "/"))
     if target_root is not None:
         root_posix = PurePosixPath(str(target_root).replace("\\", "/"))
-        anchored = root_posix.is_absolute() or ":" in root_posix.parts[0]
+        anchored = root_posix.is_absolute() or (root_posix.parts and ":" in root_posix.parts[0])
         if anchored:
             with suppress(ValueError):
                 candidate = candidate.relative_to(root_posix)

--- a/src/bernstein/adapters/gitleaks.py
+++ b/src/bernstein/adapters/gitleaks.py
@@ -8,7 +8,7 @@ import shutil
 import subprocess
 from contextlib import suppress
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, cast
 
 from bernstein.adapters._contract import (
@@ -287,11 +287,21 @@ def parse_gitleaks_sarif(report: str | bytes, *, target_root: Path | None = None
 
 
 def _normalize_path(path: str, target_root: Path | None) -> str:
-    candidate = Path(path)
-    if target_root is not None and candidate.is_absolute():
+    """Relativize *path* against *target_root* using POSIX semantics.
+
+    SARIF URIs are always POSIX-style (forward slashes). Using OS-native
+    ``Path`` (which is ``WindowsPath`` on Windows) causes ``is_absolute()``
+    to fail for rootless paths and ``relative_to()`` to raise on drive
+    mismatches. ``PurePosixPath`` gives deterministic cross-platform behavior.
+    """
+    candidate = PurePosixPath(path)
+    if target_root is not None:
+        # Convert the OS-native target_root to a PurePosixPath string
+        # so the relativization logic matches the SARIF URI.
+        root_posix = PurePosixPath(str(target_root).replace("\\", "/"))
         with suppress(ValueError):
-            candidate = candidate.relative_to(target_root.resolve())
-    return candidate.as_posix()
+            candidate = candidate.relative_to(root_posix)
+    return str(candidate)
 
 
 def _rule_descriptions(driver: dict[str, Any]) -> dict[str, str]:

--- a/src/bernstein/adapters/gitleaks.py
+++ b/src/bernstein/adapters/gitleaks.py
@@ -290,7 +290,7 @@ def _normalize_path(path: str, target_root: Path | None) -> str:
     """Relativize *path* against *target_root* using POSIX semantics."""
     candidate = PurePosixPath(path.replace("\\", "/"))
     if target_root is not None:
-        root_posix = PurePosixPath(str(target_root.resolve()).replace("\\", "/"))
+        root_posix = PurePosixPath(str(target_root).replace("\\", "/"))
         anchored = root_posix.is_absolute() or ":" in root_posix.parts[0]
         if anchored:
             with suppress(ValueError):

--- a/src/bernstein/adapters/gitleaks.py
+++ b/src/bernstein/adapters/gitleaks.py
@@ -6,9 +6,8 @@ import hashlib
 import json
 import shutil
 import subprocess
-from contextlib import suppress
 from dataclasses import dataclass
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Any, cast
 
 from bernstein.adapters._contract import (
@@ -27,6 +26,7 @@ from bernstein.adapters.scanner import (
     ScannerCategory,
     ScanResult,
     ScanScope,
+    normalize_finding_path,
 )
 from bernstein.adapters.scanner_finding import Finding
 
@@ -267,7 +267,7 @@ def parse_gitleaks_sarif(report: str | bytes, *, target_root: Path | None = None
             path = str(artifact.get("uri") or "").replace("\\", "/")
             if not path:
                 raise ValueError(f"results[{result_index}] is missing artifactLocation.uri")
-            normalized_path = _normalize_path(path, target_root)
+            normalized_path = normalize_finding_path(path, target_root)
 
             region = _mapping(physical.get("region"), "region")
             snippet = str(_mapping(region.get("snippet"), "region.snippet").get("text") or "")
@@ -284,18 +284,6 @@ def parse_gitleaks_sarif(report: str | bytes, *, target_root: Path | None = None
             )
 
     return findings
-
-
-def _normalize_path(path: str, target_root: Path | None) -> str:
-    """Relativize *path* against *target_root* using POSIX semantics."""
-    candidate = PurePosixPath(path.replace("\\", "/"))
-    if target_root is not None:
-        root_posix = PurePosixPath(str(target_root).replace("\\", "/"))
-        anchored = root_posix.is_absolute() or (root_posix.parts and ":" in root_posix.parts[0])
-        if anchored:
-            with suppress(ValueError):
-                candidate = candidate.relative_to(root_posix)
-    return str(candidate)
 
 
 def _rule_descriptions(driver: dict[str, Any]) -> dict[str, str]:

--- a/src/bernstein/adapters/gitleaks.py
+++ b/src/bernstein/adapters/gitleaks.py
@@ -287,20 +287,14 @@ def parse_gitleaks_sarif(report: str | bytes, *, target_root: Path | None = None
 
 
 def _normalize_path(path: str, target_root: Path | None) -> str:
-    """Relativize *path* against *target_root* using POSIX semantics.
-
-    SARIF URIs are always POSIX-style (forward slashes). Using OS-native
-    ``Path`` (which is ``WindowsPath`` on Windows) causes ``is_absolute()``
-    to fail for rootless paths and ``relative_to()`` to raise on drive
-    mismatches. ``PurePosixPath`` gives deterministic cross-platform behavior.
-    """
-    candidate = PurePosixPath(path)
+    """Relativize *path* against *target_root* using POSIX semantics."""
+    candidate = PurePosixPath(path.replace("\\", "/"))
     if target_root is not None:
-        # Convert the OS-native target_root to a PurePosixPath string
-        # so the relativization logic matches the SARIF URI.
-        root_posix = PurePosixPath(str(target_root).replace("\\", "/"))
-        with suppress(ValueError):
-            candidate = candidate.relative_to(root_posix)
+        root_posix = PurePosixPath(str(target_root.resolve()).replace("\\", "/"))
+        anchored = root_posix.is_absolute() or ":" in root_posix.parts[0]
+        if anchored:
+            with suppress(ValueError):
+                candidate = candidate.relative_to(root_posix)
     return str(candidate)
 
 

--- a/src/bernstein/adapters/scanner.py
+++ b/src/bernstein/adapters/scanner.py
@@ -28,8 +28,10 @@ Reused infrastructure (never reimplemented):
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from contextlib import suppress
 from dataclasses import dataclass, field
 from enum import StrEnum
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any
 
 from bernstein.adapters.base import RateLimitMeter, record_rate_limit_hit
@@ -44,6 +46,31 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # Capability enums
 # ---------------------------------------------------------------------------
+
+
+def normalize_finding_path(path: str, target_root: Path | None) -> str:
+    """Relativize *path* against *target_root* using POSIX semantics.
+
+    SARIF URIs are always POSIX-style (forward slashes). Using OS-native
+    ``Path`` (which is ``WindowsPath`` on Windows) causes ``is_absolute()``
+    to fail for rootless paths and ``relative_to()`` to raise on drive
+    mismatches. ``PurePosixPath`` gives deterministic cross-platform behavior.
+
+    Callers must pass an already-resolved *target_root*; this function does
+    not call ``.resolve()`` to preserve lexical purity and avoid filesystem
+    access during parsing.
+    """
+    candidate = PurePosixPath(path.replace("\\", "/"))
+    if target_root is not None:
+        root_posix = PurePosixPath(str(target_root).replace("\\", "/"))
+        # Gate on the root being anchored (leading '/' or a drive letter).
+        # Note: This heuristic treats POSIX directories literally named 'c:data'
+        # as anchored, which is an acceptable tradeoff for cross-platform drive-letter support.
+        anchored = root_posix.is_absolute() or (root_posix.parts and ":" in root_posix.parts[0])
+        if anchored:
+            with suppress(ValueError):
+                candidate = candidate.relative_to(root_posix)
+    return str(candidate)
 
 
 class OutputFormat(StrEnum):

--- a/src/bernstein/adapters/scanner.py
+++ b/src/bernstein/adapters/scanner.py
@@ -102,7 +102,7 @@ class ScanScope:
 
     def to_dict(self) -> dict[str, Any]:
         return {
-            "roots": [str(p) for p in self.roots],
+            "roots": [p.as_posix() for p in self.roots],
             "include": list(self.include),
             "exclude": list(self.exclude),
             "max_depth": self.max_depth,

--- a/src/bernstein/adapters/semgrep.py
+++ b/src/bernstein/adapters/semgrep.py
@@ -309,7 +309,7 @@ def _normalize_path(path: str, target_root: Path | None) -> str:
     candidate = PurePosixPath(path.replace("\\", "/"))
     if target_root is not None:
         root_posix = PurePosixPath(str(target_root).replace("\\", "/"))
-        anchored = root_posix.is_absolute() or ":" in root_posix.parts[0]
+        anchored = root_posix.is_absolute() or (root_posix.parts and ":" in root_posix.parts[0])
         if anchored:
             with suppress(ValueError):
                 candidate = candidate.relative_to(root_posix)

--- a/src/bernstein/adapters/semgrep.py
+++ b/src/bernstein/adapters/semgrep.py
@@ -308,7 +308,7 @@ def _normalize_path(path: str, target_root: Path | None) -> str:
     """Relativize *path* against *target_root* using POSIX semantics."""
     candidate = PurePosixPath(path.replace("\\", "/"))
     if target_root is not None:
-        root_posix = PurePosixPath(str(target_root.resolve()).replace("\\", "/"))
+        root_posix = PurePosixPath(str(target_root).replace("\\", "/"))
         anchored = root_posix.is_absolute() or ":" in root_posix.parts[0]
         if anchored:
             with suppress(ValueError):

--- a/src/bernstein/adapters/semgrep.py
+++ b/src/bernstein/adapters/semgrep.py
@@ -6,9 +6,8 @@ import hashlib
 import json
 import shutil
 import subprocess
-from contextlib import suppress
 from dataclasses import dataclass
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Any, cast
 
 from bernstein.adapters._contract import (
@@ -27,6 +26,7 @@ from bernstein.adapters.scanner import (
     ScannerCategory,
     ScanResult,
     ScanScope,
+    normalize_finding_path,
 )
 from bernstein.adapters.scanner_finding import Finding
 
@@ -282,7 +282,7 @@ def parse_semgrep_sarif(report: str | bytes, *, target_root: Path | None = None)
             path = str(artifact.get("uri") or "").replace("\\", "/")
             if not path:
                 raise ValueError(f"results[{result_index}] is missing artifactLocation.uri")
-            normalized_path = _normalize_path(path, target_root)
+            normalized_path = normalize_finding_path(path, target_root)
 
             region = _mapping(physical.get("region"), "region")
             snippet = str(_mapping(region.get("snippet"), "region.snippet").get("text") or "")
@@ -302,18 +302,6 @@ def parse_semgrep_sarif(report: str | bytes, *, target_root: Path | None = None)
             )
 
     return findings
-
-
-def _normalize_path(path: str, target_root: Path | None) -> str:
-    """Relativize *path* against *target_root* using POSIX semantics."""
-    candidate = PurePosixPath(path.replace("\\", "/"))
-    if target_root is not None:
-        root_posix = PurePosixPath(str(target_root).replace("\\", "/"))
-        anchored = root_posix.is_absolute() or (root_posix.parts and ":" in root_posix.parts[0])
-        if anchored:
-            with suppress(ValueError):
-                candidate = candidate.relative_to(root_posix)
-    return str(candidate)
 
 
 def _rule_descriptions(driver: dict[str, Any]) -> dict[str, str]:

--- a/src/bernstein/adapters/semgrep.py
+++ b/src/bernstein/adapters/semgrep.py
@@ -8,7 +8,7 @@ import shutil
 import subprocess
 from contextlib import suppress
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, cast
 
 from bernstein.adapters._contract import (
@@ -305,11 +305,21 @@ def parse_semgrep_sarif(report: str | bytes, *, target_root: Path | None = None)
 
 
 def _normalize_path(path: str, target_root: Path | None) -> str:
-    candidate = Path(path)
-    if target_root is not None and candidate.is_absolute():
+    """Relativize *path* against *target_root* using POSIX semantics.
+
+    SARIF URIs are always POSIX-style (forward slashes). Using OS-native
+    ``Path`` (which is ``WindowsPath`` on Windows) causes ``is_absolute()``
+    to fail for rootless paths and ``relative_to()`` to raise on drive
+    mismatches. ``PurePosixPath`` gives deterministic cross-platform behavior.
+    """
+    candidate = PurePosixPath(path)
+    if target_root is not None:
+        # Convert the OS-native target_root to a PurePosixPath string
+        # so the relativization logic matches the SARIF URI.
+        root_posix = PurePosixPath(str(target_root).replace("\\", "/"))
         with suppress(ValueError):
-            candidate = candidate.relative_to(target_root.resolve())
-    return candidate.as_posix()
+            candidate = candidate.relative_to(root_posix)
+    return str(candidate)
 
 
 def _rule_descriptions(driver: dict[str, Any]) -> dict[str, str]:

--- a/src/bernstein/adapters/semgrep.py
+++ b/src/bernstein/adapters/semgrep.py
@@ -305,20 +305,14 @@ def parse_semgrep_sarif(report: str | bytes, *, target_root: Path | None = None)
 
 
 def _normalize_path(path: str, target_root: Path | None) -> str:
-    """Relativize *path* against *target_root* using POSIX semantics.
-
-    SARIF URIs are always POSIX-style (forward slashes). Using OS-native
-    ``Path`` (which is ``WindowsPath`` on Windows) causes ``is_absolute()``
-    to fail for rootless paths and ``relative_to()`` to raise on drive
-    mismatches. ``PurePosixPath`` gives deterministic cross-platform behavior.
-    """
-    candidate = PurePosixPath(path)
+    """Relativize *path* against *target_root* using POSIX semantics."""
+    candidate = PurePosixPath(path.replace("\\", "/"))
     if target_root is not None:
-        # Convert the OS-native target_root to a PurePosixPath string
-        # so the relativization logic matches the SARIF URI.
-        root_posix = PurePosixPath(str(target_root).replace("\\", "/"))
-        with suppress(ValueError):
-            candidate = candidate.relative_to(root_posix)
+        root_posix = PurePosixPath(str(target_root.resolve()).replace("\\", "/"))
+        anchored = root_posix.is_absolute() or ":" in root_posix.parts[0]
+        if anchored:
+            with suppress(ValueError):
+                candidate = candidate.relative_to(root_posix)
     return str(candidate)
 
 

--- a/src/bernstein/adapters/trivy.py
+++ b/src/bernstein/adapters/trivy.py
@@ -313,24 +313,18 @@ def _result_path(result: dict[str, Any], result_index: int, target_root: Path | 
 
 
 def _normalize_path(uri: str, target_root: Path | None) -> str:
-    """Relativize *uri* against *target_root* using POSIX semantics.
-
-    SARIF URIs are always POSIX-style (forward slashes). Using OS-native
-    ``Path`` (which is ``WindowsPath`` on Windows) causes ``is_absolute()``
-    to fail for rootless paths and ``relative_to()`` to raise on drive
-    mismatches. ``PurePosixPath`` gives deterministic cross-platform behavior.
-    """
+    """Relativize *uri* against *target_root* using POSIX semantics."""
     parsed = urlparse(uri)
     path = unquote(parsed.path) if parsed.scheme == "file" else unquote(uri)
     candidate = PurePosixPath(path.replace("\\", "/"))
 
-    if target_root is not None and candidate.is_absolute():
-        # Determine the correct root using the OS-native Path (filesystem check)
+    if target_root is not None:
         root = target_root if target_root.is_dir() or not target_root.exists() else target_root.parent
-        # Convert the OS-native root to a PurePosixPath string for the relativization logic
-        root_posix = PurePosixPath(str(root).replace("\\", "/"))
-        with suppress(ValueError):
-            candidate = candidate.relative_to(root_posix)
+        root_posix = PurePosixPath(str(root.resolve()).replace("\\", "/"))
+        anchored = root_posix.is_absolute() or ":" in root_posix.parts[0]
+        if anchored:
+            with suppress(ValueError):
+                candidate = candidate.relative_to(root_posix)
 
     return str(candidate)
 

--- a/src/bernstein/adapters/trivy.py
+++ b/src/bernstein/adapters/trivy.py
@@ -320,7 +320,7 @@ def _normalize_path(uri: str, target_root: Path | None) -> str:
 
     if target_root is not None:
         root = target_root if target_root.is_dir() or not target_root.exists() else target_root.parent
-        root_posix = PurePosixPath(str(root.resolve()).replace("\\", "/"))
+        root_posix = PurePosixPath(str(root).replace("\\", "/"))
         anchored = root_posix.is_absolute() or ":" in root_posix.parts[0]
         if anchored:
             with suppress(ValueError):

--- a/src/bernstein/adapters/trivy.py
+++ b/src/bernstein/adapters/trivy.py
@@ -12,7 +12,7 @@ import sys
 import tempfile
 from contextlib import suppress
 from dataclasses import dataclass
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Any, cast
 from urllib.parse import unquote, urlparse
 
@@ -32,6 +32,7 @@ from bernstein.adapters.scanner import (
     ScannerCategory,
     ScanResult,
     ScanScope,
+    normalize_finding_path,
 )
 from bernstein.adapters.scanner_finding import Finding
 
@@ -316,17 +317,12 @@ def _normalize_path(uri: str, target_root: Path | None) -> str:
     """Relativize *uri* against *target_root* using POSIX semantics."""
     parsed = urlparse(uri)
     path = unquote(parsed.path) if parsed.scheme == "file" else unquote(uri)
-    candidate = PurePosixPath(path.replace("\\", "/"))
 
-    if target_root is not None:
-        root = target_root if target_root.is_dir() or not target_root.exists() else target_root.parent
-        root_posix = PurePosixPath(str(root).replace("\\", "/"))
-        anchored = root_posix.is_absolute() or (root_posix.parts and ":" in root_posix.parts[0])
-        if anchored:
-            with suppress(ValueError):
-                candidate = candidate.relative_to(root_posix)
+    root = target_root
+    if root is not None:
+        root = root if root.is_dir() or not root.exists() else root.parent
 
-    return str(candidate)
+    return normalize_finding_path(path, root)
 
 
 def _rule_summary(rule: dict[str, Any], fallback: str) -> str:

--- a/src/bernstein/adapters/trivy.py
+++ b/src/bernstein/adapters/trivy.py
@@ -12,7 +12,7 @@ import sys
 import tempfile
 from contextlib import suppress
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, cast
 from urllib.parse import unquote, urlparse
 
@@ -313,14 +313,26 @@ def _result_path(result: dict[str, Any], result_index: int, target_root: Path | 
 
 
 def _normalize_path(uri: str, target_root: Path | None) -> str:
+    """Relativize *uri* against *target_root* using POSIX semantics.
+
+    SARIF URIs are always POSIX-style (forward slashes). Using OS-native
+    ``Path`` (which is ``WindowsPath`` on Windows) causes ``is_absolute()``
+    to fail for rootless paths and ``relative_to()`` to raise on drive
+    mismatches. ``PurePosixPath`` gives deterministic cross-platform behavior.
+    """
     parsed = urlparse(uri)
     path = unquote(parsed.path) if parsed.scheme == "file" else unquote(uri)
-    candidate = Path(path.replace("\\", "/"))
+    candidate = PurePosixPath(path.replace("\\", "/"))
+
     if target_root is not None and candidate.is_absolute():
+        # Determine the correct root using the OS-native Path (filesystem check)
         root = target_root if target_root.is_dir() or not target_root.exists() else target_root.parent
+        # Convert the OS-native root to a PurePosixPath string for the relativization logic
+        root_posix = PurePosixPath(str(root).replace("\\", "/"))
         with suppress(ValueError):
-            candidate = candidate.relative_to(root.resolve())
-    return candidate.as_posix()
+            candidate = candidate.relative_to(root_posix)
+
+    return str(candidate)
 
 
 def _rule_summary(rule: dict[str, Any], fallback: str) -> str:

--- a/src/bernstein/adapters/trivy.py
+++ b/src/bernstein/adapters/trivy.py
@@ -321,7 +321,7 @@ def _normalize_path(uri: str, target_root: Path | None) -> str:
     if target_root is not None:
         root = target_root if target_root.is_dir() or not target_root.exists() else target_root.parent
         root_posix = PurePosixPath(str(root).replace("\\", "/"))
-        anchored = root_posix.is_absolute() or ":" in root_posix.parts[0]
+        anchored = root_posix.is_absolute() or (root_posix.parts and ":" in root_posix.parts[0])
         if anchored:
             with suppress(ValueError):
                 candidate = candidate.relative_to(root_posix)

--- a/tests/unit/adapters/test_gitleaks_scanner.py
+++ b/tests/unit/adapters/test_gitleaks_scanner.py
@@ -253,18 +253,29 @@ def test_scan_result_carries_the_invocation_digest(tmp_path: Path) -> None:
     assert result.invocation_digest != ""
 
 
-def test_windows_drive_letter_path_is_relativized_correctly() -> None:
+@pytest.mark.parametrize(
+    "module_name,func_name",
+    [
+        ("bernstein.adapters.gitleaks", "_normalize_path"),
+        ("bernstein.adapters.semgrep", "_normalize_path"),
+        ("bernstein.adapters.trivy", "_normalize_path"),
+    ],
+)
+def test_windows_drive_letter_path_is_relativized_correctly(module_name: str, func_name: str) -> None:
     """Reproduce the Windows path bug without needing a Windows machine.
 
     PurePosixPath doesn't consider 'C:/...' absolute, so we must gate
     on the root being anchored, not the candidate (Issue #5787).
+    Trivy was the adapter that regressed, so all three are pinned here.
     """
-    report = json.loads(_fixture_text())
-    artifact = report["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["artifactLocation"]
+    import importlib
+
+    module = importlib.import_module(module_name)
+    normalize_func = getattr(module, func_name)
 
     # Simulate a Windows drive-letter path
-    artifact["uri"] = "C:/checkout/project/app.env"
+    assert normalize_func("C:/checkout/project/app.env", Path("C:/checkout/project")) == "app.env"
+    assert normalize_func("C:\\checkout\\project\\app.env", Path("C:/checkout/project")) == "app.env"
 
-    finding = parse_gitleaks_sarif(json.dumps(report), target_root=Path("C:/checkout/project"))[0]
-
-    assert finding.path == "app.env"
+    # Ensure relative roots don't truncate relative candidates (the latent edge)
+    assert normalize_func("src/app.py", Path("src")) == "src/app.py"

--- a/tests/unit/adapters/test_gitleaks_scanner.py
+++ b/tests/unit/adapters/test_gitleaks_scanner.py
@@ -265,7 +265,8 @@ def test_windows_drive_letter_path_is_relativized_correctly(module_name: str, fu
 
     PurePosixPath doesn't consider 'C:/...' absolute, so we must gate
     on the root being anchored, not the candidate (Issue #5787).
-    Trivy was the adapter that regressed, so all three are pinned here.
+    Trivy was the adapter that regressed, so all three are pinned here
+    via the shared helper in scanner.py and trivy's URI wrapper.
     """
     import importlib
 

--- a/tests/unit/adapters/test_gitleaks_scanner.py
+++ b/tests/unit/adapters/test_gitleaks_scanner.py
@@ -256,8 +256,7 @@ def test_scan_result_carries_the_invocation_digest(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     "module_name,func_name",
     [
-        ("bernstein.adapters.gitleaks", "_normalize_path"),
-        ("bernstein.adapters.semgrep", "_normalize_path"),
+        ("bernstein.adapters.scanner", "normalize_finding_path"),
         ("bernstein.adapters.trivy", "_normalize_path"),
     ],
 )

--- a/tests/unit/adapters/test_gitleaks_scanner.py
+++ b/tests/unit/adapters/test_gitleaks_scanner.py
@@ -251,3 +251,20 @@ def test_scan_result_carries_the_invocation_digest(tmp_path: Path) -> None:
     assert adapter.last_invocation is not None
     assert result.invocation_digest == adapter.last_invocation.argv_hash
     assert result.invocation_digest != ""
+
+
+def test_windows_drive_letter_path_is_relativized_correctly() -> None:
+    """Reproduce the Windows path bug without needing a Windows machine.
+
+    PurePosixPath doesn't consider 'C:/...' absolute, so we must gate
+    on the root being anchored, not the candidate (Issue #5787).
+    """
+    report = json.loads(_fixture_text())
+    artifact = report["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["artifactLocation"]
+
+    # Simulate a Windows drive-letter path
+    artifact["uri"] = "C:/checkout/project/app.env"
+
+    finding = parse_gitleaks_sarif(json.dumps(report), target_root=Path("C:/checkout/project"))[0]
+
+    assert finding.path == "app.env"


### PR DESCRIPTION
## What

Fixes the four known Windows path normalization failures blocking the Windows test lane (progress on #5787, Step 1).

## Why

The Windows test cell invokes `run_tests.py` with `-x`, so the run stops at the first failing file. These four path-handling failures were causing the Windows lane to abort after running only a handful of files, making any Windows timing benchmarks impossible and hiding any downstream regressions.

## How

- **Design Choice:** I placed the normalization logic in the shared scope/report handling in `scanner.py` and updated the `_normalize_path` helper in `gitleaks.py`, `semgrep.py`, and `trivy.py`. 
- Applied `PurePosixPath` and `.as_posix()` to ensure path separators are standardized to `/` across all operating systems.
- **Relativization Logic:** Gates on the **root** being anchored (having a leading `/` or a drive letter) rather than the candidate. This is crucial because `PurePosixPath` does not consider `C:/...` absolute, so gating on `candidate.is_absolute()` breaks Windows drive-letter paths. Gating on the root fixes this and prevents truncating relative candidates when a relative root is passed.
- Paths relative to the scan target are correctly relativized.
- Absolute paths outside the scan target are kept absolute (just with normalized separators) as required by the issue constraints.
- Added a parametrized test (`test_windows_drive_letter_path_is_relativized_correctly`) to pin the Windows drive-letter behavior without needing a Windows runner.

## Out of Scope

- Did not drop `-x` from the Windows test step.
- Did not touch `.github/windows-lane-baseline.json` or the `established` flag.
- Did not fix any hidden failures past these four (will report those back in #5787).

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes
- [x] `uv run python scripts/run_tests.py -x` passes
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (or N/A if internal-only)
- [x] `docs/operations/<area>.md` updated (or N/A)
- [x] `docs/api/` schema regenerated if a public surface changed (or N/A)
- [x] `uv run bernstein agents-md sync` run so AGENTS.md, CLAUDE.md, `.goosehints`, `CONVENTIONS.md`, and `.cursor/rules/*.mdc` reflect any new module (or N/A)
- [x] Tests cover the documented behaviour