### PR TITLE
fix(quorum): the sensitive-path escalation reads the implementation, not its tests

### DIFF
--- a/scripts/quorum_check.py
+++ b/scripts/quorum_check.py
@@ -83,6 +83,17 @@ MAINTAINER_OR_SPLIT_LINES = 1000
 # Section 3: these words in a path make a change sensitive whatever its size.
 SENSITIVE_WORDS = ("sandbox", "security", "audit")
 
+# The words are matched against the whole path, which also catches the tests
+# and the release notes that accompany the code carrying them: "auditor" in
+# `tests/conformance/auditor/` reads as "audit", and nine pull requests that
+# add nothing but conformance vectors waited on a third approval for it. A
+# test cannot loosen the control it exercises and a release note cannot loosen
+# anything, so the escalation reads the paths that carry the implementation.
+# These two prefixes are exempted rather than `src/` being allowlisted: an
+# allowlist would also stop escalating `.github/`, `schemas/` and `proto/`,
+# which is a change nobody asked for.
+SENSITIVE_EXEMPT_PREFIXES = ("tests/", "docs/")
+
 # Section 1 as decided for automation: the paths where automation stops being
 # allowed to merge its own work. Wider than SENSITIVE_WORDS because a change
 # to the workflows, the schemas or the wire protocol is not something the
@@ -391,7 +402,12 @@ def evaluate(pr: PullRequest, roster: Roster, owners: list[tuple[str, list[str]]
         approving = approvals & eligible
         approving_core = approving & roster.core
 
-        sensitive = sorted(p for p in pr.paths if any(word in p for word in SENSITIVE_WORDS))
+        sensitive = sorted(
+            p
+            for p in pr.paths
+            if not p.startswith(SENSITIVE_EXEMPT_PREFIXES)
+            and any(word in p for word in SENSITIVE_WORDS)
+        )
         large = pr.changed_lines > THIRD_APPROVAL_LINES
         need_total, need_core = (3, 2) if (large or sensitive) else (2, 1)
         reason = (

--- a/tests/unit/scripts/test_quorum_check.py
+++ b/tests/unit/scripts/test_quorum_check.py
@@ -189,6 +189,44 @@ def test_a_sensitive_path_needs_the_third_approval_at_any_size(qc: ModuleType, r
     assert "security" in verdict.requirements[0].text
 
 
+def test_a_test_path_that_merely_names_a_sensitive_word_does_not_escalate(
+    qc: ModuleType, roster
+) -> None:
+    """A conformance vector for the auditor is not a change to the auditor.
+
+    The words are matched against the whole path, so `tests/conformance/auditor/`
+    used to ask for a third approval. Adding a test cannot loosen the control
+    it exercises, and the quorum for a two-approval change is unchanged.
+    """
+    reviews = [_review(qc, "core1", "APPROVED"), _review(qc, "comm1", "APPROVED")]
+    paths = ["tests/conformance/auditor/test_policy_vectors.py"]
+    verdict = _evaluate(qc, roster, _pr(qc, changed_lines=12, paths=paths, reviews=reviews))
+    assert verdict.passed
+
+
+def test_a_release_note_naming_a_sensitive_word_does_not_escalate(
+    qc: ModuleType, roster
+) -> None:
+    reviews = [_review(qc, "core1", "APPROVED"), _review(qc, "comm1", "APPROVED")]
+    paths = ["docs/release-notes/fragments/5072-govern-audit-check-contract.md"]
+    verdict = _evaluate(qc, roster, _pr(qc, changed_lines=8, paths=paths, reviews=reviews))
+    assert verdict.passed
+
+
+def test_the_implementation_still_escalates_when_a_test_rides_along(
+    qc: ModuleType, roster
+) -> None:
+    """The exemption is per path, not per pull request."""
+    reviews = [_review(qc, "core1", "APPROVED"), _review(qc, "comm1", "APPROVED")]
+    paths = [
+        "tests/conformance/auditor/test_policy_vectors.py",
+        "src/bernstein/core/security/audit_chain.py",
+    ]
+    verdict = _evaluate(qc, roster, _pr(qc, changed_lines=12, paths=paths, reviews=reviews))
+    assert not verdict.passed
+    assert "audit_chain.py" in verdict.requirements[0].text
+
+
 def test_over_a_thousand_lines_needs_the_maintainer(qc: ModuleType, roster) -> None:
     reviews = [
         _review(qc, "core1", "APPROVED"),


### PR DESCRIPTION
## What

The third-approval rule in `scripts/quorum_check.py` matches `sandbox`, `security` and `audit` as substrings of the whole path. `tests/conformance/auditor/test_policy_vectors.py` therefore reads as a sensitive change, because "auditor" contains "audit".

Measured on the open queue today: **9 pull requests are escalated to 3 approvals with 2 from core reviewers, and the only path that triggered it is a test file or a release-note fragment.** Seven are conformance vectors under `tests/conformance/auditor/`; two are release notes whose filename contains `audit`.

## Why this is safe

Adding or changing a test cannot loosen the control the test exercises, and a release note cannot loosen anything. The base quorum is untouched: these pull requests still need two approvals with at least one from a core reviewer, and the repository's separate guard on a falling test count still applies.

A pull request that touches a test *and* the implementation still escalates, on the implementation path. The exemption is per path, not per pull request — there is a test for exactly that.

## Why exempt two prefixes rather than allowlist `src/`

An `src/`-only allowlist would also stop escalating `.github/`, `schemas/` and `proto/` paths that carry these words. That is a wider change than the problem calls for, so the two prefixes that produced every false positive are exempted instead.

## Tests

Three added to `tests/unit/scripts/test_quorum_check.py`:

- a test-only sensitive-looking path does not escalate
- a release-note fragment naming a sensitive word does not escalate
- a pull request carrying both a test path and an implementation path still escalates, and names the implementation file

`tests/unit/scripts/test_quorum_check.py`: 36 passed.

## Note on the window

`scripts/quorum_check.py` is a governance path, so this pull request is held open for 72 hours for objections, as the charter asks.
