### PR TITLE
ci: push the drift sweep branch with an explicit token

### DIFF
--- a/.github/workflows/nightly-drift-sweep.yml
+++ b/.github/workflows/nightly-drift-sweep.yml
@@ -102,7 +102,20 @@ jobs:
           git checkout -B "${BRANCH}"
           git add -A
           git commit -m "chore(auto): nightly mirror + format drift sweep"
-          git push --force-with-lease origin "${BRANCH}"
+          # Authenticated on the command line rather than through the
+          # credential `actions/checkout` persists. That credential reaches
+          # `git push` only on a hosted runner: the checkout writes it to a
+          # side config file wired in with `includeIf.gitdir:`, and the
+          # condition stops matching on the project's own runner, where this
+          # lane runs. Nothing earlier in the job notices, because the
+          # repository is public and every read the run makes needs no
+          # credential at all. The push is also only reached on a night that
+          # finds drift, so a run that finds none looks healthy. Same form the
+          # adapter lanes push with, and the same token `gh pr create` below
+          # uses, so the branch and the pull request carry one identity.
+          git push --force --quiet \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "HEAD:refs/heads/${BRANCH}"
           gh pr create \
             --base main \
             --head "${BRANCH}" \


### PR DESCRIPTION
## What

The nightly drift sweep runs on the project's own runner and pushes its branch with the credential `actions/checkout` persists. That credential only reaches `git push` on a hosted runner — checkout writes it to a side config file wired in with `includeIf.gitdir:`, and the condition stops matching on that runner.

## Why nothing has failed yet

The push is only reached on a night that actually finds drift. A night that finds none exits before it and reports success, so the lane looks healthy. The first night with real drift would fail with `could not read Username for https://github.com` and take the sweep PR with it.

Found while checking the two adapter lanes repaired in #5821 — this is the third workflow with the same shape and the only one left.

## The change

One push, rewritten to authenticate on the command line. Same form the adapter lanes already use, and the same token `gh pr create` below it uses, so the branch and the pull request still carry one identity.

```
git push --force --quiet \
  "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
  "HEAD:refs/heads/${BRANCH}"
```

`GH_TOKEN` is already in that step's environment; `GITHUB_REPOSITORY` is always set by the runner.

## Checks

`actionlint` clean on the changed file.