### PR TITLE
ci(homebrew): name the missing tap credential, and its environment, before building (#5826)

### DIFF
--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -31,6 +31,13 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+    env:
+      # The environment this job's secrets are read from, named so the preflight
+      # below can say WHERE to define a missing one. Kept in step with the
+      # `environment:` key above by tests/unit/test_publish_homebrew_workflow_yaml.py --
+      # a preflight that named the wrong environment would send an operator to
+      # define the secret somewhere this job will never read it.
+      RELEASE_ENVIRONMENT: release-channels
     steps:
       - name: Harden runner (audit mode)
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
@@ -100,6 +107,33 @@ jobs:
             sleep 30
           done
 
+      # Preflight, before the formula is rendered (#5826).
+      #
+      # v3.19.2 failed at the LAST step -- the cross-repo push -- with
+      # "HOMEBREW_TAP_TOKEN secret not set", after the version was resolved, the
+      # sdist was hashed and the formula was written. Everything before that step
+      # was wasted, and the error named the secret without naming the one thing an
+      # operator needed: WHICH environment to define it on.
+      #
+      # That is the whole defect. #5819 moved this job from `pypi` to
+      # `release-channels`, and an environment secret does not follow a job across
+      # environments -- the value still exists on `pypi`, so the secret "is set"
+      # from every angle except the one that matters here.
+      - name: Check the tap credential is defined on this environment
+        # After `meta`, so a pre-release version still takes its deliberate skip
+        # path instead of being turned into a credential failure.
+        if: steps.meta.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -n "${GH_TOKEN:-}" ]; then
+            echo "HOMEBREW_TAP_TOKEN is defined on ${RELEASE_ENVIRONMENT}"
+            exit 0
+          fi
+          echo "::error::HOMEBREW_TAP_TOKEN is not defined on the '${RELEASE_ENVIRONMENT}' environment, which is the one this job reads. A value defined on another environment is not visible here. Define it with: gh secret set HOMEBREW_TAP_TOKEN --env ${RELEASE_ENVIRONMENT} -R ${GITHUB_REPOSITORY}"
+          exit 1
+
       - name: Generate formula
         if: steps.meta.outputs.skip != 'true'
         env:
@@ -137,8 +171,11 @@ jobs:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           META_VERSION: ${{ steps.meta.outputs.version }}
         run: |
+          # Kept as a backstop: the preflight above is what should catch this,
+          # and this step must still refuse rather than push anonymously if it
+          # is ever reached (a dry run promoted to a real one, a reordering).
           if [ -z "$GH_TOKEN" ]; then
-            echo "::error::HOMEBREW_TAP_TOKEN secret not set. Add a PAT with repo scope for chernistry/homebrew-tap."
+            echo "::error::HOMEBREW_TAP_TOKEN is not defined on the '${RELEASE_ENVIRONMENT}' environment. It needs a PAT with repo scope for chernistry/homebrew-tap."
             exit 1
           fi
 

--- a/tests/unit/test_homebrew_formula.py
+++ b/tests/unit/test_homebrew_formula.py
@@ -18,9 +18,20 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import pytest
+
 _REPO = Path(__file__).resolve().parents[2]
 FORMULA = _REPO / "packaging" / "homebrew" / "bernstein.rb"
 PUBLISH_WORKFLOW = _REPO / ".github" / "workflows" / "publish-homebrew.yml"
+
+
+def _publish_steps() -> list[object]:
+    """The steps of publish-homebrew.yml's only job, for per-step assertions."""
+    yaml = pytest.importorskip("yaml", reason="pyyaml is required to read the workflow")
+    doc = yaml.safe_load(PUBLISH_WORKFLOW.read_text(encoding="utf-8"))
+    steps = doc["jobs"]["update-formula"]["steps"]
+    assert isinstance(steps, list)
+    return list(steps)
 
 
 def _code(body: str) -> str:
@@ -215,6 +226,14 @@ def test_a_skipped_version_stops_the_publishing_steps() -> None:
     code = _code(body)
 
     assert 'echo "skip=true" >> "$GITHUB_OUTPUT"' in code, "the skip path must record itself as an output"
-    assert code.count("steps.meta.outputs.skip != 'true'") == 2, (
-        "both the formula generation and the tap push must be guarded on the skip output"
-    )
+
+    # Asserted per STEP rather than as a count of the guard. A count says "exactly two steps are
+    # guarded", which is not the property -- the property is that no step after `meta` runs on a
+    # skipped version. Counting made adding a third guarded step (the credential preflight, #5826)
+    # fail a test whose subject it satisfies, and would equally have passed if the two guards had
+    # both landed on the wrong steps.
+    guarded = {str(step.get("name", "")): step.get("if") for step in _publish_steps() if isinstance(step, dict)}
+    for name in ("Generate formula", "Push to homebrew-tap repo"):
+        assert guarded.get(name) == "steps.meta.outputs.skip != 'true'", (
+            f"{name!r} must be guarded on the skip output, or it runs with an empty version"
+        )

--- a/tests/unit/test_publish_homebrew_workflow_yaml.py
+++ b/tests/unit/test_publish_homebrew_workflow_yaml.py
@@ -1,0 +1,106 @@
+"""The tap credential is checked before the formula is built, and the error names where to fix it.
+
+v3.19.2 failed at the LAST step of `publish-homebrew.yml` -- the cross-repo push -- with
+``HOMEBREW_TAP_TOKEN secret not set``, after the version had been resolved, the sdist hashed and the
+formula written. The tap stayed on 3.19.1 (#5826).
+
+The wasted work is the smaller half. The error named the secret and not the one thing an operator
+needed: **which environment to define it on**. #5819 moved this job from `pypi` to
+`release-channels`, and an environment secret does not follow a job across environments -- the value
+still exists on `pypi`, so from every angle except the one that matters the secret "is set". An
+error that does not name the environment sends the reader to look at a secret that is right there.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "publish-homebrew.yml"
+
+PREFLIGHT = "Check the tap credential is defined on this environment"
+
+
+def _job() -> dict[str, Any]:
+    doc = cast("dict[str, Any]", yaml.safe_load(WORKFLOW.read_text(encoding="utf-8")))
+    job = doc["jobs"]["update-formula"]
+    assert isinstance(job, dict)
+    return cast("dict[str, Any]", job)
+
+
+def _steps() -> list[dict[str, Any]]:
+    return [step for step in _job().get("steps", []) if isinstance(step, dict)]
+
+
+def _step_names() -> list[str]:
+    return [str(step.get("name", "")) for step in _steps()]
+
+
+def _step(name: str) -> dict[str, Any]:
+    for step in _steps():
+        if step.get("name") == name:
+            return step
+    pytest.fail(f"publish-homebrew.yml has no step named {name!r}")
+
+
+def test_workflow_exists() -> None:
+    assert WORKFLOW.is_file()
+
+
+def test_the_credential_is_checked_before_the_formula_is_built() -> None:
+    """Failing last wasted every step before it, and shipped nothing."""
+    names = _step_names()
+
+    assert PREFLIGHT in names
+    assert names.index(PREFLIGHT) < names.index("Generate formula")
+    assert names.index(PREFLIGHT) < names.index("Push to homebrew-tap repo")
+
+
+def test_the_preflight_runs_after_the_version_is_resolved() -> None:
+    """A pre-release takes a deliberate skip path; it must not become a credential failure."""
+    names = _step_names()
+
+    assert names.index("Get version and SHA") < names.index(PREFLIGHT)
+    assert _step(PREFLIGHT).get("if") == "steps.meta.outputs.skip != 'true'"
+
+
+def test_the_error_names_the_environment_the_job_reads() -> None:
+    """The secret exists on `pypi`. Naming only the secret sends the reader to look at it."""
+    run = str(_step(PREFLIGHT).get("run", ""))
+
+    assert "${RELEASE_ENVIRONMENT}" in run
+    assert "gh secret set HOMEBREW_TAP_TOKEN --env" in run
+    assert "is not visible here" in run
+
+
+def test_the_named_environment_is_the_one_the_job_actually_uses() -> None:
+    """A preflight naming the wrong environment is worse than one naming none.
+
+    It would send an operator to define the secret somewhere this job will never read it, and the
+    next run would fail identically with the same confident advice.
+    """
+    job = _job()
+
+    assert job.get("env", {}).get("RELEASE_ENVIRONMENT") == job.get("environment")
+
+
+def test_the_push_step_still_refuses_without_the_credential() -> None:
+    """The preflight is what should catch this; the push must not push anonymously if reached."""
+    run = str(_step("Push to homebrew-tap repo").get("run", ""))
+
+    assert 'if [ -z "$GH_TOKEN" ]' in run
+    assert "exit 1" in run
+    assert "${RELEASE_ENVIRONMENT}" in run
+
+
+def test_the_credential_is_never_printed() -> None:
+    """A preflight that leaks a PAT into a public log is worse than no preflight."""
+    run = str(_step(PREFLIGHT).get("run", ""))
+
+    for leak in ('echo "$GH_TOKEN', 'echo "${GH_TOKEN', "printf '%s' \"${GH_TOKEN"):
+        assert leak not in run


### PR DESCRIPTION
Addresses the follow-up in #5826. **Does not close it** — the two secrets still have to be defined on `release-channels` by a maintainer who has the values, and nothing here can do that.

> A follow-up worth its own PR: `publish-homebrew` and `publish-npm` should fail in a preflight step that names the missing secret and the environment it reads from, before the formula is rendered or the package is built.

This is the `publish-homebrew` half. The `publish-npm` half is #5807.

## The half that is not about wasted work

v3.19.2 failed at the **last** step, after the version was resolved, the sdist hashed and the formula written. That is worth fixing on its own, but it is the smaller half.

The error named the secret and not the one thing an operator needed: **which environment to define it on**. #5819 moved this job from `pypi` to `release-channels`, and an environment secret does not follow a job across environments — the value still exists on `pypi`, so from every angle except the one that matters the secret *is* set. An error that does not name the environment sends the reader to look at a secret that is right there and correct.

So the preflight says it:

```
::error::HOMEBREW_TAP_TOKEN is not defined on the 'release-channels' environment, which is the
one this job reads. A value defined on another environment is not visible here. Define it with:
gh secret set HOMEBREW_TAP_TOKEN --env release-channels -R sipyourdrink-ltd/bernstein
```

## Where it sits

After `Get version and SHA`, before `Generate formula`.

- **After**, so a pre-release version still takes its deliberate skip path (`skip=true`, exit 0) instead of being turned into a credential failure. A `v3.15.0rc1` tag should not go red for a secret it was never going to use.
- **Before**, so nothing is built for a run that cannot publish.

The push step keeps its own check as a backstop — the preflight is what should catch this, and the push must still refuse rather than push anonymously if it is ever reached. It names the environment now too.

## The environment name cannot drift

`RELEASE_ENVIRONMENT` is job-level `env`, pinned equal to the `environment:` key by a test. A preflight naming the **wrong** environment is worse than one naming none: it would send an operator to define the secret somewhere this job never reads, and the next run would fail identically with the same confident advice.

## One existing test changed

`test_a_skipped_version_stops_the_publishing_steps` asserted `code.count("steps.meta.outputs.skip != 'true'") == 2`.

A count is not the property the test describes. It made adding a third guarded step — this preflight — fail a test whose subject it satisfies, and it would equally have passed if the two guards had both landed on the wrong steps. It now asserts per step that `Generate formula` and `Push to homebrew-tap repo` each carry the guard.

## Verification

```
uv run --group dev pytest tests/unit/test_homebrew_formula.py \
  tests/unit/test_publish_homebrew_workflow_yaml.py \
  tests/unit/test_workflow_topology_report.py   # 25 passed
uv run --group dev ruff check && ruff format --check   # clean
```

Seven new tests: the preflight runs before the build and after `meta`, the error names the environment and the `gh secret set` command, the named environment equals the job's, the push step still refuses, and the token is never printed. Six fail against main.

`docs/operations/ci-topology.md` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)