### PR TITLE
fix(project-pulse): retry transient GitHub rate limits

### DIFF
--- a/scripts/project_pulse.py
+++ b/scripts/project_pulse.py
@@ -102,6 +102,10 @@ SEARCH_RESULT_CAP = 1000
 #: requests per minute; a full collection issues roughly 25.
 SEARCH_INTERVAL_SECONDS = 2.5
 
+#: A server-directed retry is useful for a transient Search API allowance, but
+#: it must not turn a weekly job into an unbounded sleep.
+RATE_LIMIT_RETRY_LIMIT = 3
+
 #: The maintainer account. Its merged pull requests are counted separately
 #: from outside contributions so the outside number is not flattered by them.
 MAINTAINER_LOGIN = "chernistry"
@@ -171,27 +175,44 @@ class GitHubClient:
 
     def get(self, path: str, params: dict[str, str] | None = None) -> tuple[Any, dict[str, str]]:
         """GET *path*, returning ``(decoded_body, response_headers)``."""
-        self._throttle()
         url = f"{API_ROOT}/{path.lstrip('/')}"
         if params:
             url = f"{url}?{urllib.parse.urlencode(params)}"
-        request = urllib.request.Request(
-            url,
-            headers={
-                "Authorization": f"Bearer {self._token}",
-                "Accept": "application/vnd.github+json",
-                "X-GitHub-Api-Version": "2022-11-28",
-                "User-Agent": USER_AGENT,
-            },
-        )
-        try:
-            with urllib.request.urlopen(request, timeout=60) as response:
-                raw = response.read()
-                headers = {k.lower(): v for k, v in response.headers.items()}
-        except urllib.error.HTTPError as exc:
-            raise PulseError(f"GitHub API {exc.code} for {url}") from exc
-        except (urllib.error.URLError, TimeoutError, OSError) as exc:
-            raise PulseError(f"GitHub API request failed for {url}: {exc}") from exc
+        rate_limit_retries = 0
+        while True:
+            self._throttle()
+            request = urllib.request.Request(
+                url,
+                headers={
+                    "Authorization": f"Bearer {self._token}",
+                    "Accept": "application/vnd.github+json",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                    "User-Agent": USER_AGENT,
+                },
+            )
+            try:
+                with urllib.request.urlopen(request, timeout=60) as response:
+                    raw = response.read()
+                    headers = {k.lower(): v for k, v in response.headers.items()}
+                break
+            except urllib.error.HTTPError as exc:
+                retry_after = exc.headers.get("retry-after")
+                if exc.code != 403 or retry_after is None:
+                    raise PulseError(f"GitHub API {exc.code} for {url}") from exc
+                try:
+                    delay = float(retry_after)
+                except ValueError as parse_error:
+                    raise PulseError(f"GitHub API 403 has invalid retry-after for {url}") from parse_error
+                if not math.isfinite(delay) or delay < 0:
+                    raise PulseError(f"GitHub API 403 has invalid retry-after for {url}") from exc
+                if rate_limit_retries >= RATE_LIMIT_RETRY_LIMIT:
+                    reset = exc.headers.get("x-ratelimit-reset", f"retry-after {delay:g}s")
+                    message = f"GitHub API 403 rate limit retry budget exhausted for {url}; reset at {reset}"
+                    raise PulseError(message) from exc
+                time.sleep(delay)
+                rate_limit_retries += 1
+            except (urllib.error.URLError, TimeoutError, OSError) as exc:
+                raise PulseError(f"GitHub API request failed for {url}: {exc}") from exc
         try:
             return json.loads(raw.decode("utf-8")), headers
         except (UnicodeDecodeError, json.JSONDecodeError) as exc:

--- a/tests/unit/test_project_pulse.py
+++ b/tests/unit/test_project_pulse.py
@@ -23,12 +23,16 @@ unattended every week into an issue everyone can read:
 from __future__ import annotations
 
 import importlib.util
+import io
 import itertools
 import json
 import re
+import urllib.error
 import xml.etree.ElementTree as ET
+from email.message import Message
 from pathlib import Path
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 
@@ -88,6 +92,86 @@ def _history(weeks: int) -> dict[str, Any]:
         data["pr_merged_within_24h_pct"] = 80.0 + i
         history = _MOD.append_history(history, data)
     return history
+
+
+class _Response:
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+        self.headers = Message()
+
+    def __enter__(self) -> _Response:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def _http_error(status: int, **headers: str) -> urllib.error.HTTPError:
+    response_headers = Message()
+    for name, value in headers.items():
+        response_headers[name] = value
+    return urllib.error.HTTPError(
+        "https://api.github.com/test",
+        status,
+        "test failure",
+        response_headers,
+        io.BytesIO(b"{}"),
+    )
+
+
+def _urlopen_sequence(monkeypatch: pytest.MonkeyPatch, *responses: object) -> Mock:
+    urlopen = Mock(side_effect=list(responses))
+    monkeypatch.setattr(_MOD.urllib.request, "urlopen", urlopen)
+    return urlopen
+
+
+# ---------------------------------------------------------------------------
+# HTTP layer: bounded server-directed rate-limit recovery
+# ---------------------------------------------------------------------------
+
+
+def test_get_retries_rate_limit_using_retry_after(monkeypatch: pytest.MonkeyPatch) -> None:
+    urlopen = _urlopen_sequence(
+        monkeypatch,
+        _http_error(403, **{"Retry-After": "7"}),
+        _Response(b'{"ok": true}'),
+    )
+    sleeps: list[float] = []
+    monkeypatch.setattr(_MOD.time, "sleep", sleeps.append)
+
+    body, _ = _MOD.GitHubClient("token", interval_seconds=0).get("test")
+
+    assert body == {"ok": True}
+    assert urlopen.call_count == 2
+    assert sleeps == [7.0]
+
+
+@pytest.mark.parametrize("status,headers", [(403, {}), (404, {}), (500, {})])
+def test_get_keeps_non_rate_limit_http_errors_fail_closed(
+    monkeypatch: pytest.MonkeyPatch, status: int, headers: dict[str, str]
+) -> None:
+    urlopen = _urlopen_sequence(monkeypatch, _http_error(status, **headers))
+
+    with pytest.raises(_MOD.PulseError, match=f"GitHub API {status}"):
+        _MOD.GitHubClient("token", interval_seconds=0).get("test")
+
+    assert urlopen.call_count == 1
+
+
+def test_get_bounds_rate_limit_retries_and_reports_reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    error = _http_error(403, **{"Retry-After": "1", "X-RateLimit-Reset": "1789060000"})
+    urlopen = _urlopen_sequence(monkeypatch, *([error] * (_MOD.RATE_LIMIT_RETRY_LIMIT + 1)))
+    sleeps: list[float] = []
+    monkeypatch.setattr(_MOD.time, "sleep", sleeps.append)
+
+    with pytest.raises(_MOD.PulseError, match="reset at 1789060000"):
+        _MOD.GitHubClient("token", interval_seconds=0).get("test")
+
+    assert urlopen.call_count == _MOD.RATE_LIMIT_RETRY_LIMIT + 1
+    assert sleeps == [1.0] * _MOD.RATE_LIMIT_RETRY_LIMIT
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The weekly pulse collector currently treats every GitHub API 403 as a terminal error. A transient search rate-limit response includes a server-provided `Retry-After` delay and should be retried within a bounded budget.

## Changes

- Retry GitHub API 403 responses only when `Retry-After` is present and valid.
- Sleep for the server-provided delay, with at most three retries per request.
- Preserve fail-closed behavior for 403 responses without the header and for other HTTP errors.
- Report the reset information when the bounded retry budget is exhausted.
- Add focused unit coverage for successful retry, non-rate-limit failures, and exhaustion.
- Keep rendering and workflow behavior unchanged; the change is limited to the HTTP transport and its tests.

## Validation

- `uv run --no-project --with pytest --with pytest-asyncio --with pyyaml pytest tests/unit/test_project_pulse.py -q --basetemp .pytest-tmp-after-lint` — 49 passed.
- `uv run --no-project --with ruff ruff check scripts/project_pulse.py tests/unit/test_project_pulse.py` — passed.
- `git diff --check` — passed.
- Pre-PR runner on `codex-ci/python:3.14-build` executed the focused suite successfully (49 passed); the runner then reported permission errors while cleaning task artifacts. A follow-up clean-run attempt was also prevented by all six CI workers being occupied.

Fixes #5810
