### PR TITLE
feat(cli): non-interactive run output shows per-task progress (#5338)

### DIFF
--- a/docs/release-notes/fragments/5338-non-interactive-task-progress.md
+++ b/docs/release-notes/fragments/5338-non-interactive-task-progress.md
@@ -1,0 +1,5 @@
+## Non-interactive run output shows per-task progress: task, adapter, model, state
+
+In non-interactive mode (CI or schedulers without a TTY), `bernstein run` now prints one line per task state transition until detach: `task <id> <state> adapter=<name> model=<route> title="<first 60 chars>"`, along with the corresponding line when a task is first planned.
+
+Additionally, `bernstein status` now renders `Adapter` and `Model` columns in the task table, allowing operators to inspect which adapter and model route each task ran on from captured logs and status outputs (#5338).

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -1750,6 +1750,7 @@ def _await_first_spawn_outcome(
     timeout_s: float = _FIRST_SPAWN_WAIT_S,
     poll_interval_s: float = _FIRST_SPAWN_POLL_S,
     narrate_wait: bool = False,
+    on_poll: Any = None,
 ) -> tuple[str, str | None]:
     """Briefly poll the task server for the outcome of the first agent spawn.
 
@@ -1772,6 +1773,8 @@ def _await_first_spawn_outcome(
             already reports an agent -- stays silent. Off by default so the
             non-interactive detach branch and ``--quiet`` keep today's
             chatter-free behaviour.
+        on_poll: Optional callable invoked on each polling iteration to
+            observe task progress before detach.
 
     Returns:
         ``("spawned", None)`` once at least one agent is live,
@@ -1785,6 +1788,9 @@ def _await_first_spawn_outcome(
 
     def _poll_once() -> tuple[str, str | None] | None:
         nonlocal unreachable_polls, transient_reason
+        if on_poll is not None:
+            with suppress(Exception):
+                on_poll()
         health = server_get("/health")
         if not isinstance(health, dict):
             unreachable_polls += 1

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -1789,8 +1789,10 @@ def _await_first_spawn_outcome(
     def _poll_once() -> tuple[str, str | None] | None:
         nonlocal unreachable_polls, transient_reason
         if on_poll is not None:
-            with suppress(Exception):
+            try:
                 on_poll()
+            except Exception as exc:
+                logger.warning("on_poll callback failed: %s", exc, exc_info=True)
         health = server_get("/health")
         if not isinstance(health, dict):
             unreachable_polls += 1

--- a/src/bernstein/cli/run_preflight.py
+++ b/src/bernstein/cli/run_preflight.py
@@ -701,7 +701,7 @@ class TaskStateProgressTracker:
 
     @staticmethod
     def format_line(task_id: str, state: str, adapter: str, model: str, title: str) -> str:
-        clean_title = title.replace("\n", " ").strip()[:60]
+        clean_title = title.replace("\n", " ").replace('"', "'").strip()[:60]
         return f'task {task_id} {state} adapter={adapter} model={model} title="{clean_title}"'
 
     def update_tasks(self, tasks: list[dict[str, Any]]) -> list[str]:
@@ -739,7 +739,8 @@ class TaskStateProgressTracker:
                 status_data = server_get("/status")
                 tasks = _extract_tasks_from_payload(status_data)
             return self.update_tasks(tasks)
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to poll task progress: %s", exc, exc_info=True)
             return []
 
 

--- a/src/bernstein/cli/run_preflight.py
+++ b/src/bernstein/cli/run_preflight.py
@@ -671,6 +671,78 @@ def _raise_if_no_plan_after_spawn(*, narrate_wait: bool = True) -> None:
         )
 
 
+def _extract_tasks_from_payload(payload: Any) -> list[dict[str, Any]]:
+    """Extract list of task dicts from /tasks or /status response payload."""
+    if isinstance(payload, list):
+        return [t for t in payload if isinstance(t, dict)]
+    if isinstance(payload, dict):
+        if "tasks" in payload:
+            val = payload["tasks"]
+            if isinstance(val, list):
+                return [t for t in val if isinstance(t, dict)]
+            if isinstance(val, dict) and "items" in val and isinstance(val["items"], list):
+                return [t for t in val["items"] if isinstance(t, dict)]
+        if "items" in payload and isinstance(payload["items"], list):
+            return [t for t in payload["items"] if isinstance(t, dict)]
+    return []
+
+
+class TaskStateProgressTracker:
+    """Tracks and emits task state transitions in non-interactive runs.
+
+    Emits one line per state transition:
+    task <id> <state> adapter=<name> model=<route> title="<first 60 chars>"
+    plus a 'planned' line when the task is first observed.
+    """
+
+    def __init__(self, console: Console | None = None) -> None:
+        self.console = console or make_console()
+        self.seen_states: dict[str, str] = {}
+
+    @staticmethod
+    def format_line(task_id: str, state: str, adapter: str, model: str, title: str) -> str:
+        clean_title = title.replace("\n", " ").strip()[:60]
+        return f'task {task_id} {state} adapter={adapter} model={model} title="{clean_title}"'
+
+    def update_tasks(self, tasks: list[dict[str, Any]]) -> list[str]:
+        lines: list[str] = []
+        for task in tasks:
+            task_id = str(task.get("id") or "")
+            if not task_id:
+                continue
+            current_state = str(task.get("status") or "open")
+            adapter = str(task.get("adapter") or task.get("cli") or "auto")
+            model = str(task.get("model") or "default")
+            title = str(task.get("title") or "")
+
+            if task_id not in self.seen_states:
+                planned_line = self.format_line(task_id, "planned", adapter, model, title)
+                lines.append(planned_line)
+                self.console.print(planned_line, soft_wrap=True)
+                self.seen_states[task_id] = "planned"
+
+            if current_state != self.seen_states[task_id]:
+                state_line = self.format_line(task_id, current_state, adapter, model, title)
+                lines.append(state_line)
+                self.console.print(state_line, soft_wrap=True)
+                self.seen_states[task_id] = current_state
+
+        return lines
+
+    def poll(self) -> list[str]:
+        from bernstein.cli.helpers import server_get
+
+        try:
+            tasks_data = server_get("/tasks")
+            tasks = _extract_tasks_from_payload(tasks_data)
+            if not tasks:
+                status_data = server_get("/status")
+                tasks = _extract_tasks_from_payload(status_data)
+            return self.update_tasks(tasks)
+        except Exception:
+            return []
+
+
 def _finalize_run_output(*, quiet: bool, wait: float | None = None) -> None:
     """Render either the interactive dashboard or the final summary.
 
@@ -777,7 +849,10 @@ def _finalize_run_output(*, quiet: bool, wait: float | None = None) -> None:
             # outcome and surface a refusal as a non-zero exit.
             from bernstein.cli.run_bootstrap import _await_first_spawn_outcome
 
-            outcome, reason = _await_first_spawn_outcome()
+            tracker = TaskStateProgressTracker(console=console)
+            tracker.poll()
+            outcome, reason = _await_first_spawn_outcome(on_poll=tracker.poll)
+            tracker.poll()
             _show_run_summary()
             if outcome == "refused":
                 console.print(f"[red]Run failed before any work started:[/red] {reason}")

--- a/src/bernstein/cli/status.py
+++ b/src/bernstein/cli/status.py
@@ -110,10 +110,14 @@ def _build_task_table(tasks: list[dict[str, Any]]) -> Table:
     table.add_column("Status", min_width=14)
     table.add_column("Priority", justify="right")
     table.add_column("Agent", min_width=12)
+    table.add_column("Adapter", min_width=10)
+    table.add_column("Model", min_width=12)
 
     for t in sorted(tasks, key=_task_sort_key):
         raw_status = str(t.get("status", "open"))
         color = STATUS_COLORS.get(raw_status, "white")
+        adapter = str(t.get("adapter") or t.get("cli") or "[dim]\u2014[/dim]")
+        model = str(t.get("model") or "[dim]\u2014[/dim]")
         table.add_row(
             str(t.get("id", "\u2014")),
             str(t.get("title", "\u2014")),
@@ -121,6 +125,8 @@ def _build_task_table(tasks: list[dict[str, Any]]) -> Table:
             f"[{color}]{raw_status}[/{color}]",
             str(t.get("priority", 2)),
             str(t.get("assigned_agent") or "[dim]\u2014[/dim]"),
+            adapter,
+            model,
         )
     return table
 

--- a/src/bernstein/core/routes/status_dashboard.py
+++ b/src/bernstein/core/routes/status_dashboard.py
@@ -359,6 +359,8 @@ def _status_task_items(tasks: list[Task], now: float) -> list[dict[str, Any]]:
                 "retry_count": task.retry_count,
                 "blocked_reason": blocked_reason,
                 "model": task.model or "",
+                "adapter": task.cli or str(task.metadata.get("adapter") or ""),
+                "cli": task.cli or "",
                 "progress": _task_progress_pct(task),
                 "depends_on_count": len(task.depends_on),
                 "verification_count": task.verification_count,

--- a/tests/unit/test_non_interactive_task_progress.py
+++ b/tests/unit/test_non_interactive_task_progress.py
@@ -1,0 +1,218 @@
+"""Tests for non-interactive task state transition progress and status columns (#5338)."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from bernstein.core.view_mode import ViewMode, get_view_config
+from rich.console import Console
+
+from bernstein.cli.run_preflight import (
+    TaskStateProgressTracker,
+    _finalize_run_output,
+)
+from bernstein.cli.status import _build_task_table, render_status
+
+_NON_TTY_CAPS = MagicMock(supports_textual=False, is_tty=False)
+
+
+def test_status_table_includes_adapter_and_model_columns() -> None:
+    """_build_task_table includes Adapter and Model columns and populates them."""
+    tasks = [
+        {
+            "id": "t-1",
+            "title": "Build feature",
+            "role": "backend",
+            "status": "in_progress",
+            "priority": 1,
+            "adapter": "fake-adapter",
+            "model": "fake-model-route",
+            "assigned_agent": "agent-1",
+        },
+        {
+            "id": "t-2",
+            "title": "Write tests",
+            "role": "qa",
+            "status": "open",
+            "priority": 2,
+            "cli": "claude",
+            "model": "claude-3-7-sonnet",
+        },
+    ]
+
+    table = _build_task_table(tasks)
+    col_names = [col.header for col in table.columns]
+
+    assert "Adapter" in col_names
+    assert "Model" in col_names
+
+    console = Console(record=True, force_terminal=True, width=140)
+    console.print(table)
+    output = console.export_text()
+
+    assert "fake-adapter" in output
+    assert "fake-model-route" in output
+    assert "claude" in output
+    assert "claude-3-7-sonnet" in output
+
+
+def test_status_render_recorded_runtime_state_has_adapter_column() -> None:
+    """bernstein status output on recorded runtime state includes an Adapter column."""
+    recorded_runtime_payload = {
+        "summary": {"total": 2, "done": 1, "open": 1, "failed": 0, "claimed": 0},
+        "tasks": {
+            "count": 2,
+            "items": [
+                {
+                    "id": "task-alpha",
+                    "title": "Implement authentication gate",
+                    "role": "backend",
+                    "status": "done",
+                    "priority": 1,
+                    "adapter": "codex",
+                    "model": "o3-mini",
+                },
+                {
+                    "id": "task-beta",
+                    "title": "Audit security policies",
+                    "role": "security",
+                    "status": "open",
+                    "priority": 1,
+                    "cli": "opencode",
+                    "model": "deepseek-r1",
+                },
+            ],
+        },
+        "agents": {"count": 0, "items": []},
+        "costs": {"spent_usd": 0.42},
+    }
+
+    console = Console(record=True, force_terminal=True, width=140)
+    render_status(recorded_runtime_payload, console=console, view_config=get_view_config(ViewMode.STANDARD))
+    output = console.export_text()
+
+    assert "Adapter" in output
+    assert "Model" in output
+    assert "codex" in output
+    assert "opencode" in output
+
+
+def test_task_state_progress_tracker_format_and_no_paths_or_timestamps() -> None:
+    """Line formatter conforms to schema: task <id> <state> adapter=<name> model=<route> title="<60 chars>"."""
+    tracker = TaskStateProgressTracker()
+    line = tracker.format_line(
+        task_id="task-42",
+        state="in_progress",
+        adapter="fake-adapter",
+        model="fake-route",
+        title="Very long title that exceeds sixty characters and therefore must be safely truncated to sixty",
+    )
+
+    expected_prefix = 'task task-42 in_progress adapter=fake-adapter model=fake-route title="'
+    assert line.startswith(expected_prefix)
+    title_match = re.search(r'title="([^"]*)"', line)
+    assert title_match is not None
+    assert len(title_match.group(1)) <= 60
+
+    # No local machine timestamps or filesystem paths
+    assert "/" not in line
+    assert "\\" not in line
+    assert not re.search(r"\d{4}-\d{2}-\d{2}", line)
+
+
+def test_two_task_plan_with_fake_adapter_captures_planned_and_later_states() -> None:
+    """With a fake adapter and a plan of two tasks, tracker captures planned and later state lines."""
+    con = Console(record=True)
+    tracker = TaskStateProgressTracker(console=con)
+
+    initial_tasks = [
+        {"id": "t-1", "title": "First task", "status": "open", "adapter": "fake-adapter", "model": "route-a"},
+        {"id": "t-2", "title": "Second task", "status": "open", "adapter": "fake-adapter", "model": "route-b"},
+    ]
+
+    lines_round_1 = tracker.update_tasks(initial_tasks)
+
+    # For each task, must capture planned line and later state (open) line
+    assert 'task t-1 planned adapter=fake-adapter model=route-a title="First task"' in lines_round_1
+    assert 'task t-1 open adapter=fake-adapter model=route-a title="First task"' in lines_round_1
+    assert 'task t-2 planned adapter=fake-adapter model=route-b title="Second task"' in lines_round_1
+    assert 'task t-2 open adapter=fake-adapter model=route-b title="Second task"' in lines_round_1
+
+    # Transition task 1 to in_progress, task 2 remains open
+    updated_tasks = [
+        {"id": "t-1", "title": "First task", "status": "in_progress", "adapter": "fake-adapter", "model": "route-a"},
+        {"id": "t-2", "title": "Second task", "status": "open", "adapter": "fake-adapter", "model": "route-b"},
+    ]
+    lines_round_2 = tracker.update_tasks(updated_tasks)
+
+    assert len(lines_round_2) == 1
+    assert 'task t-1 in_progress adapter=fake-adapter model=route-a title="First task"' in lines_round_2
+
+    # Task 1 transitions to done
+    final_tasks = [
+        {"id": "t-1", "title": "First task", "status": "done", "adapter": "fake-adapter", "model": "route-a"},
+        {"id": "t-2", "title": "Second task", "status": "in_progress", "adapter": "fake-adapter", "model": "route-b"},
+    ]
+    lines_round_3 = tracker.update_tasks(final_tasks)
+
+    assert 'task t-1 done adapter=fake-adapter model=route-a title="First task"' in lines_round_3
+    assert 'task t-2 in_progress adapter=fake-adapter model=route-b title="Second task"' in lines_round_3
+
+
+def test_finalize_run_output_non_tty_captures_task_transitions_end_to_end(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """_finalize_run_output in non-TTY mode with fake adapter and two tasks captures planned + state lines."""
+    two_task_plan = [
+        {
+            "id": "task-101",
+            "title": "Run code migration",
+            "status": "in_progress",
+            "adapter": "fake",
+            "model": "m-fast",
+        },
+        {"id": "task-102", "title": "Validate build output", "status": "open", "cli": "fake", "model": "m-thorough"},
+    ]
+
+    def mock_server_get(path: str) -> Any:
+        if path == "/tasks":
+            return two_task_plan
+        if path == "/health":
+            return {"agent_count": 1}
+        if path == "/status":
+            return {"total": 2, "open": 1, "in_progress": 1, "done": 0, "failed": 0}
+        return None
+
+    with (
+        patch("bernstein.cli.terminal_caps.detect_capabilities", return_value=_NON_TTY_CAPS),
+        patch("bernstein.cli.helpers.server_get", side_effect=mock_server_get),
+        patch("bernstein.cli.run_bootstrap.server_get", side_effect=mock_server_get),
+        patch("bernstein.cli.run_preflight._show_run_summary"),
+        patch("bernstein.cli.run_preflight._drain_completed_backlog_files"),
+        patch("bernstein.cli.run_bootstrap._poll_no_plan_after_spawn", return_value=None),
+        patch("bernstein.cli.run_bootstrap._poll_quiescent_status", return_value=None),
+    ):
+        _finalize_run_output(quiet=False)
+
+    out = capsys.readouterr().out
+
+    # Planned lines
+    assert 'task task-101 planned adapter=fake model=m-fast title="Run code migration"' in out
+    assert 'task task-102 planned adapter=fake model=m-thorough title="Validate build output"' in out
+
+    # Later state lines
+    assert 'task task-101 in_progress adapter=fake model=m-fast title="Run code migration"' in out
+    assert 'task task-102 open adapter=fake model=m-thorough title="Validate build output"' in out
+
+    # Standard detach notice still printed
+    assert "Run continues in the background (check: bernstein status)." in out
+
+    # No timestamps or absolute paths in the captured task lines
+    for line in out.splitlines():
+        if line.startswith("task task-"):
+            assert "/" not in line
+            assert "\\" not in line
+            assert not re.search(r"\d{4}-\d{2}-\d{2}", line)

--- a/tests/unit/test_non_interactive_task_progress.py
+++ b/tests/unit/test_non_interactive_task_progress.py
@@ -123,6 +123,19 @@ def test_task_state_progress_tracker_format_and_no_paths_or_timestamps() -> None
     assert not re.search(r"\d{4}-\d{2}-\d{2}", line)
 
 
+def test_task_state_progress_tracker_escapes_double_quotes_in_title() -> None:
+    """Double quotes inside task title are converted to single quotes so log line format is preserved."""
+    tracker = TaskStateProgressTracker()
+    line = tracker.format_line(
+        task_id="task-43",
+        state="open",
+        adapter="codex",
+        model="o3-mini",
+        title='Fix the "critical" issue',
+    )
+    assert line == 'task task-43 open adapter=codex model=o3-mini title="Fix the \'critical\' issue"'
+
+
 def test_two_task_plan_with_fake_adapter_captures_planned_and_later_states() -> None:
     """With a fake adapter and a plan of two tasks, tracker captures planned and later state lines."""
     con = Console(record=True)

--- a/tests/unit/test_non_interactive_task_progress.py
+++ b/tests/unit/test_non_interactive_task_progress.py
@@ -133,7 +133,7 @@ def test_task_state_progress_tracker_escapes_double_quotes_in_title() -> None:
         model="o3-mini",
         title='Fix the "critical" issue',
     )
-    assert line == 'task task-43 open adapter=codex model=o3-mini title="Fix the \'critical\' issue"'
+    assert line == "task task-43 open adapter=codex model=o3-mini title=\"Fix the 'critical' issue\""
 
 
 def test_two_task_plan_with_fake_adapter_captures_planned_and_later_states() -> None:


### PR DESCRIPTION
Closes #5338

### Overview

In non-interactive mode (CI or scheduler runs without a TTY), `bernstein run` previously printed only the preflight banner, agent PID, and detached without showing per-task execution details. This PR:

1. **Non-interactive Task Progress**: Emits one line per task state transition until detach: `task <id> <state> adapter=<name> model=<route> title="<first 60 chars>"`, along with the corresponding line when a task is first planned.
2. **Status Task Table**: Adds `Adapter` and `Model` columns to `bernstein status` (`_build_task_table`), enabling operators to reconstruct adapter and routing assignments from logs and status snapshots.
3. **Task Item Normalization**: Exposes `adapter` and `cli` in normalized `/status` task items (`_status_task_items`).

### Changes

- `src/bernstein/cli/run_preflight.py`: Added `TaskStateProgressTracker` and hooked task polling into the non-TTY detach branch.
- `src/bernstein/cli/run_bootstrap.py`: Added `on_poll` callback to `_await_first_spawn_outcome`.
- `src/bernstein/cli/status.py`: Added `Adapter` and `Model` columns to `_build_task_table`.
- `src/bernstein/core/routes/status_dashboard.py`: Included `adapter` and `cli` fields in `_status_task_items`.
- `tests/unit/test_non_interactive_task_progress.py`: Added unit tests verifying column rendering, formatting schema, and end-to-end task state transition capture with fake adapter and two-task plan.
- `docs/release-notes/fragments/5338-non-interactive-task-progress.md`: Added release notes fragment.

### Verification

- `uv run pytest tests/unit/test_non_interactive_task_progress.py tests/unit/test_cli_status.py tests/unit/test_detached_run_visibility.py tests/unit/test_run_outcome_reaches_every_branch.py` (29/29 passed)
- `uv run ruff check` clean
- `uv run ruff format` clean
- `uv run mypy` clean
