### PR TITLE
ci(quorum): the hourly sweep can find the runs it exists to re-run (#5827)

### DIFF
--- a/.github/workflows/quorum-rerun.yml
+++ b/.github/workflows/quorum-rerun.yml
@@ -51,16 +51,34 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Look the run up BY COMMIT, never by workflow file.
+          #
+          # The repository carries two workflow registrations for quorum.yml.
+          # `gh run list --workflow quorum.yml` resolves to 354225427, whose
+          # only runs are workflow_dispatch; every pull_request and merge_group
+          # run of the check carries workflow_id 354268719, and
+          # GET /actions/workflows/354268719 is a 404. So the lookup returned
+          # nothing for exactly the runs this sweep exists to re-run, and every
+          # governance pull request was reported as "already green or never
+          # ran" while its check sat red (#5827).
+          #
+          # `gh run rerun` refuses for the same reason -- it resolves the
+          # workflow before posting -- so the rerun goes through the REST
+          # endpoint, which works on these runs today.
           rerun_for () {  # rerun_for <pr-number>
             local pr="$1" head run
             head=$(gh pr view "$pr" --repo "$REPO" --json headRefOid --jq .headRefOid)
-            run=$(gh run list --repo "$REPO" --workflow quorum.yml --commit "$head" \
-                    --limit 1 --json databaseId,conclusion --jq '.[0] | select(.conclusion != "success") | .databaseId')
+            # The check run names its own run in html_url; that is the id the
+            # rerun endpoint wants, and it is reachable without the workflow.
+            run=$(gh api "repos/${REPO}/commits/${head}/check-runs?check_name=quorum" \
+                    --jq '.check_runs[] | select(.conclusion != null and .conclusion != "success") | .html_url' \
+                  | sed -E 's#.*/actions/runs/([0-9]+)(/.*)?$#\1#' | head -1)
             if [ -n "${run:-}" ]; then
               echo "re-running quorum for #$pr (run $run, head ${head:0:9})"
-              gh run rerun "$run" --repo "$REPO" || echo "  rerun refused; the next push will re-evaluate"
+              gh api -X POST "repos/${REPO}/actions/runs/${run}/rerun" >/dev/null \
+                || echo "  rerun refused; the next push will re-evaluate"
             else
-              echo "#$pr: quorum already green or never ran; nothing to do"
+              echo "#$pr: quorum already green, still running, or never ran; nothing to do"
             fi
           }
 

--- a/tests/unit/test_quorum_rerun_workflow_yaml.py
+++ b/tests/unit/test_quorum_rerun_workflow_yaml.py
@@ -1,0 +1,108 @@
+"""The hourly sweep has to be able to find the runs it exists to re-run.
+
+`quorum-rerun.yml` is the only thing that closes the 72-hour objection window: the requirement is
+satisfied by the clock rather than by an event, so without the sweep a governance pull request stays
+red until somebody pushes -- and a push restarts the window.
+
+It looked its runs up with ``gh run list --workflow quorum.yml``. The repository carries two workflow
+registrations for that file: the one ``/actions/workflows`` lists, whose only runs are
+``workflow_dispatch``, and the one every ``pull_request`` and ``merge_group`` run of the check
+actually carries, which 404s. So the lookup returned nothing for exactly the runs the sweep exists to
+re-run, and every governance pull request was reported as "already green or never ran" while its
+check sat red (#5827).
+
+Nothing about that failure is visible: the sweep is green, its log is a list of reassuring lines, and
+the only symptom is a pull request that never goes green on its own. So the shape of the lookup is
+asserted here rather than left to be noticed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "quorum-rerun.yml"
+
+
+def _rerun_step() -> str:
+    """The `run:` body of the step that finds and re-runs the check, comments included."""
+    doc = cast("dict[str, Any]", yaml.safe_load(WORKFLOW.read_text(encoding="utf-8")))
+    for step in doc["jobs"]["rerun"]["steps"]:
+        if isinstance(step, dict) and step.get("name") == "Re-run quorum":
+            run = step.get("run")
+            assert isinstance(run, str)
+            return run
+    pytest.fail("quorum-rerun.yml has no step named 'Re-run quorum'")
+
+
+def _rerun_code() -> str:
+    """The same body with comments stripped.
+
+    The file explains in prose why the old lookup was wrong, and that explanation has to be allowed
+    to name the thing it removed -- otherwise the only way to pass these guards is to delete the
+    reasoning, which is the opposite of what they are for.
+    """
+    return "\n".join(line for line in _rerun_step().splitlines() if not line.lstrip().startswith("#"))
+
+
+def test_workflow_exists() -> None:
+    assert WORKFLOW.is_file()
+
+
+def test_the_run_is_not_looked_up_by_workflow_file() -> None:
+    """`--workflow quorum.yml` resolves to the registration these runs are not on."""
+    assert "--workflow quorum.yml" not in _rerun_code(), (
+        "the sweep resolves quorum.yml, whose only runs are workflow_dispatch; every "
+        "pull_request and merge_group run of the check carries a different, un-resolvable "
+        "workflow id, so this lookup finds nothing for exactly the runs it is meant to find"
+    )
+
+
+def test_the_run_is_looked_up_by_commit() -> None:
+    """The check run on the head commit is reachable without resolving any workflow."""
+    step = _rerun_step()
+
+    assert "check-runs?check_name=quorum" in step
+    assert "${head}" in step or '"$head"' in step
+
+
+def test_a_still_running_check_is_not_treated_as_a_red_one() -> None:
+    """A queued or in-progress check has `conclusion: null`, which is not a failure.
+
+    Re-running a check that has not finished cancels the answer that was coming, and the sweep
+    runs every hour -- so the same pull request would be restarted forever and never conclude.
+    """
+    assert "conclusion != null" in _rerun_step()
+
+
+def test_the_rerun_does_not_resolve_the_workflow_either() -> None:
+    """`gh run rerun` refuses these runs for the same reason the lookup missed them.
+
+    It resolves the workflow before posting. The REST endpoint does not, and works on them today.
+    """
+    step = _rerun_code()
+
+    assert "gh run rerun" not in step
+    assert "/rerun" in step
+    assert "-X POST" in step
+
+
+def test_the_sweep_logs_the_run_id_it_found() -> None:
+    """The failure mode was a reassuring log, so the log has to carry the evidence.
+
+    A run id in the line is what makes "it found nothing again" distinguishable from "there was
+    nothing to find" without opening the API.
+    """
+    step = _rerun_step()
+
+    assert "re-running quorum for #$pr (run $run" in step
+
+
+def test_the_quiet_line_does_not_claim_more_than_it_knows() -> None:
+    """ "Already green or never ran" was wrong in a third way: still running."""
+    assert "already green, still running, or never ran" in _rerun_step()


### PR DESCRIPTION
Closes #5827.

## Reproduced before changing anything

Against the live repository, on the two open governance pull requests to hand:

| PR | head | `gh run list --workflow quorum.yml --commit` | check-runs lookup |
|---|---|---|---|
| #5804 | `6922e6367` | *(nothing)* | `34488356933` |
| #5811 | `1bbf79eb8` | *(nothing)* | `34493141504` |

Exactly as the issue describes: the old lookup finds nothing for the runs the sweep exists to re-run.

## Change

Look the run up **by commit** through the check-runs API, which resolves no workflow, and re-run through `POST /actions/runs/{id}/rerun`. `gh run rerun` refuses these runs for the same reason the lookup missed them — it resolves the workflow before posting.

## One addition beyond the issue

`conclusion != "success"` is also true of a check that has **not finished**, whose `conclusion` is `null`. Re-running one of those cancels the answer that was coming, and the sweep runs hourly — so the same pull request would be restarted forever and never conclude. The filter is now `conclusion != null and conclusion != "success"`.

The quiet line says so too. "Already green or never ran" was wrong in a third way, and a log line that overclaims is what made this defect invisible for as long as it was:

```
#5764: quorum already green, still running, or never ran; nothing to do
```

## Why it needs tests at all

Nothing about the old failure was visible. The sweep ran, exited green, and printed a list of reassuring lines; the only symptom was a governance pull request that never went green on its own, which reads as the window not having closed yet. So the shape of the lookup is asserted rather than left to be noticed: that no step resolves the workflow file, that the lookup is by commit, that an unfinished check is not treated as red, that the rerun does not go through `gh run rerun`, and that the log carries the run id it found — which is what the issue's "done when" asks for.

Five of the seven fail against main.

The guards read the step with comments stripped: the file explains in prose why the old lookup was wrong, and that explanation has to be allowed to name what it removed.

## Verification

```
uv run --group dev pytest tests/unit/test_quorum_rerun_workflow_yaml.py tests/unit/test_quorum_workflow_yaml.py   # 13 passed
uv run --group dev ruff check && ruff format --check   # clean
```

`docs/operations/ci-topology.md` regenerated.

## Interaction with #5804

Both touch `quorum-rerun.yml`. They are independent and complementary — #5804 fixes *which* pull requests the sweep selects (it restated the governance path list in a jq literal, so a path added to the check was never swept), this fixes *whether it can find the run* once it has selected one. Whichever lands second needs a small rebase in `rerun_for`'s neighbourhood.

Worth saying plainly: with both defects present the sweep did nothing at all, for two independent reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)