### PR TITLE
refactor(core): migrate tracker, sandbox, and storage registries to DuplicateGuard (#5104)

### DIFF
--- a/src/bernstein/core/registry_guard.py
+++ b/src/bernstein/core/registry_guard.py
@@ -115,7 +115,7 @@ class DuplicateGuard:
             existing_module = self._modules.get(key)
             if existing_module is not None:
                 raise error_type(
-                    f"{self._registry_name} {key!r} is already registered from "
+                    f"Duplicate {self._registry_name}: {key!r} is already registered from "
                     f"{existing_module!r}; refusing second registration from {module_path!r}"
                 )
             self._modules[key] = module_path

--- a/src/bernstein/core/sandbox/registry.py
+++ b/src/bernstein/core/sandbox/registry.py
@@ -23,6 +23,8 @@ import threading
 from importlib.metadata import entry_points
 from typing import TYPE_CHECKING
 
+from bernstein.core.registry_guard import DuplicateGuard, caller_module_name
+
 if TYPE_CHECKING:
     from bernstein.core.sandbox.backend import SandboxBackend
 
@@ -41,6 +43,7 @@ class _Registry:
     def __init__(self) -> None:
         self._backends: dict[str, SandboxBackend] = {}
         self._factories: dict[str, type[SandboxBackend]] = {}
+        self._guard = DuplicateGuard("sandbox backend")
         self._lock = threading.RLock()
         self._builtins_loaded = False
         self._entrypoints_loaded = False
@@ -66,8 +69,10 @@ class _Registry:
         if not normalized:
             raise ValueError("Sandbox backend name must be non-empty")
         with self._lock:
-            if normalized in self._backends or normalized in self._factories:
-                raise ValueError(f"Duplicate sandbox backend: {normalized!r}")
+            module_name = caller_module_name()
+            if module_name == __name__:
+                module_name = caller_module_name(depth=2)
+            self._guard.register(normalized, module_name)
             if inspect.isclass(backend):
                 self._factories[normalized] = backend
             else:
@@ -81,6 +86,7 @@ class _Registry:
         with self._lock:
             self._backends.pop(name, None)
             self._factories.pop(name, None)
+            self._guard.forget(name)
 
     def get(self, name: str) -> SandboxBackend:
         """Return the backend registered under *name*.
@@ -167,6 +173,7 @@ class _Registry:
         for name, cls in builtins:
             if name in self._all_names():
                 continue
+            self._guard.register(name, cls.__module__)
             self._factories[name] = cls
 
     def _load_entrypoints(self) -> None:
@@ -185,6 +192,8 @@ class _Registry:
             except Exception as exc:
                 logger.warning("Failed to load sandbox backend entry-point %r: %s", name, exc)
                 continue
+            module_name = str(getattr(loaded, "__module__", None) or getattr(ep, "value", "<entrypoint>"))
+            self._guard.register(name, module_name)
             if inspect.isclass(loaded):
                 self._factories[name] = loaded  # type: ignore[assignment]  # dynamic registry
             else:

--- a/src/bernstein/core/storage/registry.py
+++ b/src/bernstein/core/storage/registry.py
@@ -23,6 +23,8 @@ import threading
 from importlib.metadata import entry_points
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.registry_guard import DuplicateGuard, caller_module_name
+
 if TYPE_CHECKING:
     from bernstein.core.storage.sink import ArtifactSink
 
@@ -45,6 +47,7 @@ class _Registry:
     def __init__(self) -> None:
         self._sinks: dict[str, ArtifactSink] = {}
         self._factories: dict[str, Any] = {}
+        self._guard = DuplicateGuard("artifact sink")
         self._lock = threading.RLock()
         self._builtins_loaded = False
         self._entrypoints_loaded = False
@@ -68,8 +71,10 @@ class _Registry:
         if not normalised:
             raise ValueError("Artifact sink name must be non-empty")
         with self._lock:
-            if normalised in self._sinks or normalised in self._factories:
-                raise ValueError(f"Duplicate artifact sink: {normalised!r}")
+            module_name = caller_module_name()
+            if module_name == __name__:
+                module_name = caller_module_name(depth=2)
+            self._guard.register(normalised, module_name)
             if inspect.isclass(sink):
                 self._factories[normalised] = sink
             else:
@@ -80,6 +85,7 @@ class _Registry:
         with self._lock:
             self._sinks.pop(name, None)
             self._factories.pop(name, None)
+            self._guard.forget(name)
 
     def get(self, name: str) -> ArtifactSink:
         """Return the sink registered under *name*.
@@ -147,6 +153,7 @@ class _Registry:
         from bernstein.core.storage.sinks.local_fs import LocalFsSink
 
         if "local_fs" not in self._all_names():
+            self._guard.register("local_fs", LocalFsSink.__module__)
             self._factories["local_fs"] = LocalFsSink
 
         self._register_cloud_factory(
@@ -183,6 +190,8 @@ class _Registry:
         if name in self._all_names():
             return
 
+        self._guard.register(name, module)
+
         def _factory() -> ArtifactSink:
             import importlib
 
@@ -213,6 +222,8 @@ class _Registry:
             except Exception as exc:
                 logger.warning("Failed to load artifact sink entry-point %r: %s", name, exc)
                 continue
+            module_name = str(getattr(loaded, "__module__", None) or getattr(ep, "value", "<entrypoint>"))
+            self._guard.register(name, module_name)
             if inspect.isclass(loaded):
                 self._factories[name] = loaded
             else:

--- a/src/bernstein/core/trackers/registry.py
+++ b/src/bernstein/core/trackers/registry.py
@@ -33,6 +33,8 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol
 
+from bernstein.core.registry_guard import DuplicateGuard, caller_module_name
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
 
@@ -105,6 +107,7 @@ class TrackerRegistry:
 
     def __init__(self) -> None:
         self._entries: dict[str, TrackerRegistration] = {}
+        self._guard = DuplicateGuard("tracker adapter")
 
     def register(
         self,
@@ -137,14 +140,12 @@ class TrackerRegistry:
             DuplicateTrackerError: When ``name`` is already registered
                 and ``overwrite`` is ``False``.
         """
-        if name in self._entries and not overwrite:
-            existing = self._entries[name]
-            msg = (
-                f"Tracker {name!r} is already registered "
-                f"(source={existing.source}, provenance={existing.provenance!r}). "
-                "Pass overwrite=True to replace it."
-            )
-            raise DuplicateTrackerError(msg)
+        if overwrite:
+            self._guard.forget(name)
+        module_name = provenance or caller_module_name()
+        if module_name == __name__:
+            module_name = caller_module_name(depth=2)
+        self._guard.register(name, module_name, error_type=DuplicateTrackerError)
         entry = TrackerRegistration(
             name=name,
             factory=factory,
@@ -160,6 +161,7 @@ class TrackerRegistry:
     def unregister(self, name: str) -> None:
         """Remove ``name`` from the registry (no-op if absent)."""
         self._entries.pop(name, None)
+        self._guard.forget(name)
 
     def get(self, name: str) -> TrackerRegistration:
         """Return the registration for ``name``.

--- a/tests/unit/core/test_registry_duplicate_guard.py
+++ b/tests/unit/core/test_registry_duplicate_guard.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import importlib
 import sys
+from typing import Any
 
 import pytest
 from bernstein.core.models import ModelConfig
@@ -153,3 +154,89 @@ def test_duplicate_id_registration_raises_at_import() -> None:
     message = str(excinfo.value)
     assert f"{_FIXTURE_PACKAGE}.first" in message
     assert f"{_FIXTURE_PACKAGE}.second" in message
+
+
+# --- Slices migrated under issue #5104 ---
+
+
+def _dummy_tracker_factory(**kwargs: Any) -> Any:
+    return None
+
+
+class TestTrackersRegistryDuplicateGuard:
+    def test_tracker_registry_duplicate_raises_duplicate_tracker_error(self) -> None:
+        from bernstein.core.trackers.registry import DuplicateTrackerError, TrackerRegistry
+
+        registry = TrackerRegistry()
+        registry.register("test-tracker", _dummy_tracker_factory)
+
+        with pytest.raises(DuplicateTrackerError) as excinfo:
+            registry.register("test-tracker", _dummy_tracker_factory)
+
+        assert "test-tracker" in str(excinfo.value)
+        assert __name__ in str(excinfo.value)
+
+    def test_tracker_registry_overwrite_allows_reregistration(self) -> None:
+        from bernstein.core.trackers.registry import TrackerRegistry
+
+        registry = TrackerRegistry()
+        registry.register("test-tracker", _dummy_tracker_factory, summary="first")
+        registry.register("test-tracker", _dummy_tracker_factory, summary="second", overwrite=True)
+        assert registry.get("test-tracker").summary == "second"
+
+    def test_tracker_registry_unregister_allows_reregistration(self) -> None:
+        from bernstein.core.trackers.registry import TrackerRegistry
+
+        registry = TrackerRegistry()
+        registry.register("test-tracker", _dummy_tracker_factory)
+        registry.unregister("test-tracker")
+        registry.register("test-tracker", _dummy_tracker_factory)  # must not raise
+        assert registry.get("test-tracker") is not None
+
+
+class TestSandboxRegistryDuplicateGuard:
+    def test_sandbox_registry_duplicate_raises(self) -> None:
+        from bernstein.core.sandbox.registry import _Registry
+
+        registry = _Registry()
+        dummy_backend = object()  # type: ignore[arg-type]
+        registry.register("test-sandbox", dummy_backend)
+
+        with pytest.raises(DuplicateRegistrationError) as excinfo:
+            registry.register("test-sandbox", dummy_backend)
+
+        assert "Duplicate sandbox backend" in str(excinfo.value)
+        assert "test-sandbox" in str(excinfo.value)
+
+    def test_sandbox_registry_unregister_allows_reregistration(self) -> None:
+        from bernstein.core.sandbox.registry import _Registry
+
+        registry = _Registry()
+        dummy_backend = object()  # type: ignore[arg-type]
+        registry.register("test-sandbox", dummy_backend)
+        registry.unregister("test-sandbox")
+        registry.register("test-sandbox", dummy_backend)  # must not raise
+
+
+class TestStorageRegistryDuplicateGuard:
+    def test_storage_registry_duplicate_raises(self) -> None:
+        from bernstein.core.storage.registry import _Registry
+
+        registry = _Registry()
+        dummy_sink = object()  # type: ignore[arg-type]
+        registry.register("test-sink", dummy_sink)
+
+        with pytest.raises(DuplicateRegistrationError) as excinfo:
+            registry.register("test-sink", dummy_sink)
+
+        assert "Duplicate artifact sink" in str(excinfo.value)
+        assert "test-sink" in str(excinfo.value)
+
+    def test_storage_registry_unregister_allows_reregistration(self) -> None:
+        from bernstein.core.storage.registry import _Registry
+
+        registry = _Registry()
+        dummy_sink = object()  # type: ignore[arg-type]
+        registry.register("test-sink", dummy_sink)
+        registry.unregister("test-sink")
+        registry.register("test-sink", dummy_sink)  # must not raise


### PR DESCRIPTION
## Summary

Part of #5104. Migrates three core registries onto the shared `DuplicateGuard` helper (`src/bernstein/core/registry_guard.py`) introduced in slice 1:
1. `TrackerRegistry` in `src/bernstein/core/trackers/registry.py`
2. `_Registry` in `src/bernstein/core/sandbox/registry.py`
3. `_Registry` in `src/bernstein/core/storage/registry.py`

## Changes

- **Tracker registry (`core/trackers/registry.py`)**:
  - Composes `DuplicateGuard("tracker adapter")`.
  - On `register()`, raises `DuplicateTrackerError` naming originating and conflicting module names, with support for `overwrite=True`.
  - On `unregister()`, forgets key in `DuplicateGuard`.
- **Sandbox registry (`core/sandbox/registry.py`)**:
  - Composes `DuplicateGuard("sandbox backend")`.
  - Tracks built-in and entrypoint registrations into `_guard`.
  - Replaces hand-rolled duplicate dictionary check with `self._guard.register(normalized, module_name)`.
  - Unregister drops tracking via `forget()`.
- **Storage registry (`core/storage/registry.py`)**:
  - Composes `DuplicateGuard("artifact sink")`.
  - Tracks built-in and entrypoint registrations into `_guard`.
  - Replaces hand-rolled duplicate dictionary check with `self._guard.register(normalised, module_name)`.
  - Unregister drops tracking via `forget()`.
- **DuplicateGuard (`core/registry_guard.py`)**:
  - Prefixes error messages with `Duplicate <registry_name>:` for consistency with legacy `ValueError` substring matching.
- **Tests**:
  - Added regression test suite in `tests/unit/core/test_registry_duplicate_guard.py` verifying duplicate rejection and re-registration after overwrite/unregister across all three registries.

## Verification

- `uv run pytest tests/unit/core/test_registry_duplicate_guard.py tests/unit/trackers/test_registry.py tests/unit/sandbox/test_registry.py` (43 passed).
- `uv run ruff check` passed clean.
- `uv run ruff format --check` passed clean.
- `uv run mypy src/bernstein/core/registry_guard.py src/bernstein/core/trackers/registry.py src/bernstein/core/sandbox/registry.py src/bernstein/core/storage/registry.py` (0 issues).
