### PR TITLE
fix(identity): replace silent tenant_id default with UNSPECIFIED_TENANT sentinel (#5028)

### DIFF
--- a/docs/release-notes/fragments/5028-tenant-id-unspecified-sentinel.md
+++ b/docs/release-notes/fragments/5028-tenant-id-unspecified-sentinel.md
@@ -1,0 +1,3 @@
+# Security / Identity
+
+- `tenant_id`: removed silent `"default"` string default on `AgentCredential`, `TokenUsage`, and `_ChatTaskRequest`. Records created without an explicit tenant now carry `UNSPECIFIED_TENANT` (`<unspecified>`), preventing records with missing tenants from collapsing into the `"default"` tenant and ensuring isolation checks fail closed (#5028).

--- a/src/bernstein/cli/commands/chat_cmd.py
+++ b/src/bernstein/cli/commands/chat_cmd.py
@@ -32,6 +32,7 @@ from bernstein.core.chat import (
     load_allow_list,
     load_driver,
 )
+from bernstein.core.security.tenanting import UNSPECIFIED_TENANT
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -536,7 +537,7 @@ class _ChatTaskRequest:
     estimated_minutes: int | None = None
     parent_task_id: str | None = None
     depends_on_repo: str | None = None
-    tenant_id: str = "default"
+    tenant_id: str | Any = UNSPECIFIED_TENANT
     cell_id: str | None = None
     repo: str | None = None
     model: str | None = None

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -1936,6 +1936,7 @@ class AgentSpawner:
         task_ids: list[str],
         *,
         parent_identity_id: str | None = None,
+        tenant_id: str | None = None,
     ) -> Path:
         """Issue a short-lived task-scoped JWT and write it to a 0600 token file.
 
@@ -1959,6 +1960,9 @@ class AgentSpawner:
                 identity for a nested spawn, otherwise the run root.  Minting
                 with it records one delegation hop (#5047); ``None`` records
                 none, which is the pre-#5047 behaviour.
+            tenant_id: The tenant the agent's tasks belong to.  Signed into
+                the credential; ``None`` leaves it unspecified, which the
+                server refuses to bind to any tenant (#5028).
 
         Returns:
             Absolute path to the written token file.
@@ -1975,7 +1979,11 @@ class AgentSpawner:
             role,
             parent_identity_id=parent_identity_id,
             task_ids=task_ids,
-            metadata={"source": "spawner", "run_id": getattr(self, "_run_id", "")},
+            metadata={
+                "source": "spawner",
+                "run_id": getattr(self, "_run_id", ""),
+                **({"tenant_id": tenant_id} if tenant_id else {}),
+            },
         )
 
         # ``resolve(strict=False)`` returns an absolute path even when the
@@ -4775,11 +4783,15 @@ class AgentSpawner:
         _delegating_identity: str | None = session.parent_id or getattr(self, "_run_root_identity_id", "") or None
         try:
             task_ids_for_scope = [t.id for t in tasks]
+            # One credential is minted for the whole batch, so it can only
+            # name a tenant when every task in the batch agrees on one.
+            _batch_tenants = {t.tenant_id for t in tasks}
             _token_path = self._issue_agent_token(
                 session_id,
                 role,
                 task_ids_for_scope,
                 parent_identity_id=_delegating_identity,
+                tenant_id=_batch_tenants.pop() if len(_batch_tenants) == 1 else None,
             )
             prompt = prompt + _render_auth_section(_token_path, self._workdir)
         except DelegationWriteError as _deleg_exc:

--- a/src/bernstein/core/cost/cost_tracker.py
+++ b/src/bernstein/core/cost/cost_tracker.py
@@ -46,7 +46,7 @@ from bernstein.core.persistence.anchored_write import (
     anchored_write_text,
     mkdir_anchored,
 )
-from bernstein.core.tenanting import DEFAULT_TENANT_ID, normalize_tenant_id
+from bernstein.core.tenanting import DEFAULT_TENANT_ID, UNSPECIFIED_TENANT, normalize_tenant_id
 
 logger = logging.getLogger(__name__)
 
@@ -156,6 +156,8 @@ def _usage_tenant_scope(raw: object) -> str:
     """
     if raw is None:
         return cast(str, DEFAULT_TENANT_ID)
+    if raw == "<unspecified>" or raw is UNSPECIFIED_TENANT:
+        return UNSPECIFIED_TENANT
     if not isinstance(raw, str):
         raise ValueError(f"usage tenant_id must be a string, got {type(raw).__name__}")
     return cast(str, normalize_tenant_id(raw))
@@ -366,7 +368,7 @@ class TokenUsage:
     cost_usd: float
     agent_id: str
     task_id: str
-    tenant_id: str = "default"
+    tenant_id: str | Any = UNSPECIFIED_TENANT
     timestamp: float = field(default_factory=time.time)
     cache_hit: bool = False  # Prompt cache hit tracking (legacy)
     cached_tokens: int = 0  # Tokens served from cache (legacy)
@@ -387,7 +389,7 @@ class TokenUsage:
             "cost_usd": self.cost_usd,
             "agent_id": self.agent_id,
             "task_id": self.task_id,
-            "tenant_id": self.tenant_id,
+            "tenant_id": str(self.tenant_id) if self.tenant_id is not UNSPECIFIED_TENANT else "<unspecified>",
             "timestamp": self.timestamp,
             "cache_hit": self.cache_hit,
             "cached_tokens": self.cached_tokens,
@@ -408,6 +410,12 @@ class TokenUsage:
             tags = {}
         env_raw: object = d.get("quota_envelope", DEFAULT_QUOTA_ENVELOPE)
         envelope = str(env_raw) if env_raw else DEFAULT_QUOTA_ENVELOPE
+        raw_tenant = d.get("tenant_id")
+        tenant_id_val: str | Any = (
+            UNSPECIFIED_TENANT
+            if (raw_tenant is None or raw_tenant == "<unspecified>" or raw_tenant is UNSPECIFIED_TENANT)
+            else str(raw_tenant)
+        )
         return cls(
             input_tokens=int(d["input_tokens"]),
             output_tokens=int(d["output_tokens"]),
@@ -415,7 +423,7 @@ class TokenUsage:
             cost_usd=float(d["cost_usd"]),
             agent_id=str(d["agent_id"]),
             task_id=str(d["task_id"]),
-            tenant_id=str(d.get("tenant_id", "default") or "default"),
+            tenant_id=tenant_id_val,
             timestamp=float(d.get("timestamp", 0.0)),
             cache_hit=bool(d.get("cache_hit", False)),
             cached_tokens=int(d.get("cached_tokens", 0)),
@@ -691,7 +699,7 @@ class CostTracker:
         output_tokens: int,
         cost_usd: float | None = None,
         *,
-        tenant_id: str = "default",
+        tenant_id: str | Any = UNSPECIFIED_TENANT,
         cache_read_tokens: int = 0,
         cache_write_tokens: int = 0,
         role: str = "",
@@ -737,7 +745,10 @@ class CostTracker:
                 :class:`PrincipalEnvelope` and admitting this call would
                 breach its ceiling.
         """
-        normalized_tenant = normalize_tenant_id(tenant_id)
+        if tenant_id is UNSPECIFIED_TENANT or tenant_id is None or tenant_id == "<unspecified>":
+            normalized_tenant = UNSPECIFIED_TENANT
+        else:
+            normalized_tenant = normalize_tenant_id(tenant_id)
         if cost_usd is None:
             cost_usd = estimate_cost(
                 model,
@@ -908,7 +919,7 @@ class CostTracker:
         total_output_tokens: int,
         total_cost_usd: float | None = None,
         *,
-        tenant_id: str = "default",
+        tenant_id: str | Any = UNSPECIFIED_TENANT,
         total_cache_read_tokens: int = 0,
         total_cache_write_tokens: int = 0,
         role: str = "",
@@ -976,7 +987,7 @@ class CostTracker:
             input_tokens=delta_input,
             output_tokens=delta_output,
             cost_usd=delta_cost,
-            tenant_id=normalize_tenant_id(tenant_id),
+            tenant_id=tenant_id,
             cache_read_tokens=delta_cache_read,
             cache_write_tokens=delta_cache_write,
             role=role,

--- a/src/bernstein/core/identity/agent_jwt.py
+++ b/src/bernstein/core/identity/agent_jwt.py
@@ -27,6 +27,7 @@ from bernstein.core.security.auth import create_jwt, verify_jwt
 from bernstein.core.security.sanitize import sanitize_log
 from bernstein.core.security.tenanting import (
     DEFAULT_TENANT_ID,
+    UNSPECIFIED_TENANT,
     InvalidTenantIdError,
     normalize_tenant_id,
 )
@@ -304,7 +305,7 @@ def _require_matching_scope(field: str, on_identity: list[str], on_credential: l
         )
 
 
-def _credential_tenant_id(raw: Any) -> str:
+def _credential_tenant_id(raw: Any) -> Any:
     """Return the tenant a persisted credential is scoped to.
 
     The value is read back as the authenticated scope for every request this
@@ -332,6 +333,8 @@ def _credential_tenant_id(raw: Any) -> str:
     """
     if raw is _TENANT_KEY_ABSENT:
         return DEFAULT_TENANT_ID
+    if raw == "<unspecified>" or raw is UNSPECIFIED_TENANT:
+        return UNSPECIFIED_TENANT
     if not isinstance(raw, str):
         raise ValueError(f"credential tenant_id must be a string, got {type(raw).__name__}")
     if not raw.strip():
@@ -401,7 +404,7 @@ class AgentCredential:
     token_type: TokenType = "opaque"
     algorithm: str = "HS256"
     jti: str = ""
-    tenant_id: str = "default"
+    tenant_id: str | Any = UNSPECIFIED_TENANT
     # Zero-trust: task scope - the task IDs this credential is authorised to act on.
     # An empty list means no task-scope restriction (legacy / manager tokens).
     task_ids: list[str] = field(default_factory=list)
@@ -428,7 +431,7 @@ class AgentCredential:
             "token_type": self.token_type,
             "algorithm": self.algorithm,
             "jti": self.jti,
-            "tenant_id": self.tenant_id,
+            "tenant_id": str(self.tenant_id) if self.tenant_id is not UNSPECIFIED_TENANT else "<unspecified>",
             "task_ids": self.task_ids.copy(),
             "allowed_files": self.allowed_files.copy(),
         }
@@ -929,14 +932,20 @@ class AgentIdentityStore:
         # Use shorter expiry (4 h) for task-scoped tokens to limit blast radius.
         default_expiry = 14400 if scoped_task_ids else 86400
         expiry_s = int(token_expiry_s if token_expiry_s > 0 else default_expiry)
-        tenant_id = normalize_tenant_id(str((metadata or {}).get("tenant_id", "default")))
+        raw_metadata_tenant = (metadata or {}).get("tenant_id")
+        if raw_metadata_tenant is None or raw_metadata_tenant is UNSPECIFIED_TENANT:
+            tenant_id: str | Any = UNSPECIFIED_TENANT
+            claim_tenant_val = "<unspecified>"
+        else:
+            tenant_id = normalize_tenant_id(str(raw_metadata_tenant))
+            claim_tenant_val = tenant_id
         raw_token = create_jwt(
             claims={
                 "sub": identity_id,
                 "sid": session_id,
                 "role": role,
                 "scopes": sorted(permissions),
-                "tenant_id": tenant_id,
+                "tenant_id": claim_tenant_val,
                 "task_ids": scoped_task_ids,
                 "allowed_files": scoped_files,
             },
@@ -1128,10 +1137,14 @@ class AgentIdentityStore:
         # (already valid) tenant, so it is a claim mismatch like any other -
         # deny rather than letting the refusal escape this bool-returning
         # validator and surface as a server error at the auth boundary.
-        try:
-            claim_tenant = normalize_tenant_id(str(claims.get("tenant_id", "default")))
-        except InvalidTenantIdError:
-            return False
+        claim_tenant_raw = claims.get("tenant_id")
+        if claim_tenant_raw == "<unspecified>" or claim_tenant_raw is None or claim_tenant_raw is UNSPECIFIED_TENANT:
+            claim_tenant: str | Any = UNSPECIFIED_TENANT
+        else:
+            try:
+                claim_tenant = normalize_tenant_id(str(claim_tenant_raw))
+            except InvalidTenantIdError:
+                return False
         if claim_tenant != cred.tenant_id:
             return False
         claim_scopes = _claim_string_list(claims.get("scopes", []))

--- a/src/bernstein/core/identity/principal.py
+++ b/src/bernstein/core/identity/principal.py
@@ -28,7 +28,11 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
-from bernstein.core.security.tenanting import DEFAULT_TENANT_ID, normalize_tenant_id
+from bernstein.core.security.tenanting import (
+    DEFAULT_TENANT_ID,
+    UNSPECIFIED_TENANT,
+    normalize_tenant_id,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
@@ -320,7 +324,8 @@ def principal_from_agent_identity(identity: AgentIdentity) -> AgentPrincipal:
                 algorithm=credential.algorithm if is_jwt else "",
             ),
         )
-        tenant_id = credential.tenant_id
+        if credential.tenant_id is not UNSPECIFIED_TENANT and credential.tenant_id != "<unspecified>":
+            tenant_id = credential.tenant_id
     return AgentPrincipal(
         id=identity.id,
         role=identity.role,

--- a/src/bernstein/core/security/auth_middleware.py
+++ b/src/bernstein/core/security/auth_middleware.py
@@ -154,6 +154,7 @@ from bernstein.core.routes.route_table import iter_route_paths, route_path_templ
 from bernstein.core.security.sanitize import sanitize_log
 from bernstein.core.security.tenanting import (
     DEFAULT_TENANT_ID,
+    InvalidTenantIdError,
     bind_request_tenant,
     requested_tenant_override,
 )
@@ -1139,7 +1140,14 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
         # An agent works one tenant's tasks - the tenant its token was issued
         # for - whichever tenant it names in a header.
         credential = getattr(agent_identity, "credential", None)
-        bind_request_tenant(request, getattr(credential, "tenant_id", None))
+        try:
+            bind_request_tenant(request, getattr(credential, "tenant_id", None))
+        except InvalidTenantIdError:
+            # A credential minted without a tenant carries the unspecified
+            # sentinel, which names no tenant (#5028).  Refuse it as an auth
+            # failure rather than letting the raise surface as a 500.
+            logger.warning("Agent %s denied: credential names no tenant", sanitize_log(agent_identity.id))
+            return JSONResponse(status_code=401, content={"detail": "Invalid or expired authentication token"})
 
         required_permission = _get_required_permission(path, request.method)
 

--- a/src/bernstein/core/security/tenant_isolation.py
+++ b/src/bernstein/core/security/tenant_isolation.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 from bernstein.core.persistence.anchored_write import mkdir_anchored
 from bernstein.core.security.tenanting import (
-    DEFAULT_TENANT_ID,
+    UNSPECIFIED_TENANT,
     TenantRegistry,
     ensure_tenant_layout,
     normalize_tenant_id,
@@ -200,7 +200,9 @@ class TenantIsolationManager:
             Filtered dict containing only the tenant's tasks.
         """
         normalized = normalize_tenant_id(tenant_id)
-        return {tid: task for tid, task in tasks.items() if getattr(task, "tenant_id", DEFAULT_TENANT_ID) == normalized}
+        return {
+            tid: task for tid, task in tasks.items() if getattr(task, "tenant_id", UNSPECIFIED_TENANT) == normalized
+        }
 
     def check_quota(self, tenant_id: str, current_task_count: int) -> tuple[bool, str]:
         """Check whether a tenant can create another task.

--- a/src/bernstein/core/security/tenanting.py
+++ b/src/bernstein/core/security/tenanting.py
@@ -17,6 +17,36 @@ if TYPE_CHECKING:
 DEFAULT_TENANT_ID = "default"
 
 
+class _UnspecifiedTenantSentinel:
+    """Explicit sentinel indicating an unspecified tenant.
+
+    Distinguishable from a tenant literally named 'default', and treated
+    as *not a tenant* by isolation and normalisation checks (#5028).
+    """
+
+    _instance: _UnspecifiedTenantSentinel | None = None
+
+    def __new__(cls) -> _UnspecifiedTenantSentinel:
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "UNSPECIFIED_TENANT"
+
+    def __str__(self) -> str:
+        return "<unspecified>"
+
+    def __eq__(self, other: object) -> bool:
+        return other is self or isinstance(other, _UnspecifiedTenantSentinel)
+
+    def __hash__(self) -> int:
+        return hash("UNSPECIFIED_TENANT")
+
+
+UNSPECIFIED_TENANT: Final = _UnspecifiedTenantSentinel()
+
+
 @dataclass(frozen=True)
 class TenantConfig:
     """Configured tenant boundary.
@@ -163,11 +193,13 @@ def _describe_tenant_id(value: str) -> str:
     return repr(shown)
 
 
-def normalize_tenant_id(raw: str | None) -> str:
+def normalize_tenant_id(raw: str | object | None) -> str:
     """Normalize a raw tenant ID into a stable non-empty value.
 
     Absent or blank input keeps its established meaning and resolves to
     `DEFAULT_TENANT_ID`; callers that are simply tenant-unaware rely on that.
+    An explicit unspecified sentinel (`UNSPECIFIED_TENANT` or `"<unspecified>"`)
+    is rejected: a real tenant is required (#5028).
     A value that is present but not a usable path segment is a caller error
     rather than a default, so it is refused.
 
@@ -178,8 +210,15 @@ def normalize_tenant_id(raw: str | None) -> str:
         The normalized tenant ID, or `DEFAULT_TENANT_ID` when *raw* is blank.
 
     Raises:
-        InvalidTenantIdError: If *raw* is non-blank and not a valid tenant ID.
+        InvalidTenantIdError: If *raw* is non-blank and not a valid tenant ID,
+            or if *raw* is the unspecified tenant sentinel.
     """
+    if raw is UNSPECIFIED_TENANT or (isinstance(raw, str) and raw.strip() == "<unspecified>"):
+        raise InvalidTenantIdError(
+            f"unspecified tenant sentinel {raw!r} cannot name a tenant: a real tenant is required (#5028)"
+        )
+    if raw is not None and not isinstance(raw, str):
+        raise InvalidTenantIdError(f"invalid tenant id {raw!r}: expected string, got {type(raw).__name__}")
 
     value = (raw or "").strip()
     if not value:
@@ -222,7 +261,8 @@ def try_normalize_tenant_id(raw: object) -> str | None:
     Returns:
         The normalized tenant ID, or None if it cannot be normalized.
     """
-
+    if raw is UNSPECIFIED_TENANT or raw == "<unspecified>":
+        return None
     if raw is not None and not isinstance(raw, str):
         return None
     try:

--- a/tests/unit/security/test_tenant_defaults.py
+++ b/tests/unit/security/test_tenant_defaults.py
@@ -1,0 +1,106 @@
+"""Tests for Issue #5028: tenant_id defaults to 'default' removal and UNSPECIFIED_TENANT sentinel."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from bernstein.cli.commands.chat_cmd import _ChatTaskRequest
+from bernstein.core.cost.cost_tracker import TokenUsage
+from bernstein.core.identity.agent_jwt import AgentCredential
+from bernstein.core.security.tenant_isolation import TenantIsolationManager
+from bernstein.core.security.tenanting import (
+    DEFAULT_TENANT_ID,
+    InvalidTenantIdError,
+    normalize_tenant_id,
+)
+
+# Import UNSPECIFIED_TENANT if already defined, or sentinel dummy for pre-implementation testing
+try:
+    from bernstein.core.security.tenanting import UNSPECIFIED_TENANT
+except ImportError:
+    UNSPECIFIED_TENANT = object()
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_record_without_tenant_is_not_attributed_to_the_default_tenant() -> None:
+    """A record constructed without tenant_id must not be attributed to 'default'."""
+    cred = AgentCredential(token_hash="hash-123")
+    assert cred.tenant_id != DEFAULT_TENANT_ID
+    assert cred.tenant_id is UNSPECIFIED_TENANT
+
+    usage = TokenUsage(
+        input_tokens=10,
+        output_tokens=20,
+        model="sonnet",
+        cost_usd=0.05,
+        agent_id="agent-1",
+        task_id="task-1",
+    )
+    assert usage.tenant_id != DEFAULT_TENANT_ID
+    assert usage.tenant_id is UNSPECIFIED_TENANT
+
+
+def test_isolation_check_fails_closed_on_unspecified_tenant(tmp_path: Path) -> None:
+    """Isolation checks must fail closed when encountering the unspecified sentinel."""
+    with pytest.raises(InvalidTenantIdError):
+        normalize_tenant_id(UNSPECIFIED_TENANT)  # type: ignore[arg-type]
+
+    mgr = TenantIsolationManager(tmp_path / ".sdd")
+    with pytest.raises(InvalidTenantIdError):
+        mgr.get_context(UNSPECIFIED_TENANT)  # type: ignore[arg-type]
+
+    @dataclass
+    class FakeTask:
+        tenant_id: Any = UNSPECIFIED_TENANT
+
+    tasks = {
+        "t1": FakeTask(tenant_id=UNSPECIFIED_TENANT),
+        "t2": FakeTask(tenant_id="default"),
+    }
+    filtered = mgr.filter_tasks(tasks, "default")
+    assert "t1" not in filtered
+    assert set(filtered.keys()) == {"t2"}
+
+
+def test_explicit_default_tenant_and_omitted_tenant_produce_different_records() -> None:
+    """Distinguishing test: explicit default tenant and omitted tenant produce different records."""
+    cred_explicit = AgentCredential(token_hash="hash-123", tenant_id="default")
+    cred_omitted = AgentCredential(token_hash="hash-123")
+    assert cred_explicit != cred_omitted
+    assert cred_explicit.tenant_id != cred_omitted.tenant_id
+
+    usage_explicit = TokenUsage(
+        input_tokens=10,
+        output_tokens=20,
+        model="sonnet",
+        cost_usd=0.05,
+        agent_id="agent-1",
+        task_id="task-1",
+        tenant_id="default",
+    )
+    usage_omitted = TokenUsage(
+        input_tokens=10,
+        output_tokens=20,
+        model="sonnet",
+        cost_usd=0.05,
+        agent_id="agent-1",
+        task_id="task-1",
+    )
+    assert usage_explicit != usage_omitted
+    assert usage_explicit.tenant_id != usage_omitted.tenant_id
+
+
+def test_no_tenant_id_field_declares_a_string_default() -> None:
+    """Static assertion that no targeted dataclass declares a string default for tenant_id."""
+    target_classes = [AgentCredential, TokenUsage, _ChatTaskRequest]
+    for cls in target_classes:
+        for f in fields(cls):
+            if f.name == "tenant_id":
+                assert not isinstance(f.default, str), (
+                    f"{cls.__name__}.tenant_id declares a string default: {f.default!r}"
+                )

--- a/tests/unit/test_auth_middleware.py
+++ b/tests/unit/test_auth_middleware.py
@@ -298,7 +298,9 @@ def _app_with_agent_identity_store(tmp_path: Any) -> tuple[TestClient, Any]:
 def test_agent_jwt_with_task_scope_allows_own_task(tmp_path: Any) -> None:
     """An agent JWT scoped to task-A allows completing task-A."""
     client, store = _app_with_agent_identity_store(tmp_path)
-    _, token = store.create_identity("agent-session-1", "backend", task_ids=["task-abc"])
+    _, token = store.create_identity(
+        "agent-session-1", "backend", task_ids=["task-abc"], metadata={"tenant_id": "default"}
+    )
 
     response = client.post(
         "/tasks/task-abc/complete",
@@ -315,7 +317,9 @@ def test_agent_jwt_with_task_scope_allows_own_task(tmp_path: Any) -> None:
 def test_agent_jwt_with_task_scope_denies_out_of_scope_task(tmp_path: Any) -> None:
     """An agent JWT scoped to task-A must be denied when it tries to act on task-B."""
     client, store = _app_with_agent_identity_store(tmp_path)
-    _, token = store.create_identity("agent-session-2", "backend", task_ids=["task-abc"])
+    _, token = store.create_identity(
+        "agent-session-2", "backend", task_ids=["task-abc"], metadata={"tenant_id": "default"}
+    )
 
     response = client.post(
         "/tasks/task-xyz/complete",
@@ -333,7 +337,7 @@ def test_agent_jwt_without_task_scope_is_unrestricted(tmp_path: Any) -> None:
     """An orchestrator/manager agent JWT (task_ids=[]) may act on any task."""
     client, store = _app_with_agent_identity_store(tmp_path)
     # No task_ids → unrestricted manager token
-    _, token = store.create_identity("manager-session-1", "manager", task_ids=[])
+    _, token = store.create_identity("manager-session-1", "manager", task_ids=[], metadata={"tenant_id": "default"})
 
     response = client.post(
         "/tasks/any-task-id/complete",
@@ -347,7 +351,9 @@ def test_agent_jwt_without_task_scope_is_unrestricted(tmp_path: Any) -> None:
 def test_agent_jwt_read_requests_not_scope_checked(tmp_path: Any) -> None:
     """GET requests bypass task-scope enforcement even for scoped agents."""
     client, store = _app_with_agent_identity_store(tmp_path)
-    _, token = store.create_identity("agent-session-3", "backend", task_ids=["task-abc"])
+    _, token = store.create_identity(
+        "agent-session-3", "backend", task_ids=["task-abc"], metadata={"tenant_id": "default"}
+    )
 
     response = client.get("/status", headers={"Authorization": f"Bearer {token}"})
 
@@ -395,7 +401,7 @@ def test_agent_jwt_denied_on_shutdown_route(tmp_path: Any) -> None:
     from bernstein.core.identity.agent_jwt import AgentIdentityStore
 
     store = AgentIdentityStore(Path(str(tmp_path)))
-    _, token = store.create_identity("manager-1", "manager", task_ids=[])
+    _, token = store.create_identity("manager-1", "manager", task_ids=[], metadata={"tenant_id": "default"})
 
     app = FastAPI()
     app.add_middleware(SSOAuthMiddleware, agent_identity_store=store)
@@ -418,7 +424,7 @@ def test_agent_jwt_denied_on_broadcast_and_drain(tmp_path: Any) -> None:
     from bernstein.core.identity.agent_jwt import AgentIdentityStore
 
     store = AgentIdentityStore(Path(str(tmp_path)))
-    _, token = store.create_identity("mgr-2", "manager", task_ids=[])
+    _, token = store.create_identity("mgr-2", "manager", task_ids=[], metadata={"tenant_id": "default"})
 
     app = FastAPI()
     app.add_middleware(SSOAuthMiddleware, agent_identity_store=store)
@@ -447,3 +453,17 @@ def test_check_agent_task_scope_denies_out_of_scope_task() -> None:
     assert error is not None
     assert "task-xyz" in error
     assert "task-abc" in error
+
+
+def test_agent_jwt_without_a_tenant_is_refused_not_a_500(tmp_path: Any) -> None:
+    """A credential minted with no tenant names none; it is an auth failure (#5028)."""
+    client, store = _app_with_agent_identity_store(tmp_path)
+    _, token = store.create_identity("agent-no-tenant", "backend", task_ids=["task-abc"])
+
+    response = client.post(
+        "/tasks/task-abc/complete",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"result_summary": "done"},
+    )
+
+    assert response.status_code == 401

--- a/tests/unit/test_auth_middleware_agent_route_permissions.py
+++ b/tests/unit/test_auth_middleware_agent_route_permissions.py
@@ -90,6 +90,7 @@ def _agent_headers(
         role,
         task_ids=task_ids,
         extra_permissions=extra_permissions,
+        metadata={"tenant_id": "default"},
     )
     return {"Authorization": f"Bearer {token}"}
 

--- a/tests/unit/test_auth_middleware_defaults.py
+++ b/tests/unit/test_auth_middleware_defaults.py
@@ -587,7 +587,7 @@ def test_agent_jwt_token_accepted_under_default_on_auth(monkeypatch: pytest.Monk
     from bernstein.core.identity.agent_jwt import AgentIdentityStore
 
     store = AgentIdentityStore(tmp_path)
-    _, token = store.create_identity("agent-1", "backend", task_ids=[])
+    _, token = store.create_identity("agent-1", "backend", task_ids=[], metadata={"tenant_id": "default"})
 
     app = FastAPI()
     app.add_middleware(SSOAuthMiddleware, agent_identity_store=store)

--- a/tests/unit/test_auth_middleware_log_sanitization.py
+++ b/tests/unit/test_auth_middleware_log_sanitization.py
@@ -107,7 +107,9 @@ def app(tmp_path: Path) -> FastAPI:
 
 def _agent_headers(application: FastAPI, *, task_ids: list[str]) -> dict[str, str]:
     store: Any = application.state.identity_store
-    _, token = store.create_identity("session-log-injection-probe", "backend", task_ids=task_ids)
+    _, token = store.create_identity(
+        "session-log-injection-probe", "backend", task_ids=task_ids, metadata={"tenant_id": "default"}
+    )
     return {"Authorization": f"Bearer {token}"}
 
 

--- a/tests/unit/test_auth_middleware_task_scope_indirect.py
+++ b/tests/unit/test_auth_middleware_task_scope_indirect.py
@@ -94,7 +94,7 @@ def _operator_headers() -> dict[str, str]:
 def _agent_headers(application: FastAPI, session: str, task_ids: list[str]) -> dict[str, str]:
     """Mint an agent identity token scoped to *task_ids*."""
     identity_store: Any = application.state.identity_store
-    _, token = identity_store.create_identity(session, "backend", task_ids=task_ids)
+    _, token = identity_store.create_identity(session, "backend", task_ids=task_ids, metadata={"tenant_id": "default"})
     return {"Authorization": f"Bearer {token}"}
 
 

--- a/tests/unit/test_auth_middleware_task_scope_routes.py
+++ b/tests/unit/test_auth_middleware_task_scope_routes.py
@@ -129,7 +129,9 @@ def test_every_mutating_task_route_denies_out_of_scope_identity(app: FastAPI) ->
     for a task the token was not issued for.
     """
     store: Any = app.state.identity_store
-    _, token = store.create_identity("session-scope-probe", "backend", task_ids=[_IN_SCOPE_TASK_ID])
+    _, token = store.create_identity(
+        "session-scope-probe", "backend", task_ids=[_IN_SCOPE_TASK_ID], metadata={"tenant_id": "default"}
+    )
     headers = {"Authorization": f"Bearer {token}"}
 
     routes = _mutating_task_id_routes(app)
@@ -330,7 +332,9 @@ def test_body_scoped_routes_deny_an_out_of_scope_task_id(authed_app: FastAPI) ->
     victim_id = _create_task(authed_app, 0, "victim")
     own_id = _create_task(authed_app, 1, "own")
     store: Any = authed_app.state.identity_store
-    _, token = store.create_identity("session-body-scope", "backend", task_ids=[own_id])
+    _, token = store.create_identity(
+        "session-body-scope", "backend", task_ids=[own_id], metadata={"tenant_id": "default"}
+    )
     headers = {"Authorization": f"Bearer {token}"}
     before = authed_app.state.store.get_task(victim_id)
     assert before is not None
@@ -356,7 +360,9 @@ def test_body_scoped_routes_allow_the_agents_own_task(authed_app: FastAPI) -> No
 
     for index, segment in enumerate(sorted(TASK_BODY_SCOPED_SEGMENTS)):
         own_id = _create_task(authed_app, 20 + index, f"own-{segment}")
-        _, token = store.create_identity(f"session-own-{segment}", "backend", task_ids=[own_id])
+        _, token = store.create_identity(
+            f"session-own-{segment}", "backend", task_ids=[own_id], metadata={"tenant_id": "default"}
+        )
         response = _client(authed_app, 30 + index).post(
             f"/tasks/{segment}",
             headers={"Authorization": f"Bearer {token}"},
@@ -371,7 +377,7 @@ def test_body_scoped_routes_allow_the_agents_own_task(authed_app: FastAPI) -> No
 def test_body_scoped_routes_allow_an_unscoped_manager_token(authed_app: FastAPI) -> None:
     """A token with ``task_ids == []`` stays unrestricted, as on the path gate."""
     store: Any = authed_app.state.identity_store
-    _, token = store.create_identity("session-manager", "backend", task_ids=[])
+    _, token = store.create_identity("session-manager", "backend", task_ids=[], metadata={"tenant_id": "default"})
 
     for index, segment in enumerate(sorted(TASK_BODY_SCOPED_SEGMENTS)):
         # A task the manager token was never scoped to, fresh per segment so
@@ -398,7 +404,9 @@ def test_batch_ops_scope_check_sees_the_normalised_id(authed_app: FastAPI) -> No
     victim_id = _create_task(authed_app, 60, "victim-normalised")
     own_id = _create_task(authed_app, 61, "own-normalised")
     store: Any = authed_app.state.identity_store
-    _, token = store.create_identity("session-normalised", "backend", task_ids=[own_id])
+    _, token = store.create_identity(
+        "session-normalised", "backend", task_ids=[own_id], metadata={"tenant_id": "default"}
+    )
 
     response = _client(authed_app, 62).post(
         "/tasks/batch-ops",


### PR DESCRIPTION
## Summary

Fixes #5028.

Removes the silent `tenant_id: str = "default"` default on `AgentCredential`, `TokenUsage`, and `_ChatTaskRequest`, replacing it with an explicit `UNSPECIFIED_TENANT` sentinel (`<unspecified>`). Downstream multi-tenant isolation and normalization checks now fail closed on missing/unspecified tenants instead of silently conflating them with the `"default"` tenant.

## Root Cause

Previously, three dataclasses defaulted `tenant_id` to `"default"`:
- `AgentCredential` in `src/bernstein/core/identity/agent_jwt.py`
- `TokenUsage` in `src/bernstein/core/cost/cost_tracker.py`
- `_ChatTaskRequest` in `src/bernstein/cli/commands/chat_cmd.py`

This made a caller that genuinely operates in the `"default"` tenant indistinguishable from a caller that omitted or forgot to thread `tenant_id`. Downstream isolation checks in `TenantIsolationManager.filter_tasks` would fall back to `"default"`, preventing detection of tenancy gaps.

## Key Changes

1. **`UNSPECIFIED_TENANT` Sentinel**:
   - Added singleton `_UnspecifiedTenantSentinel` (`UNSPECIFIED_TENANT`) in `src/bernstein/core/security/tenanting.py`.
   - String representation is `<unspecified>`, which is invalid as a real tenant path segment.
2. **Dataclass Defaults**:
   - Changed `tenant_id` default in `AgentCredential`, `TokenUsage`, and `_ChatTaskRequest` from `"default"` to `UNSPECIFIED_TENANT`.
3. **Fail-Closed Validation & Isolation**:
   - `normalize_tenant_id` explicitly rejects `UNSPECIFIED_TENANT` and `<unspecified>` with `InvalidTenantIdError`.
   - `try_normalize_tenant_id` returns `None` for `UNSPECIFIED_TENANT` and `<unspecified>`.
   - `TenantIsolationManager.filter_tasks` uses `UNSPECIFIED_TENANT` as fallback in `getattr`, ensuring unspecified tasks match no tenant.
4. **Agent Identity & Cost Tracker Serialization**:
   - Serialized as `<unspecified>` in JSON/JWT claims and parsed back to `UNSPECIFIED_TENANT`.
5. **Testing**:
   - Added `tests/unit/security/test_tenant_defaults.py` covering all 4 acceptance criteria (pre-verified RED on `main` before fix):
     - `test_record_without_tenant_is_not_attributed_to_the_default_tenant`
     - `test_isolation_check_fails_closed_on_unspecified_tenant`
     - `test_explicit_default_tenant_and_omitted_tenant_produce_different_records`
     - `test_no_tenant_id_field_declares_a_string_default`
   - Verified that existing multi-tenant and cost suites remain green.
