### PR TITLE
quorum: recompute the check when a review lands

### DIFF
--- a/.github/workflows/quorum.yml
+++ b/.github/workflows/quorum.yml
@@ -31,6 +31,14 @@ name: quorum
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+  # An approval is not a `pull_request` event. Without this trigger the check
+  # is never recomputed after somebody reviews, so a pull request that has
+  # just earned its quorum keeps the red check it was given before the
+  # approvals landed, and the only thing that clears it is an unrelated push.
+  # Reviews are the event this check exists to measure; it has to listen to
+  # them.
+  pull_request_review:
+    types: [submitted, dismissed]
   merge_group: {}
   workflow_dispatch:
     inputs:
@@ -39,8 +47,16 @@ on:
         required: true
         type: string
 
+# `inputs.pr` is part of the key because a manual run carries no pull request
+# in its event payload. Without it every manual run fell into a single group
+# keyed on the default branch and cancelled the one before it: of the last 44
+# runs, 34 were cancelled that way and each cancellation was a manual check of
+# one pull request killed by the manual check of the next.
+#
+# Superseded pull_request runs still cancel, per the concurrency policy in
+# docs/operations/ci.md.
 concurrency:
-  group: quorum-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
+  group: quorum-${{ github.event.pull_request.number || inputs.pr || github.event.merge_group.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -65,7 +65,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/publish-homebrew.yml | Publish Homebrew Formula | release, workflow_dispatch | {"cancel-in-progress": "false", "group": "publish-homebrew-${{ github.ref }}"} | 1 |
 | .github/workflows/publish.yml | Publish | push, workflow_dispatch | - | 10 |
 | .github/workflows/quorum-rerun.yml | quorum rerun | pull_request_review, schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "quorum-rerun-${{ github.event.pull_request.number \|\| 'sweep' }}"} | 1 |
-| .github/workflows/quorum.yml | quorum | merge_group, pull_request, workflow_dispatch | {"cancel-in-progress": "true", "group": "quorum-${{ github.event.pull_request.number \|\| github.event.merge_group.head_ref \|\| github.ref }}"} | 1 |
+| .github/workflows/quorum.yml | quorum | merge_group, pull_request, pull_request_review, workflow_dispatch | {"cancel-in-progress": "true", "group": "quorum-${{ github.event.pull_request.number \|\| inputs.pr \|\| github.event.merge_group.head_ref \|\| github.ref }}"} | 1 |
 | .github/workflows/reconcile-release.yml | Reconcile release drift | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "reconcile-release"} | 1 |
 | .github/workflows/release-major-minor.yml | Major/Minor Release | workflow_dispatch | {"cancel-in-progress": "false", "group": "release-major-minor-${{ github.ref }}"} | 1 |
 | .github/workflows/rendering-lane.yml | Rendering lane | pull_request, workflow_dispatch | {"cancel-in-progress": "true", "group": "rendering-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) \|\| format('branch-{0}-{1}', github.ref, github.sha) }}"} | 1 |


### PR DESCRIPTION
The `quorum` check answers a question about reviews, but it only ran on `pull_request` events. An approval is not one of those, so the verdict a pull request receives before its approvals land is the verdict it keeps — and the only thing that has been clearing it is an unrelated push, which moves the head SHA and makes those same approvals stale in the check's own eyes. `pull_request_review` makes the check recompute when the thing it measures changes.

Second fix to the same job: a manual run carries no pull request in its event payload, so every manual run fell into a single concurrency group keyed on the default branch and cancelled its predecessor. Of the last 44 runs, 34 were cancelled that way — each a manual check of one pull request killed by the manual check of the next. `inputs.pr` now takes part in the key.

Superseded `pull_request` runs still cancel, per the concurrency policy in `docs/operations/ci.md`. The rule itself is untouched: same script, same roster, same thresholds, same pinned default-branch checkout.