### PR TITLE
fix(tests): read the reliability docs as UTF-8, not the host default

### DIFF
--- a/docs/release-notes/fragments/bench-reliability-docs-utf8.md
+++ b/docs/release-notes/fragments/bench-reliability-docs-utf8.md
@@ -1,0 +1,11 @@
+## The reliability docs assertion reads its file as UTF-8
+
+`tests/unit/eval/bench/test_reliability.py` read `docs/eval/reliability.md`
+with a bare `read_text()`, so the decoding depended on the host's preferred
+encoding. That file carries 96 non-ASCII bytes, including U+2500 box drawing:
+it raises `UnicodeDecodeError` on a host whose default is cp932, and under
+cp1252 it decodes to 64 characters that are not what the file says, so the
+assertions run against mojibake rather than failing.
+
+Every other call site in the same directory already passes
+`encoding="utf-8"`, including the assertion eleven lines below this one.

--- a/tests/unit/eval/bench/test_reliability.py
+++ b/tests/unit/eval/bench/test_reliability.py
@@ -648,7 +648,7 @@ class TestDocs:
         docs_path = repo_root / "docs" / "eval" / "reliability.md"
         if not docs_path.exists():
             pytest.skip("docs file missing — caught by test_reliability_docs_file_exists")
-        content = docs_path.read_text()
+        content = docs_path.read_text(encoding="utf-8")
         assert "--reliability" in content
         assert "reliability-verify" in content
         assert "reliability-check" in content


### PR DESCRIPTION
## The bug

`TestDocs.test_docs_cover_commands_and_metrics` reads `docs/eval/reliability.md` with a bare `read_text()`, so decoding follows the host's preferred encoding. That file carries **96 non-ASCII bytes**, including U+2500 box drawing:

```
utf-8    10491 chars   correct
cp1252   10555 chars   decodes, but 64 characters are not what the file says
cp932    UnicodeDecodeError at byte 1206
ascii    UnicodeDecodeError at byte 1204
```

Two failure modes, and the quieter one is worse. On a cp932 host the test raises. On cp1252 it *passes* — while asserting against mojibake, so it is no longer checking the document it names.

The assertion eleven lines below it, in the same class, already reads:

```python
assert "reliability" in bench_docs.read_text(encoding="utf-8")
```

ddc630a7b (#5562) fixed `test_bench.py:513` and `test_reliability.py:662` and missed this one. `test_harness_fingerprint.py` passes it at all three of its call sites.

## The change

One line, plus a release-note fragment.

## Scope

The three remaining bare `read_text()` calls in this directory (`test_bench.py:142,226`, `test_reliability.py:260`) are left alone deliberately: each is `json.loads(path.read_text())` on a bundle the test itself just wrote with `json.dumps`, which is `ensure_ascii=True` by default, so those bytes are ASCII by construction. Only the two docs reads were ever exposed, and one of them was already fixed.

## Verification

```
tests/unit/eval/bench/test_reliability.py    47 passed
```

## Why separately

This one line currently appears as a duplicated hunk in six open pull requests (#5470, #5485, #5487, #5489, #5492, #5496, #5566). Landing it on its own removes that hunk from every one of their rebases.
