### PR TITLE
ci(macos): run the nightly matrix on hosted runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,4 +3,3 @@
 self-hosted-runner:
   labels:
     - vps
-    - mac-night

--- a/.github/workflows/ci-macos-nightly.yml
+++ b/.github/workflows/ci-macos-nightly.yml
@@ -11,26 +11,14 @@ name: CI (macOS nightly)
 # tag. The job mirrors the `test` matrix in ci.yml so the signal is
 # directly comparable.
 #
-# Runner split: the scheduled matrix runs on a project-owned macOS
-# runner during a fixed nightly window; push-to-main and on-demand runs
-# stay on the hosted pool so an operator can always get a macOS answer
-# outside that window. `workflow_dispatch` carries a `runner` input so
-# the owned lane can be exercised on demand without waiting for the
-# schedule.
+# Every leg of this workflow runs on the hosted macOS pool, so a
+# scheduled run, a push to main and an on-demand dispatch all produce
+# the same signal on the same image.
 
 on:
   schedule:
-    # 23:00 UTC daily. Chosen so the run starts inside the nightly
-    # maintenance window of the project-owned macOS runner in both
-    # daylight-saving seasons (02:00 IDT / 01:00 IST).
-    - cron: "0 23 * * *"
+    - cron: "0 6 * * *"
   workflow_dispatch:
-    inputs:
-      runner:
-        description: "Runner pool for the macOS matrix"
-        type: choice
-        options: [hosted, mac-night]
-        default: hosted
   push:
     branches: [main]
     paths:
@@ -69,9 +57,7 @@ permissions:
 jobs:
   test-macos-nightly:
     name: Test (macOS, Python ${{ matrix.python-version }}, shard ${{ matrix.shard }})
-    # Scheduled runs, and dispatches that ask for it, go to the
-    # project-owned macOS runner; everything else stays hosted.
-    runs-on: ${{ (github.event_name == 'schedule' || inputs.runner == 'mac-night') && fromJSON('["self-hosted","macOS","ARM64","mac-night"]') || 'macos-latest' }}
+    runs-on: macos-latest
     timeout-minutes: 90
     permissions:
       contents: read
@@ -94,9 +80,6 @@ jobs:
         shard: [1, 2, 3, 4]
     steps:
       - name: Harden runner (audit mode)
-        # Not supported on self-hosted runners; the owned lane relies on
-        # the single-job ephemeral VM instead.
-        if: runner.environment == 'github-hosted'
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
           egress-policy: audit

--- a/.github/workflows/runner-canary.yml
+++ b/.github/workflows/runner-canary.yml
@@ -12,15 +12,6 @@
 # scheduled job moved onto the group has to keep both properties; this
 # file is the reference, and it deliberately prints nothing about the host
 # beyond pass or fail.
-#
-# A second job proves the macOS lane. That runner is a throwaway virtual
-# machine that exists only inside a nightly maintenance window, so the
-# job is dispatch-only: on a schedule it would queue against a machine
-# that is deliberately absent for most of the day. Its assertions are
-# containment assertions -- the job must be inside a VM, must not be the
-# account that owns the physical machine, must see no home directory but
-# its own, and must see no network share -- and, like the Linux canary,
-# it reports pass or fail rather than describing the host.
 name: Runner canary
 
 on:
@@ -54,60 +45,6 @@ jobs:
             echo "::error::runner is executing as root"
             exit 1
           fi
-      - name: Reach the API
-        run: |
-          set -o pipefail
-          curl -fsSI https://api.github.com | head -1
-
-  macos-canary:
-    name: macOS runner canary
-    # Dispatch only: see the note at the top of the file.
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: [self-hosted, macOS, ARM64, mac-night]
-    timeout-minutes: 15
-    steps:
-      - name: Assert the runner is a virtual machine
-        run: |
-          set -eu
-          model="$(sysctl -n hw.model)"
-          case "$model" in
-            *VirtualMac*) echo "virtualised" ;;
-            *) echo "::error::runner is not a virtual machine"; exit 1 ;;
-          esac
-      - name: Assert the runner account is the image account
-        run: |
-          set -eu
-          if [ "$(whoami)" != "admin" ]; then
-            echo "::error::runner is not executing as the image account"
-            exit 1
-          fi
-          if [ "$(id -u)" -eq 0 ]; then
-            echo "::error::runner is executing as root"
-            exit 1
-          fi
-      - name: Assert no home directory but the image account's is visible
-        run: |
-          set -eu
-          # Anything outside this set means the job can read a home
-          # directory that belongs to the machine hosting the VM.
-          for entry in /Users/*; do
-            case "$(basename "$entry")" in
-              admin|runner|Shared|Guest|.localized) ;;
-              \*) ;;
-              *) echo "::error::an unexpected home directory is visible to the runner"; exit 1 ;;
-            esac
-          done
-          echo "home-directories-confined"
-      - name: Assert no network share is mounted
-        run: |
-          set -eu
-          # A share belonging to the machine that hosts the VM would
-          # appear here as one of these filesystem types.
-          if mount | grep -Eq '\((smbfs|nfs|afpfs|webdav|ftp)[,)]'; then
-            echo "::error::a network share is mounted inside the runner"
-            exit 1
-          fi
-          echo "no-network-share"
       - name: Reach the API
         run: |
           set -o pipefail

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -70,7 +70,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/release-major-minor.yml | Major/Minor Release | workflow_dispatch | {"cancel-in-progress": "false", "group": "release-major-minor-${{ github.ref }}"} | 1 |
 | .github/workflows/rendering-lane.yml | Rendering lane | pull_request, workflow_dispatch | {"cancel-in-progress": "true", "group": "rendering-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) \|\| format('branch-{0}-{1}', github.ref, github.sha) }}"} | 1 |
 | .github/workflows/required-check-canary.yml | Required-check name canary | pull_request, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "required-check-canary-${{ github.event.pull_request.number \|\| github.ref }}"} | 1 |
-| .github/workflows/runner-canary.yml | Runner canary | schedule, workflow_dispatch | - | 2 |
+| .github/workflows/runner-canary.yml | Runner canary | schedule, workflow_dispatch | - | 1 |
 | .github/workflows/sbom.yml | SBOM | release, workflow_dispatch | {"cancel-in-progress": "false", "group": "sbom-${{ github.ref }}"} | 1 |
 | .github/workflows/scorecard.yml | OSSF Scorecard | branch_protection_rule, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "scorecard-${{ github.ref }}"} | 2 |
 | .github/workflows/soc2-evidence-weekly.yml | soc2-evidence-weekly | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "soc2-evidence-${{ github.ref }}"} | 2 |
@@ -149,7 +149,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/release-major-minor.yml | release: ${{ inputs.bump }} release |
 | .github/workflows/rendering-lane.yml | rendering: Rendering fetcher (browser-backed) |
 | .github/workflows/required-check-canary.yml | verify: Required-check name canary |
-| .github/workflows/runner-canary.yml | canary: Runner canary<br>macos-canary: macOS runner canary |
+| .github/workflows/runner-canary.yml | canary: Runner canary |
 | .github/workflows/sbom.yml | sbom: Generate SBOM |
 | .github/workflows/scorecard.yml | analysis: Scorecard analysis<br>upload: Filter suppressions and upload to Code Scanning |
 | .github/workflows/soc2-evidence-weekly.yml | pack: generate evidence pack<br>preflight: preflight (gate) |


### PR DESCRIPTION
## What

The nightly macOS matrix runs on the hosted macOS pool again, and the
dispatch-only macOS containment canary that existed alongside it is
removed.

## Why

The matrix was split across two pools by event: `schedule` (and a
dispatch that asked for it) went to a project-owned runner label, and
everything else stayed hosted. That split was there to spare hosted
macOS concurrency. The organisation's macOS concurrency has since been
raised, so a single pool covers every leg of the workflow — and one pool
means a scheduled run, a push to `main` and an on-demand dispatch all
produce the same signal on the same image, which the split could not
promise.

## Changes

| File | Change |
|---|---|
| `.github/workflows/ci-macos-nightly.yml` | `runs-on: macos-latest` for the matrix, replacing the event-dependent expression. The `runner` `workflow_dispatch` input is dropped — there is no second pool to choose. The schedule returns to `0 6 * * *`; the `0 23 * * *` slot existed only to line the run up with a fixed nightly maintenance window, and the header comment has described 06:00 UTC throughout. `step-security/harden-runner` loses its `runner.environment == 'github-hosted'` gate, so every leg of the nightly is back under egress audit. |
| `.github/workflows/runner-canary.yml` | The `macos-canary` job is removed. Its assertions were containment assertions about the project-owned macOS runner; with no such runner they have nothing to assert. The Linux canary is untouched. |
| `.github/actionlint.yaml` | The retired runner label is no longer declared. |
| `docs/operations/ci-topology.md` | Regenerated. |

Restoring the schedule also re-aligns the documentation: the "What runs
when" table in `docs/operations/ci.md` lists the nightly as a "Daily 06:00
UTC schedule", which stopped being true when the cron moved and is true
again now. Same for this workflow's own header comment.

The `open-failure-issue` job is unchanged: it still runs on the Linux
self-hosted label and still opens or updates a tracking issue when a
scheduled or push-to-`main` nightly fails.

## Verification

- `actionlint` clean on both edited workflows and across the repository.
- `python scripts/gen_workflow_topology.py --check` clean.
- `tests/unit/test_self_hosted_runner_scope.py`,
  `tests/unit/test_workflow_topology_report.py`,
  `tests/unit/test_required_check_canary_workflow_yaml.py`,
  `tests/unit/test_bot_pull_request_tokens_yaml.py` pass locally (76 tests).
- `ruff check .` clean.
- After merge: the nightly's next scheduled run is the check — the matrix
  should report four hosted `macos-latest` shards.
