### PR TITLE
feat(govern): reconcile --explain names the layer behind every clause (#5117)

### DIFF
--- a/docs/release-notes/fragments/5117-govern-reconcile-explain.md
+++ b/docs/release-notes/fragments/5117-govern-reconcile-explain.md
@@ -1,0 +1,18 @@
+## `govern reconcile --explain` names the layer behind every clause
+
+`bernstein govern reconcile --explain <target> --policy-set layers.json` prints
+one target's effective policy with the layer each clause came from, composed in
+the fixed order: classification, baseline, instrumentation, then exactly one
+class overlay.
+
+Each row names the tier *and* the named layer — "the baseline said so" is not an
+answer when the baseline is an ordered list of named sub-policies — and a clause
+that overrode a lower layer says which one it displaced.
+
+A target matching zero or more than one class overlay is reported as a finding
+and exits 2, rather than resolved by whichever overlay declaration order reached
+last. Its lower layers still print: posture that is not in doubt is not withheld
+because the class is.
+
+`--json` prints the same composition for a machine. The command reads and
+composes only; it records nothing.

--- a/src/bernstein/cli/commands/govern_cmd.py
+++ b/src/bernstein/cli/commands/govern_cmd.py
@@ -3,6 +3,7 @@
 Issue #5085::
 
     bernstein govern reconcile --propose --desired desired.json [--workdir w] [--full]
+    bernstein govern reconcile --explain <target> --policy-set layers.json [--class c]...
 
 The propose run enumerates every registered adapter, cost lane, scheduled task
 and capability entry, diffs that snapshot against the desired-state document,
@@ -21,6 +22,19 @@ Output and exit codes:
 By default only drifted entities are printed -- a consecutive run reports what
 moved since the previous run's record. ``--full`` prints one ``state`` line per
 entity regardless.
+
+``--explain <target>`` answers the other question (issue #5117): not what
+drifted, but which layer wrote each clause that applies to one target. The
+composition order is fixed -- classification, baseline, instrumentation, then
+exactly one class overlay -- and each printed row names the tier AND the layer,
+because "the baseline said so" is not an answer when the baseline is an ordered
+list of named sub-policies. A target that matches zero or more than one overlay
+is reported as a finding rather than resolved by declaration order, and its
+lower layers still print: posture that is not in doubt should not be withheld
+because the class is.
+
+It reads the policy-set document and composes; it records nothing and touches
+no lineage, so it is safe to run against a production root.
 """
 
 from __future__ import annotations
@@ -31,6 +45,7 @@ from pathlib import Path
 
 import click
 
+from bernstein.core.govern.policy_layers import EffectivePolicy, PolicyCompositionError, PolicySet
 from bernstein.core.govern.reconcile import propose_reconcile, snapshot_surface
 from bernstein.core.govern.reconcile_models import DesiredState, ReconcileEntry
 from bernstein.core.security.audit import load_or_create_audit_key
@@ -51,9 +66,37 @@ RECONCILE_RUN_ID = "govern-reconcile"
 @click.option(
     "--desired",
     "desired_file",
-    required=True,
+    # Required for --propose, and meaningless for --explain. Enforced in the
+    # body rather than by click so the two modes can each name what THEY need,
+    # instead of one mode's requirement rejecting the other's call.
     type=click.Path(exists=True, dir_okay=False),
-    help="JSON desired-state document (entities with prune / self_heal).",
+    help="JSON desired-state document (entities with prune / self_heal). Required with --propose.",
+)
+@click.option(
+    "--explain",
+    "explain_target",
+    metavar="TARGET",
+    default=None,
+    help="Print one target's effective policy and the layer each clause came from.",
+)
+@click.option(
+    "--policy-set",
+    "policy_set_file",
+    type=click.Path(exists=True, dir_okay=False),
+    help="JSON layer document (classification / baseline / instrumentation / class overlays). Required with --explain.",
+)
+@click.option(
+    "--class",
+    "classifications",
+    multiple=True,
+    help="A classification value for the target; repeatable. Decides which class overlay applies.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="With --explain, print the composed policy as JSON instead of a table.",
 )
 @click.option(
     "--workdir",
@@ -69,13 +112,29 @@ RECONCILE_RUN_ID = "govern-reconcile"
     default=False,
     help="Print one line per entity instead of only what drifted.",
 )
-def govern_reconcile_cmd(propose: bool, desired_file: str, workdir: str, full: bool) -> None:
-    """Diff the governed surface against the desired state and record it.
+def govern_reconcile_cmd(
+    propose: bool,
+    desired_file: str | None,
+    workdir: str,
+    full: bool,
+    explain_target: str | None,
+    policy_set_file: str | None,
+    classifications: tuple[str, ...],
+    as_json: bool,
+) -> None:
+    """Diff the governed surface against the desired state, or explain one target's policy.
 
-    Exit codes: 0 = no drift, 1 = unreadable desired state, 2 = drift.
+    Exit codes: 0 = no drift / composed cleanly, 1 = unreadable input,
+    2 = drift / the target's class overlay could not be chosen.
     """
+    if explain_target is not None:
+        _explain(explain_target, policy_set_file, classifications, as_json=as_json)
+        return
     if not propose:
-        click.echo("govern reconcile requires --propose; applying a diff is not implemented.", err=True)
+        click.echo("govern reconcile requires --propose or --explain; applying a diff is not implemented.", err=True)
+        raise SystemExit(1)
+    if desired_file is None:
+        click.echo("govern reconcile --propose requires --desired", err=True)
         raise SystemExit(1)
 
     root = Path(workdir).resolve()
@@ -108,6 +167,61 @@ def govern_reconcile_cmd(propose: bool, desired_file: str, workdir: str, full: b
         click.echo(f"no drift -- {len(diff.entries)} entities, all unchanged")
         raise SystemExit(0)
     raise SystemExit(2)
+
+
+def _explain(
+    target: str,
+    policy_set_file: str | None,
+    classifications: tuple[str, ...],
+    *,
+    as_json: bool,
+) -> None:
+    """Print one target's effective policy, and exit 2 when its overlay is ambiguous.
+
+    Composition lives in :mod:`bernstein.core.govern.policy_layers` and not here,
+    so the answer does not depend on which command asked for it.
+    """
+    if policy_set_file is None:
+        click.echo("govern reconcile --explain requires --policy-set", err=True)
+        raise SystemExit(1)
+    try:
+        raw = json.loads(Path(policy_set_file).read_text(encoding="utf-8"))
+        policy_set = PolicySet.from_dict(raw)
+    except (OSError, json.JSONDecodeError, PolicyCompositionError, TypeError, ValueError) as exc:
+        click.echo(f"unreadable policy set: {exc}", err=True)
+        raise SystemExit(1) from exc
+
+    policy = policy_set.compose(target, classifications)
+    if as_json:
+        click.echo(json.dumps(policy.to_dict(), ensure_ascii=False, sort_keys=True))
+    else:
+        _print_explain_table(policy)
+    if policy.is_ambiguous:
+        raise SystemExit(2)
+    raise SystemExit(0)
+
+
+def _print_explain_table(policy: EffectivePolicy) -> None:
+    """Render the composed policy as aligned rows, plus the finding when there is one.
+
+    Widths come from the rows themselves so a long surface name does not push the
+    origin column off into prose. Rows are already ordered by
+    :class:`EffectivePolicy`, so two runs over one document print identically.
+    """
+    rows, reason = policy.explain()
+    click.echo(f"target {policy.target}")
+    if not rows:
+        click.echo("no clause applies to this target")
+    else:
+        surface_width = max(len(surface) for surface, _, _ in rows)
+        origin_width = max(len(origin) for _, _, origin in rows)
+        for surface, clause, origin in rows:
+            click.echo(f"{origin:<{origin_width}}  {surface:<{surface_width}}  {clause}")
+    click.echo(f"clauses {len(rows)}")
+    if reason is not None:
+        # An error stream, because this is the thing the operator has to act on
+        # and a table is easy to read past.
+        click.echo(f"finding {reason}", err=True)
 
 
 def _verdict_line(entry: ReconcileEntry) -> str:

--- a/src/bernstein/core/govern/policy_layers.py
+++ b/src/bernstein/core/govern/policy_layers.py
@@ -37,7 +37,7 @@ import hashlib
 import json
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
@@ -66,6 +66,14 @@ class LayerKind(StrEnum):
 
 #: The fixed order, derived from the enum so the two cannot drift apart.
 COMPOSITION_ORDER: tuple[LayerKind, ...] = tuple(LayerKind)
+
+
+#: Keys a serialized layer may carry. Declared once so ``from_dict`` can tell a
+#: key the schema does not know from one it merely left unset.
+_LAYER_KEYS = frozenset({"kind", "name", "clauses", "applies_to"})
+
+#: Keys a serialized policy set may carry, for the same reason.
+_POLICY_SET_KEYS = frozenset({"layers"})
 
 
 class PolicyCompositionError(ValueError):
@@ -115,6 +123,42 @@ class PolicyLayer:
         if self.applies_to:
             result["applies_to"] = list(self.applies_to)
         return result
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> PolicyLayer:
+        """Rebuild a layer from a serialized dict.
+
+        Strict about unknown keys, for the reason the playbook models are: a
+        dropped key in a posture document is a rule that silently does not
+        apply, and this document decides what wins.
+
+        Raises:
+            PolicyCompositionError: *raw* carries an unknown key, names a layer
+                kind outside the four, or fails the layer's own construction
+                rules.
+        """
+        from bernstein.core.govern.playbook_models import PlaybookClause
+
+        unknown = set(raw) - _LAYER_KEYS
+        if unknown:
+            raise PolicyCompositionError(
+                f"unknown layer field(s) {sorted(unknown)} for layer {raw.get('name')!r}: "
+                f"known fields are {sorted(_LAYER_KEYS)}"
+            )
+        kind_value = str(raw.get("kind", ""))
+        try:
+            kind = LayerKind(kind_value)
+        except ValueError as exc:
+            raise PolicyCompositionError(
+                f"unknown layer kind {kind_value!r}: must be one of {[layer.value for layer in COMPOSITION_ORDER]}"
+            ) from exc
+        clauses = tuple(PlaybookClause.from_dict(clause) for clause in raw.get("clauses", []))
+        return cls(
+            kind=kind,
+            name=str(raw.get("name", "")),
+            clauses=clauses,
+            applies_to=tuple(str(value) for value in raw.get("applies_to", ())),
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -238,6 +282,33 @@ class PolicySet:
     """
 
     layers: tuple[PolicyLayer, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical serialization, layers in DECLARED order.
+
+        Not sorted, unlike a playbook's clauses: order is meaning here, and a
+        round trip that canonicalized it away would erase the precedence this
+        module exists to make explicit.
+        """
+        return {"layers": [layer.to_dict() for layer in self.layers]}
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> PolicySet:
+        """Rebuild a policy set from a serialized dict, preserving layer order.
+
+        Raises:
+            PolicyCompositionError: *raw* or a nested layer carries an unknown
+                key, or a layer fails its own construction rules.
+        """
+        unknown = set(raw) - _POLICY_SET_KEYS
+        if unknown:
+            raise PolicyCompositionError(
+                f"unknown policy-set field(s) {sorted(unknown)}: known fields are {sorted(_POLICY_SET_KEYS)}"
+            )
+        layers = raw.get("layers", [])
+        if not isinstance(layers, list):
+            raise PolicyCompositionError(f"`layers` must be a list, got {type(layers).__name__}")
+        return cls(layers=tuple(PolicyLayer.from_dict(layer) for layer in cast("list[Any]", layers)))
 
     def of_kind(self, kind: LayerKind) -> tuple[PolicyLayer, ...]:
         """The declared layers of one kind, in declaration order."""

--- a/tests/unit/test_govern_reconcile_explain.py
+++ b/tests/unit/test_govern_reconcile_explain.py
@@ -1,0 +1,186 @@
+"""``bernstein govern reconcile --explain <target>``: the effective policy, and where it came from.
+
+Slice 3 of #5117. The composition model and the ordered-baseline hash already
+exist in ``core/govern/policy_layers.py``; until this command nothing outside
+the package imported them, which is the same "built and never wired" failure
+#5105 catalogues for ``security_posture.py``.
+
+What an operator needs from this is not "what applies" -- the flat clause list
+answered that -- but WHICH LAYER wrote each clause, and whether the class
+overlay could be chosen at all. Both are asserted here through the CLI, because
+the composition being right in a library nothing calls is exactly the state this
+slice exists to leave.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.govern_cmd import govern_reconcile_cmd
+
+BASELINE_CLAUSE = "MFA required"
+
+LAYERS = {
+    "layers": [
+        {
+            "kind": "classification",
+            "name": "facts",
+            "clauses": [{"surface": "region", "clause": "runs in eu-west-1", "kind": "permitted"}],
+        },
+        {
+            "kind": "baseline",
+            "name": "common",
+            "clauses": [
+                {"surface": "s3", "clause": "no public buckets", "kind": "forbidden"},
+                {"surface": "iam", "clause": BASELINE_CLAUSE, "kind": "required"},
+            ],
+        },
+        {
+            "kind": "instrumentation",
+            "name": "audit-hooks",
+            "clauses": [{"surface": "audit", "clause": "hooks enabled", "kind": "required"}],
+        },
+        {
+            "kind": "class_overlay",
+            "name": "prod",
+            "applies_to": ["production"],
+            "clauses": [{"surface": "iam", "clause": BASELINE_CLAUSE, "kind": "forbidden"}],
+        },
+        {
+            "kind": "class_overlay",
+            "name": "regulated",
+            "applies_to": ["production", "pci"],
+            "clauses": [{"surface": "s3", "clause": "no public buckets", "kind": "forbidden"}],
+        },
+    ]
+}
+
+
+@pytest.fixture
+def policy_set(tmp_path: Path) -> Path:
+    path = tmp_path / "layers.json"
+    path.write_text(json.dumps(LAYERS), encoding="utf-8")
+    return path
+
+
+def _explain(policy_set: Path, target: str, *classes: str, json_out: bool = False):
+    args = ["--explain", target, "--policy-set", str(policy_set)]
+    for value in classes:
+        args += ["--class", value]
+    if json_out:
+        args.append("--json")
+    return CliRunner().invoke(govern_reconcile_cmd, args)
+
+
+def test_every_row_names_the_layer_that_wrote_it(policy_set: Path) -> None:
+    """The tier alone is not the answer when the baseline is a list of named sub-policies."""
+    result = _explain(policy_set, "web-1", "pci")
+
+    assert result.exit_code == 0, result.output
+    assert "baseline:common" in result.stdout
+    assert "instrumentation:audit-hooks" in result.stdout
+    assert "class_overlay:regulated" in result.stdout
+    assert "classification:facts" in result.stdout
+
+
+def test_the_overlay_wins_over_the_baseline_for_the_same_clause(policy_set: Path) -> None:
+    """Composition order is the point: a class overlay can tighten or relax the baseline."""
+    # `pci` matches exactly one overlay; `production` matches two and is the
+    # ambiguous case pinned separately below.
+    result = _explain(policy_set, "web-1", "pci")
+    payload = json.loads(_explain(policy_set, "web-1", "pci", json_out=True).stdout)
+    s3 = next(c for c in payload["clauses"] if c["surface"] == "s3")
+
+    assert result.exit_code == 0
+    assert s3["layer"] == "class_overlay"
+    assert s3["source"] == "regulated"
+    assert s3["overridden"] == ["baseline:common"]
+
+
+def test_two_matching_overlays_are_a_finding_not_a_default(policy_set: Path) -> None:
+    """Whichever overlay declaration order reached last is not an answer."""
+    result = _explain(policy_set, "web-2", "production")
+
+    assert result.exit_code == 2
+    assert "2 class overlays apply" in result.stderr
+    assert "prod" in result.stderr
+    assert "regulated" in result.stderr
+
+
+def test_no_matching_overlay_is_also_a_finding(policy_set: Path) -> None:
+    """Silently composing three layers and calling it complete is the same lie."""
+    result = _explain(policy_set, "web-3")
+
+    assert result.exit_code == 2
+    assert "no class overlay applies" in result.stderr
+
+
+def test_an_ambiguous_target_still_reports_the_layers_below(policy_set: Path) -> None:
+    """Posture that is not in doubt should not be withheld because the class is."""
+    result = _explain(policy_set, "web-2", "production")
+
+    assert "baseline:common" in result.stdout
+    assert "instrumentation:audit-hooks" in result.stdout
+    assert "class_overlay" not in result.stdout
+
+
+def test_two_runs_over_one_document_print_identically(policy_set: Path) -> None:
+    """An explain a human diffs against last week's is worth nothing if it reorders."""
+    first = _explain(policy_set, "web-1", "pci").stdout
+    second = _explain(policy_set, "web-1", "pci").stdout
+
+    assert first == second
+
+
+def test_explain_records_nothing(policy_set: Path, tmp_path: Path) -> None:
+    """It reads and composes; it must be safe to run against a production root."""
+    lineage = tmp_path / ".sdd" / "lineage"
+
+    _explain(policy_set, "web-1", "pci")
+
+    assert not lineage.exists()
+
+
+def test_explain_needs_its_own_document_not_the_desired_state(policy_set: Path) -> None:
+    """The two modes want different inputs; neither should reject the other's call."""
+    missing = CliRunner().invoke(govern_reconcile_cmd, ["--explain", "web-1"])
+
+    assert missing.exit_code == 1
+    assert "--policy-set" in missing.stderr
+
+
+def test_a_propose_run_still_requires_its_desired_state() -> None:
+    """Relaxing `--desired` at the click level must not make it optional in practice."""
+    result = CliRunner().invoke(govern_reconcile_cmd, ["--propose"])
+
+    assert result.exit_code == 1
+    assert "--desired" in result.stderr
+
+
+def test_an_unknown_layer_field_is_rejected_rather_than_dropped(tmp_path: Path) -> None:
+    """A dropped key in a posture document is a rule that silently does not apply."""
+    path = tmp_path / "layers.json"
+    path.write_text(
+        json.dumps({"layers": [{"kind": "baseline", "name": "common", "clauses": [], "applies_too": ["x"]}]}),
+        encoding="utf-8",
+    )
+
+    result = _explain(path, "web-1")
+
+    assert result.exit_code == 1
+    assert "unreadable policy set" in result.stderr
+    assert "applies_too" in result.stderr
+
+
+def test_an_unknown_layer_kind_names_the_four(tmp_path: Path) -> None:
+    path = tmp_path / "layers.json"
+    path.write_text(json.dumps({"layers": [{"kind": "overlayy", "name": "x", "clauses": []}]}), encoding="utf-8")
+
+    result = _explain(path, "web-1")
+
+    assert result.exit_code == 1
+    assert "class_overlay" in result.stderr


### PR DESCRIPTION
Closes #5117 (slice 3; slices 1 and 2 are already on main).

## State on main

`src/bernstein/core/govern/policy_layers.py` already has all of slice 1 and slice 2: `LayerKind` with the fixed order, `PolicySet.content_hash` folding layer position in so a silent baseline reorder moves the digest, `OverlayFinding` for zero-or-multiple matches, and `EffectivePolicy.explain()` returning printable rows.

Nothing outside that package imports any of it — the only reference is the `core/govern/__init__.py` re-export. That is the same "built and never wired" state #5105 catalogues for `security_posture.py`, and it is exactly what slice 3 exists to end.

## Change

```
bernstein govern reconcile --explain <target> --policy-set layers.json [--class c]... [--json]
```

```
target web-1
instrumentation:audit-hooks  audit   hooks enabled
baseline:common              iam     MFA required
classification:facts         region  runs in eu-west-1
class_overlay:regulated      s3      no public buckets
clauses 4
```

Every row names the tier **and** the named layer. "The baseline said so" is not an answer when the baseline is an ordered list of named sub-policies, and `--json` carries the `overridden` chain so a clause that displaced a lower layer says which one it displaced.

An ambiguous target exits 2 and **still prints the layers below the overlay** — posture that is not in doubt should not be withheld because the class is. The finding goes to stderr, because it is the thing the operator has to act on and a table is easy to read past:

```
finding 2 class overlays apply to this target (prod, regulated); which one wins
would depend on declaration order, so neither is applied
```

Composition stays in `policy_layers.py`; the command formats. The answer must not depend on which command asked for it.

## Two supporting changes

**`PolicyLayer.from_dict` / `PolicySet.from_dict`.** The module could serialize a policy set and not read one back. Strict about unknown keys for the reason the playbook models are: a dropped key in a posture document is a rule that silently does not apply, and this is the document that decides what wins.

`PolicySet.to_dict` keeps layers in **declared** order rather than sorting them the way a playbook sorts clauses. Order is meaning here — a round trip that canonicalized it away would erase the precedence the module exists to make explicit, and would undo the hash property slice 1 added.

**`--desired` is no longer `required=True` at the click level.** The two modes want different inputs, so each validates what it needs in the body instead of one mode's requirement rejecting the other's call. A `--propose` run without `--desired` still exits 1, and that is pinned by a test so the relaxation cannot quietly become optional.

## Tests

11 in `tests/unit/test_govern_reconcile_explain.py`, through the CLI — the composition being right in a library nothing calls is the state this slice exists to leave. They cover: every tier appears with its layer name; the overlay wins over the baseline for the same key and records what it overrode; two matching overlays are a finding, not a default; zero matching overlays likewise; an ambiguous target still reports its lower layers; two runs print identically; the command writes no lineage; each mode rejects a call missing its own input; and an unknown layer field or kind is rejected rather than dropped.

## Verification

```
uv run --group dev pytest tests/unit/test_govern_reconcile_explain.py tests/unit/test_govern_cmd.py   # 23 passed
uv run --group dev ruff check && ruff format --check && mypy src/bernstein/cli/commands/govern_cmd.py src/bernstein/core/govern/policy_layers.py   # clean
```

Exercised by hand against a three-overlay document for the one-match, two-match and no-match cases; exit codes 0, 2, 2.

## Out of scope

`bernstein config explain` (#5110) — this borrows the shape of the problem, not the implementation. Nothing about how `prune`/`self_heal` interact with layering, per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)