### PR TITLE
ci(codeql): analyse the trunk and the schedule, not every pull request (#5795)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,32 +11,27 @@ on:
       - "uv.lock"
       - ".github/workflows/codeql.yml"
       - ".github/codeql/**"
-  # Path-scoped on pull_request: CodeQL analyzes Python sources only, so
-  # PRs that touch no analyzable path (docs-only, workflow-only) skip the
-  # run and free a runner slot. This is safe for branch protection: the
-  # required status check on `main` is `CI gate` only, so a skipped
-  # CodeQL run cannot deadlock a PR. Push-to-main and
-  # the weekly schedule keep full-coverage analysis on everything that
-  # lands.
-  pull_request:
-    branches: [main]
-    paths:
-      - "src/**"
-      - "tests/**"
-      - "scripts/**"
-      - "pyproject.toml"
-      - "uv.lock"
-      - ".github/workflows/codeql.yml"
-      - ".github/codeql/**"
+  # No `pull_request` trigger, deliberately (#5795). It ran 517 times in one
+  # week for 2 165 job-minutes and gated nothing: branch protection requires
+  # `CI gate` and `shipped bundle matches the lockfile`, not CodeQL. Every
+  # commit that reaches `main` is analysed again by the push run minutes
+  # later, so the pull-request run was a second analysis of the same code
+  # whose only output was an advisory annotation.
+  #
+  # Stated plainly, the cost: a newly introduced finding now surfaces after
+  # the merge rather than before it. Alerts are triaged against the trunk,
+  # which is where the push run and the weekly schedule raise them.
   schedule:
     - cron: "0 4 * * 1"  # Weekly Monday 4 AM UTC
 
 concurrency:
   group: codeql-${{ github.ref }}
-  # Cancel superseded PR analyses, but never cancel a main-branch analysis
-  # mid-run: a cancelled CodeQL run leaves code scanning in a "CodeQL exited
-  # with errors" configuration-error state and drops that commit's coverage.
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Never cancel in flight. Both remaining triggers analyse the trunk, and a
+  # cancelled CodeQL run leaves code scanning in a "CodeQL exited with errors"
+  # configuration-error state and drops that commit's coverage. This was
+  # `github.event_name == 'pull_request'` while pull requests ran; with that
+  # trigger gone the expression could only ever be false.
+  cancel-in-progress: false
 
 # Default-deny at workflow scope; the analyze job re-asserts the narrow
 # writes it actually needs (Scorecard token-permissions).

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -32,7 +32,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/cleanup-runs.yml | Cleanup Action Runs | workflow_dispatch | {"cancel-in-progress": "false", "group": "cleanup-runs-${{ github.ref }}"} | 1 |
 | .github/workflows/cluster-e2e.yml | cluster-e2e | pull_request, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "cluster-e2e-${{ github.ref }}"} | 1 |
 | .github/workflows/cluster-tunnel-e2e.yml | cluster-tunnel-e2e | schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "cluster-tunnel-e2e-${{ github.ref }}"} | 1 |
-| .github/workflows/codeql.yml | CodeQL Security Analysis | pull_request, push, schedule | {"cancel-in-progress": "${{ github.event_name == 'pull_request' }}", "group": "codeql-${{ github.ref }}"} | 1 |
+| .github/workflows/codeql.yml | CodeQL Security Analysis | push, schedule | {"cancel-in-progress": "false", "group": "codeql-${{ github.ref }}"} | 1 |
 | .github/workflows/contract-drift-autofix.yml | Contract Drift Autofix | pull_request | {"cancel-in-progress": "true", "group": "contract-drift-${{ github.event.pull_request.number }}"} | 1 |
 | .github/workflows/coverage-ratchet-weekly.yml | Coverage ratchet (weekly floor bump) | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "coverage-ratchet-weekly"} | 1 |
 | .github/workflows/coverage-ratchet.yml | Coverage ratchet (total) | workflow_run | {"cancel-in-progress": "false", "group": "coverage-ratchet"} | 1 |

--- a/tests/unit/test_codeql_workflow_yaml.py
+++ b/tests/unit/test_codeql_workflow_yaml.py
@@ -1,0 +1,89 @@
+"""Structural assertions for the CodeQL lane's triggers.
+
+CodeQL analysed every pull request 517 times in one week for 2 165
+job-minutes and gated nothing: branch protection on `main` requires `CI gate`
+and `shipped bundle matches the lockfile`, and CodeQL is neither. Every commit
+that lands is analysed again by the push run minutes later, so the
+pull-request run was a second analysis of the same code whose only output was
+an advisory annotation (#5795).
+
+The trigger set is the whole of that decision and nothing red appears when it
+regresses -- re-adding `pull_request` restores 2 165 job-minutes a week and
+still gates nothing. It is decided by static structure, so it is asserted
+statically here, in the shape `cifuzz-weekly` uses for the same reason.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "codeql.yml"
+
+
+def _doc() -> dict[str, Any]:
+    data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), f"{WORKFLOW.name} is not a mapping"
+    return cast("dict[str, Any]", data)
+
+
+def _triggers() -> dict[str, Any]:
+    doc = _doc()
+    # PyYAML resolves a bare `on:` key to the boolean True.
+    triggers = doc.get(True, doc.get("on"))
+    assert isinstance(triggers, dict), "the `on:` block is not a mapping"
+    return cast("dict[str, Any]", triggers)
+
+
+def test_workflow_file_exists() -> None:
+    assert WORKFLOW.is_file()
+
+
+def test_there_is_no_pull_request_trigger() -> None:
+    """The advisory pull-request run was dropped; re-adding it costs the same again."""
+    assert "pull_request" not in _triggers()
+    assert "pull_request_target" not in _triggers()
+
+
+def test_the_trunk_and_the_schedule_both_still_analyse() -> None:
+    """Dropping the PR run is only defensible while these two remain.
+
+    The trunk run is what makes "surfaces after the merge rather than before
+    it" a latency cost rather than a coverage loss; the weekly run catches
+    findings that come from a new query version rather than from a new commit.
+    """
+    triggers = _triggers()
+    assert "schedule" in triggers
+    push = triggers.get("push")
+    assert isinstance(push, dict), "the push trigger is not a mapping"
+    assert push.get("branches") == ["main"]
+
+
+def test_analysis_is_never_cancelled_mid_run() -> None:
+    """A cancelled CodeQL run leaves code scanning in a configuration-error state.
+
+    It was previously safe to cancel a superseded *pull request* analysis, and
+    the guard was written as `github.event_name == 'pull_request'`. With that
+    trigger gone the expression can only be false, and leaving it in place
+    would read as if some run were still cancellable.
+    """
+    concurrency = _doc().get("concurrency")
+    assert isinstance(concurrency, dict), "concurrency is not a mapping"
+    assert concurrency.get("cancel-in-progress") is False
+
+
+def test_no_step_branches_on_a_pull_request_event() -> None:
+    """A leftover `event_name == 'pull_request'` guard is dead and misleading.
+
+    Comments are excluded: the file explains in prose why the trigger is gone,
+    and that sentence has to be allowed to name the thing it removed.
+    """
+    body = WORKFLOW.read_text(encoding="utf-8").split("concurrency:", 1)[1]
+    code = [line for line in body.splitlines() if not line.lstrip().startswith("#")]
+    offenders = [line.strip() for line in code if "pull_request" in line]
+    assert offenders == []


### PR DESCRIPTION
Closes #5795.

## Change

Drops the `pull_request` trigger from `.github/workflows/codeql.yml`. `push` to `main` and the weekly schedule stay.

The pull-request run was advisory — branch protection requires `CI gate` and `shipped bundle matches the lockfile`, and CodeQL is neither — and every commit that lands is analysed again by the push run minutes later. So it was a second analysis of the same code, 517 times a week for 2 165 job-minutes, producing an annotation nobody gated on.

The cost, stated plainly: a newly introduced finding surfaces after the merge rather than before it. That is one merge of latency on a signal that is triaged against the trunk anyway.

## `cancel-in-progress`

It read `${{ github.event_name == 'pull_request' }}`, which existed only to cancel superseded pull-request analyses. With that trigger gone the expression can only ever be false, so it is now written as `false`. Leaving the expression would suggest some run is still cancellable, and a cancelled CodeQL run is not free: it leaves code scanning in a "CodeQL exited with errors" configuration-error state and drops that commit's coverage.

## Test

`tests/unit/test_codeql_workflow_yaml.py`, in the shape `test_cifuzz_weekly_workflow_yaml.py` uses for the same class of decision. The trigger set is the whole of this change, and nothing turns red if it regresses — re-adding `pull_request` costs 2 165 job-minutes a week again and still gates nothing.

It asserts the pull-request trigger is gone (including `pull_request_target`), that both remaining triggers survive — the trunk run is what makes this a latency cost rather than a coverage loss, and the weekly run catches findings that come from a new query version rather than a new commit — that `cancel-in-progress` is `false`, and that no step still branches on a pull-request event.

## Acceptance criteria

- `CodeQL Security Analysis` has zero `pull_request` runs — the trigger is gone; the test pins it.
- The trunk run still uploads results for every commit that lands — `push` to `main` is unchanged, including its path filter, and the test asserts it.
- Open alert count one week out — observable after merge, not assertable here.
- `required-check-canary.yml` still passes — it pins `["CI gate", "shipped bundle matches the lockfile"]`; no CodeQL context appears in it, and this PR does not touch it.

## Verification

```
uv run --group dev pytest tests/unit/test_codeql_workflow_yaml.py   # 5 passed
uv run --group dev ruff check && ruff format --check                # clean
```

No other workflow references CodeQL's pull-request run; the `github/codeql-action/upload-sarif` uses in `scorecard.yml` and `static-analysis-extended.yml` are separate lanes with their own triggers and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)