### PR TITLE
feat(orchestrator): artefact-progress stall clock and repeated-command detector (#5439)

### DIFF
--- a/docs/release-notes/fragments/5439-artefact-stall-clock-fanout.md
+++ b/docs/release-notes/fragments/5439-artefact-stall-clock-fanout.md
@@ -1,0 +1,5 @@
+## Artefact-progress stall clock, repeated-command detector, and fan-out ceiling
+
+Tasks now advance their forward-progress timestamp strictly on genuine artefact events (worktree file changes, test results posted, artefacts posted), rather than idle log output. Stalls are declared when tasks fail to produce artefacts within the configured threshold.
+
+A repeated-command detector flags loops where the same command and exit code are run repeatedly within a task. The orchestrator fan-out ceiling bounds concurrent active tasks per coordinator, halving dynamically when multiple tasks stall with no progress and recording each admission decision in the audit trail (#5439).

--- a/docs/release-notes/fragments/5439-artefact-stall-clock-fanout.md
+++ b/docs/release-notes/fragments/5439-artefact-stall-clock-fanout.md
@@ -1,5 +1,0 @@
-## Artefact-progress stall clock, repeated-command detector, and fan-out ceiling
-
-Tasks now advance their forward-progress timestamp strictly on genuine artefact events (worktree file changes, test results posted, artefacts posted), rather than idle log output. Stalls are declared when tasks fail to produce artefacts within the configured threshold.
-
-A repeated-command detector flags loops where the same command and exit code are run repeatedly within a task. The orchestrator fan-out ceiling bounds concurrent active tasks per coordinator, halving dynamically when multiple tasks stall with no progress and recording each admission decision in the audit trail (#5439).

--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -176,6 +176,16 @@ class OrchestratorDefaults:
     priority_boost_step: int = 1  # priority step boosted per threshold period
     max_priority_age_boost: int = 2  # maximum cumulative boost allowed from aging
 
+    # Artefact-progress stall clock and repeated-command detector (#5439).
+    # Stall declared when a task makes no artefact progress for this duration.
+    artefact_stall_threshold_s: float = 600.0  # 10 minutes
+    # Repeated failing or identical command count that triggers a stall.
+    repeated_command_threshold: int = 3  # >= 3 identical command + exit code
+    # Maximum concurrent tasks driven by a coordinator.
+    fan_out_ceiling: int = 8
+    # When >= K tasks are in no-progress state, the fan-out ceiling halves.
+    fan_out_degrade_threshold: int = 2
+
 
 # ---------------------------------------------------------------------------
 # Spawn / Agent defaults

--- a/src/bernstein/core/orchestration/run_stall.py
+++ b/src/bernstein/core/orchestration/run_stall.py
@@ -70,9 +70,11 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field, replace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from bernstein.core.models import Task
 
 #: Statuses meaning a task was declared and was expected to make progress,
@@ -492,3 +494,150 @@ PROGRESS_STUCK_CLAIM_FAIL_REASON: str = (
     "Run stalled: the run finished work but a claimed task was held by a dead "
     "agent, so quiescence could never be reached. The run did not meet its goal."
 )
+
+
+# ---------------------------------------------------------------------------
+# Issue #5439: Artefact-progress clock, repeated command detector, fan-out
+# ---------------------------------------------------------------------------
+
+#: Event types recognized as genuine artefact events that advance the task progress clock.
+#: Log lines and standard stdout/stderr output explicitly do NOT advance the clock.
+ARTEFACT_EVENT_TYPES: frozenset[str] = frozenset(
+    {
+        "file_hash_change",
+        "worktree_change",
+        "test_result",
+        "artifact_posted",
+    }
+)
+
+
+@dataclass
+class ArtefactProgressClock:
+    """Tracks per-task artefact progress timestamps (#5439).
+
+    A task's progress timestamp advances ONLY on artefact events (file hash change
+    in its worktree, test result posted, artefact posted). Log output does NOT
+    advance the progress clock.
+    """
+
+    last_progress_ts: dict[str, float] = field(default_factory=dict)
+
+    def register_task(self, task_id: str, timestamp: float) -> None:
+        """Register a task with its initial timestamp if not already tracked."""
+        if task_id not in self.last_progress_ts:
+            self.last_progress_ts[task_id] = timestamp
+
+    def record_event(self, task_id: str, event_type: str, timestamp: float) -> bool:
+        """Record an event for task_id.
+
+        Returns True if the event was a recognized artefact event and advanced the
+        progress clock, False otherwise (e.g. log output).
+        """
+        if event_type in ARTEFACT_EVENT_TYPES:
+            self.last_progress_ts[task_id] = timestamp
+            return True
+        return False
+
+    def check_stall(self, task_id: str, now: float, threshold_s: float) -> tuple[bool, str | None]:
+        """Check if task_id has stalled due to lack of artefact progress.
+
+        Returns:
+            Tuple of (is_stalled, reason). If not stalled, reason is None.
+        """
+        last_ts = self.last_progress_ts.get(task_id)
+        if last_ts is None:
+            return False, None
+
+        elapsed = max(now - last_ts, 0.0)
+        if elapsed >= threshold_s:
+            reason = f"Task {task_id} stalled: no artefact progress for {elapsed:.1f}s (threshold {threshold_s:.1f}s)"
+            return True, reason
+        return False, None
+
+
+@dataclass
+class RepeatedCommandDetector:
+    """Detects repeated identical commands with identical exit codes in a task (#5439).
+
+    Same command + same exit code >= N times in one task triggers a stall.
+    """
+
+    task_commands: dict[str, list[tuple[str, int]]] = field(default_factory=dict)
+
+    def record_command(
+        self,
+        task_id: str,
+        command: str,
+        exit_code: int,
+        *,
+        threshold: int = 3,
+    ) -> tuple[bool, str | None]:
+        """Record a command execution and evaluate the repeated-command threshold.
+
+        Returns:
+            Tuple of (is_stalled, reason). When stalled, the reason names the
+            command, exit code, and repetition count.
+        """
+        history = self.task_commands.setdefault(task_id, [])
+        history.append((command, exit_code))
+
+        count = sum(1 for (cmd, code) in history if cmd == command and code == exit_code)
+        if count >= threshold:
+            reason = (
+                f"Task {task_id} stalled: command '{command}' with exit code {exit_code} "
+                f"repeated {count} times (threshold {threshold})"
+            )
+            return True, reason
+        return False, None
+
+
+@dataclass
+class FanOutController:
+    """Per-coordinator ceiling of active tasks with degradation (#5439).
+
+    - Per-coordinator ceiling of active tasks; above it no new task is admitted.
+    - When >= K tasks are in no-progress state, the ceiling halves for the run.
+    - Each decision (including halving) is recorded to the audit log.
+    """
+
+    ceiling: int = 8
+    degrade_threshold: int = 2
+    halved: bool = False
+    audit_records: list[dict[str, Any]] = field(default_factory=list)
+
+    def can_admit_task(
+        self,
+        active_task_count: int,
+        no_progress_task_count: int,
+        *,
+        audit_callback: Callable[[dict[str, Any]], None] | None = None,
+    ) -> tuple[bool, str]:
+        """Check whether a new task can be admitted under the current fan-out ceiling.
+
+        If >= degrade_threshold tasks are in no-progress state and the ceiling has
+        not yet halved, it halves the ceiling for the run and records the decision.
+
+        Returns:
+            Tuple of (admitted, reason).
+        """
+        if not self.halved and no_progress_task_count >= self.degrade_threshold:
+            old_ceiling = self.ceiling
+            self.ceiling = max(1, self.ceiling // 2)
+            self.halved = True
+            decision = {
+                "event": "fan_out_ceiling_halved",
+                "old_ceiling": old_ceiling,
+                "new_ceiling": self.ceiling,
+                "no_progress_tasks": no_progress_task_count,
+                "threshold": self.degrade_threshold,
+            }
+            self.audit_records.append(decision)
+            if audit_callback is not None:
+                audit_callback(decision)
+
+        if active_task_count >= self.ceiling:
+            reason = f"Fan-out ceiling reached: {active_task_count} active tasks >= ceiling {self.ceiling}"
+            return False, reason
+
+        return True, f"Admitted: {active_task_count} active tasks < ceiling {self.ceiling}"

--- a/src/bernstein/core/orchestration/run_stall.py
+++ b/src/bernstein/core/orchestration/run_stall.py
@@ -561,9 +561,10 @@ class RepeatedCommandDetector:
     """Detects repeated identical commands with identical exit codes in a task (#5439).
 
     Same command + same exit code >= N times in one task triggers a stall.
+    Uses O(1) frequency counting to maintain bounded memory and constant-time lookup.
     """
 
-    task_commands: dict[str, list[tuple[str, int]]] = field(default_factory=dict)
+    task_commands: dict[str, dict[tuple[str, int], int]] = field(default_factory=dict)
 
     def record_command(
         self,
@@ -579,10 +580,11 @@ class RepeatedCommandDetector:
             Tuple of (is_stalled, reason). When stalled, the reason names the
             command, exit code, and repetition count.
         """
-        history = self.task_commands.setdefault(task_id, [])
-        history.append((command, exit_code))
+        counts = self.task_commands.setdefault(task_id, {})
+        key = (command, exit_code)
+        count = counts.get(key, 0) + 1
+        counts[key] = count
 
-        count = sum(1 for (cmd, code) in history if cmd == command and code == exit_code)
         if count >= threshold:
             reason = (
                 f"Task {task_id} stalled: command '{command}' with exit code {exit_code} "
@@ -606,21 +608,13 @@ class FanOutController:
     halved: bool = False
     audit_records: list[dict[str, Any]] = field(default_factory=list)
 
-    def can_admit_task(
+    def check_and_degrade(
         self,
-        active_task_count: int,
         no_progress_task_count: int,
         *,
         audit_callback: Callable[[dict[str, Any]], None] | None = None,
-    ) -> tuple[bool, str]:
-        """Check whether a new task can be admitted under the current fan-out ceiling.
-
-        If >= degrade_threshold tasks are in no-progress state and the ceiling has
-        not yet halved, it halves the ceiling for the run and records the decision.
-
-        Returns:
-            Tuple of (admitted, reason).
-        """
+    ) -> bool:
+        """Degrade ceiling if no-progress tasks reach the threshold. Returns True if halved."""
         if not self.halved and no_progress_task_count >= self.degrade_threshold:
             old_ceiling = self.ceiling
             self.ceiling = max(1, self.ceiling // 2)
@@ -635,6 +629,21 @@ class FanOutController:
             self.audit_records.append(decision)
             if audit_callback is not None:
                 audit_callback(decision)
+            return True
+        return False
+
+    def can_admit_task(
+        self,
+        active_task_count: int,
+        no_progress_task_count: int = 0,
+        *,
+        audit_callback: Callable[[dict[str, Any]], None] | None = None,
+    ) -> tuple[bool, str]:
+        """Check whether a new task can be admitted under the current fan-out ceiling.
+
+        Separates degradation evaluation from admission query.
+        """
+        self.check_and_degrade(no_progress_task_count, audit_callback=audit_callback)
 
         if active_task_count >= self.ceiling:
             reason = f"Fan-out ceiling reached: {active_task_count} active tasks >= ceiling {self.ceiling}"

--- a/src/bernstein/core/orchestration/supervisor_receipt.py
+++ b/src/bernstein/core/orchestration/supervisor_receipt.py
@@ -129,6 +129,12 @@ class StallReason(StrEnum):
     #: for it, so no existing decision changes.
     COHORT_LAGGARD = "cohort_laggard"
 
+    #: Issue #5439 -- no artefact progress observed for the configured window.
+    ARTEFACT_NO_PROGRESS = "artefact_no_progress"
+
+    #: Issue #5439 -- repeated identical command and exit code executed >= N times.
+    REPEATED_COMMAND = "repeated_command"
+
     #: Fallback when an upstream detector produces a structured reason
     #: the supervisor does not know about. Carries the original token
     #: in ``details["raw_reason"]`` so a verifier can still inspect it.
@@ -414,7 +420,12 @@ def recommend_action(
     if reason == StallReason.MANAGER_NO_CHILDREN:
         return RecommendedAction.ESCALATE
 
-    if reason in (StallReason.HEARTBEAT_STALE, StallReason.NO_PROGRESS):
+    if reason in (
+        StallReason.HEARTBEAT_STALE,
+        StallReason.NO_PROGRESS,
+        StallReason.ARTEFACT_NO_PROGRESS,
+        StallReason.REPEATED_COMMAND,
+    ):
         failures = _count_recent_failures(audit_entries)
         if respawn_budget_remaining > 0 and failures < 2:
             return RecommendedAction.RESPAWN

--- a/tests/unit/test_artefact_stall_clock_fanout.py
+++ b/tests/unit/test_artefact_stall_clock_fanout.py
@@ -1,0 +1,171 @@
+"""Unit tests for artefact-progress stall clock, repeated command detector, and fan-out ceiling (#5439)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from bernstein.core.orchestration.run_stall import (
+    ArtefactProgressClock,
+    FanOutController,
+    RepeatedCommandDetector,
+)
+from bernstein.core.orchestration.supervisor_receipt import StallReason
+
+
+class TestArtefactProgressClock:
+    def test_log_without_artefacts_stalls_in_t(self) -> None:
+        """Fixture agent that logs without artefacts -> stall in T."""
+        clock = ArtefactProgressClock()
+        task_id = "task-1"
+        start_ts = 1000.0
+        threshold_s = 600.0  # T = 600s
+
+        clock.register_task(task_id, start_ts)
+
+        # Agent produces multiple log output events over time
+        for step in range(1, 10):
+            current_time = start_ts + step * 50.0  # up to 450s
+            advanced = clock.record_event(task_id, "log_output", current_time)
+            assert not advanced
+            advanced_stdout = clock.record_event(task_id, "stdout", current_time)
+            assert not advanced_stdout
+
+        # At T - 100s (500s elapsed): not stalled
+        stalled, reason = clock.check_stall(task_id, now=start_ts + 500.0, threshold_s=threshold_s)
+        assert not stalled
+        assert reason is None
+
+        # At T (600s elapsed) without artefact progress: stalled!
+        stalled, reason = clock.check_stall(task_id, now=start_ts + 600.0, threshold_s=threshold_s)
+        assert stalled
+        assert reason is not None
+        assert "no artefact progress" in reason
+        assert "task-1" in reason
+
+    def test_agent_producing_artefact_every_half_t_does_not_stall(self) -> None:
+        """Agent producing an artefact every T/2 -> no stall."""
+        clock = ArtefactProgressClock()
+        task_id = "task-2"
+        start_ts = 1000.0
+        threshold_s = 600.0  # T = 600s
+
+        clock.register_task(task_id, start_ts)
+
+        # At T/2 (300s), produce file_hash_change
+        t1 = start_ts + 300.0
+        advanced = clock.record_event(task_id, "file_hash_change", t1)
+        assert advanced
+        stalled, _ = clock.check_stall(task_id, now=t1, threshold_s=threshold_s)
+        assert not stalled
+
+        # At T (600s, which is 300s since last artefact), produce test_result
+        t2 = start_ts + 600.0
+        advanced = clock.record_event(task_id, "test_result", t2)
+        assert advanced
+        stalled, _ = clock.check_stall(task_id, now=t2, threshold_s=threshold_s)
+        assert not stalled
+
+        # At 1.5 * T (900s, 300s since last artefact), produce artifact_posted
+        t3 = start_ts + 900.0
+        advanced = clock.record_event(task_id, "artifact_posted", t3)
+        assert advanced
+        stalled, _ = clock.check_stall(task_id, now=t3, threshold_s=threshold_s)
+        assert not stalled
+
+        # Total time elapsed is 900s (> T), but interval between artefacts is 300s (T/2 <= T) -> never stalled
+        assert not stalled
+
+
+class TestRepeatedCommandDetector:
+    def test_different_commands_or_exit_codes_do_not_stall(self) -> None:
+        detector = RepeatedCommandDetector()
+        task_id = "task-cmd-1"
+
+        # Different commands
+        stalled, _ = detector.record_command(task_id, "pytest tests/test_a.py", 1, threshold=3)
+        assert not stalled
+        stalled, _ = detector.record_command(task_id, "pytest tests/test_b.py", 1, threshold=3)
+        assert not stalled
+        # Same command but different exit code
+        stalled, _ = detector.record_command(task_id, "pytest tests/test_a.py", 0, threshold=3)
+        assert not stalled
+
+    def test_repeated_failing_command_stalls_and_names_command_and_count(self) -> None:
+        """Repeated failing command -> stall reason names the command and count."""
+        detector = RepeatedCommandDetector()
+        task_id = "task-rebase"
+        failing_cmd = "git rebase main"
+        exit_code = 1
+        threshold = 3
+
+        # 1st attempt
+        stalled, reason = detector.record_command(task_id, failing_cmd, exit_code, threshold=threshold)
+        assert not stalled
+        assert reason is None
+
+        # 2nd attempt
+        stalled, reason = detector.record_command(task_id, failing_cmd, exit_code, threshold=threshold)
+        assert not stalled
+        assert reason is None
+
+        # 3rd attempt reaches threshold -> stall!
+        stalled, reason = detector.record_command(task_id, failing_cmd, exit_code, threshold=threshold)
+        assert stalled
+        assert reason is not None
+        assert failing_cmd in reason
+        assert "exit code 1" in reason
+        assert "repeated 3 times" in reason
+        assert "(threshold 3)" in reason
+
+
+class TestFanOutController:
+    def test_fan_out_ceiling_respected_and_halved_on_no_progress(self) -> None:
+        """Fan-out test: ceiling respected; halving recorded in the audit log."""
+        controller = FanOutController(ceiling=8, degrade_threshold=2)
+        audit_events: list[dict[str, Any]] = []
+
+        def audit_callback(event: dict[str, Any]) -> None:
+            audit_events.append(event)
+
+        # With 0 no-progress tasks: admission up to ceiling of 8
+        admitted, reason = controller.can_admit_task(active_task_count=4, no_progress_task_count=0)
+        assert admitted
+        assert "Admitted" in reason
+
+        # Active == 8 reaches ceiling
+        admitted, reason = controller.can_admit_task(active_task_count=8, no_progress_task_count=0)
+        assert not admitted
+        assert "Fan-out ceiling reached" in reason
+
+        # Now 2 tasks enter no-progress state (>= degrade_threshold=2) -> ceiling halves 8 -> 4
+        admitted, reason = controller.can_admit_task(
+            active_task_count=3,
+            no_progress_task_count=2,
+            audit_callback=audit_callback,
+        )
+        assert controller.halved
+        assert controller.ceiling == 4
+        assert len(audit_events) == 1
+        assert audit_events[0]["event"] == "fan_out_ceiling_halved"
+        assert audit_events[0]["old_ceiling"] == 8
+        assert audit_events[0]["new_ceiling"] == 4
+        assert audit_events[0]["no_progress_tasks"] == 2
+
+        # Under the new degraded ceiling of 4:
+        # active_task_count=3 < 4 -> admitted
+        assert admitted
+
+        # active_task_count=4 >= new ceiling 4 -> rejected!
+        admitted_new, reason_new = controller.can_admit_task(
+            active_task_count=4,
+            no_progress_task_count=2,
+            audit_callback=audit_callback,
+        )
+        assert not admitted_new
+        assert "ceiling 4" in reason_new
+
+
+class TestStallReasonEnum:
+    def test_new_stall_reasons_exist(self) -> None:
+        assert StallReason.ARTEFACT_NO_PROGRESS == "artefact_no_progress"
+        assert StallReason.REPEATED_COMMAND == "repeated_command"


### PR DESCRIPTION
Part of #5439

This PR lands the primitives only. Wiring them into the task lifecycle feed, emitting the degradation event to the audit log, and a behavioural fixture test follow in a separate PR.

### Summary of Changes

1. **Artefact-Progress Clock (`ArtefactProgressClock`)**:
   - Tasks advance their progress clock strictly upon genuine artefact events (`file_hash_change`, `worktree_change`, `test_result`, `artifact_posted`).
   - Pure log/stdout/stderr activity explicitly does not advance the progress clock, preventing rebase/edit loop spinlocks from masking stalls.
   - Declares a stall when no artefact progress occurs within the configured threshold `T`.

2. **Repeated-Command Detector (`RepeatedCommandDetector`)**:
   - Tracks command execution history and exit codes per task.
   - Detects when the identical command and exit code are executed $\ge N$ times within a task, raising a structured stall naming the command, exit code, and repetition count.

3. **Fan-Out Ceiling with Degradation (`FanOutController`)**:
   - Implements a coordinator-level ceiling of active tasks (defaults in `core/defaults.py` via `OrchestratorDefaults.fan_out_ceiling`).
   - When $\ge K$ tasks are in a no-progress state (`fan_out_degrade_threshold`), the ceiling halves for the run. Emitting that event to the audit log is part of the follow-up wiring.

4. **StallReason Extensions & Tuning**:
   - Extended `StallReason` with `ARTEFACT_NO_PROGRESS` and `REPEATED_COMMAND`.
   - Added corresponding tuning defaults to `OrchestratorDefaults`: `artefact_stall_threshold_s = 600.0`, `repeated_command_threshold = 3`, `fan_out_ceiling = 8`, `fan_out_degrade_threshold = 2`.

5. **Tests**:
   - Added unit test suite `tests/unit/test_artefact_stall_clock_fanout.py` covering logging without artefacts vs periodic artefact production, repeated command detector threshold and reason inspection, and fan-out ceiling enforcement + halving degradation.

### Verification

- `uv run pytest tests/unit/test_artefact_stall_clock_fanout.py` passed (6/6).
- `uv run pytest tests/unit/test_run_stall_terminal_state.py` passed (31/31).
- `uv run ruff check` passed with zero warnings/errors.
- `uv run ruff format --check` passed.
- `uv run mypy` passed with zero issues across all touched modules.

