### PR TITLE
fix(governance): queue_hygiene --apply crashed listing existing labels

### DIFF
--- a/scripts/queue_hygiene.py
+++ b/scripts/queue_hygiene.py
@@ -274,7 +274,7 @@ _LABELS_TO_ENSURE = (
 
 
 def ensure_labels(repo: str) -> None:
-    existing = set(gh_json("label", "list", "--repo", repo, "--limit", "300", "--json", "name"))
+    existing = gh_json("label", "list", "--repo", repo, "--limit", "300", "--json", "name")
     existing_names = {e["name"] for e in existing} if existing and isinstance(existing, list) else set()
     for name, color, description in _LABELS_TO_ENSURE:
         if name in existing_names:

--- a/tests/unit/scripts/test_queue_hygiene.py
+++ b/tests/unit/scripts/test_queue_hygiene.py
@@ -250,3 +250,45 @@ def test_pr_filter_does_not_weaken_cross_pr_rules(qh: ModuleType) -> None:
         "over-wip must still fire for the filtered PR - the rule needed to "
         "see all 6 of this author's PRs, not just the filtered-to-one list"
     )
+
+
+# --- ensure_labels ----------------------------------------------------------
+
+
+def _label_list(*names: str) -> list[dict[str, str]]:
+    """The shape ``gh label list --json name`` really returns: a list of
+    ``{"name": ...}`` dicts, one per label, not a list of strings."""
+    return [{"name": name} for name in names]
+
+
+def test_ensure_labels_is_a_no_op_when_every_label_already_exists(
+    qh: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression test: the first cut wrapped the ``gh label list`` result in
+    ``set()``, which raises ``TypeError: unhashable type: 'dict'`` on the list
+    of dicts gh actually returns - and ``ensure_labels`` is the first thing
+    ``main()`` calls under ``--apply``, so every live run crashed before any
+    intent was applied. With every label present, nothing may be created.
+    """
+    wanted = [name for name, _color, _description in qh._LABELS_TO_ENSURE]
+    monkeypatch.setattr(qh, "gh_json", lambda *args: _label_list("bug", "duplicate", "area:core", *wanted))
+
+    def fake_gh(*args: str) -> None:
+        raise AssertionError(f"gh must not be called when every label exists, got {args}")
+
+    monkeypatch.setattr(qh, "gh", fake_gh)
+    qh.ensure_labels("owner/repo")  # must not raise
+
+
+def test_ensure_labels_creates_exactly_the_one_missing_label(qh: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    missing, color, description = qh._LABELS_TO_ENSURE[0]
+    present = [name for name, _color, _description in qh._LABELS_TO_ENSURE if name != missing]
+    monkeypatch.setattr(qh, "gh_json", lambda *args: _label_list("bug", "duplicate", *present))
+    created: list[tuple[str, ...]] = []
+    monkeypatch.setattr(qh, "gh", lambda *args: created.append(args))
+
+    qh.ensure_labels("owner/repo")
+
+    assert created == [
+        ("label", "create", missing, "--repo", "owner/repo", "--color", color, "--description", description)
+    ]


### PR DESCRIPTION
## What

`python scripts/queue_hygiene.py --apply` crashes with `TypeError: unhashable type: 'dict'` before applying any intent. One-line fix in `ensure_labels`, plus two tests that pin it.

## Why

`gh label list --json name` returns a JSON array of dicts (`[{"name": "bug"}, ...]`), and `ensure_labels` (introduced in #5687) wrapped that in `set()`:

```python
existing = set(gh_json("label", "list", "--repo", repo, "--limit", "300", "--json", "name"))
existing_names = {e["name"] for e in existing} if existing and isinstance(existing, list) else set()
```

`set()` of a list of dicts raises immediately — confirmed against the live repo's 131 labels. `ensure_labels` is the first thing `main()` calls under `--apply`, so no live run of the workflow has ever got past it. Even if `set()` had accepted the dicts, `isinstance(existing, list)` is `False` for a set, so `existing_names` would always be empty and every label would be re-created (and warned about) on every run.

## How

Drop the `set()`; the list-of-dicts comprehension on the next line already does the right thing. Nothing else in the script is touched — #5739 is open against the same file and this stays clear of it (the new tests are appended at the end of the test file, outside every hunk in that PR).

Two tests in `tests/unit/scripts/test_queue_hygiene.py`, both monkeypatching `gh_json` to return the real list-of-dicts shape:

- every label in `_LABELS_TO_ENSURE` already present → `ensure_labels` neither raises nor calls `gh` at all
- one label missing → exactly one `gh label create` call, carrying that label's colour and description

Both fail on the unfixed script with the `TypeError` at line 277 and pass with the fix.

## Checklist

- [x] `ruff check` and `ruff format` on the two changed files pass (`scripts/` is outside `src/`, so the `src/` lint and pyright surface is unaffected)
- [x] `pytest tests/unit/scripts/test_queue_hygiene.py` → 19 passed (17 existing + 2 new)
- [x] New code has type hints

### Documentation duty

- [x] N/A — internal bug fix to a governance script; no user-visible behaviour, operator workflow, public API, or module map change. Tests cover the fixed behaviour.
