### PR TITLE
docs: regenerate adapter last-green table from canary receipts

### DIFF
--- a/docs/adapters/conformance-canary.md
+++ b/docs/adapters/conformance-canary.md
@@ -214,15 +214,15 @@ covered under *Chronic-skip handling*.
 | Adapter | Binary | Last-green version | Verified | Receipt |
 |---|---|---|---|---|
 | agy | `agy` | 1.0.0 | 2026-07-11T05:57:23Z (not probed) | `006fb946868d` |
-| aider | `aider` | 0.86.2 | 2026-09-09T09:16:05Z | `1dab2d381bf2` |
-| claude | `claude` | 2.1.266 | 2026-09-09T09:16:05Z | `549e9feefb2c` |
-| codex | `codex` | 0.153.4 | 2026-09-09T09:16:05Z | `0a3dc659fe5d` |
-| copilot | `copilot` | 1.0.83 | 2026-09-09T09:16:05Z | `779833bc00d6` |
-| gemini | `gemini` | 0.59.0 | 2026-09-09T09:16:05Z | `e707320ee80f` |
-| kimi | `kimi` | 1.50.0 | 2026-09-09T09:16:05Z | `f4837eddc03d` |
-| opencode | `opencode` | 1.18.30 | 2026-09-09T09:16:05Z | `e29b19ee8b05` |
-| pydantic_ai | `clai` | 2.42.0 | 2026-09-09T09:16:05Z | `6e67950e159e` |
-| qwen | `qwen` | 0.23.1 | 2026-09-09T09:16:05Z | `9624c21714b7` |
+| aider | `aider` | 0.86.2 | 2026-09-10T22:08:07Z | `cdedcde5e6d2` |
+| claude | `claude` | 2.1.268 | 2026-09-10T22:08:07Z | `44ff6771aef0` |
+| codex | `codex` | 0.154.0 | 2026-09-10T22:08:07Z | `54fe316f4f7c` |
+| copilot | `copilot` | 1.0.83 | 2026-09-10T22:08:07Z | `2cf4e7c891a4` |
+| gemini | `gemini` | 0.59.0 | 2026-09-10T22:08:07Z | `85239227ecfc` |
+| kimi | `kimi` | 1.50.0 | 2026-09-10T22:08:07Z | `d6d987083f66` |
+| opencode | `opencode` | 1.18.30 | 2026-09-10T22:08:07Z | `4ea3cf413135` |
+| pydantic_ai | `clai` | 2.42.0 | 2026-09-10T22:08:07Z | `dc21eb5f0b5d` |
+| qwen | `qwen` | 0.23.3 | 2026-09-10T22:08:07Z | `7e267b441433` |
 <!-- last-green:end -->
 
 ## Operator knobs

--- a/src/bernstein/adapters/last_green.json
+++ b/src/bernstein/adapters/last_green.json
@@ -8,59 +8,59 @@
     },
     "aider": {
       "binary": "aider",
-      "receipt_sha256": "1dab2d381bf2a9d093b6a8620c341567a6627a958ef65b0de12e0f420b2cf98a",
-      "recorded_at": "2026-09-09T09:16:05Z",
+      "receipt_sha256": "cdedcde5e6d2b3d165833751d7d7f64607d47fe9c812a3450183aa18128b2429",
+      "recorded_at": "2026-09-10T22:08:07Z",
       "version": "0.86.2"
     },
     "claude": {
       "binary": "claude",
-      "receipt_sha256": "549e9feefb2ce813ab8dce3fda1fd94376a96a8497c2e03820bbbb4d909581e8",
-      "recorded_at": "2026-09-09T09:16:05Z",
-      "version": "2.1.266"
+      "receipt_sha256": "44ff6771aef04536658c85e4417cc24650271fd36564af8ac6d165d64eabc21d",
+      "recorded_at": "2026-09-10T22:08:07Z",
+      "version": "2.1.268"
     },
     "codex": {
       "binary": "codex",
-      "receipt_sha256": "0a3dc659fe5d539671a6463f0eb5cce13971236c2851c8f85c5c5812547369e7",
-      "recorded_at": "2026-09-09T09:16:05Z",
-      "version": "0.153.4"
+      "receipt_sha256": "54fe316f4f7c2456e1a6b0dd8b739099c6273f01db27dffb8aee09a7f4e774d6",
+      "recorded_at": "2026-09-10T22:08:07Z",
+      "version": "0.154.0"
     },
     "copilot": {
       "binary": "copilot",
-      "receipt_sha256": "779833bc00d6bd6f4a0fcae506bc79e6ebf53f6700bdf87352750190a9ab167e",
-      "recorded_at": "2026-09-09T09:16:05Z",
+      "receipt_sha256": "2cf4e7c891a4b6020f3735ef85473eb20ad8fd6ff50b34ece8574e896d60e86b",
+      "recorded_at": "2026-09-10T22:08:07Z",
       "version": "1.0.83"
     },
     "gemini": {
       "binary": "gemini",
-      "receipt_sha256": "e707320ee80f672c980cdefae8fb9b3e82a6f6a76d2f70fcb8d3cf878e2aa7dc",
-      "recorded_at": "2026-09-09T09:16:05Z",
+      "receipt_sha256": "85239227ecfccc3bcad613165aa6f3f8c8dd1ae13d74c35c064c8925a4f5f909",
+      "recorded_at": "2026-09-10T22:08:07Z",
       "version": "0.59.0"
     },
     "kimi": {
       "binary": "kimi",
-      "receipt_sha256": "f4837eddc03d6ce8f0c24c7bc7dee0683b224252b557a366ee58dd06dfefd794",
-      "recorded_at": "2026-09-09T09:16:05Z",
+      "receipt_sha256": "d6d987083f66dbf1011bda9fdfebb95be865d5d31d421528c63c2fd524311e65",
+      "recorded_at": "2026-09-10T22:08:07Z",
       "version": "1.50.0"
     },
     "opencode": {
       "binary": "opencode",
-      "receipt_sha256": "e29b19ee8b05eb3493f40570b2f39c9604fe90b73aa36e15dc872ffb8ef41c4f",
-      "recorded_at": "2026-09-09T09:16:05Z",
+      "receipt_sha256": "4ea3cf4131355f72c7a6c7366495158c37d6ae310eecc154ba656fd27f1d4b55",
+      "recorded_at": "2026-09-10T22:08:07Z",
       "version": "1.18.30"
     },
     "pydantic_ai": {
       "binary": "clai",
-      "receipt_sha256": "6e67950e159e82efc0acd6a37d0ae4069138779df1a8462b5630c6b97e41a336",
-      "recorded_at": "2026-09-09T09:16:05Z",
+      "receipt_sha256": "dc21eb5f0b5d63d1eada08673c92fdf60125ab3305a742ed02ea2f96469da378",
+      "recorded_at": "2026-09-10T22:08:07Z",
       "version": "2.42.0"
     },
     "qwen": {
       "binary": "qwen",
-      "receipt_sha256": "9624c21714b79b32c8c5c9a80b21ddef63f879816fa1b2193286b1ef4953e488",
-      "recorded_at": "2026-09-09T09:16:05Z",
-      "version": "0.23.1"
+      "receipt_sha256": "7e267b441433ffd1ecbf161a066851df3799e652b2bc3a5dc24af551cea03b27",
+      "recorded_at": "2026-09-10T22:08:07Z",
+      "version": "0.23.3"
     }
   },
-  "projection_sha256": "eb3b6ffb41f26186057c0ee93a36a241363414b97dd6eeb38eaeb6f87242c59a",
+  "projection_sha256": "3a4eb122b8b77ee5b58a4ecf4430e4aecb9ce372a2458d6ee115bee0b5d0b529",
   "schema_version": 2
 }


### PR DESCRIPTION
Nightly adapter conformance canary regeneration of the per-adapter last-green projection (packaged last_green.json + the docs table). Every row is anchored to the receipt that attested it; receipts for this run are attached to the workflow run as artifacts.

Workflow run: https://github.com/sipyourdrink-ltd/bernstein/actions/runs/34535601802