### PR TITLE
ci(publish): keep the MCP registry version check stdlib-only

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -590,12 +590,12 @@ jobs:
             --build-id "${BUILD_ID}" \
             --deadline-seconds "${COPR_WATCH_SECONDS}"
 
-  # MCP registry listing (#2369). Regenerated from pyproject.toml by
-  # scripts/gen_distribution_manifests.py so the listing can never drift
-  # from the released package version; the check step blocks the publish
-  # on drift instead of shipping a stale manifest. Registry submission is
-  # not on the release critical path (external review latency), so a
-  # registry outage cannot fail the release itself.
+  # MCP registry listing (#2369). server.json is regenerated from
+  # pyproject.toml by scripts/gen_distribution_manifests.py, so the listing
+  # cannot drift from the released package version; the version check below
+  # blocks the submission rather than shipping a stale manifest. Registry
+  # submission is not on the release critical path (external review
+  # latency), so a registry outage cannot fail the release itself.
   publish-mcp-registry:
     name: Publish MCP registry listing
     runs-on: ubuntu-latest
@@ -618,10 +618,20 @@ jobs:
         with:
           ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
-      - name: Check manifest sync with release version
+      # Stdlib only, on purpose: this job installs no dependencies, so a
+      # step here must not import the package. Regenerating the manifests
+      # does import it (scripts/gen_distribution_manifests.py reaches
+      # src/bernstein/core/skills/, which needs the project environment),
+      # and that regeneration is already covered before the tag exists --
+      # by the "Distribution manifest drift check" step of the Repo hygiene
+      # job in ci.yml, which bootstraps the environment first. Repo hygiene
+      # is a `needs` of the required "CI gate" check, so a drifted manifest
+      # cannot reach main and therefore cannot be tagged. What is left for
+      # release time is the one thing CI cannot know: whether the listing
+      # about to be submitted carries the version being released.
+      - name: Check server.json version matches the release tag
         run: |
           set -euo pipefail
-          python3 scripts/gen_distribution_manifests.py --check
           VERSION="${RELEASE_TAG#v}"
           MANIFEST_VERSION=$(python3 -c "import json; print(json.load(open('server.json'))['version'])")
           if [ "$MANIFEST_VERSION" != "$VERSION" ]; then

--- a/docs/integrations/agent-session.md
+++ b/docs/integrations/agent-session.md
@@ -158,11 +158,14 @@ The offline check is a deterministic projection of the two manifests. With
 `--online` it additionally runs `gh attestation verify oci://<ref>` against the
 live Sigstore attestation (when the `gh` CLI and a network are available; absent
 tooling leaves the offline verdict standing). The same consistency check is a
-release gate: `scripts/gen_distribution_manifests.py --check` -- run in the
-publish workflow before the registry listing is pushed -- fails the release if
-the listing and the catalog disagree or the tag does not pin the version. Exit
-codes: `0` consistent (and, with `--online`, attestation verified or tooling
-unavailable), `2` a manifest mismatch or a failed online attestation.
+merge gate: `scripts/gen_distribution_manifests.py --check` -- run by the `Repo
+hygiene` job in `.github/workflows/ci.yml`, which `CI gate` requires -- fails
+the pull request if the listing and the catalog disagree or the version is not
+pinned, so no such commit can be tagged. The publish workflow then re-asserts
+the version agreement on its own, with the standard library alone, before the
+registry listing is pushed. Exit codes: `0` consistent (and, with `--online`,
+attestation verified or tooling unavailable), `2` a manifest mismatch or a
+failed online attestation.
 
 ## The plugin bundle
 

--- a/scripts/gen_distribution_manifests.py
+++ b/scripts/gen_distribution_manifests.py
@@ -15,9 +15,13 @@ Usage::
     python scripts/gen_distribution_manifests.py            # rewrite in place
     python scripts/gen_distribution_manifests.py --check    # exit 1 on drift
 
-``--check`` is wired into the unit suite and the publish workflow, so a
-stale ``server.json`` blocks the registry publish step instead of shipping
-a listing that resolves to the wrong package version.
+``--check`` needs the project environment (it imports the package), so it
+is wired into the unit suite and into the ``Repo hygiene`` job of
+``.github/workflows/ci.yml``, which bootstraps that environment. Repo
+hygiene is a ``needs`` of the required ``CI gate`` check, so a stale
+``server.json`` cannot reach ``main`` and therefore cannot be tagged. The
+publish workflow re-asserts only the version agreement, with the standard
+library alone, immediately before the registry submission.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Fixes #5813

## The defect

`Publish MCP registry listing` in `.github/workflows/publish.yml` installs no
dependencies — its steps are `Harden runner`, `actions/checkout`, then straight to the
check, with no `uses: ./.github/actions/bootstrap` (unlike `Build` at
`.github/workflows/publish.yml:197`). Its first step nonetheless ran

```
python3 scripts/gen_distribution_manifests.py --check
```

which imports the package. In the v3.19.2 run
([job 102875845049](https://github.com/sipyourdrink-ltd/bernstein/actions/runs/34476626709/job/102875845049)):

```
  File "src/bernstein/core/skills/manifest.py", line 30, in <module>
    from pydantic import BaseModel, ConfigDict, Field, ValidationError
ModuleNotFoundError: No module named 'pydantic'
##[error]Process completed with exit code 1.
```

`set -euo pipefail` then aborted the rest of the block, so the version comparison that
is the job's actual purpose never ran, and all four later steps — including
`Publish server.json` — were skipped. The release shipped (the job is
`continue-on-error: true`); the registry listing did not, and neither did the guard.

## The change

The version comparison stays in the publish job, stdlib-only. The manifest regeneration
check is dropped from this job rather than given a bootstrap, because it already has a
home that installs dependencies:

| Where `--check` runs | Environment |
|---|---|
| `.github/workflows/ci.yml:504-510`, `Distribution manifest drift check` in `Repo hygiene` | `uses: ./.github/actions/bootstrap` at `.github/workflows/ci.yml:479` |
| `tests/unit/test_distribution_manifests.py:245`, `tests/unit/test_repo_root_mcp_bridge.py:130` | unit suite |

`Repo hygiene` is a `needs` of `CI gate` (`.github/workflows/ci.yml:2337-2339`), and
`CI gate` is the required status check on the merge queue, so a drifted manifest cannot
reach `main` and therefore cannot be tagged. On the exact commit tagged v3.19.2
(`f569d3fd`) that step ran green in
[run 34472497436](https://github.com/sipyourdrink-ltd/bernstein/actions/runs/34472497436)
minutes before the publish job re-ran the same check without dependencies and died.
Adding a bootstrap here instead would install the full dependency set into a job holding
`id-token: write`, for coverage that already exists one lane earlier.

The step is renamed to `Check server.json version matches the release tag`, after the one
assertion it now makes, so a failure names the check rather than covering two unrelated
ones. Comment, docstring and prose that claimed the drift gate lived in the publish
workflow are corrected to point at `Repo hygiene`.

## Verification

`actionlint`, same flags as the `Workflow lint` job (`.github/workflows/ci.yml:610-615`):

```
$ actionlint -shellcheck= .github/workflows/publish.yml
$ echo $?
0
$ actionlint -shellcheck=          # all workflows
$ echo $?
0
```

The new step's `run:` body extracted verbatim out of the patched workflow and executed
under `bash -e` on `/usr/bin/python3` (3.9.6) with no project dependencies installed —
a harsher interpreter than the runner's, which proves the step is stdlib-only:

```
server.json version = 3.19.2

=== A: matching tag (v3.19.2) — must pass ===
EXIT=0

=== B: mismatching tag (v9.9.9) — must fail with ::error:: ===
::error::server.json version 3.19.2 does not match release 9.9.9
EXIT=1
```

Before/after on one dependency-free interpreter, same harness, matching tag:

```
BEFORE (step body on main)  exit=1   # dies before the version comparison
AFTER  (patched step body)  exit=0
AFTER  (mismatching tag)    exit=1
```

The drift check still passes where it lives, and it is fully offline — the same run with
all network egress blocked produces the same verdict, so the signed-image provenance leg
is a projection of the committed manifests rather than a live registry query. Running it
at pull-request time is therefore equivalent to running it at release time; the removed
duplicate could not have caught anything the earlier lane misses:

```
$ uv run python scripts/gen_distribution_manifests.py --check
distribution manifests in sync (version 3.19.2)
signed-image provenance OK: ghcr.io/sipyourdrink-ltd/bernstein:3.19.2
$ echo $?
0

$ # again, with no network egress permitted
$ uv run --offline python scripts/gen_distribution_manifests.py --check
distribution manifests in sync (version 3.19.2)
signed-image provenance OK: ghcr.io/sipyourdrink-ltd/bernstein:3.19.2
$ echo $?
0
```

Meta-tests over the touched surfaces:

```
$ uv run pytest tests/unit/test_publish_workflow_yaml.py \
    tests/unit/test_distribution_manifests.py \
    tests/unit/test_repo_root_mcp_bridge.py \
    tests/unit/test_release_bump_add_paths.py -q --no-cov
72 passed in 10.90s
```

`ruff check`, `ruff format --check` and `typos` all clean on the changed files.

## What this does not prove

`publish.yml` executes only on a tag push or a `workflow_dispatch`, so a green pull-request
lane says nothing about it. The simulations above run the step body outside Actions; they
cover the shell and the interpreter, not the runner image, the `RELEASE_TAG` expression
expansion, or the four steps downstream. **That the job now reaches `Publish server.json`
can only be observed on the next real release**, and acceptance criterion 7 in #5813 is
open until then.

Separately: the v3.19.2 listing was never submitted to the registry. The job is idempotent
and re-runnable via `workflow_dispatch` with the tag; that backfill is deliberately out of
scope here.

## Also failing in that run, not addressed here

`Publish npm wrapper` failed in the same release run. Different job, different cause,
already tracked in #5800 with a fix open in #5807.
