### PR TITLE
ci(publish): narrow the release approval gate to PyPI

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -28,7 +28,13 @@ jobs:
     name: Build and push image to GHCR
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: pypi
+    # Approval lives on publish.yml's `publish` job (PyPI trusted
+    # publishing, OIDC-scoped to the pypi environment). This job logs in to
+    # GHCR with GITHUB_TOKEN and its id-token: write is for the Sigstore
+    # build-provenance attestation below -- a different, unrelated OIDC
+    # audience -- so pinning it to the same environment only added an
+    # approval click without adding protection.
+    environment: release-channels
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -23,7 +23,11 @@ jobs:
   update-formula:
     name: Update Homebrew formula
     runs-on: ubuntu-latest
-    environment: pypi
+    # Approval lives on publish.yml's `publish` job (PyPI trusted
+    # publishing, OIDC-scoped to the pypi environment). This job pushes to
+    # the tap with HOMEBREW_TAP_TOKEN instead, so it has no environment-
+    # scoped credential that the approval was protecting.
+    environment: release-channels
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -246,7 +246,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 10
-    environment: pypi
+    # Approval stays only on the `publish` job below: that is the one job in
+    # this graph whose OIDC exchange is scoped to the pypi environment (PyPI
+    # trusted publishing). This job does its own token/API auth instead, so
+    # gating it on the same environment only added a second approval click
+    # for no additional protection.
+    environment: release-channels
     permissions:
       contents: write
       # actions: write is required to dispatch the release follow-up workflows
@@ -338,7 +343,11 @@ jobs:
   publish-npm:
     name: Publish npm wrapper
     runs-on: ubuntu-latest
-    environment: pypi
+    # Approval stays only on the `publish` job below: the npm wrapper still
+    # publishes with a long-lived NPM_TOKEN rather than OIDC trusted
+    # publishing (see the comment on that step), so this job has no
+    # environment-scoped credential that the approval was protecting.
+    environment: release-channels
     needs: build
     timeout-minutes: 15
     permissions:
@@ -605,7 +614,13 @@ jobs:
     # publish-docker.yml, up to ~14 min) before submitting.
     timeout-minutes: 25
     continue-on-error: true
-    environment: pypi
+    # Approval stays only on the `publish` job below. This job also holds
+    # id-token: write, but the MCP registry's GitHub OIDC exchange only
+    # checks the token's repository-owner claim (io.github.<owner>/* is
+    # granted to any workflow run in the org) -- it does not check which
+    # environment, if any, the run declared, so gating it on the pypi
+    # environment added an approval click without adding protection.
+    environment: release-channels
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -40,7 +40,11 @@ jobs:
     name: Generate SBOM
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    environment: pypi
+    # Approval lives on publish.yml's `publish` job (PyPI trusted
+    # publishing, OIDC-scoped to the pypi environment). This job only
+    # writes release assets with the repo token, so it has no environment-
+    # scoped credential that the approval was protecting.
+    environment: release-channels
     permissions:
       contents: write  # Required to attach SBOMs to the release
     steps:

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -24,6 +24,29 @@ Update this table whenever a release workflow is added, renamed, or moved.
 | `.github/workflows/publish-homebrew.yml` | Publish Homebrew Formula | `release`, `workflow_dispatch` | Updates the Homebrew tap formula for a released version. | Dispatched by `publish.yml` after it creates the release; the `release` event covers releases created in the UI. |
 | `.github/workflows/sbom.yml` | SBOM | `release`, `workflow_dispatch` | Generates SPDX + CycloneDX SBOMs and attaches them to the release that exists for the built ref. | Dispatched by `publish.yml` after it creates the release; the `release` event covers releases created in the UI. |
 
+## Release Approval Gates
+
+A release touches four independent publish channels (PyPI, npm, the Copr
+RPM build, the MCP registry listing) plus the GitHub Release page, the
+Docker image, the Homebrew formula and the SBOM attachments. Only one of
+them needs a human in front of it: PyPI. `publish.yml`'s `publish` job
+carries PyPI's trusted-publisher OIDC exchange, which is scoped to the
+`pypi` environment on the PyPI project side -- that binding is what the
+approval actually protects.
+
+Every other job that used to sit behind the same `pypi` environment
+(`github-release`, `publish-npm`, `publish-mcp-registry`, and the single
+job in each of `publish-docker.yml`, `publish-homebrew.yml`, `sbom.yml`)
+authenticates a different way -- `GITHUB_TOKEN`, a long-lived `NPM_TOKEN`
+or `HOMEBREW_TAP_TOKEN`, or an OIDC audience that is not scoped by
+environment at all (the MCP registry's GitHub OIDC exchange grants
+`io.github.<owner>/*` off the token's repository-owner claim only). None
+of them had a credential the approval was protecting, so they now run
+under `release-channels`, an environment with the same branch/tag
+restriction as `pypi` (`main`, `v*`, `ext-v*`) but no required reviewer.
+
+PyPI waits for a human; the other channels do not.
+
 ## Release Milestones
 
 Bernstein uses GitHub milestones to plan minor and major releases. Patch releases do not get milestones; they ship from `main` as the `auto-release.yml` workflow determines they have meaningful changes.


### PR DESCRIPTION
## Why

`publish.yml` and its three follow-up workflows (`publish-docker.yml`,
`publish-homebrew.yml`, `sbom.yml`) publish four independent channels --
PyPI, npm, the Copr RPM build, and the MCP registry listing -- plus the
GitHub Release page, the Docker image, the Homebrew formula and the SBOM
attachments. Every job that isn't gated behind another job's success sat
behind the same `pypi` environment, so one approval click was standing in
front of all of it, and a channel that only needed a retry (see the
companion `registry_only` PR) still needed that same click.

Only one job actually needs a human there: `publish` (PyPI), which carries
PyPI's trusted-publisher OIDC exchange -- scoped, on the PyPI project side,
to the `pypi` environment. That's what the approval protects.

## What was checked before removing the others

- `github-release`: uses `GITHUB_TOKEN` (`gh release create/upload`), no OIDC.
- `publish-npm`: publishes with a long-lived `NPM_TOKEN`; the step's own
  comment already notes trusted publishing isn't wired up for the npm
  wrapper yet.
- `publish-mcp-registry`: does use GitHub OIDC (`mcp-publisher login
  github-oidc`), but the registry's token-exchange handler only reads the
  `repository_owner` claim and grants `io.github.<owner>/*` from that --
  no environment claim enters the permission check at all.
- `publish-docker.yml`: logs in to GHCR with `GITHUB_TOKEN`; its own
  `id-token: write` is for the Sigstore build-provenance attestation, a
  separate OIDC audience.
- `publish-homebrew.yml`: pushes to the tap with `HOMEBREW_TAP_TOKEN`.
- `sbom.yml`: writes release assets with the repo token.

None of the six had a credential the `pypi` environment's approval was
protecting.

## What changes

- New `release-channels` environment: same branch/tag restriction as
  `pypi` (`main`, `v*`, `ext-v*`), no required reviewer.
- The six jobs above move to it.
- `publish-copr` is untouched -- it already needs `publish` (PyPI) and
  `rpm-install-smoke` (which itself waits for the release to be visible on
  PyPI), so it can't run ahead of PyPI regardless of its own environment.
- `docs/operations/release.md` gets a section spelling this shape out, so
  the next channel added to this graph has something to check against
  instead of copying `environment: pypi` by default.

## Not in scope

The `registry_only` republish input is a separate PR so the two changes
review independently.