### PR TITLE
test(config): pin explain chain keeps losing layers (#5110)

### DIFF
--- a/src/bernstein/cli/commands/workspace_cmd.py
+++ b/src/bernstein/cli/commands/workspace_cmd.py
@@ -276,19 +276,24 @@ def config_explain(key: str | None, project_dir: str, as_json: bool) -> None:
         CONFIG_PRECEDENCE,
         BernsteinHome,
         ConfigSource,
-        resolve_config,
+        resolve_config_bundle,
     )
 
     home = BernsteinHome.default()
-    keys = [key] if key else sorted(_DEFAULTS.keys())
     if key and key not in _DEFAULTS:
         console.print(f"[red]unknown config key:[/red] {key}")
         console.print(f"[dim]known keys: {', '.join(sorted(_DEFAULTS))}[/dim]")
         raise SystemExit(1)
 
+    # Same bundle call as ``config conflicts`` — provenance is already on each
+    # ConfigResolution; this command only renders it (#5110).
+    bundle = resolve_config_bundle(
+        home=home,
+        project_dir=Path(project_dir),
+        keys=(key,) if key else None,
+    )
     rows: list[dict[str, Any]] = []
-    for name in keys:
-        result = resolve_config(name, home=home, project_dir=Path(project_dir))
+    for name, result in bundle.items():
         # The redacted value is what gets printed. A resolution report is
         # exactly the output an operator pastes into an issue, so a secret
         # resolved from any layer must not be the thing that leaks.

--- a/src/bernstein/cli/commands/workspace_cmd.py
+++ b/src/bernstein/cli/commands/workspace_cmd.py
@@ -285,7 +285,7 @@ def config_explain(key: str | None, project_dir: str, as_json: bool) -> None:
         console.print(f"[dim]known keys: {', '.join(sorted(_DEFAULTS))}[/dim]")
         raise SystemExit(1)
 
-    # Same bundle call as ``config conflicts`` — provenance is already on each
+    # Same bundle call as ``config conflicts``: provenance is already on each
     # ConfigResolution; this command only renders it (#5110).
     bundle = resolve_config_bundle(
         home=home,

--- a/tests/unit/test_config_explain_cmd.py
+++ b/tests/unit/test_config_explain_cmd.py
@@ -115,6 +115,26 @@ def test_explain_names_the_layer_a_value_came_from(project: Path) -> None:
     assert setting["path"].endswith("config.yaml")
 
 
+def test_effective_value_names_its_source_layer(project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Load-bearing (#5110): winning layer is named, and the losing layer stays in the chain.
+
+    Collapsing the chain to a single value would still report the winner and
+    silently drop the question "what else defined this key".
+    """
+    monkeypatch.setenv("BERNSTEIN_CLI", "gemini")
+
+    code, output = _explain("cli", "--project-dir", str(project), "--json")
+    assert code == 0
+    setting = json.loads(output)["settings"][0]
+    assert setting["value"] == "gemini"
+    assert setting["layer"] == "session"
+    sources = [layer["source"] for layer in setting["chain"]]
+    assert sources[0] == "session"
+    assert "project" in sources
+    project_layer = next(layer for layer in setting["chain"] if layer["source"] == "project")
+    assert project_layer["value"] == "codex"
+
+
 def test_explain_reports_the_file_each_layer_was_read_from(project: Path) -> None:
     """`config list` answers the layer question but never names the file."""
     _, output = _explain("max_agents", "--project-dir", str(project), "--json")


### PR DESCRIPTION
## Summary
- Slice 1 of #5110 already landed in #5523. This PR is a small follow-up:
  - `config explain` renders `resolve_config_bundle` (same call as `config conflicts`), not a parallel per-key `resolve_config` walk. Behavior-preserving refactor.
  - Adds `test_effective_value_names_its_source_layer` as a named pin for "winner + loser still in `chain`". It is not a red-to-green for this diff (passes against the old loop too); existing tests already cover winner/layer. Kept under the name the issue brief asked for.
- Slice 3 (per-layer schema validation) remains out of scope.

## JSON shape (unchanged from #5523)
One object under `settings` **per key** (list), not a map keyed by name. Easier for CI to iterate, and `precedence` sits beside the list.

## Test plan
- [x] `uv run pytest tests/unit/test_config_explain_cmd.py -x -q` -- 13 passed
- [ ] CI green / review quorum

Partial implementation of #5110
Refs #5110