### PR TITLE
ci: eight shards on the row that is the critical path (#5794)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1836,12 +1836,28 @@ jobs:
     env:
       # Single source of truth for the shard count. The `--shard i/N`
       # denominator below and the per-shard slice both key off this; bump
-      # it (and the `shard:` list) together to rescale the fan-out.
-      # The merge-queue lane fans out over eight shards: each queue build is
-      # on the critical path of every entry behind it, and the per-shard
-      # suite is the longest job in the run. Pull requests and pushes keep
-      # four; their shards run alongside other work rather than ahead of it.
-      TEST_SHARD_COUNT: ${{ github.event_name == 'merge_group' && '8' || '4' }}
+      # it (and the `shard:` list, plus the windows `exclude` rows) together
+      # to rescale the fan-out.
+      #
+      # Eight on ubuntu, four on windows -- keyed on the ROW rather than the
+      # event (#5794). The merge queue took eight first, because each queue
+      # build sits on the critical path of every entry behind it. The same
+      # argument turned out to hold for push: measured 2026-09-03..09-10, a
+      # single ubuntu shard was the critical path of every trunk run at a
+      # 28.7 min median against a 30.8 min median to `CI gate` -- under three
+      # minutes of everything else.
+      #
+      # "Their shards run alongside other work rather than ahead of it" was
+      # the reason to keep four, and the concurrency numbers do not support
+      # it: peak was 80 simultaneous hosted jobs, and the repository spent
+      # only 1.5% of that window at 60 or more. The suite runs each file in
+      # its own subprocess, so per-shard wall is close to linear in file
+      # count and doubling the fan-out roughly halves it.
+      #
+      # Windows stays at four: it is not on the critical path (the ubuntu
+      # row is slower), and a windows runner-minute is dearer than a linux
+      # one. See the `exclude` rows that drop shards 5-8 there.
+      TEST_SHARD_COUNT: ${{ matrix.os == 'windows-latest' && '4' || '8' }}
       # Main push coverage runs are slower than local file runs; keep the
       # per-file guard, but allow heavy adapter contract files to finish.
       BERNSTEIN_TEST_FILE_TIMEOUT_SECONDS: "600"
@@ -1872,13 +1888,26 @@ jobs:
         # operator invoking the workflow by hand is asking for coverage,
         # not queue throughput.
         python-version: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && fromJSON('["3.12", "3.13"]') || fromJSON('["3.13"]') }}
-        # Fan the per-file suite out across 4 deterministic shards per
-        # cell. Keep this list in sync with TEST_SHARD_COUNT above.
-        shard: ${{ github.event_name == 'merge_group' && fromJSON('[1, 2, 3, 4, 5, 6, 7, 8]') || fromJSON('[1, 2, 3, 4]') }}
+        # Fan the per-file suite out across deterministic shards per cell.
+        # The list is the WIDEST row (ubuntu, 8); windows drops 5-8 in
+        # `exclude` below because a matrix dimension cannot be computed from
+        # another dimension. Keep all three in sync with TEST_SHARD_COUNT.
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
         exclude:
           # Coverage/JUnit upload only on ubuntu; skip duplicate slow jobs on Windows for 3.12
           - os: windows-latest
             python-version: "3.12"
+          # Windows runs four shards, so its TEST_SHARD_COUNT is 4 and shards
+          # 5-8 do not exist there. Without these rows they would run
+          # `--shard 5/4` and either fail or silently test nothing.
+          - os: windows-latest
+            shard: 5
+          - os: windows-latest
+            shard: 6
+          - os: windows-latest
+            shard: 7
+          - os: windows-latest
+            shard: 8
     steps:
       - name: Harden runner (audit mode)
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1

--- a/tests/unit/test_ci_shard_fanout_yaml.py
+++ b/tests/unit/test_ci_shard_fanout_yaml.py
@@ -1,0 +1,106 @@
+"""The unit-test fan-out is the critical path, and its three declarations must agree.
+
+Measured 2026-09-03..09-10, a single `Test (ubuntu-latest, …)` shard was the critical path of every
+merge-queue and trunk run: 28.7 min median shard wall against 30.8 min median to `CI gate` — under
+three minutes for everything else in the workflow. The suite runs each of ~1.4k files in its own
+subprocess, so per-shard wall is close to linear in file count and the fan-out is the whole lever
+(#5794).
+
+The fan-out is declared in three places that GitHub cannot cross-check: `TEST_SHARD_COUNT` (the
+`--shard i/N` denominator), the `shard:` matrix list, and the `exclude` rows that trim the list on
+rows running fewer shards. A disagreement is silent in the worst direction — `--shard 7/4` either
+fails the run or, on a slicer that clamps, tests nothing and reports success — so it is asserted
+here.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+UBUNTU = "ubuntu-latest"
+WINDOWS = "windows-latest"
+
+
+def _test_job() -> dict[str, Any]:
+    doc = cast("dict[str, Any]", yaml.safe_load(WORKFLOW.read_text(encoding="utf-8")))
+    job = doc["jobs"]["test"]
+    assert isinstance(job, dict)
+    return cast("dict[str, Any]", job)
+
+
+def _shard_count_for(os_name: str) -> int:
+    """The `--shard i/N` denominator this row resolves to.
+
+    Read out of the expression rather than restated, so the test cannot pass against a workflow that
+    no longer says what it says here.
+    """
+    expression = str(_test_job()["env"]["TEST_SHARD_COUNT"])
+    counts = re.findall(r"'(\d+)'", expression)
+    assert len(counts) == 2, f"expected a two-branch shard-count expression, got {expression!r}"
+    windows_count, other_count = (int(value) for value in counts)
+    assert WINDOWS in expression, "the shard count no longer keys off the matrix row"
+    return windows_count if os_name == WINDOWS else other_count
+
+
+def _declared_shards() -> list[int]:
+    shards = _test_job()["strategy"]["matrix"]["shard"]
+    assert isinstance(shards, list), "the shard list is an expression again; keep it literal"
+    return [int(value) for value in shards]
+
+
+def _excluded_shards_for(os_name: str) -> set[int]:
+    excludes = _test_job()["strategy"]["matrix"].get("exclude", [])
+    return {
+        int(row["shard"]) for row in excludes if isinstance(row, dict) and row.get("os") == os_name and "shard" in row
+    }
+
+
+def _shards_that_run_on(os_name: str) -> list[int]:
+    excluded = _excluded_shards_for(os_name)
+    return [shard for shard in _declared_shards() if shard not in excluded]
+
+
+@pytest.mark.parametrize("os_name", [UBUNTU, WINDOWS])
+def test_every_row_runs_exactly_its_own_shard_count(os_name: str) -> None:
+    """`--shard i/N` for i beyond N is either a hard failure or a silent no-op."""
+    running = _shards_that_run_on(os_name)
+    assert running == list(range(1, _shard_count_for(os_name) + 1)), (
+        f"{os_name} runs shards {running} against a count of {_shard_count_for(os_name)}"
+    )
+
+
+@pytest.mark.parametrize("os_name", [UBUNTU, WINDOWS])
+def test_the_slices_cover_the_file_list_once_each(os_name: str) -> None:
+    """Disjoint AND complete: a gap is a test that never ran and reported green."""
+    running = _shards_that_run_on(os_name)
+    assert len(running) == len(set(running)), f"{os_name} declares a duplicate shard"
+    assert min(running) == 1
+    assert max(running) == _shard_count_for(os_name)
+
+
+def test_the_critical_path_row_carries_the_wider_fan_out() -> None:
+    """Ubuntu is the slowest row and the one on the critical path; it gets the shards.
+
+    Windows deliberately stays narrower: it is not the critical path, and a windows runner-minute
+    costs more than a linux one.
+    """
+    assert _shard_count_for(UBUNTU) > _shard_count_for(WINDOWS)
+
+
+def test_the_matrix_list_is_the_widest_row() -> None:
+    """A matrix dimension cannot be computed from another dimension.
+
+    So the list has to be the widest row and the narrower ones trim it with `exclude`. If the list
+    ever shrinks below the ubuntu count, ubuntu quietly stops running its last shards.
+    """
+    assert max(_declared_shards()) == _shard_count_for(UBUNTU)
+    assert _excluded_shards_for(UBUNTU) == set()


### PR DESCRIPTION
Closes #5794.

## State on main

The merge-queue half of this has already landed — `TEST_SHARD_COUNT` is `merge_group ? 8 : 4`, with the reasoning that a queue build sits ahead of every entry behind it. What remains is the push/PR lane, which is where the issue's `push` row was measured: 28.7 min median shard wall against 30.8 min median to `CI gate`.

## Change

Key the count on the matrix **row** rather than the event: ubuntu 8, windows 4.

That is what the issue asks for ("for the ubuntu row"), and it is more precise than doubling everything. Windows is not the critical path — the ubuntu row is slower — and a windows runner-minute costs more than a linux one. This also removes the event branch entirely: the merge queue is ubuntu-only, so it keeps its 8 without a special case.

A matrix dimension cannot be computed from another dimension, so `shard:` becomes the widest row (`[1..8]`) and windows trims 5–8 with `exclude`. Without those rows windows would run `--shard 5/4`.

## On the reason that was given for keeping four

> Pull requests and pushes keep four; their shards run alongside other work rather than ahead of it.

The concurrency measurement in the issue does not support it: peak was 80 simultaneous hosted jobs (65 on `ubuntu-latest`), and the repository spent 36.8% of the window at ≥20, 12.9% at ≥40, and only 1.5% at ≥60. There is headroom for four more ubuntu jobs per run.

## test-macos stays at four

The issue lists it under "where the code is". I have not changed it: macOS is a conditional lane, off the critical path, on the most expensive runners in the fleet, and nothing in the measurement argues for spending there. Say if you would rather it moved together.

## Test

`tests/unit/test_ci_shard_fanout_yaml.py`. The fan-out is now declared in three places GitHub cannot cross-check — the `--shard i/N` denominator, the matrix list, and the `exclude` rows — and a disagreement is silent in the worst direction: a shard index past the count either fails the run or, on a slicer that clamps, tests nothing and reports success.

It reads the count out of the expression rather than restating it, and asserts per row that the shards which actually run are exactly `1..N`, contiguous and without duplicates; that the wider fan-out is on the critical-path row; and that the matrix list is the widest row with no ubuntu exclusions.

**Control run:** 4 of the 6 fail against main.

## Acceptance criteria

- Ubuntu shard median at or below 15 min, and merge_group→`CI gate` at or below 18 min — observable after merge. The merge-queue lane is unchanged by this PR (already 8); this is the push/PR lane reaching the same fan-out.
- `CI gate` still fails when any single shard fails — the roll-up reads the matrix `.result`, which is `failure` if any cell fails. Untouched.
- Count and matrix stay in sync, slices disjoint and complete — the new test, per row.

## Verification

```
uv run --group dev pytest tests/unit/test_ci_shard_fanout_yaml.py   # 6 passed
uv run --group dev ruff check && ruff format --check                # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)