### PR TITLE
feat(govern): audit emits JSON and SARIF with CI exit code gating (#5076)

### DIFF
--- a/docs/release-notes/fragments/5076-govern-audit-json-sarif.md
+++ b/docs/release-notes/fragments/5076-govern-audit-json-sarif.md
@@ -1,0 +1,8 @@
+## govern audit: JSON and SARIF output, and CI exit code gating
+
+`bernstein govern audit` emits machine-readable findings and a CI-gated exit code (#5076):
+
+- `--format json` outputs a JSON list containing one object per finding with every contract field.
+- `--format sarif` outputs standard SARIF 2.1.0 with `ruleId = finding.id` and a `kind` property carrying the three-state verdict.
+- Exit codes: 0 when every required check is measured and passed; 1 when any required check is measured and failed; 2 when any required check is `not_measurable` and `--strict` is set. Declared findings never change the exit code.
+- `--quiet` suppresses all terminal output, leaving the exit code as the sole result.

--- a/src/bernstein/cli/commands/governance_cmd.py
+++ b/src/bernstein/cli/commands/governance_cmd.py
@@ -56,6 +56,11 @@ from rich.table import Table
 
 from bernstein.cli.commands.govern_cmd import govern_inventory_cmd, govern_reconcile_cmd
 from bernstein.cli.helpers import console
+from bernstein.core.checks import (
+    compute_audit_exit_code,
+    findings_to_json,
+    findings_to_sarif,
+)
 from bernstein.core.govern import collect_remediation as _collect_remediation
 from bernstein.core.govern import compute_plan as _compute_plan
 from bernstein.core.govern.audit_sweep import CheckVerdict
@@ -90,6 +95,7 @@ def govern_group() -> None:
       bernstein govern ingest --spans spans.json --source otel-collector-prod
       bernstein govern posture [--workdir w] [--json-output]
       bernstein govern inventory --render mermaid|dot --store PATH
+      bernstein govern audit [--format text|json|sarif] [--strict] [--quiet]
       bernstein govern audit-compliance [--workdir .] [--only CMP] [--skip ID] [--profile soc2]
       bernstein govern audit-keys
     """
@@ -892,7 +898,7 @@ def governance_ingest_cmd(
 )
 @click.option("--list", "list_only", is_flag=True, help="Print the registered check ids and exit.")
 @click.option("--json-output", "as_json", is_flag=True, help="Print the report as JSON and nothing else.")
-def govern_audit_cmd(
+def govern_audit_compliance_cmd(
     workdir: Path,
     only: tuple[str, ...],
     skip: tuple[str, ...],
@@ -1015,19 +1021,94 @@ def _run_verifier_key_staleness_check() -> None:
 
 
 @govern_group.command("audit")
-def governance_audit_cmd() -> None:
-    """[Deprecated] Use ``bernstein govern audit-keys`` instead.
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json", "sarif"], case_sensitive=False),
+    default="text",
+    show_default=True,
+    help="Output format: text, json (one object per finding), or sarif (SARIF 2.1.0).",
+)
+@click.option(
+    "--strict",
+    is_flag=True,
+    default=False,
+    help="Exit 2 when any required check is not_measurable.",
+)
+@click.option(
+    "--quiet",
+    "-q",
+    is_flag=True,
+    default=False,
+    help="Print nothing; exit code only.",
+)
+@click.option(
+    "--required",
+    "-r",
+    "required_ids",
+    multiple=True,
+    help="Check ID(s) required to pass (defaults to all executed checks).",
+)
+@click.option(
+    "--workdir",
+    "-w",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Project root directory to audit.",
+)
+@click.pass_context
+def govern_audit_cmd(
+    ctx: click.Context,
+    output_format: str,
+    strict: bool,
+    quiet: bool,
+    required_ids: tuple[str, ...],
+    workdir: Path | None,
+) -> None:
+    """Run registered audit checks over the install and report findings (#5076).
 
-    The compliance policy library moved to ``bernstein govern audit-compliance``
-    in #5075; this alias preserves the prior verifier-key staleness behaviour
-    for one release and prints a deprecation notice on every invocation.
+    Supports text, JSON (one object per finding with every contract field),
+    and SARIF 2.1.0 output.
+
+    Exit codes:
+    - 0: every required check is measured and passed
+    - 1: any required check is measured and failed
+    - 2: any required check is not_measurable and --strict is set
+    Declared findings never change the exit code.
     """
-    click.echo(
-        "WARNING: 'bernstein govern audit' is deprecated and will be removed in v3.0.0 (#5075): "
-        "use 'bernstein govern audit-keys' instead.",
-        err=True,
-    )
-    _run_verifier_key_staleness_check()
+    from bernstein.core.checks.registry import _DEFAULT_REGISTRY
+
+    registry = _DEFAULT_REGISTRY
+    if ctx.obj and isinstance(ctx.obj, dict) and "check_registry" in ctx.obj:
+        registry = ctx.obj["check_registry"]
+
+    findings = registry.run_all(workdir)
+
+    required_set: set[str] | None = None
+    if required_ids:
+        required_set = set()
+        for item in required_ids:
+            for piece in item.split(","):
+                if piece.strip():
+                    required_set.add(piece.strip())
+
+    exit_code = compute_audit_exit_code(findings, strict=strict, required=required_set)
+
+    if quiet:
+        raise SystemExit(exit_code)
+
+    if output_format.lower() == "json":
+        click.echo(findings_to_json(findings))
+    elif output_format.lower() == "sarif":
+        click.echo(json.dumps(findings_to_sarif(findings), indent=2))
+    else:
+        click.echo(f"govern audit -- {len(findings)} checks")
+        for f in findings:
+            state = "pass" if f.passed else ("fail" if f.passed is False else "")
+            verdict_str = f.verdict.value if not state else f"{f.verdict.value} {state}"
+            click.echo(f"  {f.id:<30} {verdict_str:<20} {f.summary or f.message}")
+
+    raise SystemExit(exit_code)
 
 
 @govern_group.command("audit-keys")

--- a/src/bernstein/core/checks/__init__.py
+++ b/src/bernstein/core/checks/__init__.py
@@ -12,6 +12,12 @@ from bernstein.core.checks.contract import (
     Finding,
     Verdict,
 )
+from bernstein.core.checks.formatters import (
+    compute_audit_exit_code,
+    findings_to_json,
+    findings_to_sarif,
+    verdict_to_kind,
+)
 from bernstein.core.checks.registry import (
     CheckRegistry,
     clear,
@@ -31,9 +37,13 @@ __all__ = [
     "Finding",
     "Verdict",
     "clear",
+    "compute_audit_exit_code",
+    "findings_to_json",
+    "findings_to_sarif",
     "get_check",
     "iter_checks",
     "register",
     "run_all",
     "unregister",
+    "verdict_to_kind",
 ]

--- a/src/bernstein/core/checks/contract.py
+++ b/src/bernstein/core/checks/contract.py
@@ -158,6 +158,39 @@ class Finding:
         """Alias for :attr:`check_id`."""
         return self.check_id
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize finding to a dictionary containing every contract field."""
+        return {
+            "id": self.id,
+            "check_id": self.check_id,
+            "area": self.area,
+            "verdict": self.verdict.value if isinstance(self.verdict, Verdict) else str(self.verdict),
+            "evidence": [{"locator": e.locator, "sha256": e.sha256} for e in self.evidence],
+            "what_would_make_it_measurable": self.what_would_make_it_measurable,
+            "reason": self.reason,
+            "message": self.message,
+            "summary": self.summary,
+            "remediation": self.remediation,
+            "passed": self.passed,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Finding:
+        """Construct a Finding from a dictionary."""
+        evidence_list = [Evidence(locator=e["locator"], sha256=e["sha256"]) for e in data.get("evidence", [])]
+        return cls(
+            check_id=data.get("check_id") or data["id"],
+            verdict=Verdict(data["verdict"]),
+            evidence=tuple(evidence_list),
+            what_would_make_it_measurable=data.get("what_would_make_it_measurable"),
+            reason=data.get("reason"),
+            message=data.get("message", ""),
+            summary=data.get("summary", ""),
+            remediation=data.get("remediation", ""),
+            area=data.get("area", ""),
+            passed=data.get("passed"),
+        )
+
 
 # ---------------------------------------------------------------------------
 # Check Protocol

--- a/src/bernstein/core/checks/formatters.py
+++ b/src/bernstein/core/checks/formatters.py
@@ -1,0 +1,130 @@
+"""Output formatters and exit code calculator for govern audit (#5076).
+
+Emits JSON (one object per finding with every contract field) and SARIF 2.1.0
+(with ruleId = finding.id and kind property carrying the three-state verdict).
+Computes CI exit codes according to the check contract truth table.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.checks.contract import Finding, Verdict
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+SARIF_VERSION = "2.1.0"
+SARIF_SCHEMA = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/Schemata/sarif-schema-2.1.0.json"
+
+
+def verdict_to_kind(finding: Finding) -> str:
+    """Map a finding to its three-state verdict kind (pass, fail, not_measurable) or declared."""
+    if finding.verdict == Verdict.NOT_MEASURABLE:
+        return "not_measurable"
+    if finding.verdict == Verdict.DECLARED:
+        return "declared"
+    if finding.verdict == Verdict.FAIL or finding.passed is False:
+        return "fail"
+    if finding.verdict == Verdict.PASS or finding.passed is True:
+        return "pass"
+    return str(finding.verdict.value)
+
+
+def findings_to_json(findings: Sequence[Finding], *, indent: int = 2) -> str:
+    """Serialize findings to JSON containing one object per finding with every contract field."""
+    return json.dumps([f.to_dict() for f in findings], indent=indent, ensure_ascii=False)
+
+
+def findings_to_sarif(findings: Sequence[Finding]) -> dict[str, Any]:
+    """Emit a SARIF 2.1.0 log dictionary with ruleId = finding.id and kind carrying the verdict."""
+    rules: list[dict[str, Any]] = []
+    seen_rule_ids: set[str] = set()
+    results: list[dict[str, Any]] = []
+
+    for f in findings:
+        rule_id = f.id
+        if rule_id not in seen_rule_ids:
+            seen_rule_ids.add(rule_id)
+            desc = f.summary or f.message or rule_id
+            rules.append(
+                {
+                    "id": rule_id,
+                    "shortDescription": {"text": desc},
+                    "fullDescription": {"text": f.message or desc},
+                }
+            )
+
+        kind = verdict_to_kind(f)
+        if kind == "fail":
+            level = "error"
+        elif kind == "pass":
+            level = "none"
+        else:
+            level = "warning"
+
+        result: dict[str, Any] = {
+            "ruleId": rule_id,
+            "kind": kind,
+            "level": level,
+            "message": {"text": f.message or f.summary or rule_id},
+            "properties": {
+                "kind": kind,
+                "verdict": f.verdict.value if isinstance(f.verdict, Verdict) else str(f.verdict),
+                "area": f.area,
+                "passed": f.passed,
+                "remediation": f.remediation,
+                "what_would_make_it_measurable": f.what_would_make_it_measurable,
+            },
+        }
+        results.append(result)
+
+    return {
+        "$schema": SARIF_SCHEMA,
+        "version": SARIF_VERSION,
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "bernstein-govern-audit",
+                        "informationUri": "https://bernstein.run",
+                        "rules": rules,
+                    }
+                },
+                "results": results,
+            }
+        ],
+    }
+
+
+def compute_audit_exit_code(
+    findings: Sequence[Finding],
+    *,
+    strict: bool = False,
+    required: frozenset[str] | set[str] | None = None,
+) -> int:
+    """Compute the CI exit code from audit findings.
+
+    Rules:
+    - 0: every required check is measured and passed (or no failures/strict not_measurable).
+    - 1: any required check is measured and failed.
+    - 2: any required check is not_measurable and strict is set.
+    - Declared findings never change the exit code.
+    """
+    gated_findings = [
+        f
+        for f in findings
+        if f.verdict != Verdict.DECLARED and (required is None or f.id in required or f.check_id in required)
+    ]
+
+    has_failure = any(f.verdict == Verdict.FAIL or f.passed is False for f in gated_findings)
+    if has_failure:
+        return 1
+
+    if strict:
+        has_not_measurable = any(f.verdict == Verdict.NOT_MEASURABLE for f in gated_findings)
+        if has_not_measurable:
+            return 2
+
+    return 0

--- a/tests/unit/checks/test_govern_audit_cli.py
+++ b/tests/unit/checks/test_govern_audit_cli.py
@@ -1,0 +1,510 @@
+"""Tests for govern audit JSON and SARIF output, and CI exit code gating (#5076).
+
+Acceptance criteria:
+- `--format json` emits one object per finding with every contract field;
+- `--format sarif` emits SARIF 2.1.0 with ruleId = finding.id and a kind property
+  carrying the three-state verdict.
+- Exit code: 0 when every required check is measured and passed; 1 when any
+  required check is measured and failed; 2 when any required check is
+  not_measurable and --strict is set. Declared findings never change the exit code.
+- `--quiet` prints nothing; the exit code is the whole answer.
+- Tests cover each exit path with a fixture registry of three checks.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.governance_cmd import govern_group
+from bernstein.core.checks.contract import Evidence, Finding, Verdict
+from bernstein.core.checks.formatters import (
+    compute_audit_exit_code,
+    findings_to_json,
+    findings_to_sarif,
+    verdict_to_kind,
+)
+from bernstein.core.checks.registry import CheckRegistry
+
+
+class _DummyCheck:
+    """Fixture check returning a pre-configured Finding."""
+
+    def __init__(self, finding: Finding) -> None:
+        self._finding = finding
+
+    @property
+    def check_id(self) -> str:
+        return self._finding.check_id
+
+    @property
+    def title(self) -> str:
+        return f"Dummy {self._finding.check_id}"
+
+    @property
+    def description(self) -> str:
+        return f"Check {self._finding.check_id}"
+
+    def run(self, workdir: Path | None = None) -> Finding:
+        return self._finding
+
+    def __call__(self, workdir: Path | None = None) -> Finding:
+        return self.run(workdir)
+
+
+@pytest.fixture
+def evidence_sample() -> tuple[Evidence, ...]:
+    return (Evidence.from_bytes("file:///etc/bernstein/conf.json", b'{"configured": true}'),)
+
+
+@pytest.fixture
+def pass_finding(evidence_sample: tuple[Evidence, ...]) -> Finding:
+    return Finding(
+        check_id="sec:encryption_at_rest",
+        verdict=Verdict.PASS,
+        evidence=evidence_sample,
+        summary="Storage encryption is enabled",
+        remediation="Ensure disks are encrypted",
+        passed=True,
+    )
+
+
+@pytest.fixture
+def fail_finding(evidence_sample: tuple[Evidence, ...]) -> Finding:
+    return Finding(
+        check_id="sec:access_control",
+        verdict=Verdict.FAIL,
+        evidence=evidence_sample,
+        summary="Access control violation detected",
+        remediation="Revoke unauthorized principal access",
+        passed=False,
+    )
+
+
+@pytest.fixture
+def not_measurable_finding() -> Finding:
+    return Finding(
+        check_id="obs:audit_pipeline",
+        verdict=Verdict.NOT_MEASURABLE,
+        what_would_make_it_measurable="Configure audit log ingestion endpoint",
+        reason="ConfigurationMissing",
+        summary="Audit log pipeline not reachable",
+        remediation="Set AUDIT_LOG_ENDPOINT env var",
+    )
+
+
+@pytest.fixture
+def declared_finding() -> Finding:
+    return Finding(
+        check_id="gov:training_policy",
+        verdict=Verdict.DECLARED,
+        summary="Security training completed on declaration",
+        remediation="File declaration with compliance team",
+    )
+
+
+@pytest.fixture
+def three_checks_registry(
+    pass_finding: Finding,
+    fail_finding: Finding,
+    not_measurable_finding: Finding,
+) -> CheckRegistry:
+    """Fixture registry of three checks: pass, fail, not_measurable."""
+    registry = CheckRegistry()
+    registry.register(_DummyCheck(pass_finding))
+    registry.register(_DummyCheck(fail_finding))
+    registry.register(_DummyCheck(not_measurable_finding))
+    return registry
+
+
+# ---------------------------------------------------------------------------
+# 1. JSON output formatting tests
+# ---------------------------------------------------------------------------
+
+
+def test_finding_to_dict_contains_all_contract_fields(pass_finding: Finding) -> None:
+    """Finding.to_dict() emits every single contract field."""
+    d = pass_finding.to_dict()
+    assert d["id"] == "sec:encryption_at_rest"
+    assert d["check_id"] == "sec:encryption_at_rest"
+    assert d["area"] == "sec"
+    assert d["verdict"] == "pass"
+    assert len(d["evidence"]) == 1
+    assert d["evidence"][0]["locator"] == "file:///etc/bernstein/conf.json"
+    assert d["evidence"][0]["sha256"].startswith("sha256:")
+    assert d["summary"] == "Storage encryption is enabled"
+    assert d["message"] == "Storage encryption is enabled"
+    assert d["remediation"] == "Ensure disks are encrypted"
+    assert d["passed"] is True
+    assert "what_would_make_it_measurable" in d
+    assert "reason" in d
+
+
+def test_finding_from_dict_roundtrip(
+    pass_finding: Finding,
+    not_measurable_finding: Finding,
+) -> None:
+    """Finding round-trips through to_dict and from_dict."""
+    d_pass = pass_finding.to_dict()
+    restored_pass = Finding.from_dict(d_pass)
+    assert restored_pass.id == pass_finding.id
+    assert restored_pass.verdict == pass_finding.verdict
+    assert restored_pass.passed == pass_finding.passed
+    assert restored_pass.evidence == pass_finding.evidence
+
+    d_nm = not_measurable_finding.to_dict()
+    restored_nm = Finding.from_dict(d_nm)
+    assert restored_nm.id == not_measurable_finding.id
+    assert restored_nm.verdict == Verdict.NOT_MEASURABLE
+    assert restored_nm.what_would_make_it_measurable == not_measurable_finding.what_would_make_it_measurable
+
+
+def test_cli_format_json_emits_one_object_per_finding_with_every_contract_field(
+    three_checks_registry: CheckRegistry,
+) -> None:
+    """`--format json` emits one object per finding with every contract field."""
+    runner = CliRunner()
+    result = runner.invoke(
+        govern_group,
+        ["audit", "--format", "json"],
+        obj={"check_registry": three_checks_registry},
+    )
+    # Registry has a failing check, so exit code is 1
+    assert result.exit_code == 1
+
+    payload = json.loads(result.output)
+    assert isinstance(payload, list)
+    assert len(payload) == 3
+
+    contract_fields = {
+        "id",
+        "check_id",
+        "area",
+        "verdict",
+        "evidence",
+        "what_would_make_it_measurable",
+        "reason",
+        "message",
+        "summary",
+        "remediation",
+        "passed",
+    }
+    for item in payload:
+        assert contract_fields.issubset(item.keys()), f"Missing fields in {item}"
+
+    ids = [item["id"] for item in payload]
+    assert ids == [
+        "sec:encryption_at_rest",
+        "sec:access_control",
+        "obs:audit_pipeline",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 2. SARIF 2.1.0 output formatting tests
+# ---------------------------------------------------------------------------
+
+
+def test_cli_format_sarif_emits_sarif_210_with_rule_id_and_kind(
+    three_checks_registry: CheckRegistry,
+) -> None:
+    """`--format sarif` emits SARIF 2.1.0 with ruleId = finding.id and kind property."""
+    runner = CliRunner()
+    result = runner.invoke(
+        govern_group,
+        ["audit", "--format", "sarif"],
+        obj={"check_registry": three_checks_registry},
+    )
+    assert result.exit_code == 1
+
+    sarif = json.loads(result.output)
+    assert sarif["version"] == "2.1.0"
+    assert "sarif-schema-2.1.0" in sarif["$schema"]
+
+    runs = sarif["runs"]
+    assert len(runs) == 1
+    run = runs[0]
+
+    rules = run["tool"]["driver"]["rules"]
+    rule_ids = [r["id"] for r in rules]
+    assert rule_ids == [
+        "sec:encryption_at_rest",
+        "sec:access_control",
+        "obs:audit_pipeline",
+    ]
+
+    results = run["results"]
+    assert len(results) == 3
+
+    # Check 1: Pass
+    res0 = results[0]
+    assert res0["ruleId"] == "sec:encryption_at_rest"
+    assert res0["kind"] == "pass"
+    assert res0["properties"]["kind"] == "pass"
+    assert res0["level"] == "none"
+
+    # Check 2: Fail
+    res1 = results[1]
+    assert res1["ruleId"] == "sec:access_control"
+    assert res1["kind"] == "fail"
+    assert res1["properties"]["kind"] == "fail"
+    assert res1["level"] == "error"
+
+    # Check 3: Not Measurable
+    res2 = results[2]
+    assert res2["ruleId"] == "obs:audit_pipeline"
+    assert res2["kind"] == "not_measurable"
+    assert res2["properties"]["kind"] == "not_measurable"
+    assert res2["level"] == "warning"
+    assert res2["properties"]["what_would_make_it_measurable"] == ("Configure audit log ingestion endpoint")
+
+
+# ---------------------------------------------------------------------------
+# 3. Exit code truth table tests with fixture registry
+# ---------------------------------------------------------------------------
+
+
+def test_exit_code_0_when_every_required_check_measured_and_passed(
+    pass_finding: Finding,
+) -> None:
+    """Exit 0 when every required check is measured and passed."""
+    reg = CheckRegistry()
+    reg.register(_DummyCheck(pass_finding))
+
+    runner = CliRunner()
+    result = runner.invoke(govern_group, ["audit"], obj={"check_registry": reg})
+    assert result.exit_code == 0
+    assert "sec:encryption_at_rest" in result.output
+
+
+def test_exit_code_1_when_any_required_check_measured_and_failed(
+    pass_finding: Finding,
+    fail_finding: Finding,
+) -> None:
+    """Exit 1 when any required check is measured and failed."""
+    reg = CheckRegistry()
+    reg.register(_DummyCheck(pass_finding))
+    reg.register(_DummyCheck(fail_finding))
+
+    runner = CliRunner()
+    result = runner.invoke(govern_group, ["audit"], obj={"check_registry": reg})
+    assert result.exit_code == 1
+
+
+def test_exit_code_0_when_not_measurable_without_strict(
+    pass_finding: Finding,
+    not_measurable_finding: Finding,
+) -> None:
+    """Exit 0 when a check is not_measurable and --strict is NOT set."""
+    reg = CheckRegistry()
+    reg.register(_DummyCheck(pass_finding))
+    reg.register(_DummyCheck(not_measurable_finding))
+
+    runner = CliRunner()
+    result = runner.invoke(govern_group, ["audit"], obj={"check_registry": reg})
+    assert result.exit_code == 0
+
+
+def test_exit_code_2_when_any_required_check_not_measurable_and_strict_set(
+    pass_finding: Finding,
+    not_measurable_finding: Finding,
+) -> None:
+    """Exit 2 when any required check is not_measurable and --strict is set."""
+    reg = CheckRegistry()
+    reg.register(_DummyCheck(pass_finding))
+    reg.register(_DummyCheck(not_measurable_finding))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        govern_group,
+        ["audit", "--strict"],
+        obj={"check_registry": reg},
+    )
+    assert result.exit_code == 2
+
+
+def test_exit_code_1_takes_precedence_over_strict_not_measurable(
+    pass_finding: Finding,
+    fail_finding: Finding,
+    not_measurable_finding: Finding,
+) -> None:
+    """Failure (1) takes precedence over strict not_measurable (2)."""
+    reg = CheckRegistry()
+    reg.register(_DummyCheck(pass_finding))
+    reg.register(_DummyCheck(fail_finding))
+    reg.register(_DummyCheck(not_measurable_finding))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        govern_group,
+        ["audit", "--strict"],
+        obj={"check_registry": reg},
+    )
+    assert result.exit_code == 1
+
+
+def test_declared_findings_never_change_exit_code(
+    pass_finding: Finding,
+    declared_finding: Finding,
+) -> None:
+    """Declared findings never change the exit code."""
+    # Pass + Declared -> 0
+    reg = CheckRegistry()
+    reg.register(_DummyCheck(pass_finding))
+    reg.register(_DummyCheck(declared_finding))
+
+    runner = CliRunner()
+    result = runner.invoke(govern_group, ["audit"], obj={"check_registry": reg})
+    assert result.exit_code == 0
+
+    # Only Declared -> 0
+    reg_only_declared = CheckRegistry()
+    reg_only_declared.register(_DummyCheck(declared_finding))
+    res_decl = runner.invoke(govern_group, ["audit"], obj={"check_registry": reg_only_declared})
+    assert res_decl.exit_code == 0
+
+    # Only Declared with --strict -> 0 (strict only affects not_measurable)
+    res_decl_strict = runner.invoke(
+        govern_group,
+        ["audit", "--strict"],
+        obj={"check_registry": reg_only_declared},
+    )
+    assert res_decl_strict.exit_code == 0
+
+
+def test_selective_required_checks_gate_exit_code(
+    pass_finding: Finding,
+    fail_finding: Finding,
+    not_measurable_finding: Finding,
+) -> None:
+    """`--required` selectively gates exit code on the named check IDs."""
+    reg = CheckRegistry()
+    reg.register(_DummyCheck(pass_finding))
+    reg.register(_DummyCheck(fail_finding))
+    reg.register(_DummyCheck(not_measurable_finding))
+
+    runner = CliRunner()
+    # When only the passing check is required, exit code is 0
+    res_pass_only = runner.invoke(
+        govern_group,
+        ["audit", "--required", "sec:encryption_at_rest"],
+        obj={"check_registry": reg},
+    )
+    assert res_pass_only.exit_code == 0
+
+    # When the failing check is required, exit code is 1
+    res_fail_req = runner.invoke(
+        govern_group,
+        ["audit", "--required", "sec:access_control"],
+        obj={"check_registry": reg},
+    )
+    assert res_fail_req.exit_code == 1
+
+    # When not_measurable is required with --strict, exit code is 2
+    res_nm_strict = runner.invoke(
+        govern_group,
+        ["audit", "--strict", "--required", "obs:audit_pipeline"],
+        obj={"check_registry": reg},
+    )
+    assert res_nm_strict.exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# 4. --quiet prints nothing; exit code is the whole answer
+# ---------------------------------------------------------------------------
+
+
+def test_quiet_suppresses_all_output_and_preserves_exit_code(
+    pass_finding: Finding,
+    fail_finding: Finding,
+    not_measurable_finding: Finding,
+) -> None:
+    """`--quiet` prints nothing; the exit code is the whole answer."""
+    runner = CliRunner()
+
+    # Pass case -> exit 0, empty stdout
+    reg_pass = CheckRegistry()
+    reg_pass.register(_DummyCheck(pass_finding))
+    res_pass = runner.invoke(
+        govern_group,
+        ["audit", "--quiet"],
+        obj={"check_registry": reg_pass},
+    )
+    assert res_pass.exit_code == 0
+    assert res_pass.output == ""
+
+    # Fail case -> exit 1, empty stdout
+    reg_fail = CheckRegistry()
+    reg_fail.register(_DummyCheck(fail_finding))
+    res_fail = runner.invoke(
+        govern_group,
+        ["audit", "-q"],
+        obj={"check_registry": reg_fail},
+    )
+    assert res_fail.exit_code == 1
+    assert res_fail.output == ""
+
+    # Strict not_measurable case -> exit 2, empty stdout
+    reg_nm = CheckRegistry()
+    reg_nm.register(_DummyCheck(not_measurable_finding))
+    res_nm = runner.invoke(
+        govern_group,
+        ["audit", "--strict", "--quiet"],
+        obj={"check_registry": reg_nm},
+    )
+    assert res_nm.exit_code == 2
+    assert res_nm.output == ""
+
+
+# ---------------------------------------------------------------------------
+# 5. Direct unit tests for compute_audit_exit_code
+# ---------------------------------------------------------------------------
+
+
+def test_compute_audit_exit_code_truth_table(
+    pass_finding: Finding,
+    fail_finding: Finding,
+    not_measurable_finding: Finding,
+    declared_finding: Finding,
+) -> None:
+    """Exhaustive truth table test on compute_audit_exit_code."""
+    assert compute_audit_exit_code([]) == 0
+    assert compute_audit_exit_code([pass_finding]) == 0
+    assert compute_audit_exit_code([pass_finding, declared_finding]) == 0
+    assert compute_audit_exit_code([declared_finding]) == 0
+    assert compute_audit_exit_code([pass_finding, fail_finding]) == 1
+    assert compute_audit_exit_code([pass_finding, not_measurable_finding], strict=False) == 0
+    assert compute_audit_exit_code([pass_finding, not_measurable_finding], strict=True) == 2
+    assert compute_audit_exit_code([fail_finding, not_measurable_finding], strict=True) == 1
+    assert compute_audit_exit_code([declared_finding], strict=True) == 0
+
+
+def test_verdict_to_kind_mapping(
+    pass_finding: Finding,
+    fail_finding: Finding,
+    not_measurable_finding: Finding,
+    declared_finding: Finding,
+) -> None:
+    """verdict_to_kind maps verdicts to three-state strings or declared."""
+    assert verdict_to_kind(pass_finding) == "pass"
+    assert verdict_to_kind(fail_finding) == "fail"
+    assert verdict_to_kind(not_measurable_finding) == "not_measurable"
+    assert verdict_to_kind(declared_finding) == "declared"
+
+
+def test_findings_to_json_and_sarif_direct(
+    pass_finding: Finding,
+    fail_finding: Finding,
+) -> None:
+    """Direct invocation of findings_to_json and findings_to_sarif."""
+    raw_json = findings_to_json([pass_finding, fail_finding])
+    parsed_json = json.loads(raw_json)
+    assert len(parsed_json) == 2
+    assert parsed_json[0]["id"] == pass_finding.id
+
+    sarif_dict = findings_to_sarif([pass_finding, fail_finding])
+    assert sarif_dict["version"] == "2.1.0"
+    assert len(sarif_dict["runs"][0]["results"]) == 2

--- a/tests/unit/test_govern_cmd.py
+++ b/tests/unit/test_govern_cmd.py
@@ -167,7 +167,7 @@ def test_audit_no_verifier_files_exit_0(filename: str, tmp_path: Path, monkeypat
     monkeypatch.setenv(http_signing.ENV_KEY_DIR, str(key_dir))
 
     runner = CliRunner()
-    result = runner.invoke(govern_group, ["audit"])
+    result = runner.invoke(govern_group, ["audit-keys"])
     assert result.exit_code == 0, result.output
     assert "up to date" in result.output
 
@@ -186,7 +186,7 @@ def test_audit_current_keyid_exit_0(filename: str, tmp_path: Path, monkeypatch: 
     verifier_dir.joinpath(filename).write_text(json.dumps({"keys": [{"kid": current_keyid}]}))
 
     runner = CliRunner()
-    result = runner.invoke(govern_group, ["audit"])
+    result = runner.invoke(govern_group, ["audit-keys"])
     assert result.exit_code == 0, result.output
     assert "up to date" in result.output
 
@@ -208,7 +208,7 @@ def test_audit_stale_keyid_exit_2(filename: str, tmp_path: Path, monkeypatch: py
     monkeypatch.setenv(http_signing.ENV_KEY_DIR, str(second_key_dir))
 
     runner = CliRunner()
-    result = runner.invoke(govern_group, ["audit"])
+    result = runner.invoke(govern_group, ["audit-keys"])
     assert result.exit_code == 2, result.output
     assert "stale" in result.output.lower() or "predates" in result.output.lower()
 
@@ -226,6 +226,6 @@ def test_audit_unreadable_verifier_exit_1(filename: str, tmp_path: Path, monkeyp
     verifier_dir.joinpath(filename).write_text("not valid json")
 
     runner = CliRunner()
-    result = runner.invoke(govern_group, ["audit"])
+    result = runner.invoke(govern_group, ["audit-keys"])
     assert result.exit_code == 1, result.output
     assert "unreadable" in result.output.lower()


### PR DESCRIPTION
## Overview

Part of #5071 · Implements #5076 (Slice 5 of govern audit).

Adds machine-readable output formats (`--format json`, `--format sarif`) and a deterministic CI exit code gating contract to `bernstein govern audit`.

## Acceptance Criteria Verified

- [x] `--format json` emits one object per finding with every contract field (`id`, `check_id`, `area`, `verdict`, `evidence`, `what_would_make_it_measurable`, `reason`, `message`, `summary`, `remediation`, `passed`).
- [x] `--format sarif` emits SARIF 2.1.0 with `ruleId = finding.id` and a `kind` property carrying the three-state verdict (`pass`, `fail`, `not_measurable`).
- [x] Exit code truth table:
  - `0`: when every required check is measured and passed (or no failures/strict not_measurable).
  - `1`: when any required check is measured and failed (`verdict == fail` or `passed is False`).
  - `2`: when any required check is `not_measurable` and `--strict` is set.
  - Declared findings never change the exit code.
  - Failure (`1`) takes precedence over `--strict` `not_measurable` (`2`).
- [x] `--quiet` / `-q` prints nothing; the exit code is the whole answer.
- [x] Tests cover each exit path with a fixture registry of three checks.

## Key Changes

1. **Check Contract (`src/bernstein/core/checks/contract.py`)**:
   - Added `to_dict()` and `from_dict()` on `Finding` ensuring every contract field is serialized.

2. **Formatters and Exit Code Logic (`src/bernstein/core/checks/formatters.py`)**:
   - `findings_to_json()`: Emits a JSON list containing one serialized finding object per entry with all contract fields.
   - `findings_to_sarif()`: Formats findings into a SARIF 2.1.0 log document with tool driver rules and results containing `ruleId`, `kind`, `level`, and property bags with `kind`, `verdict`, and `what_would_make_it_measurable`.
   - `compute_audit_exit_code()`: Computes the CI exit code with truth table handling failure precedence, `--strict` not_measurable gating, and declared finding neutrality.

3. **CLI Command (`src/bernstein/cli/commands/governance_cmd.py`)**:
   - Implemented `govern audit` with `--format text|json|sarif`, `--strict`, `--quiet`, `--required`, and `--workdir`.
   - Disambiguated `govern audit-compliance` handler name to avoid conflict.

4. **Tests (`tests/unit/checks/test_govern_audit_cli.py`)**:
   - Comprehensive test suite covering JSON serialization, SARIF 2.1.0 schema, all exit code paths, `--strict`, `--quiet`, and selective `--required` gating.

5. **Release Notes Fragment (`docs/release-notes/fragments/5076-govern-audit-json-sarif.md`)**.

## Verification

```bash
uv run pytest tests/unit/checks tests/unit/cli/test_govern_audit_cmd.py -v
uv run ruff check src/bernstein/core/checks src/bernstein/cli/commands/governance_cmd.py tests/unit/checks
uv run ruff format --check src/bernstein/core/checks src/bernstein/cli/commands/governance_cmd.py tests/unit/checks
uv run mypy src/bernstein/core/checks/formatters.py src/bernstein/core/checks/contract.py src/bernstein/core/checks/__init__.py src/bernstein/cli/commands/governance_cmd.py tests/unit/checks/test_govern_audit_cli.py
```
All passed cleanly with 0 errors.
