### PR TITLE
ci: repair the two scheduled adapter lanes on the project's own runner

### DIFF
--- a/.github/workflows/adapter-conformance-canary.yml
+++ b/.github/workflows/adapter-conformance-canary.yml
@@ -46,7 +46,17 @@ permissions:
 jobs:
   canary:
     name: Canary matrix
-    runs-on: [self-hosted, linux, vps]
+    # Hosted, unlike the rest of the scheduled lane: this job pushes the
+    # last-green branch, and on the project's own runner the credential
+    # `actions/checkout` persists is never applied to `git push`. The
+    # checkout writes it to a side config file wired in through
+    # `includeIf.gitdir:`, which stops matching once the runner's work
+    # directory resolves to a different real path than the one recorded.
+    # `git fetch` still succeeds -- the repository is public, so the fetch
+    # needs no credential at all -- so the job gets all the way to the push
+    # and only then fails with "could not read Username for
+    # https://github.com".
+    runs-on: ubuntu-latest
     environment: automation
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/adapter-conformance-canary.yml
+++ b/.github/workflows/adapter-conformance-canary.yml
@@ -46,17 +46,7 @@ permissions:
 jobs:
   canary:
     name: Canary matrix
-    # Hosted, unlike the rest of the scheduled lane: this job pushes the
-    # last-green branch, and on the project's own runner the credential
-    # `actions/checkout` persists is never applied to `git push`. The
-    # checkout writes it to a side config file wired in through
-    # `includeIf.gitdir:`, which stops matching once the runner's work
-    # directory resolves to a different real path than the one recorded.
-    # `git fetch` still succeeds -- the repository is public, so the fetch
-    # needs no credential at all -- so the job gets all the way to the push
-    # and only then fails with "could not read Username for
-    # https://github.com".
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, vps]
     environment: automation
     timeout-minutes: 20
     permissions:
@@ -241,6 +231,7 @@ jobs:
           # that it ran. The GITHUB_TOKEN fallback keeps forks and
           # secret-less environments working; see docs/operations/ci.md.
           GH_TOKEN: ${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN || secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           if git diff --quiet -- src/bernstein/adapters/last_green.json docs/adapters/conformance-canary.md; then
@@ -260,7 +251,20 @@ jobs:
           uv run python scripts/canary_propose_branch.py \
             --branch "$BRANCH" \
             --base-ref main
-          git push --force -u origin "$BRANCH"
+          # Authenticated on the command line rather than through the
+          # credential `actions/checkout` persists. That credential reaches
+          # `git push` only on a hosted runner: the checkout writes it to a
+          # side config file wired in with `includeIf.gitdir:`, and the
+          # condition stops matching on the project's own runner. Nothing
+          # earlier in the job notices, because the repository is public and
+          # every read the run makes -- including the script's own fetch --
+          # needs no credential at all, so the failure surfaces here as
+          # "could not read Username for https://github.com" (#5770 moved
+          # this lane onto that runner). Same form the pulse lane already
+          # pushes with, and the same token the `gh pr create` below uses,
+          # so the branch and the pull request still carry one identity.
+          git push --force --quiet "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" \
+            "HEAD:refs/heads/${BRANCH}"
           EXISTING=$(gh pr list \
             --repo "${{ github.repository }}" \
             --head "$BRANCH" \

--- a/.github/workflows/adapter-contract-drift.yml
+++ b/.github/workflows/adapter-contract-drift.yml
@@ -230,6 +230,16 @@ jobs:
         with:
           persist-credentials: false
 
+      # The summariser below runs `python`. The project's own runner has no
+      # bare `python` on PATH, only `python3`, so the interpreter has to be
+      # provisioned here the way the matrix job above provisions it -- the
+      # aggregate job is otherwise the one step in this workflow that never
+      # sets one up, and it exited 127 the first night the workflow ran off
+      # a hosted runner.
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.14'
+
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: drift-out


### PR DESCRIPTION
## What

Repairs the two scheduled adapter lanes that went red on their first run after #5770 moved them onto the project's own runner.

| Workflow | Last green | Failure |
|---|---|---|
| Adapter contract drift | 09.09 | `Aggregate drift report` exit 127, `python: command not found` |
| Adapter conformance canary | 09.09 | `git push` exit 128, `could not read Username for 'https://github.com'` |

## Why

#5770 changed `runs-on` and nothing else, so neither failure is a defect in what the jobs do — both are steps that had been relying on something only a hosted runner image happens to provide.

**Adapter contract drift.** The `aggregate` job summarises the matrix artifacts with an inline `python - <<'PY'` heredoc, but it is the one job in the workflow that never sets an interpreter up — the `check` job above it provisions one with `setup-python`. A hosted image ships a bare `python` on PATH; the project's runner ships only `python3`. All 15 matrix rows passed and the run still went red on the summary step.

**Adapter conformance canary.** The credential `actions/checkout` persists reaches `git push` only on a hosted runner: the checkout writes it to a side config file wired in with `includeIf.gitdir:`, and that condition stops matching on the project's own runner. Nothing earlier in the job notices, because the repository is public and every read the run makes — including the proposal script's own fetch — needs no credential at all. The run gets all the way to the push and only then fails.

Only the nights that regenerate the projection reach the push, so the lane looked intermittent rather than broken — 08.09 and 09.09 exited early with nothing to propose and reported green. The 07.09 failure was a different thing entirely, still on a hosted runner: `GH006 Protected branch update failed … added to a merge queue`.

**Evidence that the credential mechanism, not pushing in general, is what breaks there.** Every successful push from a lane that relies on the persisted credential predates its move onto the runner: the nightly drift sweep last pushed on 09.09 at 11:14Z, ten hours before #5763 moved it, and its first run on the runner skipped the push because there was no drift. Meanwhile the pulse lane, which pushes with the token on the command line, published to its data branch from that same box on 10.09, after #5768 moved it. Lanes that push through `create-pull-request`'s own token are unaffected. That is why only this one lane went red.

## How

- `adapter-contract-drift.yml`: provision an interpreter in `aggregate` the same way `check` provisions one, with the same pinned action.
- `adapter-conformance-canary.yml`: authenticate the push explicitly, in the same form the pulse lane already uses, and keep the job on the project's own runner. The token is the one `gh pr create` below it already uses, so the branch and the pull request still carry one identity.

No trigger or permission is touched, and neither lane moves off the runner.

## Verification

```
$ pytest tests/unit/test_self_hosted_runner_scope.py \
         tests/unit/test_adapter_contract_drift_workflow_yaml.py \
         tests/unit/test_bot_pull_request_tokens_yaml.py -q
46 passed
```

Both workflows are dispatched on `main` after merge to confirm the runs go green; the canary's push path is exercised only on a night that regenerates the projection, so a dispatch is how it gets covered.

## Checklist

- [x] `uv run ruff check src/` passes (no `src/` change)
- [x] Workflow YAML parses; `runs-on` verified per job
- [x] Tests cover the documented behaviour (existing runner-scope and workflow-yaml guards)
- [x] Docs N/A — `docs/operations/ci-topology.md` is generated and records no `runs-on`
