### PR TITLE
feat(govern): injectable failure sentinel for end-to-end detection (#5091)

### DIFF
--- a/docs/release-notes/fragments/5091-govern-audit-sentinel.md
+++ b/docs/release-notes/fragments/5091-govern-audit-sentinel.md
@@ -1,0 +1,7 @@
+## govern audit: injectable failure sentinel for end-to-end detection testing
+
+Adds an injectable audit failure sentinel to prove the detect -> record -> notify path end to end (#5091):
+
+- Setting `BERNSTEIN_AUDIT_SENTINEL` (or `.sdd/audit_failure.sentinel`) forces the named check `sentinel:injected_failure` to report `measured, failed` with reason `InjectedAuditFailureSentinel`.
+- The sentinel's presence is explicitly reported in run outputs (`[SENTINEL ACTIVE]`) so an active sentinel cannot be mistaken for an unnoticed organic failure.
+- Audit runs record events in the lineage journal under `.sdd/lineage/govern-audit/events.jsonl`, and failed checks emit notifications (`[SENTINEL ALERT]`).

--- a/docs/sdd/module-map.md
+++ b/docs/sdd/module-map.md
@@ -28,7 +28,7 @@ Full per-file module map. `AGENTS.md`'s own "Module map" section links here inst
 | `autofix/`                  | Bernstein autofix daemon - auto-repair CI failures on Bernstein PRs |
 | `autoheal/`                 | Auto-heal v2 subpackage |
 | `chat/`                     | Chat-control bridges for driving Bernstein agents from messaging apps |
-| `checks/`                   | Audit check contract, registry, and producer adapters (#5072) |
+| `checks/`                   | Audit check contract, registry, and producer adapters (#5072, #5076, #5091) |
 | `communication/`            | communication sub-package |
 | `compliance/`               | Compliance subpackage |
 | `config/`                   | Config: seed parsing, config management, settings, feature gates |

--- a/src/bernstein/cli/commands/governance_cmd.py
+++ b/src/bernstein/cli/commands/governance_cmd.py
@@ -56,6 +56,16 @@ from rich.table import Table
 
 from bernstein.cli.commands.govern_cmd import govern_inventory_cmd, govern_reconcile_cmd
 from bernstein.cli.helpers import console
+from bernstein.core.checks import (
+    AuditSentinelCheck,
+    compute_audit_exit_code,
+    findings_to_json,
+    findings_to_sarif,
+    get_active_sentinel,
+    is_sentinel_active,
+    notify_audit_failures,
+    record_audit_run,
+)
 from bernstein.core.govern import collect_remediation as _collect_remediation
 from bernstein.core.govern import compute_plan as _compute_plan
 from bernstein.core.govern.audit_sweep import CheckVerdict
@@ -892,7 +902,7 @@ def governance_ingest_cmd(
 )
 @click.option("--list", "list_only", is_flag=True, help="Print the registered check ids and exit.")
 @click.option("--json-output", "as_json", is_flag=True, help="Print the report as JSON and nothing else.")
-def govern_audit_cmd(
+def govern_audit_compliance_cmd(
     workdir: Path,
     only: tuple[str, ...],
     skip: tuple[str, ...],
@@ -1015,19 +1025,112 @@ def _run_verifier_key_staleness_check() -> None:
 
 
 @govern_group.command("audit")
-def governance_audit_cmd() -> None:
-    """[Deprecated] Use ``bernstein govern audit-keys`` instead.
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json", "sarif"], case_sensitive=False),
+    default="text",
+    show_default=True,
+    help="Output format: text, json (one object per finding), or sarif (SARIF 2.1.0).",
+)
+@click.option(
+    "--strict",
+    is_flag=True,
+    default=False,
+    help="Exit 2 when any required check is not_measurable.",
+)
+@click.option(
+    "--quiet",
+    "-q",
+    is_flag=True,
+    default=False,
+    help="Print nothing; exit code only.",
+)
+@click.option(
+    "--required",
+    "-r",
+    "required_ids",
+    multiple=True,
+    help="Check ID(s) required to pass (defaults to all executed checks).",
+)
+@click.option(
+    "--workdir",
+    "-w",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Project root directory to audit.",
+)
+@click.pass_context
+def govern_audit_cmd(
+    ctx: click.Context,
+    output_format: str,
+    strict: bool,
+    quiet: bool,
+    required_ids: tuple[str, ...],
+    workdir: Path | None,
+) -> None:
+    """Run registered audit checks over the install and report findings (#5076, #5091).
 
-    The compliance policy library moved to ``bernstein govern audit-compliance``
-    in #5075; this alias preserves the prior verifier-key staleness behaviour
-    for one release and prints a deprecation notice on every invocation.
+    Supports text, JSON, and SARIF 2.1.0 output. Injected failure sentinels are
+    detected, reported in the run, and recorded in the audit journal.
     """
-    click.echo(
-        "WARNING: 'bernstein govern audit' is deprecated and will be removed in v3.0.0 (#5075): "
-        "use 'bernstein govern audit-keys' instead.",
-        err=True,
-    )
-    _run_verifier_key_staleness_check()
+    from bernstein.core.checks.registry import _DEFAULT_REGISTRY
+
+    registry = _DEFAULT_REGISTRY
+    if ctx.obj and isinstance(ctx.obj, dict) and "check_registry" in ctx.obj:
+        registry = ctx.obj["check_registry"]
+
+    resolved_workdir = (workdir or Path(".")).resolve()
+    findings = list(registry.run_all(resolved_workdir))
+
+    # Always evaluate the failure injection sentinel check if not already in registry (#5091)
+    if not any(f.check_id == "sentinel:injected_failure" for f in findings):
+        sentinel_finding = AuditSentinelCheck().run(resolved_workdir)
+        # If sentinel is active, or if registry had no other checks, include sentinel finding
+        if is_sentinel_active(resolved_workdir) or not findings:
+            findings.append(sentinel_finding)
+
+    active_sentinel = get_active_sentinel(resolved_workdir)
+
+    # Record the audit run in the lineage journal if .sdd directory is present (#5091)
+    record_audit_run(findings, workdir=resolved_workdir)
+
+    # Dispatch notifications for any failed checks (#5091)
+    notifications = notify_audit_failures(findings, workdir=resolved_workdir)
+
+    required_set: set[str] | None = None
+    if required_ids:
+        required_set = set()
+        for item in required_ids:
+            for piece in item.split(","):
+                if piece.strip():
+                    required_set.add(piece.strip())
+
+    exit_code = compute_audit_exit_code(findings, strict=strict, required=required_set)
+
+    if quiet:
+        raise SystemExit(exit_code)
+
+    if active_sentinel and output_format.lower() == "text":
+        click.echo(f"  [SENTINEL ACTIVE] Injected failure sentinel is active ({active_sentinel})")
+
+    if output_format.lower() == "json":
+        click.echo(findings_to_json(findings))
+    elif output_format.lower() == "sarif":
+        click.echo(json.dumps(findings_to_sarif(findings), indent=2))
+    else:
+        click.echo(f"govern audit -- {len(findings)} checks")
+        for f in findings:
+            state = "pass" if f.passed else ("fail" if f.passed is False else "")
+            verdict_str = f.verdict.value if not state else f"{f.verdict.value} {state}"
+            click.echo(f"  {f.id:<30} {verdict_str:<20} {f.summary or f.message}")
+
+        if notifications:
+            for n in notifications:
+                tag = "[SENTINEL ALERT]" if n.get("sentinel") else "[ALERT]"
+                click.echo(f"  {tag} {n['check_id']}: {n['summary']}")
+
+    raise SystemExit(exit_code)
 
 
 @govern_group.command("audit-keys")

--- a/src/bernstein/core/checks/__init__.py
+++ b/src/bernstein/core/checks/__init__.py
@@ -1,4 +1,4 @@
-"""Audit check contract, registry, and producer adapters (#5072)."""
+"""Audit check contract, registry, and producer adapters (#5072, #5076, #5091)."""
 
 from __future__ import annotations
 
@@ -12,6 +12,12 @@ from bernstein.core.checks.contract import (
     Finding,
     Verdict,
 )
+from bernstein.core.checks.formatters import (
+    compute_audit_exit_code,
+    findings_to_json,
+    findings_to_sarif,
+    verdict_to_kind,
+)
 from bernstein.core.checks.registry import (
     CheckRegistry,
     clear,
@@ -21,8 +27,24 @@ from bernstein.core.checks.registry import (
     run_all,
     unregister,
 )
+from bernstein.core.checks.sentinel import (
+    SENTINEL_CHECK_ID,
+    SENTINEL_ENV_VAR,
+    SENTINEL_FILE_NAME,
+    SENTINEL_REASON,
+    AuditSentinelCheck,
+    get_active_sentinel,
+    is_sentinel_active,
+    notify_audit_failures,
+    record_audit_run,
+)
 
 __all__ = [
+    "SENTINEL_CHECK_ID",
+    "SENTINEL_ENV_VAR",
+    "SENTINEL_FILE_NAME",
+    "SENTINEL_REASON",
+    "AuditSentinelCheck",
     "Check",
     "CheckRegistry",
     "ComplianceEncryptionAtRestAdapter",
@@ -31,9 +53,17 @@ __all__ = [
     "Finding",
     "Verdict",
     "clear",
+    "compute_audit_exit_code",
+    "findings_to_json",
+    "findings_to_sarif",
+    "get_active_sentinel",
     "get_check",
+    "is_sentinel_active",
     "iter_checks",
+    "notify_audit_failures",
+    "record_audit_run",
     "register",
     "run_all",
     "unregister",
+    "verdict_to_kind",
 ]

--- a/src/bernstein/core/checks/contract.py
+++ b/src/bernstein/core/checks/contract.py
@@ -158,6 +158,39 @@ class Finding:
         """Alias for :attr:`check_id`."""
         return self.check_id
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize finding to a dictionary containing every contract field."""
+        return {
+            "id": self.id,
+            "check_id": self.check_id,
+            "area": self.area,
+            "verdict": self.verdict.value if isinstance(self.verdict, Verdict) else str(self.verdict),
+            "evidence": [{"locator": e.locator, "sha256": e.sha256} for e in self.evidence],
+            "what_would_make_it_measurable": self.what_would_make_it_measurable,
+            "reason": self.reason,
+            "message": self.message,
+            "summary": self.summary,
+            "remediation": self.remediation,
+            "passed": self.passed,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Finding:
+        """Construct a Finding from a dictionary."""
+        evidence_list = [Evidence(locator=e["locator"], sha256=e["sha256"]) for e in data.get("evidence", [])]
+        return cls(
+            check_id=data.get("check_id") or data["id"],
+            verdict=Verdict(data["verdict"]),
+            evidence=tuple(evidence_list),
+            what_would_make_it_measurable=data.get("what_would_make_it_measurable"),
+            reason=data.get("reason"),
+            message=data.get("message", ""),
+            summary=data.get("summary", ""),
+            remediation=data.get("remediation", ""),
+            area=data.get("area", ""),
+            passed=data.get("passed"),
+        )
+
 
 # ---------------------------------------------------------------------------
 # Check Protocol

--- a/src/bernstein/core/checks/formatters.py
+++ b/src/bernstein/core/checks/formatters.py
@@ -1,0 +1,118 @@
+"""Output formatters and exit code calculator for govern audit (#5076, #5091)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.checks.contract import Finding, Verdict
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+SARIF_VERSION = "2.1.0"
+SARIF_SCHEMA = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/Schemata/sarif-schema-2.1.0.json"
+
+
+def verdict_to_kind(finding: Finding) -> str:
+    """Map a finding to its three-state verdict kind (pass, fail, not_measurable) or declared."""
+    if finding.verdict == Verdict.NOT_MEASURABLE:
+        return "not_measurable"
+    if finding.verdict == Verdict.DECLARED:
+        return "declared"
+    if finding.verdict == Verdict.FAIL or finding.passed is False:
+        return "fail"
+    if finding.verdict == Verdict.PASS or finding.passed is True:
+        return "pass"
+    return str(finding.verdict.value)
+
+
+def findings_to_json(findings: Sequence[Finding], *, indent: int = 2) -> str:
+    """Serialize findings to JSON containing one object per finding with every contract field."""
+    return json.dumps([f.to_dict() for f in findings], indent=indent, ensure_ascii=False)
+
+
+def findings_to_sarif(findings: Sequence[Finding]) -> dict[str, Any]:
+    """Emit a SARIF 2.1.0 log dictionary with ruleId = finding.id and kind carrying the verdict."""
+    rules: list[dict[str, Any]] = []
+    seen_rule_ids: set[str] = set()
+    results: list[dict[str, Any]] = []
+
+    for f in findings:
+        rule_id = f.id
+        if rule_id not in seen_rule_ids:
+            seen_rule_ids.add(rule_id)
+            desc = f.summary or f.message or rule_id
+            rules.append(
+                {
+                    "id": rule_id,
+                    "shortDescription": {"text": desc},
+                    "fullDescription": {"text": f.message or desc},
+                }
+            )
+
+        kind = verdict_to_kind(f)
+        if kind == "fail":
+            level = "error"
+        elif kind == "pass":
+            level = "none"
+        else:
+            level = "warning"
+
+        result: dict[str, Any] = {
+            "ruleId": rule_id,
+            "kind": kind,
+            "level": level,
+            "message": {"text": f.message or f.summary or rule_id},
+            "properties": {
+                "kind": kind,
+                "verdict": f.verdict.value if isinstance(f.verdict, Verdict) else str(f.verdict),
+                "area": f.area,
+                "passed": f.passed,
+                "remediation": f.remediation,
+                "what_would_make_it_measurable": f.what_would_make_it_measurable,
+            },
+        }
+        results.append(result)
+
+    return {
+        "$schema": SARIF_SCHEMA,
+        "version": SARIF_VERSION,
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "bernstein-govern-audit",
+                        "informationUri": "https://bernstein.run",
+                        "rules": rules,
+                    }
+                },
+                "results": results,
+            }
+        ],
+    }
+
+
+def compute_audit_exit_code(
+    findings: Sequence[Finding],
+    *,
+    strict: bool = False,
+    required: frozenset[str] | set[str] | None = None,
+) -> int:
+    """Compute the CI exit code from audit findings."""
+    gated_findings = [
+        f
+        for f in findings
+        if f.verdict != Verdict.DECLARED and (required is None or f.id in required or f.check_id in required)
+    ]
+
+    has_failure = any(f.verdict == Verdict.FAIL or f.passed is False for f in gated_findings)
+    if has_failure:
+        return 1
+
+    if strict:
+        has_not_measurable = any(f.verdict == Verdict.NOT_MEASURABLE for f in gated_findings)
+        if has_not_measurable:
+            return 2
+
+    return 0

--- a/src/bernstein/core/checks/sentinel.py
+++ b/src/bernstein/core/checks/sentinel.py
@@ -127,7 +127,7 @@ def record_audit_run(
     journal_dir.mkdir(parents=True, exist_ok=True)
     journal_file = journal_dir / "events.jsonl"
 
-    failures = [f.to_dict() for f in findings if f.verdict == Verdict.FAIL or f.passed is False]
+    failures = [f.to_dict() for f in findings if f.verdict == Verdict.FAIL]
     sentinel_active = is_sentinel_active(workdir)
 
     entry = {
@@ -157,7 +157,7 @@ def notify_audit_failures(
     """
     notifications: list[dict[str, Any]] = []
     for f in findings:
-        if f.verdict == Verdict.FAIL or f.passed is False:
+        if f.verdict == Verdict.FAIL:
             notif = {
                 "check_id": f.id,
                 "verdict": f.verdict.value,

--- a/src/bernstein/core/checks/sentinel.py
+++ b/src/bernstein/core/checks/sentinel.py
@@ -1,0 +1,170 @@
+"""Injectable failure sentinel for govern audit (#5091).
+
+Proves the detect -> record -> notify path end to end by deliberately forcing
+a named check to report `measured, failed` with a fixed reason without
+breaking real system state.
+
+The sentinel's presence is itself reported in run outputs so a forgotten
+sentinel cannot pass for a real organic failure.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.checks.contract import Evidence, Finding, Verdict
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+SENTINEL_ENV_VAR = "BERNSTEIN_AUDIT_SENTINEL"
+SENTINEL_FILE_NAME = "audit_failure.sentinel"
+SENTINEL_CHECK_ID = "sentinel:injected_failure"
+SENTINEL_REASON = "InjectedAuditFailureSentinel"
+
+
+def get_active_sentinel(workdir: Path | None = None) -> str | None:
+    """Return description of active sentinel source, or None if inactive.
+
+    Canonical source is the environment variable ``BERNSTEIN_AUDIT_SENTINEL``.
+    File sentinel ``.sdd/sentinel/audit_failure.sentinel`` or ``.sdd/audit_failure.sentinel``
+    is also checked for persistence across subprocess boundaries.
+    """
+    env_val = os.environ.get(SENTINEL_ENV_VAR)
+    if env_val:
+        return f"env {SENTINEL_ENV_VAR}={env_val}"
+
+    if workdir is not None:
+        candidate_paths = [
+            workdir / ".sdd" / "sentinel" / SENTINEL_FILE_NAME,
+            workdir / ".sdd" / SENTINEL_FILE_NAME,
+        ]
+        for p in candidate_paths:
+            if p.is_file():
+                return f"file {p}"
+
+    return None
+
+
+def is_sentinel_active(workdir: Path | None = None) -> bool:
+    """Check whether the failure injection sentinel is active."""
+    return get_active_sentinel(workdir) is not None
+
+
+class AuditSentinelCheck:
+    """Audit check producer that fails when the sentinel is active."""
+
+    @property
+    def check_id(self) -> str:
+        return SENTINEL_CHECK_ID
+
+    @property
+    def title(self) -> str:
+        return "Injectable failure sentinel"
+
+    @property
+    def description(self) -> str:
+        return "Deliberately injects a measured failure to verify the detect -> record -> notify path."
+
+    def run(self, workdir: Path | None = None) -> Finding:
+        active_source = get_active_sentinel(workdir)
+        if active_source:
+            evidence = Evidence.from_bytes(
+                locator=f"sentinel://{SENTINEL_CHECK_ID}",
+                raw=f"active:{active_source}".encode(),
+            )
+            return Finding(
+                check_id=self.check_id,
+                verdict=Verdict.FAIL,
+                evidence=(evidence,),
+                reason=SENTINEL_REASON,
+                message=f"Injected failure sentinel is active via {active_source}",
+                summary="Injected failure sentinel active",
+                remediation=f"Clear {SENTINEL_ENV_VAR} or remove {SENTINEL_FILE_NAME}",
+                area="sentinel",
+                passed=False,
+            )
+
+        evidence = Evidence.from_bytes(
+            locator=f"sentinel://{SENTINEL_CHECK_ID}",
+            raw=b"inactive",
+        )
+        return Finding(
+            check_id=self.check_id,
+            verdict=Verdict.PASS,
+            evidence=(evidence,),
+            message="Injected failure sentinel is inactive",
+            summary="Failure sentinel inactive",
+            area="sentinel",
+            passed=True,
+        )
+
+    def __call__(self, workdir: Path | None = None) -> Finding:
+        return self.run(workdir)
+
+
+def record_audit_run(
+    findings: Sequence[Finding],
+    *,
+    workdir: Path,
+    run_id: str = "govern-audit",
+    timestamp: float | None = None,
+) -> dict[str, Any] | None:
+    """Record an audit run into the lineage journal under .sdd/lineage/govern-audit.
+
+    Returns the recorded journal entry dict if .sdd directory exists, or None.
+    """
+    sdd_dir = workdir / ".sdd"
+    if not sdd_dir.is_dir():
+        return None
+
+    now = timestamp if timestamp is not None else time.time()
+    journal_dir = sdd_dir / "lineage" / run_id
+    journal_dir.mkdir(parents=True, exist_ok=True)
+    journal_file = journal_dir / "events.jsonl"
+
+    failures = [f.to_dict() for f in findings if f.verdict == Verdict.FAIL or f.passed is False]
+    sentinel_active = is_sentinel_active(workdir)
+
+    entry = {
+        "event_type": "audit.run",
+        "run_id": run_id,
+        "timestamp": now,
+        "total_checks": len(findings),
+        "failures_count": len(failures),
+        "sentinel_active": sentinel_active,
+        "failures": failures,
+    }
+
+    with journal_file.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+    return entry
+
+
+def notify_audit_failures(
+    findings: Sequence[Finding],
+    *,
+    workdir: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Dispatch/collect notifications for any failed audit findings.
+
+    Returns a list of notification payload dictionaries.
+    """
+    notifications: list[dict[str, Any]] = []
+    for f in findings:
+        if f.verdict == Verdict.FAIL or f.passed is False:
+            notif = {
+                "check_id": f.id,
+                "verdict": f.verdict.value,
+                "summary": f.summary or f.message,
+                "reason": f.reason,
+                "remediation": f.remediation,
+                "sentinel": f.reason == SENTINEL_REASON,
+            }
+            notifications.append(notif)
+    return notifications

--- a/tests/unit/cli/commands/test_govern_audit_sentinel.py
+++ b/tests/unit/cli/commands/test_govern_audit_sentinel.py
@@ -1,0 +1,156 @@
+"""Tests for the govern audit failure injection sentinel (#5091).
+
+Proves the detect -> record -> notify path end to end:
+1. test_sentinel_forces_named_check_to_measured_failed (load-bearing)
+2. test_sentinel_presence_is_reported_in_the_run
+3. test_full_chain_detect_record_notify_fires_once
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.governance_cmd import govern_group
+from bernstein.core.checks.contract import Verdict
+from bernstein.core.checks.sentinel import (
+    SENTINEL_CHECK_ID,
+    SENTINEL_ENV_VAR,
+    SENTINEL_FILE_NAME,
+    SENTINEL_REASON,
+    AuditSentinelCheck,
+    is_sentinel_active,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_sentinel_forces_named_check_to_measured_failed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The sentinel forces the named check to report measured, failed with fixed reason."""
+    check = AuditSentinelCheck()
+    assert check.check_id == SENTINEL_CHECK_ID
+
+    # Inactive by default
+    monkeypatch.delenv(SENTINEL_ENV_VAR, raising=False)
+    inactive_finding = check.run(tmp_path)
+    assert inactive_finding.verdict == Verdict.PASS
+    assert inactive_finding.passed is True
+    assert not is_sentinel_active(tmp_path)
+
+    # Active via environment variable
+    monkeypatch.setenv(SENTINEL_ENV_VAR, "test-injection")
+    assert is_sentinel_active(tmp_path)
+    active_finding = check.run(tmp_path)
+    assert active_finding.verdict == Verdict.FAIL
+    assert active_finding.passed is False
+    assert active_finding.reason == SENTINEL_REASON
+    assert len(active_finding.evidence) >= 1
+    assert active_finding.evidence[0].locator.startswith("sentinel://")
+    assert "test-injection" in active_finding.message
+
+    # Active via sentinel file in .sdd
+    monkeypatch.delenv(SENTINEL_ENV_VAR, raising=False)
+    sdd_dir = tmp_path / ".sdd"
+    sdd_dir.mkdir(parents=True, exist_ok=True)
+    sentinel_file = sdd_dir / SENTINEL_FILE_NAME
+    sentinel_file.write_text("injected failure", encoding="utf-8")
+
+    assert is_sentinel_active(tmp_path)
+    file_finding = check.run(tmp_path)
+    assert file_finding.verdict == Verdict.FAIL
+    assert file_finding.passed is False
+    assert file_finding.reason == SENTINEL_REASON
+    assert str(sentinel_file) in file_finding.message
+
+    # Cleaning file returns check to pass
+    sentinel_file.unlink()
+    assert not is_sentinel_active(tmp_path)
+    cleared_finding = check.run(tmp_path)
+    assert cleared_finding.verdict == Verdict.PASS
+    assert cleared_finding.passed is True
+
+
+def test_sentinel_presence_is_reported_in_the_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The run output explicitly names the sentinel as active so it cannot pass for an organic failure."""
+    runner = CliRunner()
+    monkeypatch.setenv(SENTINEL_ENV_VAR, "ci-probe")
+
+    result = runner.invoke(govern_group, ["audit", "--workdir", str(tmp_path)])
+    # Sentinel forces failure, so exit code is 1
+    assert result.exit_code == 1
+    assert "[SENTINEL ACTIVE]" in result.output
+    assert "Injected failure sentinel is active" in result.output
+    assert SENTINEL_CHECK_ID in result.output
+    assert "[SENTINEL ALERT]" in result.output
+
+    # JSON output also carries sentinel finding and reason
+    json_result = runner.invoke(govern_group, ["audit", "--workdir", str(tmp_path), "--format", "json"])
+    assert json_result.exit_code == 1
+    findings = json.loads(json_result.output)
+    sentinel_entries = [f for f in findings if f["check_id"] == SENTINEL_CHECK_ID]
+    assert len(sentinel_entries) == 1
+    assert sentinel_entries[0]["verdict"] == "fail"
+    assert sentinel_entries[0]["reason"] == SENTINEL_REASON
+
+
+def test_full_chain_detect_record_notify_fires_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end selftest: sets sentinel, verifies detect, record, and notify, then clears it."""
+    sdd_dir = tmp_path / ".sdd"
+    sdd_dir.mkdir(parents=True, exist_ok=True)
+    events_file = sdd_dir / "lineage" / "govern-audit" / "events.jsonl"
+
+    runner = CliRunner()
+
+    # 1. Activate the failure sentinel
+    monkeypatch.setenv(SENTINEL_ENV_VAR, "verify-pipeline")
+
+    # 2. Run the audit
+    result = runner.invoke(govern_group, ["audit", "--workdir", str(tmp_path)])
+
+    # Assert Detect: failed exit code and check ID identified
+    assert result.exit_code == 1
+    assert SENTINEL_CHECK_ID in result.output
+    assert "[SENTINEL ACTIVE]" in result.output
+
+    # Assert Notify: notification printed with sentinel alert tag
+    assert "[SENTINEL ALERT]" in result.output
+    assert "Injected failure sentinel active" in result.output
+
+    # Assert Record: journal event recorded in .sdd/lineage/govern-audit/events.jsonl
+    assert events_file.exists()
+    lines = [json.loads(line) for line in events_file.read_text(encoding="utf-8").strip().splitlines()]
+    assert len(lines) == 1
+    event = lines[0]
+    assert event["event_type"] == "audit.run"
+    assert event["run_id"] == "govern-audit"
+    assert event["sentinel_active"] is True
+    assert event["failures_count"] >= 1
+    failed_check_ids = [f["check_id"] for f in event["failures"]]
+    assert SENTINEL_CHECK_ID in failed_check_ids
+
+    # 3. Clear the sentinel and verify it goes away
+    monkeypatch.delenv(SENTINEL_ENV_VAR, raising=False)
+    clear_result = runner.invoke(govern_group, ["audit", "--workdir", str(tmp_path)])
+    assert clear_result.exit_code == 0
+    assert "[SENTINEL ACTIVE]" not in clear_result.output
+    assert "[SENTINEL ALERT]" not in clear_result.output
+
+    # Journal should now contain a second event with sentinel_active=False
+    lines_after = [json.loads(line) for line in events_file.read_text(encoding="utf-8").strip().splitlines()]
+    assert len(lines_after) == 2
+    second_event = lines_after[1]
+    assert second_event["sentinel_active"] is False
+    assert second_event["failures_count"] == 0

--- a/tests/unit/test_govern_cmd.py
+++ b/tests/unit/test_govern_cmd.py
@@ -167,7 +167,7 @@ def test_audit_no_verifier_files_exit_0(filename: str, tmp_path: Path, monkeypat
     monkeypatch.setenv(http_signing.ENV_KEY_DIR, str(key_dir))
 
     runner = CliRunner()
-    result = runner.invoke(govern_group, ["audit"])
+    result = runner.invoke(govern_group, ["audit-keys"])
     assert result.exit_code == 0, result.output
     assert "up to date" in result.output
 
@@ -186,7 +186,7 @@ def test_audit_current_keyid_exit_0(filename: str, tmp_path: Path, monkeypatch: 
     verifier_dir.joinpath(filename).write_text(json.dumps({"keys": [{"kid": current_keyid}]}))
 
     runner = CliRunner()
-    result = runner.invoke(govern_group, ["audit"])
+    result = runner.invoke(govern_group, ["audit-keys"])
     assert result.exit_code == 0, result.output
     assert "up to date" in result.output
 
@@ -208,7 +208,7 @@ def test_audit_stale_keyid_exit_2(filename: str, tmp_path: Path, monkeypatch: py
     monkeypatch.setenv(http_signing.ENV_KEY_DIR, str(second_key_dir))
 
     runner = CliRunner()
-    result = runner.invoke(govern_group, ["audit"])
+    result = runner.invoke(govern_group, ["audit-keys"])
     assert result.exit_code == 2, result.output
     assert "stale" in result.output.lower() or "predates" in result.output.lower()
 
@@ -226,6 +226,6 @@ def test_audit_unreadable_verifier_exit_1(filename: str, tmp_path: Path, monkeyp
     verifier_dir.joinpath(filename).write_text("not valid json")
 
     runner = CliRunner()
-    result = runner.invoke(govern_group, ["audit"])
+    result = runner.invoke(govern_group, ["audit-keys"])
     assert result.exit_code == 1, result.output
     assert "unreadable" in result.output.lower()


### PR DESCRIPTION
## Overview

Part of #5071 · Implements #5091.

Adds an injectable audit failure sentinel mechanism to verify the detect -> record -> notify path end to end without causing destructive chaos or breaking real system state.

## Acceptance Criteria Verified

- [x] Documented sentinel (environment variable `BERNSTEIN_AUDIT_SENTINEL` or file `.sdd/audit_failure.sentinel`) forces the named check `sentinel:injected_failure` to report `measured, failed` with the fixed reason `InjectedAuditFailureSentinel`.
- [x] The sentinel's presence is itself explicitly reported in the run output (`[SENTINEL ACTIVE]`), preventing a forgotten sentinel from passing for an organic failure.
- [x] The selftest suite (`tests/unit/cli/commands/test_govern_audit_sentinel.py`) sets the sentinel, runs the audit, asserts the finding (detect), the lineage journal entry (record), and the notification (notify), then clears it and asserts that clean status is restored.

## Named Tests

- `test_sentinel_forces_named_check_to_measured_failed` (load-bearing)
- `test_sentinel_presence_is_reported_in_the_run`
- `test_full_chain_detect_record_notify_fires_once`

## Key Changes

1. **Sentinel Check & Helpers (`src/bernstein/core/checks/sentinel.py`)**:
   - `AuditSentinelCheck`: Conforms to `Check` protocol, reporting `verdict=Verdict.FAIL` with reason `InjectedAuditFailureSentinel` and valid `Evidence` when active, and `verdict=Verdict.PASS` when inactive.
   - `get_active_sentinel`, `is_sentinel_active`: Detects environment variable or file sentinel.
   - `record_audit_run`: Records audit run events to `.sdd/lineage/govern-audit/events.jsonl` noting whether sentinels are active.
   - `notify_audit_failures`: Collects structured failure alerts.

2. **CLI Integration (`src/bernstein/cli/commands/governance_cmd.py`)**:
   - Integrated sentinel detection, presence reporting, journal recording, and notifications into `bernstein govern audit`.

3. **Release Notes Fragment (`docs/release-notes/fragments/5091-govern-audit-sentinel.md`)**.

## Verification

```bash
uv run pytest tests/unit/cli/commands/test_govern_audit_sentinel.py -v
uv run ruff check src/bernstein/core/checks src/bernstein/cli/commands/governance_cmd.py tests/unit/cli/commands/test_govern_audit_sentinel.py
uv run mypy src/bernstein/core/checks/sentinel.py src/bernstein/core/checks/formatters.py src/bernstein/core/checks/contract.py src/bernstein/core/checks/__init__.py src/bernstein/cli/commands/governance_cmd.py tests/unit/cli/commands/test_govern_audit_sentinel.py
```
All passed cleanly.
