### PR TITLE
feat(govern): ingest adapter for role-and-crew agent runtimes mapping handoffs to delegation receipts (#4965)

### DIFF
--- a/docs/release-notes/fragments/4965-crew-ingest-delegation-receipts.md
+++ b/docs/release-notes/fragments/4965-crew-ingest-delegation-receipts.md
@@ -1,0 +1,8 @@
+<!-- Release notes fragment for #4965 -->
+### Ingest adapter for role-and-crew agent runtimes mapping handoffs to delegation receipts (#4965)
+
+- **Role-and-crew ingest adapter**: Added `CrewIngestAdapter` and `CrewIngestPlugin` under `bernstein.adapters.crew_ingest`, implementing the `provide_ingest_adapter` extension point for multi-agent role-and-crew runtimes.
+- **Trace normalization**: Normalizes foreign traces containing roles, tasks, tool call argument SHA-256 digests, and handoff sequences.
+- **Cryptographic delegation mapping**: Maps role-to-role handoffs into HMAC-chained delegation receipts with parent reference linkage (`DelegationLedger.record_hop`).
+- **Fail-closed parent verification**: Missing or non-existent parent receipts fail closed rather than accepting unverified root handoffs.
+- **Idempotent ingestion**: Re-ingesting existing traces returns verified receipts without creating duplicate delegation hops.

--- a/docs/sdd/module-map.md
+++ b/docs/sdd/module-map.md
@@ -132,6 +132,7 @@ Full per-file module map. `AGENTS.md`'s own "Module map" section links here inst
 | `continue_dev.py`           | Continue.dev CLI adapter |
 | `copilot.py`                | GitHub Copilot CLI adapter |
 | `council_runner.py`         | Task-level "council of agents" runner |
+| `crew_ingest.py`            | Ingest adapter for role-and-crew agent runtimes (#4965) |
 | `cursor.py`                 | Cursor Agent CLI adapter |
 | `devin_terminal.py`         | Devin for Terminal (Cognition) CLI adapter |
 | `draft.py`                  | Drafting helper for adapter capability profiles |

--- a/src/bernstein/adapters/crew_ingest.py
+++ b/src/bernstein/adapters/crew_ingest.py
@@ -33,10 +33,10 @@ from bernstein.plugins import hookimpl
 
 def _canonical_json(obj: Any) -> str:
     """Deterministic JSON string without whitespace, sorted keys."""
-    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False, default=str)
 
 
-def _digest_args(args: Mapping[str, Any] | str | None) -> str:
+def _digest_args(args: Any) -> str:
     """Compute sha256 digest of tool call arguments."""
     if args is None:
         raw = "{}"
@@ -53,7 +53,7 @@ class CrewToolCall:
 
     name: str
     tool_call_id: str
-    arguments: dict[str, Any]
+    arguments: Any
     arguments_digest: str
     output: Any = None
 
@@ -64,11 +64,12 @@ class CrewToolCall:
         raw_args = raw.get("args") or raw.get("arguments") or {}
         if isinstance(raw_args, str):
             try:
-                args = json.loads(raw_args)
+                parsed = json.loads(raw_args)
+                args = parsed if isinstance(parsed, (dict, list)) else {"raw": parsed}
             except Exception:
                 args = {"raw": raw_args}
-        elif isinstance(raw_args, dict):
-            args = dict(raw_args)
+        elif isinstance(raw_args, (dict, list)):
+            args = raw_args
         else:
             args = {"raw": str(raw_args)}
 
@@ -343,7 +344,7 @@ class CrewIngestAdapter:
         # If existing receipts cover all handoffs with matching hops, return them
         if existing_receipts and len(existing_receipts) == len(run.handoffs):
             matched = True
-            for receipt, handoff in zip(existing_receipts, run.handoffs, strict=False):
+            for receipt, handoff in zip(existing_receipts, run.handoffs, strict=True):
                 if receipt.issuer != f"role:{handoff.from_role}" or receipt.subject != f"role:{handoff.to_role}":
                     matched = False
                     break
@@ -396,11 +397,10 @@ class CrewIngestAdapter:
         ledger: DelegationLedger,
         run_id: str,
         *,
-        key: bytes | None = None,
+        key: bytes,
     ) -> ChainResult:
         """Verify the cryptographic delegation chain and authority of *run_id*."""
-        hmac_key = key if key is not None else ledger._key
-        return verify_run_chain(root=ledger.root, run_id=run_id, key=hmac_key)
+        return verify_run_chain(root=ledger.root, run_id=run_id, key=key)
 
 
 class CrewCallbackHandler:
@@ -410,7 +410,7 @@ class CrewCallbackHandler:
         self.run_id = run_id
         self.crew_id = crew_id
         self._roles: dict[str, dict[str, Any]] = {}
-        self._tasks: dict[str, dict[str, Any]] = {}
+        self._tasks: list[dict[str, Any]] = []
         self._handoffs: list[dict[str, Any]] = []
         self._current_role: str | None = None
 
@@ -430,35 +430,44 @@ class CrewCallbackHandler:
         self._current_role = role_id
         if role_id not in self._roles:
             self.register_role(role_id, role_id)
-        self._tasks[task_id] = {
-            "task_id": task_id,
-            "description": description,
-            "assigned_role": role_id,
-            "tool_calls": [],
-        }
+        occurrences = sum(1 for t in self._tasks if t.get("name") == task_id or t.get("task_id") == task_id)
+        effective_id = task_id if occurrences == 0 else f"{task_id}:{occurrences}"
+        self._tasks.append(
+            {
+                "task_id": effective_id,
+                "name": task_id,
+                "description": description,
+                "assigned_role": role_id,
+                "tool_calls": [],
+            }
+        )
 
     def on_tool_call(
         self,
         task_id: str,
         tool_name: str,
         call_id: str,
-        args: dict[str, Any],
+        args: Any,
         output: Any = None,
     ) -> None:
-        if task_id in self._tasks:
-            self._tasks[task_id]["tool_calls"].append(
-                {
-                    "name": tool_name,
-                    "id": call_id,
-                    "args": args,
-                    "arguments_digest": _digest_args(args),
-                    "output": output,
-                }
-            )
+        for task in reversed(self._tasks):
+            if task.get("task_id") == task_id or task.get("name") == task_id:
+                task["tool_calls"].append(
+                    {
+                        "name": tool_name,
+                        "id": call_id,
+                        "args": args,
+                        "arguments_digest": _digest_args(args),
+                        "output": output,
+                    }
+                )
+                break
 
     def on_task_complete(self, task_id: str, output: Any = None) -> None:
-        if task_id in self._tasks:
-            self._tasks[task_id]["output"] = output
+        for task in reversed(self._tasks):
+            if task.get("task_id") == task_id or task.get("name") == task_id:
+                task["output"] = output
+                break
 
     def on_task_finish(self, task_id: str, output: Any = None) -> None:
         """Alias for on_task_complete."""
@@ -489,7 +498,7 @@ class CrewCallbackHandler:
             "run_id": self.run_id,
             "crew_id": self.crew_id,
             "roles": list(self._roles.values()),
-            "tasks": list(self._tasks.values()),
+            "tasks": list(self._tasks),
             "handoffs": list(self._handoffs),
         }
 

--- a/src/bernstein/adapters/crew_ingest.py
+++ b/src/bernstein/adapters/crew_ingest.py
@@ -1,0 +1,521 @@
+"""Ingest adapter for role-and-crew agent runtimes (#4965).
+
+Ingests foreign execution traces from role-and-crew agent runtimes (e.g. CrewAI),
+mapping roles, tasks, tool calls, and handoffs into Bernstein's identity and
+delegation receipt infrastructure (:mod:`~bernstein.core.identity.delegation`).
+
+Every foreign handoff between roles is recorded as an HMAC-chained delegation
+receipt, providing a cryptographically verifiable per-hop authorization trail
+for agent workloads Bernstein did not schedule.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from bernstein.core.identity.delegation import (
+    ChainResult,
+    DelegationLedger,
+    DelegationReceipt,
+    verify_run_chain,
+)
+from bernstein.core.observability.ingest_contract import (
+    INGEST_EVENT_TYPES,
+    IngestAdapterDeclaration,
+)
+from bernstein.plugins import hookimpl
+
+
+def _canonical_json(obj: Any) -> str:
+    """Deterministic JSON string without whitespace, sorted keys."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _digest_args(args: Mapping[str, Any] | str | None) -> str:
+    """Compute sha256 digest of tool call arguments."""
+    if args is None:
+        raw = "{}"
+    elif isinstance(args, str):
+        raw = args
+    else:
+        raw = _canonical_json(args)
+    return f"sha256:{hashlib.sha256(raw.encode('utf-8')).hexdigest()}"
+
+
+@dataclass(frozen=True, slots=True)
+class CrewToolCall:
+    """A tool call invoked by a role during a task's execution."""
+
+    name: str
+    tool_call_id: str
+    arguments: dict[str, Any]
+    arguments_digest: str
+    output: Any = None
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> CrewToolCall:
+        name = str(raw.get("name") or raw.get("tool_name") or raw.get("tool") or "")
+        tool_call_id = str(raw.get("id") or raw.get("call_id") or raw.get("tool_call_id") or "")
+        raw_args = raw.get("args") or raw.get("arguments") or {}
+        if isinstance(raw_args, str):
+            try:
+                args = json.loads(raw_args)
+            except Exception:
+                args = {"raw": raw_args}
+        elif isinstance(raw_args, dict):
+            args = dict(raw_args)
+        else:
+            args = {"raw": str(raw_args)}
+
+        digest = str(raw.get("arguments_digest") or _digest_args(args))
+        return cls(
+            name=name,
+            tool_call_id=tool_call_id,
+            arguments=args,
+            arguments_digest=digest,
+            output=raw.get("output"),
+        )
+
+    @property
+    def tool_name(self) -> str:
+        return self.name
+
+    @property
+    def args_digest(self) -> str:
+        return self.arguments_digest
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "tool_call_id": self.tool_call_id,
+            "arguments": self.arguments,
+            "arguments_digest": self.arguments_digest,
+            "output": self.output,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CrewRole:
+    """A declared specialist role in a crew."""
+
+    role_id: str
+    name: str
+    goal: str = ""
+    backstory: str = ""
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> CrewRole:
+        role_id = str(raw.get("role_id") or raw.get("id") or raw.get("name") or "")
+        name = str(raw.get("name") or role_id)
+        return cls(
+            role_id=role_id,
+            name=name,
+            goal=str(raw.get("goal") or ""),
+            backstory=str(raw.get("backstory") or ""),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "role_id": self.role_id,
+            "name": self.name,
+            "goal": self.goal,
+            "backstory": self.backstory,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CrewTask:
+    """A task assigned to and accepted by a crew role."""
+
+    task_id: str
+    description: str
+    assigned_role: str
+    tool_calls: tuple[CrewToolCall, ...] = ()
+    output: Any = None
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> CrewTask:
+        task_id = str(raw.get("task_id") or raw.get("id") or "")
+        desc = str(raw.get("description") or raw.get("name") or "")
+        role = str(raw.get("assigned_role") or raw.get("role") or raw.get("agent") or "")
+        raw_tools = raw.get("tool_calls") or ()
+        tools = tuple(CrewToolCall.from_dict(t) for t in raw_tools if isinstance(t, dict))
+        return cls(
+            task_id=task_id,
+            description=desc,
+            assigned_role=role,
+            tool_calls=tools,
+            output=raw.get("output"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "description": self.description,
+            "assigned_role": self.assigned_role,
+            "tool_calls": [t.to_dict() for t in self.tool_calls],
+            "output": self.output,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CrewHandoff:
+    """A delegation handoff between two roles in a crew."""
+
+    from_role: str
+    to_role: str
+    act: str = "task.handoff"
+    task_id: str = ""
+    timestamp: int = 0
+    parent_handoff_index: int | None = None
+    parent_ref: str | None = None
+    requires_parent: bool = False
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> CrewHandoff:
+        parent_idx = raw.get("parent_handoff_index")
+        return cls(
+            from_role=str(raw.get("from_role") or raw.get("sender") or ""),
+            to_role=str(raw.get("to_role") or raw.get("recipient") or ""),
+            act=str(raw.get("act") or "task.handoff"),
+            task_id=str(raw.get("task_id") or ""),
+            timestamp=int(raw.get("timestamp") or 0),
+            parent_handoff_index=int(parent_idx) if parent_idx is not None else None,
+            parent_ref=str(raw["parent_ref"]) if raw.get("parent_ref") is not None else None,
+            requires_parent=bool(raw.get("requires_parent", False)),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "from_role": self.from_role,
+            "to_role": self.to_role,
+            "act": self.act,
+            "task_id": self.task_id,
+            "timestamp": self.timestamp,
+        }
+        if self.parent_handoff_index is not None:
+            d["parent_handoff_index"] = self.parent_handoff_index
+        if self.parent_ref is not None:
+            d["parent_ref"] = self.parent_ref
+        if self.requires_parent:
+            d["requires_parent"] = self.requires_parent
+        return d
+
+
+@dataclass(frozen=True, slots=True)
+class IngestedCrewRun:
+    """Ingested representation of a foreign role-and-crew run."""
+
+    run_id: str
+    crew_id: str
+    roles: tuple[CrewRole, ...]
+    tasks: tuple[CrewTask, ...]
+    handoffs: tuple[CrewHandoff, ...]
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "crew_id": self.crew_id,
+            "roles": [r.to_dict() for r in self.roles],
+            "tasks": [t.to_dict() for t in self.tasks],
+            "handoffs": [h.to_dict() for h in self.handoffs],
+            "metadata": self.metadata,
+        }
+
+    def canonical_bytes(self) -> bytes:
+        return _canonical_json(self.to_dict()).encode("utf-8")
+
+
+class CrewIngestAdapter:
+    """Adapter translating role-and-crew run traces into delegation receipts."""
+
+    DECLARATION = IngestAdapterDeclaration(
+        name="crew",
+        version="1.0.0",
+        declared_event_types=("gen_ai_activity", "untyped_activity"),
+        summary="Ingest adapter for role-and-crew agent runtimes mapping handoffs to delegation receipts.",
+    )
+
+    def validate_declaration(self, declaration: IngestAdapterDeclaration) -> None:
+        """Validate that *declaration* conforms to the adapter's capabilities."""
+        if not set(declaration.declared_event_types).issubset(INGEST_EVENT_TYPES):
+            undeclared = set(declaration.declared_event_types) - set(INGEST_EVENT_TYPES)
+            raise ValueError(f"Declaration contains unknown event types: {undeclared}")
+        if not set(self.DECLARATION.declared_event_types).issubset(declaration.declared_event_types):
+            missing = set(self.DECLARATION.declared_event_types) - set(declaration.declared_event_types)
+            raise ValueError(f"Declaration does not declare required event types: {missing}")
+
+    def ingest_trace(self, data: Mapping[str, Any] | str | Path) -> IngestedCrewRun:
+        """Parse and ingest a crew execution trace dictionary, JSON string, or file path.
+
+        Raises:
+            ValueError: If roles or tasks are malformed or missing required identifiers.
+        """
+        raw_dict: dict[str, Any]
+        if isinstance(data, Path):
+            raw_dict = json.loads(data.read_text(encoding="utf-8"))
+        elif isinstance(data, str):
+            raw_dict = json.loads(data)
+        elif isinstance(data, Mapping):
+            raw_dict = dict(data)
+        else:
+            raise TypeError(f"Unsupported data type for Crew trace: {type(data)}")
+
+        run_id = str(raw_dict.get("run_id") or "foreign-crew-run")
+        crew_id = str(raw_dict.get("crew_id") or "foreign-crew")
+
+        raw_roles = raw_dict.get("roles")
+        if not isinstance(raw_roles, list):
+            raise ValueError("Crew trace must contain a 'roles' list")
+
+        roles: list[CrewRole] = []
+        for idx, item in enumerate(raw_roles):
+            if not isinstance(item, dict):
+                raise ValueError(f"Role at index {idx} must be a dictionary")
+            role = CrewRole.from_dict(item)
+            if not role.role_id:
+                raise ValueError(f"Role at index {idx} is missing 'role_id' or 'name'")
+            roles.append(role)
+
+        raw_tasks = raw_dict.get("tasks")
+        if not isinstance(raw_tasks, list):
+            raise ValueError("Crew trace must contain a 'tasks' list")
+
+        tasks: list[CrewTask] = []
+        for idx, item in enumerate(raw_tasks):
+            if not isinstance(item, dict):
+                raise ValueError(f"Task at index {idx} must be a dictionary")
+            task = CrewTask.from_dict(item)
+            if not task.task_id:
+                raise ValueError(f"Task at index {idx} is missing 'task_id'")
+            tasks.append(task)
+
+        raw_handoffs = raw_dict.get("handoffs") or []
+        if not isinstance(raw_handoffs, list):
+            raise ValueError("Crew trace 'handoffs' must be a list when present")
+
+        handoffs = [CrewHandoff.from_dict(h) for h in raw_handoffs if isinstance(h, dict)]
+
+        # Sort roles and tasks deterministically
+        roles.sort(key=lambda r: r.role_id)
+        tasks.sort(key=lambda t: t.task_id)
+
+        metadata = dict(raw_dict.get("metadata") or {})
+
+        return IngestedCrewRun(
+            run_id=run_id,
+            crew_id=crew_id,
+            roles=tuple(roles),
+            tasks=tuple(tasks),
+            handoffs=tuple(handoffs),
+            metadata=metadata,
+        )
+
+    def record_handoffs_to_ledger(
+        self,
+        ledger: DelegationLedger,
+        run: IngestedCrewRun,
+    ) -> list[DelegationReceipt]:
+        """Record foreign handoffs into *ledger* as HMAC-chained delegation receipts.
+
+        Idempotent: If receipts for this run already exist in the ledger with
+        the same sequence and content, re-ingestion returns the existing
+        receipts without adding duplicate hops.
+
+        Raises:
+            ValueError: When a handoff requires a parent receipt that is absent,
+                failing closed rather than accepting an unauthorized root.
+        """
+        existing_receipts: list[DelegationReceipt] = []
+        path = ledger.receipt_path(run.run_id)
+        if path.is_file():
+            for line in path.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if line:
+                    existing_receipts.append(DelegationReceipt(**json.loads(line)))
+
+        # If existing receipts cover all handoffs with matching hops, return them
+        if existing_receipts and len(existing_receipts) == len(run.handoffs):
+            matched = True
+            for receipt, handoff in zip(existing_receipts, run.handoffs, strict=False):
+                if receipt.issuer != f"role:{handoff.from_role}" or receipt.subject != f"role:{handoff.to_role}":
+                    matched = False
+                    break
+            if matched:
+                return existing_receipts
+
+        recorded: list[DelegationReceipt] = []
+        for idx, handoff in enumerate(run.handoffs):
+            parent_hmac: str | None = None
+            if handoff.parent_ref is not None:
+                matching = [r for r in recorded if r.hmac == handoff.parent_ref]
+                if not matching:
+                    raise ValueError(
+                        f"Handoff {idx} ({handoff.from_role} -> {handoff.to_role}) references "
+                        f"missing parent receipt HMAC: {handoff.parent_ref}"
+                    )
+                parent_hmac = handoff.parent_ref
+            elif handoff.parent_handoff_index is not None:
+                if handoff.parent_handoff_index < 0 or handoff.parent_handoff_index >= len(recorded):
+                    raise ValueError(
+                        f"Handoff {idx} ({handoff.from_role} -> {handoff.to_role}) references "
+                        f"non-existent parent handoff index {handoff.parent_handoff_index}"
+                    )
+                parent_hmac = recorded[handoff.parent_handoff_index].hmac
+            elif idx > 0:
+                # By default, a non-root handoff without an explicit index descends from
+                # the immediate prior hop, ensuring a connected chain.
+                parent_hmac = recorded[idx - 1].hmac
+            elif handoff.requires_parent:
+                raise ValueError(
+                    f"Root handoff {idx} ({handoff.from_role} -> {handoff.to_role}) "
+                    "requires parent receipt but has none"
+                )
+
+            receipt = ledger.record_hop(
+                run_id=run.run_id,
+                issuer=f"role:{handoff.from_role}",
+                subject=f"role:{handoff.to_role}",
+                audience=f"role:{handoff.to_role}",
+                act=handoff.act,
+                created=handoff.timestamp if handoff.timestamp else None,
+                parent_ref=parent_hmac,
+            )
+            recorded.append(receipt)
+
+        return recorded
+
+    def verify_run(
+        self,
+        ledger: DelegationLedger,
+        run_id: str,
+        *,
+        key: bytes | None = None,
+    ) -> ChainResult:
+        """Verify the cryptographic delegation chain and authority of *run_id*."""
+        hmac_key = key if key is not None else ledger._key
+        return verify_run_chain(root=ledger.root, run_id=run_id, key=hmac_key)
+
+
+class CrewCallbackHandler:
+    """Observer accumulating role-and-crew execution events into an ingestable trace."""
+
+    def __init__(self, run_id: str, crew_id: str = "crew") -> None:
+        self.run_id = run_id
+        self.crew_id = crew_id
+        self._roles: dict[str, dict[str, Any]] = {}
+        self._tasks: dict[str, dict[str, Any]] = {}
+        self._handoffs: list[dict[str, Any]] = []
+        self._current_role: str | None = None
+
+    def on_role_start(self, role_id: str, name: str, goal: str = "", backstory: str = "") -> None:
+        """Register a declared specialist role before or during execution."""
+        self.register_role(role_id, name, goal, backstory)
+
+    def register_role(self, role_id: str, name: str, goal: str = "", backstory: str = "") -> None:
+        self._roles[role_id] = {
+            "role_id": role_id,
+            "name": name,
+            "goal": goal,
+            "backstory": backstory,
+        }
+
+    def on_task_start(self, task_id: str, description: str, role_id: str) -> None:
+        self._current_role = role_id
+        if role_id not in self._roles:
+            self.register_role(role_id, role_id)
+        self._tasks[task_id] = {
+            "task_id": task_id,
+            "description": description,
+            "assigned_role": role_id,
+            "tool_calls": [],
+        }
+
+    def on_tool_call(
+        self,
+        task_id: str,
+        tool_name: str,
+        call_id: str,
+        args: dict[str, Any],
+        output: Any = None,
+    ) -> None:
+        if task_id in self._tasks:
+            self._tasks[task_id]["tool_calls"].append(
+                {
+                    "name": tool_name,
+                    "id": call_id,
+                    "args": args,
+                    "arguments_digest": _digest_args(args),
+                    "output": output,
+                }
+            )
+
+    def on_task_complete(self, task_id: str, output: Any = None) -> None:
+        if task_id in self._tasks:
+            self._tasks[task_id]["output"] = output
+
+    def on_task_finish(self, task_id: str, output: Any = None) -> None:
+        """Alias for on_task_complete."""
+        self.on_task_complete(task_id, output)
+
+    def on_handoff(
+        self,
+        from_role: str,
+        to_role: str,
+        act: str = "task.handoff",
+        task_id: str = "",
+        parent_index: int | None = None,
+    ) -> None:
+        self._handoffs.append(
+            {
+                "from_role": from_role,
+                "to_role": to_role,
+                "act": act,
+                "task_id": task_id,
+                "parent_handoff_index": parent_index,
+            }
+        )
+        self._current_role = to_role
+
+    def export_trace(self) -> dict[str, Any]:
+        """Export accumulated crew trace."""
+        return {
+            "run_id": self.run_id,
+            "crew_id": self.crew_id,
+            "roles": list(self._roles.values()),
+            "tasks": list(self._tasks.values()),
+            "handoffs": list(self._handoffs),
+        }
+
+    def to_trace_dict(self) -> dict[str, Any]:
+        """Alias for export_trace."""
+        return self.export_trace()
+
+
+class CrewIngestPlugin:
+    """Plugin registering the Crew ingest adapter into Bernstein."""
+
+    @hookimpl
+    def provide_ingest_adapter(self) -> IngestAdapterDeclaration:
+        return CrewIngestAdapter.DECLARATION
+
+    def get_adapter(self) -> CrewIngestAdapter:
+        return CrewIngestAdapter()
+
+
+__all__ = [
+    "CrewCallbackHandler",
+    "CrewHandoff",
+    "CrewIngestAdapter",
+    "CrewIngestPlugin",
+    "CrewRole",
+    "CrewTask",
+    "CrewToolCall",
+    "IngestedCrewRun",
+]

--- a/tests/fixtures/govern/crew_run.json
+++ b/tests/fixtures/govern/crew_run.json
@@ -1,0 +1,95 @@
+{
+  "run_id": "crew-run-alpha-4965",
+  "crew_id": "research-analysis-crew",
+  "roles": [
+    {
+      "role_id": "coordinator",
+      "name": "Coordinator",
+      "goal": "Orchestrate multi-agent investigation",
+      "backstory": "Experienced project lead directing tasks."
+    },
+    {
+      "role_id": "researcher",
+      "name": "Researcher",
+      "goal": "Gather public facts and technical data",
+      "backstory": "Detailed researcher digging into source documents."
+    },
+    {
+      "role_id": "analyst",
+      "name": "Analyst",
+      "goal": "Synthesize findings into a final report",
+      "backstory": "Senior technical analyst summarizing research findings."
+    }
+  ],
+  "tasks": [
+    {
+      "task_id": "task-init",
+      "description": "Initialize research scope and assign tasks",
+      "assigned_role": "coordinator",
+      "tool_calls": [
+        {
+          "tool_name": "config_loader",
+          "call_id": "call-1",
+          "args": {
+            "profile": "prod"
+          },
+          "output": "ok"
+        }
+      ],
+      "output": "Plan created"
+    },
+    {
+      "task_id": "task-search",
+      "description": "Perform deep research on target query",
+      "assigned_role": "researcher",
+      "tool_calls": [
+        {
+          "tool_name": "web_search",
+          "call_id": "call-2",
+          "args": {
+            "query": "agent governance"
+          },
+          "output": "Found 12 sources"
+        }
+      ],
+      "output": "Data collected"
+    },
+    {
+      "task_id": "task-summarize",
+      "description": "Synthesize findings and write audit trail",
+      "assigned_role": "analyst",
+      "tool_calls": [
+        {
+          "tool_name": "doc_writer",
+          "call_id": "call-3",
+          "args": {
+            "format": "markdown"
+          },
+          "output": "Summary written"
+        }
+      ],
+      "output": "Report complete"
+    }
+  ],
+  "handoffs": [
+    {
+      "from_role": "coordinator",
+      "to_role": "researcher",
+      "act": "task.handoff",
+      "task_id": "task-search",
+      "timestamp": 1730000100
+    },
+    {
+      "from_role": "researcher",
+      "to_role": "analyst",
+      "act": "task.handoff",
+      "task_id": "task-summarize",
+      "timestamp": 1730000200,
+      "parent_handoff_index": 0
+    }
+  ],
+  "metadata": {
+    "engine": "crew-runtime",
+    "version": "1.0.0"
+  }
+}

--- a/tests/unit/test_crew_ingest.py
+++ b/tests/unit/test_crew_ingest.py
@@ -259,3 +259,36 @@ def test_ingest_validation_errors(adapter: CrewIngestAdapter) -> None:
 
     with pytest.raises(TypeError, match="Unsupported data type"):
         adapter.ingest_trace(12345)  # type: ignore[arg-type]
+
+
+def test_tool_call_non_serializable_args_handled_gracefully() -> None:
+    """Non-serializable argument objects (e.g. datetime) serialize gracefully without error."""
+    import datetime
+    from bernstein.adapters.crew_ingest import CrewToolCall
+
+    now = datetime.datetime(2026, 9, 12, 10, 0, 0)
+    tc = CrewToolCall.from_dict({
+        "name": "calendar_query",
+        "id": "tc-date-1",
+        "args": {"time": now, "items": [1, 2]},
+    })
+    assert "2026-09-12" in tc.arguments_digest or tc.arguments_digest.startswith("sha256:")
+
+
+def test_crew_callback_handler_handles_repeated_task_ids() -> None:
+    """Repeated task starts with the same task ID (retries/loops) preserve all executions."""
+    handler = CrewCallbackHandler(run_id="run-retry", crew_id="retry-crew")
+    handler.on_task_start(task_id="retry-task", description="attempt 1", role_id="worker")
+    handler.on_tool_call(task_id="retry-task", tool_name="tool_a", call_id="c1", args={"attempt": 1})
+    handler.on_task_complete(task_id="retry-task", output="failed")
+
+    handler.on_task_start(task_id="retry-task", description="attempt 2", role_id="worker")
+    handler.on_tool_call(task_id="retry-task", tool_name="tool_a", call_id="c2", args={"attempt": 2})
+    handler.on_task_complete(task_id="retry-task", output="success")
+
+    trace = handler.export_trace()
+    assert len(trace["tasks"]) == 2
+    assert trace["tasks"][0]["task_id"] == "retry-task"
+    assert trace["tasks"][1]["task_id"] == "retry-task:1"
+    assert trace["tasks"][0]["output"] == "failed"
+    assert trace["tasks"][1]["output"] == "success"

--- a/tests/unit/test_crew_ingest.py
+++ b/tests/unit/test_crew_ingest.py
@@ -264,14 +264,17 @@ def test_ingest_validation_errors(adapter: CrewIngestAdapter) -> None:
 def test_tool_call_non_serializable_args_handled_gracefully() -> None:
     """Non-serializable argument objects (e.g. datetime) serialize gracefully without error."""
     import datetime
+
     from bernstein.adapters.crew_ingest import CrewToolCall
 
     now = datetime.datetime(2026, 9, 12, 10, 0, 0)
-    tc = CrewToolCall.from_dict({
-        "name": "calendar_query",
-        "id": "tc-date-1",
-        "args": {"time": now, "items": [1, 2]},
-    })
+    tc = CrewToolCall.from_dict(
+        {
+            "name": "calendar_query",
+            "id": "tc-date-1",
+            "args": {"time": now, "items": [1, 2]},
+        }
+    )
     assert "2026-09-12" in tc.arguments_digest or tc.arguments_digest.startswith("sha256:")
 
 

--- a/tests/unit/test_crew_ingest.py
+++ b/tests/unit/test_crew_ingest.py
@@ -1,0 +1,261 @@
+"""Tests for role-and-crew ingest adapter (#4965)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.adapters.crew_ingest import (
+    CrewCallbackHandler,
+    CrewHandoff,
+    CrewIngestAdapter,
+    CrewIngestPlugin,
+    CrewRole,
+    CrewTask,
+    IngestedCrewRun,
+)
+from bernstein.core.identity.delegation import DelegationLedger
+from bernstein.core.observability.ingest_contract import IngestAdapterDeclaration
+
+FIXTURE_PATH = Path(__file__).resolve().parents[1] / "fixtures" / "govern" / "crew_run.json"
+TEST_KEY = b"test-audit-key-32-bytes-long----"
+
+
+@pytest.fixture
+def ledger(tmp_path: Path) -> DelegationLedger:
+    return DelegationLedger(root=tmp_path, key=TEST_KEY)
+
+
+@pytest.fixture
+def adapter() -> CrewIngestAdapter:
+    return CrewIngestAdapter()
+
+
+def test_recorded_fixture_run_ingests_with_every_role_and_task_present(adapter: CrewIngestAdapter) -> None:
+    run = adapter.ingest_trace(FIXTURE_PATH)
+    assert run.run_id == "crew-run-alpha-4965"
+    assert run.crew_id == "research-analysis-crew"
+
+    # Verify all roles present and sorted deterministically
+    role_ids = [r.role_id for r in run.roles]
+    assert role_ids == ["analyst", "coordinator", "researcher"]
+
+    # Verify all tasks present and sorted deterministically
+    task_ids = [t.task_id for t in run.tasks]
+    assert task_ids == ["task-init", "task-search", "task-summarize"]
+
+    # Verify tool calls inside tasks
+    search_task = next(t for t in run.tasks if t.task_id == "task-search")
+    assert len(search_task.tool_calls) == 1
+    assert search_task.tool_calls[0].tool_name == "web_search"
+    assert search_task.tool_calls[0].args_digest.startswith("sha256:")
+
+    # Canonical bytes are stable
+    canonical = run.canonical_bytes()
+    assert isinstance(canonical, bytes)
+    assert len(canonical) > 0
+
+
+def test_each_handoff_produces_delegation_receipt_that_verifies(
+    adapter: CrewIngestAdapter,
+    ledger: DelegationLedger,
+) -> None:
+    run = adapter.ingest_trace(FIXTURE_PATH)
+    receipts = adapter.record_handoffs_to_ledger(ledger, run)
+
+    assert len(receipts) == 2
+    assert receipts[0].issuer == "role:coordinator"
+    assert receipts[0].subject == "role:researcher"
+    assert receipts[0].act == "task.handoff"
+    assert receipts[0].hop_index == 0
+
+    assert receipts[1].issuer == "role:researcher"
+    assert receipts[1].subject == "role:analyst"
+    assert receipts[1].act == "task.handoff"
+    assert receipts[1].hop_index == 1
+    assert receipts[1].prev_hmac == receipts[0].hmac
+    assert receipts[1].parent_ref == receipts[0].hmac
+
+    # Offline verification passes
+    result = adapter.verify_run(ledger, run.run_id, key=TEST_KEY)
+    assert result.valid is True
+    assert result.chain_ok is True
+    assert result.hops == 2
+    assert len(result.errors) == 0
+
+
+def test_handoff_missing_parent_receipt_fails_closed(
+    adapter: CrewIngestAdapter,
+    ledger: DelegationLedger,
+) -> None:
+    # 1. Invalid parent handoff index
+    invalid_index_run = IngestedCrewRun(
+        run_id="crew-fail-closed-1",
+        crew_id="crew-fail",
+        roles=(
+            CrewRole(role_id="lead", name="Lead"),
+            CrewRole(role_id="worker", name="Worker"),
+        ),
+        tasks=(CrewTask(task_id="t1", description="task 1", assigned_role="lead"),),
+        handoffs=(
+            CrewHandoff(
+                from_role="lead",
+                to_role="worker",
+                parent_handoff_index=42,
+            ),
+        ),
+    )
+    with pytest.raises(ValueError, match="references non-existent parent handoff index 42"):
+        adapter.record_handoffs_to_ledger(ledger, invalid_index_run)
+
+    # 2. Missing parent HMAC ref
+    missing_parent_ref_run = IngestedCrewRun(
+        run_id="crew-fail-closed-2",
+        crew_id="crew-fail",
+        roles=(
+            CrewRole(role_id="lead", name="Lead"),
+            CrewRole(role_id="worker", name="Worker"),
+        ),
+        tasks=(CrewTask(task_id="t1", description="task 1", assigned_role="lead"),),
+        handoffs=(
+            CrewHandoff(
+                from_role="lead",
+                to_role="worker",
+                parent_ref="deadbeef" * 8,
+            ),
+        ),
+    )
+    with pytest.raises(ValueError, match="references missing parent receipt HMAC"):
+        adapter.record_handoffs_to_ledger(ledger, missing_parent_ref_run)
+
+    # 3. Root handoff requiring parent fails closed
+    root_requires_parent_run = IngestedCrewRun(
+        run_id="crew-fail-closed-3",
+        crew_id="crew-fail",
+        roles=(
+            CrewRole(role_id="lead", name="Lead"),
+            CrewRole(role_id="worker", name="Worker"),
+        ),
+        tasks=(CrewTask(task_id="t1", description="task 1", assigned_role="lead"),),
+        handoffs=(
+            CrewHandoff(
+                from_role="lead",
+                to_role="worker",
+                requires_parent=True,
+            ),
+        ),
+    )
+    with pytest.raises(ValueError, match="requires parent receipt but has none"):
+        adapter.record_handoffs_to_ledger(ledger, root_requires_parent_run)
+
+
+def test_reingesting_same_fixture_is_idempotent(
+    adapter: CrewIngestAdapter,
+    ledger: DelegationLedger,
+) -> None:
+    run = adapter.ingest_trace(FIXTURE_PATH)
+    receipts_first = adapter.record_handoffs_to_ledger(ledger, run)
+    assert len(receipts_first) == 2
+
+    receipts_second = adapter.record_handoffs_to_ledger(ledger, run)
+    assert len(receipts_second) == 2
+    assert [r.hmac for r in receipts_first] == [r.hmac for r in receipts_second]
+
+    # File contains exactly 2 receipts, not 4
+    path = ledger.receipt_path(run.run_id)
+    lines = [line for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert len(lines) == 2
+
+
+def test_crew_callback_handler_records_trace(adapter: CrewIngestAdapter, ledger: DelegationLedger) -> None:
+    handler = CrewCallbackHandler(run_id="live-crew-run", crew_id="live-crew")
+    handler.on_role_start("planner", name="Planner", goal="Plan execution", backstory="Lead planner")
+    handler.on_role_start("coder", name="Coder", goal="Write code", backstory="Expert developer")
+
+    handler.on_task_start("plan-task", description="Produce design", role_id="planner")
+    handler.on_tool_call(
+        "plan-task",
+        tool_name="read_spec",
+        call_id="call-10",
+        args={"file": "spec.md"},
+        output="spec content",
+    )
+    handler.on_task_finish("plan-task", output="design.md created")
+
+    handler.on_handoff(from_role="planner", to_role="coder", task_id="code-task")
+
+    handler.on_task_start("code-task", description="Implement design", role_id="coder")
+    handler.on_tool_call(
+        "code-task",
+        tool_name="file_writer",
+        call_id="call-11",
+        args={"file": "app.py"},
+        output="written",
+    )
+    handler.on_task_finish("code-task", output="done")
+
+    trace = handler.to_trace_dict()
+    assert trace["run_id"] == "live-crew-run"
+    assert len(trace["roles"]) == 2
+    assert len(trace["tasks"]) == 2
+    assert len(trace["handoffs"]) == 1
+
+    run = adapter.ingest_trace(trace)
+    assert len(run.roles) == 2
+    assert len(run.tasks) == 2
+    assert len(run.handoffs) == 1
+
+    receipts = adapter.record_handoffs_to_ledger(ledger, run)
+    assert len(receipts) == 1
+    assert receipts[0].issuer == "role:planner"
+    assert receipts[0].subject == "role:coder"
+
+    verify_res = adapter.verify_run(ledger, "live-crew-run", key=TEST_KEY)
+    assert verify_res.valid is True
+
+
+def test_plugin_contract_integration() -> None:
+    plugin = CrewIngestPlugin()
+    declaration = plugin.provide_ingest_adapter()
+    assert declaration.name == "crew"
+    assert declaration.version == "1.0.0"
+    assert "gen_ai_activity" in declaration.declared_event_types
+    assert "untyped_activity" in declaration.declared_event_types
+
+    adapter = plugin.get_adapter()
+    assert isinstance(adapter, CrewIngestAdapter)
+    adapter.validate_declaration(declaration)
+
+    # Invalid declaration rejected
+    bad_dec = IngestAdapterDeclaration(
+        name="crew",
+        version="1.0.0",
+        declared_event_types=("non_existent_activity_type",),
+        summary="bad",
+    )
+    with pytest.raises(ValueError, match="unknown event types"):
+        adapter.validate_declaration(bad_dec)
+
+
+def test_ingest_validation_errors(adapter: CrewIngestAdapter) -> None:
+    with pytest.raises(ValueError, match="must contain a 'roles' list"):
+        adapter.ingest_trace({"run_id": "test"})
+
+    with pytest.raises(ValueError, match="must contain a 'tasks' list"):
+        adapter.ingest_trace({"run_id": "test", "roles": [{"role_id": "r1"}]})
+
+    with pytest.raises(ValueError, match="missing 'role_id' or 'name'"):
+        adapter.ingest_trace({"run_id": "test", "roles": [{}], "tasks": []})
+
+    with pytest.raises(ValueError, match="missing 'task_id'"):
+        adapter.ingest_trace(
+            {
+                "run_id": "test",
+                "roles": [{"role_id": "r1"}],
+                "tasks": [{}],
+            }
+        )
+
+    with pytest.raises(TypeError, match="Unsupported data type"):
+        adapter.ingest_trace(12345)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Part of #4965 (adapter substrate; CLI wiring is a follow-up).

This PR introduces an ingest adapter for role-and-crew multi-agent execution traces, translating role delegations and task handoffs directly into Bernstein's offline-verifiable, HMAC-chained delegation receipts.

### Key Changes

1. **Role-and-Crew Ingest Adapter (`CrewIngestAdapter`, `CrewIngestPlugin`)**:
   - Implements the plugin contract via `provide_ingest_adapter` declaring `name="crew"`, `version="1.0.0"`, and `declared_event_types=("gen_ai_activity", "untyped_activity")`.
   - Normalizes foreign traces containing declared specialist roles (`CrewRole`), tasks with tool call argument SHA-256 digests (`CrewTask`, `CrewToolCall`), and delegation handoffs (`CrewHandoff`).
   - Includes `CrewCallbackHandler` to accumulate events during live crew execution.

2. **Cryptographic Delegation Mapping (`DelegationLedger.record_hop`)**:
   - Maps role-to-role handoffs into HMAC-chained delegation receipts.
   - Enforces parent reference linkage (`parent_ref`) so multi-hop delegation chains can be verified offline via `verify_run_chain`.

3. **Fail-Closed Verification & Invariant Enforcement**:
   - When a handoff references an invalid or missing parent receipt index/HMAC, or when a root handoff requires a parent, the adapter fails closed by raising `ValueError` rather than admitting an unauthorized root.

4. **Idempotent Ingestion**:
   - Re-ingesting an already-recorded trace checks existing receipts and returns them without appending duplicate hops to the ledger.

5. **Test Fixture & Comprehensive Tests**:
   - Created realistic multi-agent trace fixture `tests/fixtures/govern/crew_run.json`.
   - Comprehensive unit test suite in `tests/unit/test_crew_ingest.py` validating trace ingestion, delegation verification, fail-closed handling, idempotent re-ingestion, callback handler recording, and plugin declaration enforcement.

6. **Release Notes Fragment**:
   - Added `docs/release-notes/fragments/4965-crew-ingest-delegation-receipts.md`.

## Verification

- `uv run pytest tests/unit/test_crew_ingest.py -v`: 7 passed in 7.43s.
- `uv run ruff check src/bernstein/adapters/crew_ingest.py tests/unit/test_crew_ingest.py`: All checks passed!
- `uv run ruff format --check src/bernstein/adapters/crew_ingest.py tests/unit/test_crew_ingest.py`: All files formatted.
- `uv run mypy src/bernstein/adapters/crew_ingest.py`: Success: no issues found.

